### PR TITLE
fix(api): TUS route cannot be in a group as we can't have overlapping middleware

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -38,7 +38,7 @@ import (
 var _ core.API = (*API)(nil)
 var _ core.APITusHandler = (*API)(nil)
 
-const TUS_HTTP_ROUTE = "/upload/tus"
+const TUS_HTTP_ROUTE = "/api/upload/tus"
 
 type API struct {
 	ctx               core.Context
@@ -335,7 +335,7 @@ func (a *API) Configure(r router.Router, accessSvc core.AccessService) error {
 		return fmt.Errorf("failed to register ipfs content routes: %w", err)
 	}
 
-	err = a.tus.SetupRoute(ipfsContentGroup, a.Subdomain(), true, false, TUS_HTTP_ROUTE)
+	err = a.tus.SetupRoute(r, a.Subdomain(), true, false, TUS_HTTP_ROUTE)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated TUS upload endpoint path to /api/upload/tus (previously /upload/tus), aligning it with the top-level API namespace.
  * The upload route is now registered at the top-level API router for consistent routing.
  * Action required: Update client integrations, scripts, and any bookmarks to use the new endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->