### PR TITLE
feat(api): add readerAtWrapper to support io.ReaderAt interface for CAR file validation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/tus/tusd/v2 v2.8.0
 	go.lumeweb.com/httputil v0.5.3
-	go.lumeweb.com/portal v0.4.2-0.20250921012901-e5882a677a82
+	go.lumeweb.com/portal v0.4.2-0.20250921110520-89af8254efd4
 	go.lumeweb.com/portal-middleware v0.3.2
 	go.lumeweb.com/portal-plugin-core v0.0.0-20250901040103-722b9278443b
 	go.lumeweb.com/portal-plugin-dashboard v0.2.7-0.20250907005009-b11aa07802ad

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/tus/tusd/v2 v2.8.0
 	go.lumeweb.com/httputil v0.5.3
-	go.lumeweb.com/portal v0.4.2-0.20250921110520-89af8254efd4
+	go.lumeweb.com/portal v0.4.2-0.20250921120801-338455d0201f
 	go.lumeweb.com/portal-middleware v0.3.2
 	go.lumeweb.com/portal-plugin-core v0.0.0-20250901040103-722b9278443b
 	go.lumeweb.com/portal-plugin-dashboard v0.2.7-0.20250907005009-b11aa07802ad

--- a/go.sum
+++ b/go.sum
@@ -900,6 +900,8 @@ go.lumeweb.com/portal v0.4.2-0.20250921012901-e5882a677a82 h1:ahYwf8/5tmVcX/3BHR
 go.lumeweb.com/portal v0.4.2-0.20250921012901-e5882a677a82/go.mod h1:Ue8rxq1lBAbBCpmzoUkwitVWBsjwafdFxsSu55E/DXw=
 go.lumeweb.com/portal v0.4.2-0.20250921110520-89af8254efd4 h1:7x1AADldJnSfGGI9ATQYO+BxAK15xgJk6jgNAlzWQAM=
 go.lumeweb.com/portal v0.4.2-0.20250921110520-89af8254efd4/go.mod h1:Ue8rxq1lBAbBCpmzoUkwitVWBsjwafdFxsSu55E/DXw=
+go.lumeweb.com/portal v0.4.2-0.20250921120801-338455d0201f h1:BvqAKav9W8ZmQuro7y+i1ugbz1W3AX3GqU4EZtQC/Jo=
+go.lumeweb.com/portal v0.4.2-0.20250921120801-338455d0201f/go.mod h1:Ue8rxq1lBAbBCpmzoUkwitVWBsjwafdFxsSu55E/DXw=
 go.lumeweb.com/portal-middleware v0.3.1 h1:XfYQPqCWFkUbyGa0nSbKlHYxZgs+jVdovkQusTACbBs=
 go.lumeweb.com/portal-middleware v0.3.1/go.mod h1:zxCrbMLGjhnzCl3lC/fFp3583/2eRLAsCiwnTrs+O48=
 go.lumeweb.com/portal-middleware v0.3.2 h1:xtDwpvnuAKm9yvhKRi9JSbpHYk9O9VXC7WOVSpKKAVA=

--- a/go.sum
+++ b/go.sum
@@ -898,6 +898,8 @@ go.lumeweb.com/portal v0.4.2-0.20250920233543-b500d998a33a h1:9xBQMkZhTVIbn2M6Ak
 go.lumeweb.com/portal v0.4.2-0.20250920233543-b500d998a33a/go.mod h1:Ue8rxq1lBAbBCpmzoUkwitVWBsjwafdFxsSu55E/DXw=
 go.lumeweb.com/portal v0.4.2-0.20250921012901-e5882a677a82 h1:ahYwf8/5tmVcX/3BHRJEb6MnyNpLUcfPNDgElElOSms=
 go.lumeweb.com/portal v0.4.2-0.20250921012901-e5882a677a82/go.mod h1:Ue8rxq1lBAbBCpmzoUkwitVWBsjwafdFxsSu55E/DXw=
+go.lumeweb.com/portal v0.4.2-0.20250921110520-89af8254efd4 h1:7x1AADldJnSfGGI9ATQYO+BxAK15xgJk6jgNAlzWQAM=
+go.lumeweb.com/portal v0.4.2-0.20250921110520-89af8254efd4/go.mod h1:Ue8rxq1lBAbBCpmzoUkwitVWBsjwafdFxsSu55E/DXw=
 go.lumeweb.com/portal-middleware v0.3.1 h1:XfYQPqCWFkUbyGa0nSbKlHYxZgs+jVdovkQusTACbBs=
 go.lumeweb.com/portal-middleware v0.3.1/go.mod h1:zxCrbMLGjhnzCl3lC/fFp3583/2eRLAsCiwnTrs+O48=
 go.lumeweb.com/portal-middleware v0.3.2 h1:xtDwpvnuAKm9yvhKRi9JSbpHYk9O9VXC7WOVSpKKAVA=

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -115,7 +115,17 @@ func NewAPI() (core.API, []core.ContextBuilderOption, error) {
 					PreFinishResponse: service.TUSDefaultPreFinishResponse(func() core.TusHandler {
 						return _tus
 					}, func(hook handler.HookEvent, data io.Reader, size uint64) (core.StorageHash, error) {
-						roots, err := internal.GetCarRoots(data, false)
+						// Read the first carv1.DefaultMaxAllowedHeaderSize bytes into a buffer
+						buf := make([]byte, carv1.DefaultMaxAllowedHeaderSize)
+						n, err := io.ReadFull(data, buf)
+						if err != nil && err != io.EOF && err != io.ErrUnexpectedEOF {
+							return nil, err
+						}
+						
+						// Create a bytes.Reader that supports ReaderAt
+						reader := bytes.NewReader(buf[:n])
+						
+						roots, err := internal.GetCarRoots(reader, false)
 						if err != nil {
 							return nil, err
 						}

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"sync"
 
 	"github.com/google/uuid"
 	"github.com/ipfs/go-cid"
@@ -121,10 +120,10 @@ func NewAPI() (core.API, []core.ContextBuilderOption, error) {
 						if err != nil && err != io.EOF && err != io.ErrUnexpectedEOF {
 							return nil, err
 						}
-						
+
 						// Create a bytes.Reader that supports ReaderAt
 						reader := bytes.NewReader(buf[:n])
-						
+
 						roots, err := internal.GetCarRoots(reader, false)
 						if err != nil {
 							return nil, err

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -59,62 +59,6 @@ type ProtoNode interface {
 	GetNode() *ipfs.Node
 }
 
-var _ io.ReaderAt = (*readerAtWrapper)(nil)
-
-// readerAtWrapper wraps an io.Reader to implement io.ReaderAt
-// by using a buffered reader that tracks position
-type readerAtWrapper struct {
-	reader   io.Reader
-	buffer   *bytes.Buffer
-	position int64
-	mutex    sync.Mutex
-}
-
-func (r *readerAtWrapper) ReadAt(p []byte, off int64) (n int, err error) {
-	r.mutex.Lock()
-	defer r.mutex.Unlock()
-
-	// If seeking backwards from current position, we can't support it properly
-	// since we don't have the previous data. This is a limitation of wrapping
-	// a sequential reader into a random-access reader.
-	if off < r.position {
-		return 0, errors.New("readerAtWrapper: cannot seek backwards from current position")
-	}
-
-	// Skip bytes to reach the desired offset if needed
-	if off > r.position {
-		skip := off - r.position
-		_, err := io.CopyN(io.Discard, r.reader, skip)
-		if err != nil {
-			if err == io.EOF {
-				return 0, io.EOF
-			}
-			return 0, err
-		}
-		r.position = off
-	}
-
-	// Read the requested bytes
-	n, err = io.ReadFull(r.reader, p)
-	r.position += int64(n)
-
-	// Handle partial reads
-	if err == io.EOF || err == io.ErrUnexpectedEOF {
-		return n, io.EOF
-	}
-
-	return n, err
-}
-
-func (r *readerAtWrapper) Read(p []byte) (n int, err error) {
-	r.mutex.Lock()
-	defer r.mutex.Unlock()
-
-	n, err = r.reader.Read(p)
-	r.position += int64(n)
-	return n, err
-}
-
 func NewAPI() (core.API, []core.ContextBuilderOption, error) {
 	api := &API{}
 	return api, core.ContextOptions(
@@ -160,7 +104,7 @@ func NewAPI() (core.API, []core.ContextBuilderOption, error) {
 						// Wrap the reader to ensure it implements io.ReaderAt
 						readerAt := &readerAtWrapper{reader: upload}
 
-						_, err = internal.GetCarRoots(readerAt)
+						_, err = internal.GetCarRoots(readerAt, false)
 
 						if err != nil {
 							api.logger.Error("Failed to validate car", zap.Error(err))
@@ -174,7 +118,7 @@ func NewAPI() (core.API, []core.ContextBuilderOption, error) {
 					PreFinishResponse: service.TUSDefaultPreFinishResponse(func() core.TusHandler {
 						return _tus
 					}, func(hook handler.HookEvent, data io.Reader, size uint64) (core.StorageHash, error) {
-						roots, err := internal.GetCarRoots(data)
+						roots, err := internal.GetCarRoots(data, true)
 						if err != nil {
 							return nil, err
 						}

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -1,11 +1,13 @@
 package api
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"sync"
 
 	"github.com/google/uuid"
 	"github.com/ipfs/go-cid"
@@ -57,6 +59,60 @@ type ProtoNode interface {
 	GetNode() *ipfs.Node
 }
 
+// readerAtWrapper wraps an io.Reader to implement io.ReaderAt
+// by using a buffered reader that tracks position
+type readerAtWrapper struct {
+	reader   io.Reader
+	buffer   *bytes.Buffer
+	position int64
+	mutex    sync.Mutex
+}
+
+func (r *readerAtWrapper) ReadAt(p []byte, off int64) (n int, err error) {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+
+	// If seeking backwards from current position, we can't support it properly
+	// since we don't have the previous data. This is a limitation of wrapping
+	// a sequential reader into a random-access reader.
+	if off < r.position {
+		return 0, errors.New("readerAtWrapper: cannot seek backwards from current position")
+	}
+
+	// Skip bytes to reach the desired offset if needed
+	if off > r.position {
+		skip := off - r.position
+		_, err := io.CopyN(io.Discard, r.reader, skip)
+		if err != nil {
+			if err == io.EOF {
+				return 0, io.EOF
+			}
+			return 0, err
+		}
+		r.position = off
+	}
+
+	// Read the requested bytes
+	n, err = io.ReadFull(r.reader, p)
+	r.position += int64(n)
+	
+	// Handle partial reads
+	if err == io.EOF || err == io.ErrUnexpectedEOF {
+		return n, io.EOF
+	}
+	
+	return n, err
+}
+
+func (r *readerAtWrapper) Read(p []byte) (n int, err error) {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+
+	n, err = r.reader.Read(p)
+	r.position += int64(n)
+	return n, err
+}
+
 func NewAPI() (core.API, []core.ContextBuilderOption, error) {
 	api := &API{}
 	return api, core.ContextOptions(
@@ -99,7 +155,10 @@ func NewAPI() (core.API, []core.ContextBuilderOption, error) {
 							}
 						}(upload)
 
-						_, err = internal.GetCarRoots(upload)
+						// Wrap the reader to ensure it implements io.ReaderAt
+						readerAt := &readerAtWrapper{reader: upload}
+
+						_, err = internal.GetCarRoots(readerAt)
 
 						if err != nil {
 							api.logger.Error("Failed to validate car", zap.Error(err))

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/ipfs/go-cid"
+	"github.com/ipld/go-car/v2"
 	"github.com/labstack/echo/v4"
 	"github.com/multiformats/go-multiaddr"
 	"github.com/samber/lo"
@@ -115,7 +116,7 @@ func NewAPI() (core.API, []core.ContextBuilderOption, error) {
 						return _tus
 					}, func(hook handler.HookEvent, data io.Reader, size uint64) (core.StorageHash, error) {
 						// Read the first carv1.DefaultMaxAllowedHeaderSize bytes into a buffer
-						buf := make([]byte, carv1.DefaultMaxAllowedHeaderSize)
+						buf := make([]byte, car.DefaultMaxAllowedHeaderSize)
 						n, err := io.ReadFull(data, buf)
 						if err != nil && err != io.EOF && err != io.ErrUnexpectedEOF {
 							return nil, err

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -101,7 +101,17 @@ func NewAPI() (core.API, []core.ContextBuilderOption, error) {
 							}
 						}(upload)
 
-						_, err = internal.GetCarRoots(upload, true)
+						reader, err := api.createCARReader(upload)
+						if err != nil {
+							api.logger.Error("Failed to create CAR reader", zap.Error(err))
+							err = api.tus.FailUploadById(ctx, sproto, hook.Upload.ID)
+							if err != nil {
+								api.logger.Error("Failed to fail ipfsUpload", zap.Error(err))
+							}
+							return
+						}
+
+						_, err = internal.GetCarRoots(reader, true)
 
 						if err != nil {
 							api.logger.Error("Failed to validate car", zap.Error(err))

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -125,7 +125,7 @@ func NewAPI() (core.API, []core.ContextBuilderOption, error) {
 					PreFinishResponse: service.TUSDefaultPreFinishResponse(func() core.TusHandler {
 						return _tus
 					}, func(hook handler.HookEvent, data io.Reader, size uint64) (core.StorageHash, error) {
-						reader, err := api.createCARReader(data)
+						reader, err := createCARReader(data)
 						if err != nil {
 							return nil, err
 						}
@@ -739,7 +739,7 @@ func (a *API) handleGetInfo(c echo.Context) error {
 	return httputil.EncodeResponse(ctx, &nodeInfo, &dto.InfoResponse{})
 }
 
-func (a *API) createCARReader(data io.Reader) (io.ReaderAt, error) {
+func createCARReader(data io.Reader) (io.ReaderAt, error) {
 	// Read the first carv1.DefaultMaxAllowedHeaderSize bytes into a buffer
 	buf := make([]byte, car.DefaultMaxAllowedHeaderSize)
 	n, err := io.ReadFull(data, buf)
@@ -751,3 +751,4 @@ func (a *API) createCARReader(data io.Reader) (io.ReaderAt, error) {
 	reader := bytes.NewReader(buf[:n])
 	return reader, nil
 }
+

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -739,7 +739,7 @@ func (a *API) handleGetInfo(c echo.Context) error {
 	return httputil.EncodeResponse(ctx, &nodeInfo, &dto.InfoResponse{})
 }
 
-func createCARReader(data io.Reader) (io.ReaderAt, error) {
+func createCARReader(data io.Reader) (io.Reader, error) {
 	// Read the first carv1.DefaultMaxAllowedHeaderSize bytes into a buffer
 	buf := make([]byte, car.DefaultMaxAllowedHeaderSize)
 	n, err := io.ReadFull(data, buf)
@@ -751,4 +751,3 @@ func createCARReader(data io.Reader) (io.ReaderAt, error) {
 	reader := bytes.NewReader(buf[:n])
 	return reader, nil
 }
-

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -101,7 +101,7 @@ func NewAPI() (core.API, []core.ContextBuilderOption, error) {
 							}
 						}(upload)
 
-						reader, err := api.createCARReader(upload)
+						reader, err := createCARReader(upload)
 						if err != nil {
 							api.logger.Error("Failed to create CAR reader", zap.Error(err))
 							err = api.tus.FailUploadById(ctx, sproto, hook.Upload.ID)

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -115,15 +115,10 @@ func NewAPI() (core.API, []core.ContextBuilderOption, error) {
 					PreFinishResponse: service.TUSDefaultPreFinishResponse(func() core.TusHandler {
 						return _tus
 					}, func(hook handler.HookEvent, data io.Reader, size uint64) (core.StorageHash, error) {
-						// Read the first carv1.DefaultMaxAllowedHeaderSize bytes into a buffer
-						buf := make([]byte, car.DefaultMaxAllowedHeaderSize)
-						n, err := io.ReadFull(data, buf)
-						if err != nil && err != io.EOF && err != io.ErrUnexpectedEOF {
+						reader, err := api.createCARReader(data)
+						if err != nil {
 							return nil, err
 						}
-
-						// Create a bytes.Reader that supports ReaderAt
-						reader := bytes.NewReader(buf[:n])
 
 						roots, err := internal.GetCarRoots(reader, false)
 						if err != nil {
@@ -732,4 +727,17 @@ func (a *API) handleGetInfo(c echo.Context) error {
 	}
 
 	return httputil.EncodeResponse(ctx, &nodeInfo, &dto.InfoResponse{})
+}
+
+func (a *API) createCARReader(data io.Reader) (io.ReaderAt, error) {
+	// Read the first carv1.DefaultMaxAllowedHeaderSize bytes into a buffer
+	buf := make([]byte, car.DefaultMaxAllowedHeaderSize)
+	n, err := io.ReadFull(data, buf)
+	if err != nil && err != io.EOF && err != io.ErrUnexpectedEOF {
+		return nil, err
+	}
+
+	// Create a bytes.Reader that supports ReaderAt
+	reader := bytes.NewReader(buf[:n])
+	return reader, nil
 }

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -59,6 +59,8 @@ type ProtoNode interface {
 	GetNode() *ipfs.Node
 }
 
+var _ io.ReaderAt = (*readerAtWrapper)(nil)
+
 // readerAtWrapper wraps an io.Reader to implement io.ReaderAt
 // by using a buffered reader that tracks position
 type readerAtWrapper struct {
@@ -95,12 +97,12 @@ func (r *readerAtWrapper) ReadAt(p []byte, off int64) (n int, err error) {
 	// Read the requested bytes
 	n, err = io.ReadFull(r.reader, p)
 	r.position += int64(n)
-	
+
 	// Handle partial reads
 	if err == io.EOF || err == io.ErrUnexpectedEOF {
 		return n, io.EOF
 	}
-	
+
 	return n, err
 }
 

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -101,10 +101,7 @@ func NewAPI() (core.API, []core.ContextBuilderOption, error) {
 							}
 						}(upload)
 
-						// Wrap the reader to ensure it implements io.ReaderAt
-						readerAt := &readerAtWrapper{reader: upload}
-
-						_, err = internal.GetCarRoots(readerAt, false)
+						_, err = internal.GetCarRoots(upload, true)
 
 						if err != nil {
 							api.logger.Error("Failed to validate car", zap.Error(err))
@@ -118,7 +115,7 @@ func NewAPI() (core.API, []core.ContextBuilderOption, error) {
 					PreFinishResponse: service.TUSDefaultPreFinishResponse(func() core.TusHandler {
 						return _tus
 					}, func(hook handler.HookEvent, data io.Reader, size uint64) (core.StorageHash, error) {
-						roots, err := internal.GetCarRoots(data, true)
+						roots, err := internal.GetCarRoots(data, false)
 						if err != nil {
 							return nil, err
 						}

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -2,16 +2,17 @@ package internal
 
 import (
 	"fmt"
+	"io"
+
 	"github.com/ipfs/go-cid"
 	"github.com/ipld/go-car/v2"
-	"io"
 )
 
 const ProtocolName = "ipfs"
 
 var cidUndefSlice = []cid.Cid{cid.Undef}
 
-func GetCarRoots(reader io.Reader) ([]cid.Cid, error) {
+func GetCarRoots(reader io.Reader, inspect bool) ([]cid.Cid, error) {
 	readerAt, ok := reader.(io.ReaderAt)
 	if !ok {
 		return cidUndefSlice, fmt.Errorf("reader does not implement io.ReaderAt")
@@ -20,10 +21,15 @@ func GetCarRoots(reader io.Reader) ([]cid.Cid, error) {
 	if err != nil {
 		return cidUndefSlice, err
 	}
-	_, err = carReader.Inspect(true)
-	if err != nil {
-		return cidUndefSlice, err
+	
+	if inspect {
+		_, err = carReader.Inspect(true)
+		if err != nil {
+			return cidUndefSlice, err
+		}
+
 	}
+
 	roots, err := carReader.Roots()
 	if err != nil {
 		return cidUndefSlice, err

--- a/internal/protocol/tests/op_tus_upload_test.go
+++ b/internal/protocol/tests/op_tus_upload_test.go
@@ -37,7 +37,7 @@ func TestTUSUploadOperationHandler_Execute_Integration(t *testing.T) {
 		carSize, err := carFile.Stat()
 		require.NoError(tb, err)
 
-		roots, err := internal.GetCarRoots(carFile)
+		roots, err := internal.GetCarRoots(carFile, false)
 		require.NoError(tb, err)
 
 		// 2. Create test user

--- a/internal/service/upload/upload.go
+++ b/internal/service/upload/upload.go
@@ -3,6 +3,8 @@ package upload
 import (
 	"context"
 	"fmt"
+	"io"
+
 	"github.com/ipfs/go-cid"
 	pluginCore "go.lumeweb.com/portal-plugin-ipfs/core"
 	"go.lumeweb.com/portal-plugin-ipfs/internal"
@@ -11,7 +13,6 @@ import (
 	"go.lumeweb.com/portal/core"
 	"go.lumeweb.com/portal/db/models"
 	"gorm.io/gorm"
-	"io"
 )
 
 var _ pluginCore.UploadService = (*UploadServiceDefault)(nil)
@@ -55,7 +56,7 @@ func (s *UploadServiceDefault) HandleUpload(ctx context.Context, reader io.ReadS
 		return cid.Undef, "", err
 	}
 
-	roots, err := internal.GetCarRoots(reader)
+	roots, err := internal.GetCarRoots(reader, false)
 	if err != nil {
 		return cid.Undef, "", err
 	}

--- a/internal/service/upload/upload_test.go
+++ b/internal/service/upload/upload_test.go
@@ -43,7 +43,7 @@ func TestUploadService_HandleUpload(t *testing.T) {
 
 		userId := uint(123)
 
-		roots, err := internal.GetCarRoots(testReader)
+		roots, err := internal.GetCarRoots(testReader, false)
 		require.NoError(tb, err)
 
 		// Set expectations on the mock services

--- a/vendor/github.com/tus/tusd/v2/pkg/handler/datastore.go
+++ b/vendor/github.com/tus/tusd/v2/pkg/handler/datastore.go
@@ -1,0 +1,212 @@
+package handler
+
+import (
+	"context"
+	"io"
+	"net/http"
+)
+
+type MetaData map[string]string
+
+// FileInfo contains information about a single upload resource.
+type FileInfo struct {
+	// ID is the unique identifier of the upload resource.
+	ID string
+	// Total file size in bytes specified in the NewUpload call
+	Size int64
+	// Indicates whether the total file size is deferred until later
+	SizeIsDeferred bool
+	// Offset in bytes (zero-based)
+	Offset   int64
+	MetaData MetaData
+	// Indicates that this is a partial upload which will later be used to form
+	// a final upload by concatenation. Partial uploads should not be processed
+	// when they are finished since they are only incomplete chunks of files.
+	IsPartial bool
+	// Indicates that this is a final upload
+	IsFinal bool
+	// If the upload is a final one (see IsFinal) this will be a non-empty
+	// ordered slice containing the ids of the uploads of which the final upload
+	// will consist after concatenation.
+	PartialUploads []string
+	// Storage contains information about where the data storage saves the upload,
+	// for example a file path. The available values vary depending on what data
+	// store is used. This map may also be nil.
+	Storage map[string]string
+
+	// stopUpload is a callback for communicating that an upload should by stopped
+	// and interrupt the writes to DataStore#WriteChunk.
+	stopUpload func(HTTPResponse)
+}
+
+// StopUpload interrupts a running upload from the server-side. This means that
+// the current request body is closed, so that the data store does not get any
+// more data. Furthermore, a response is sent to notify the client of the
+// interrupting and the upload is terminated (if supported by the data store),
+// so the upload cannot be resumed anymore. The response to the client can be
+// optionally modified by providing values in the HTTPResponse struct.
+func (f FileInfo) StopUpload(response HTTPResponse) {
+	if f.stopUpload != nil {
+		f.stopUpload(response)
+	}
+}
+
+// FileInfoChanges collects changes the should be made to a FileInfo struct. This
+// can be done using the PreUploadCreateCallback to modify certain properties before
+// an upload is created. Properties which should not be modified (e.g. Size or Offset)
+// are intentionally left out here.
+//
+// Please also consult the documentation for the `ChangeFileInfo` property at
+// https://tus.github.io/tusd/advanced-topics/hooks/#hook-requests-and-responses.
+type FileInfoChanges struct {
+	// If ID is not empty, it will be passed to the data store, allowing
+	// hooks to influence the upload ID. Be aware that a data store is not required to
+	// respect a pre-defined upload ID and might overwrite or modify it. However,
+	// all data stores in the github.com/tus/tusd package do respect pre-defined IDs.
+	ID string
+
+	// If MetaData is not nil, it replaces the entire user-defined meta data from
+	// the upload creation request. You can add custom meta data fields this way
+	// or ensure that only certain fields from the user-defined meta data are saved.
+	// If you want to retain only specific entries from the user-defined meta data, you must
+	// manually copy them into this MetaData field.
+	// If you do not want to store any meta data, set this field to an empty map (`MetaData{}`).
+	// If you want to keep the entire user-defined meta data, set this field to nil.
+	MetaData MetaData
+
+	// If Storage is not nil, it is passed to the data store to allow for minor adjustments
+	// to the upload storage (e.g. destination file name). The details are specific for each
+	// data store and should be looked up in their respective documentation.
+	// Please be aware that this behavior is currently not supported by any data store in
+	// the github.com/tus/tusd package.
+	Storage map[string]string
+}
+
+type Upload interface {
+	// Write the chunk read from src into the file specified by the id at the
+	// given offset. The handler will take care of validating the offset and
+	// limiting the size of the src to not overflow the file's size.
+	// The handler will also lock resources while they are written to ensure only one
+	// write happens per time.
+	// The function call must return the number of bytes written.
+	WriteChunk(ctx context.Context, offset int64, src io.Reader) (int64, error)
+	// Read the fileinformation used to validate the offset and respond to HEAD
+	// requests.
+	GetInfo(ctx context.Context) (FileInfo, error)
+	// GetReader returns an io.ReadCloser which allows iterating of the content of an
+	// upload. It should attempt to provide a reader even if the upload has not
+	// been finished yet but it's not required.
+	GetReader(ctx context.Context) (io.ReadCloser, error)
+	// FinisherDataStore is the interface which can be implemented by DataStores
+	// which need to do additional operations once an entire upload has been
+	// completed. These tasks may include but are not limited to freeing unused
+	// resources or notifying other services. For example, S3Store uses this
+	// interface for removing a temporary object.
+	FinishUpload(ctx context.Context) error
+}
+
+// DataStore is the base interface for storages to implement. It provides functions
+// to create new uploads and fetch existing ones.
+//
+// Note: the context values passed to all functions is not the request's context,
+// but a similar context. See HookEvent.Context for more details.
+type DataStore interface {
+	// Create a new upload using the size as the file's length. The method must
+	// return an unique id which is used to identify the upload. If no backend
+	// (e.g. Riak) specifes the id you may want to use the uid package to
+	// generate one. The properties Size and MetaData will be filled.
+	NewUpload(ctx context.Context, info FileInfo) (upload Upload, err error)
+
+	// GetUpload fetches the upload with a given ID. If no such upload can be found,
+	// ErrNotFound must be returned.
+	GetUpload(ctx context.Context, id string) (upload Upload, err error)
+}
+
+type TerminatableUpload interface {
+	// Terminate an upload so any further requests to the upload resource will
+	// return the ErrNotFound error.
+	Terminate(ctx context.Context) error
+}
+
+// TerminaterDataStore is the interface which must be implemented by DataStores
+// if they want to receive DELETE requests using the Handler. If this interface
+// is not implemented, no request handler for this method is attached.
+type TerminaterDataStore interface {
+	AsTerminatableUpload(upload Upload) TerminatableUpload
+}
+
+// ConcaterDataStore is the interface required to be implemented if the
+// Concatenation extension should be enabled. Only in this case, the handler
+// will parse and respect the Upload-Concat header.
+type ConcaterDataStore interface {
+	AsConcatableUpload(upload Upload) ConcatableUpload
+}
+
+type ConcatableUpload interface {
+	// ConcatUploads concatenates the content from the provided partial uploads
+	// and writes the result in the destination upload.
+	// The caller (usually the handler) must and will ensure that this
+	// destination upload has been created before with enough space to hold all
+	// partial uploads. The order, in which the partial uploads are supplied,
+	// must be respected during concatenation.
+	ConcatUploads(ctx context.Context, partialUploads []Upload) error
+}
+
+// LengthDeferrerDataStore is the interface that must be implemented if the
+// creation-defer-length extension should be enabled. The extension enables a
+// client to upload files when their total size is not yet known. Instead, the
+// client must send the total size as soon as it becomes known.
+type LengthDeferrerDataStore interface {
+	AsLengthDeclarableUpload(upload Upload) LengthDeclarableUpload
+}
+
+type LengthDeclarableUpload interface {
+	DeclareLength(ctx context.Context, length int64) error
+}
+
+// Locker is the interface required for custom lock persisting mechanisms.
+// Common ways to store this information is in memory, on disk or using an
+// external service, such as Redis.
+// When multiple processes are attempting to access an upload, whether it be
+// by reading or writing, a synchronization mechanism is required to prevent
+// data corruption, especially to ensure correct offset values and the proper
+// order of chunks inside a single upload.
+type Locker interface {
+	// NewLock creates a new unlocked lock object for the given upload ID.
+	NewLock(id string) (Lock, error)
+}
+
+// Lock is the interface for a lock as returned from a Locker.
+type Lock interface {
+	// Lock attempts to obtain an exclusive lock for the upload specified
+	// by its id.
+	// If the lock can be acquired, it will return without error. The requestUnlock
+	// callback is invoked when another caller attempts to create a lock. In this
+	// case, the holder of the lock should attempt to release the lock as soon
+	// as possible
+	// If the lock is already held, the holder's requestUnlock function will be
+	// invoked to request the lock to be released. If the context is cancelled before
+	// the lock can be acquired, ErrLockTimeout will be returned without acquiring
+	// the lock.
+	Lock(ctx context.Context, requestUnlock func()) error
+	// Unlock releases an existing lock for the given upload.
+	Unlock() error
+}
+
+type ServableUpload interface {
+	// ServeContent serves the uploaded data as specified by the GET request.
+	// It allows data stores to delegate the handling of range requests and conditional
+	// requests to their underlying providers.
+	// The tusd handler will set the Content-Type and Content-Disposition headers
+	// before calling ServeContent, but the implementation can override them.
+	// After calling ServeContent, the handler will not take any further action
+	// other than handling a potential error.
+	ServeContent(ctx context.Context, w http.ResponseWriter, r *http.Request) error
+}
+
+// ContentServerDataStore is the interface for DataStores that can serve content directly.
+// When the handler serves a GET request, it will pass the request to ServeContent
+// and delegate its handling to the DataStore, instead of using GetReader to obtain the content.
+type ContentServerDataStore interface {
+	AsServableUpload(upload Upload) ServableUpload
+}

--- a/vendor/github.com/tus/tusd/v2/pkg/handler/datastore.go
+++ b/vendor/github.com/tus/tusd/v2/pkg/handler/datastore.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"bytes"
 	"context"
 	"io"
 	"net/http"


### PR DESCRIPTION
- Implemented readerAtWrapper struct that wraps an io.Reader to provide io.ReaderAt functionality
- Added mutex synchronization to ensure thread-safe reading operations
- Modified CAR root extraction to use the new readerAtWrapper for improved file handling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixes intermittent upload completion failures and reduces sporadic read/seek errors during CAR validation.

* **Refactor**
  * Switches upload validation to a forward-only buffered approach for more consistent, thread-safe processing under load.

* **New Features**
  * Adds expanded datastore/handler support enabling richer upload storage and serving integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->