### PR TITLE
refactor(api): update CAR reader creation and root inspection logic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/tus/tusd/v2 v2.8.0
 	go.lumeweb.com/httputil v0.5.3
-	go.lumeweb.com/portal v0.4.2-0.20250921012901-e5882a677a82
+	go.lumeweb.com/portal v0.4.2-0.20250921120801-338455d0201f
 	go.lumeweb.com/portal-middleware v0.3.2
 	go.lumeweb.com/portal-plugin-core v0.0.0-20250901040103-722b9278443b
 	go.lumeweb.com/portal-plugin-dashboard v0.2.7-0.20250907005009-b11aa07802ad

--- a/go.sum
+++ b/go.sum
@@ -898,6 +898,10 @@ go.lumeweb.com/portal v0.4.2-0.20250920233543-b500d998a33a h1:9xBQMkZhTVIbn2M6Ak
 go.lumeweb.com/portal v0.4.2-0.20250920233543-b500d998a33a/go.mod h1:Ue8rxq1lBAbBCpmzoUkwitVWBsjwafdFxsSu55E/DXw=
 go.lumeweb.com/portal v0.4.2-0.20250921012901-e5882a677a82 h1:ahYwf8/5tmVcX/3BHRJEb6MnyNpLUcfPNDgElElOSms=
 go.lumeweb.com/portal v0.4.2-0.20250921012901-e5882a677a82/go.mod h1:Ue8rxq1lBAbBCpmzoUkwitVWBsjwafdFxsSu55E/DXw=
+go.lumeweb.com/portal v0.4.2-0.20250921110520-89af8254efd4 h1:7x1AADldJnSfGGI9ATQYO+BxAK15xgJk6jgNAlzWQAM=
+go.lumeweb.com/portal v0.4.2-0.20250921110520-89af8254efd4/go.mod h1:Ue8rxq1lBAbBCpmzoUkwitVWBsjwafdFxsSu55E/DXw=
+go.lumeweb.com/portal v0.4.2-0.20250921120801-338455d0201f h1:BvqAKav9W8ZmQuro7y+i1ugbz1W3AX3GqU4EZtQC/Jo=
+go.lumeweb.com/portal v0.4.2-0.20250921120801-338455d0201f/go.mod h1:Ue8rxq1lBAbBCpmzoUkwitVWBsjwafdFxsSu55E/DXw=
 go.lumeweb.com/portal-middleware v0.3.1 h1:XfYQPqCWFkUbyGa0nSbKlHYxZgs+jVdovkQusTACbBs=
 go.lumeweb.com/portal-middleware v0.3.1/go.mod h1:zxCrbMLGjhnzCl3lC/fFp3583/2eRLAsCiwnTrs+O48=
 go.lumeweb.com/portal-middleware v0.3.2 h1:xtDwpvnuAKm9yvhKRi9JSbpHYk9O9VXC7WOVSpKKAVA=

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/ipfs/go-cid"
+	"github.com/ipld/go-car/v2"
 	"github.com/labstack/echo/v4"
 	"github.com/multiformats/go-multiaddr"
 	"github.com/samber/lo"
@@ -99,7 +101,17 @@ func NewAPI() (core.API, []core.ContextBuilderOption, error) {
 							}
 						}(upload)
 
-						_, err = internal.GetCarRoots(upload)
+						reader, err := createCARReader(upload)
+						if err != nil {
+							api.logger.Error("Failed to create CAR reader", zap.Error(err))
+							err = api.tus.FailUploadById(ctx, sproto, hook.Upload.ID)
+							if err != nil {
+								api.logger.Error("Failed to fail ipfsUpload", zap.Error(err))
+							}
+							return
+						}
+
+						_, err = internal.GetCarRoots(reader, false)
 
 						if err != nil {
 							api.logger.Error("Failed to validate car", zap.Error(err))
@@ -113,7 +125,12 @@ func NewAPI() (core.API, []core.ContextBuilderOption, error) {
 					PreFinishResponse: service.TUSDefaultPreFinishResponse(func() core.TusHandler {
 						return _tus
 					}, func(hook handler.HookEvent, data io.Reader, size uint64) (core.StorageHash, error) {
-						roots, err := internal.GetCarRoots(data)
+						reader, err := createCARReader(data)
+						if err != nil {
+							return nil, err
+						}
+
+						roots, err := internal.GetCarRoots(reader, false)
 						if err != nil {
 							return nil, err
 						}
@@ -720,4 +737,17 @@ func (a *API) handleGetInfo(c echo.Context) error {
 	}
 
 	return httputil.EncodeResponse(ctx, &nodeInfo, &dto.InfoResponse{})
+}
+
+func createCARReader(data io.Reader) (io.Reader, error) {
+	// Read the first carv1.DefaultMaxAllowedHeaderSize bytes into a buffer
+	buf := make([]byte, car.DefaultMaxAllowedHeaderSize)
+	n, err := io.ReadFull(data, buf)
+	if err != nil && err != io.EOF && err != io.ErrUnexpectedEOF {
+		return nil, err
+	}
+
+	// Create a bytes.Reader that supports ReaderAt
+	reader := bytes.NewReader(buf[:n])
+	return reader, nil
 }

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -2,16 +2,17 @@ package internal
 
 import (
 	"fmt"
+	"io"
+
 	"github.com/ipfs/go-cid"
 	"github.com/ipld/go-car/v2"
-	"io"
 )
 
 const ProtocolName = "ipfs"
 
 var cidUndefSlice = []cid.Cid{cid.Undef}
 
-func GetCarRoots(reader io.Reader) ([]cid.Cid, error) {
+func GetCarRoots(reader io.Reader, inspect bool) ([]cid.Cid, error) {
 	readerAt, ok := reader.(io.ReaderAt)
 	if !ok {
 		return cidUndefSlice, fmt.Errorf("reader does not implement io.ReaderAt")
@@ -20,10 +21,15 @@ func GetCarRoots(reader io.Reader) ([]cid.Cid, error) {
 	if err != nil {
 		return cidUndefSlice, err
 	}
-	_, err = carReader.Inspect(true)
-	if err != nil {
-		return cidUndefSlice, err
+	
+	if inspect {
+		_, err = carReader.Inspect(true)
+		if err != nil {
+			return cidUndefSlice, err
+		}
+
 	}
+
 	roots, err := carReader.Roots()
 	if err != nil {
 		return cidUndefSlice, err

--- a/internal/protocol/tests/op_tus_upload_test.go
+++ b/internal/protocol/tests/op_tus_upload_test.go
@@ -37,7 +37,7 @@ func TestTUSUploadOperationHandler_Execute_Integration(t *testing.T) {
 		carSize, err := carFile.Stat()
 		require.NoError(tb, err)
 
-		roots, err := internal.GetCarRoots(carFile)
+		roots, err := internal.GetCarRoots(carFile, false)
 		require.NoError(tb, err)
 
 		// 2. Create test user

--- a/internal/service/upload/upload.go
+++ b/internal/service/upload/upload.go
@@ -3,6 +3,8 @@ package upload
 import (
 	"context"
 	"fmt"
+	"io"
+
 	"github.com/ipfs/go-cid"
 	pluginCore "go.lumeweb.com/portal-plugin-ipfs/core"
 	"go.lumeweb.com/portal-plugin-ipfs/internal"
@@ -11,7 +13,6 @@ import (
 	"go.lumeweb.com/portal/core"
 	"go.lumeweb.com/portal/db/models"
 	"gorm.io/gorm"
-	"io"
 )
 
 var _ pluginCore.UploadService = (*UploadServiceDefault)(nil)
@@ -55,7 +56,7 @@ func (s *UploadServiceDefault) HandleUpload(ctx context.Context, reader io.ReadS
 		return cid.Undef, "", err
 	}
 
-	roots, err := internal.GetCarRoots(reader)
+	roots, err := internal.GetCarRoots(reader, false)
 	if err != nil {
 		return cid.Undef, "", err
 	}

--- a/internal/service/upload/upload_test.go
+++ b/internal/service/upload/upload_test.go
@@ -43,7 +43,7 @@ func TestUploadService_HandleUpload(t *testing.T) {
 
 		userId := uint(123)
 
-		roots, err := internal.GetCarRoots(testReader)
+		roots, err := internal.GetCarRoots(testReader, false)
 		require.NoError(tb, err)
 
 		// Set expectations on the mock services


### PR DESCRIPTION
- Added `createCARReader` helper function to ensure `io.ReaderAt` compatibility for CAR processing
- Modified `GetCarRoots` to accept an `inspect` boolean parameter, controlling whether full inspection occurs
- Updated calls to `GetCarRoots` throughout the codebase to pass the new `inspect` parameter
- Bumped `go.lumeweb.com/portal` dependency version in `go.mod` and `go.sum`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of CAR file uploads by validating roots and failing fast on invalid files.
  * Added clearer error messaging when no roots are found in uploaded CAR files.
  * Enhanced upload processing to ensure consistent handling across upload and pre-finish steps.

* **Chores**
  * Updated a dependency to the latest version for compatibility and stability improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->