### PR TITLE
refactor(pin): implement conditional core unpinning and pin counting

### DIFF
--- a/internal/service/pin/pin.go
+++ b/internal/service/pin/pin.go
@@ -27,6 +27,7 @@ type PinServiceDefault struct {
 	logger   *core.Logger
 	workflow core.WorkflowService
 	ipfs     *protocol.Protocol
+	pinSvc   core.PinService
 }
 
 // Ensure PinServiceDefault implements the interface
@@ -42,6 +43,7 @@ func NewPinService() (core.Service, []core.ContextBuilderOption, error) {
 			svc.logger = ctx.ServiceLogger(svc)
 			svc.db = ctx.DB()
 			svc.workflow = core.GetService[core.WorkflowService](ctx, core.WORKFLOW_SERVICE)
+			svc.pinSvc = core.GetService[core.PinService](ctx, core.PIN_SERVICE)
 			proto := core.GetProtocol(internal.ProtocolName)
 			ipfsProto, ok := proto.(*protocol.Protocol)
 			if !ok {
@@ -201,7 +203,54 @@ func (s *PinServiceDefault) ReplacePin(ctx context.Context, _ uint, _ string, ol
 
 // DeletePin soft-deletes a pin job by its RequestID.
 func (s *PinServiceDefault) DeletePin(ctx context.Context, requestID types.BinaryUUID) error {
-	err := db.RetryableTransaction(s.ctx, s.db, func(g *gorm.DB) *gorm.DB {
+	// First, get the pin record being deleted to extract UserID and CID
+	pin, err := s.GetPinByRequestID(ctx, requestID)
+	if err != nil {
+		return err
+	}
+
+	// If pin doesn't exist, nothing to do
+	if pin == nil {
+		return nil
+	}
+
+	// Count other active pins by the same user for the same CID
+	otherPinsCount, err := s.countUserPinsByCID(ctx, pin.UserID, pin.CID, requestID)
+	if err != nil {
+		s.logger.Error("Failed to count other user pins for CID",
+			zap.Error(err),
+			zap.Uint("user_id", pin.UserID),
+			zap.Binary("cid", pin.CID),
+			zap.String("request_id", requestID.String()))
+		return err
+	}
+
+	// Only call core unpin operation if there are no other active pins for this user/CID combination
+	if otherPinsCount == 0 {
+		cidToUnpin, err := cid.Parse(pin.CID)
+		if err != nil {
+			s.logger.Error("Failed to parse CID for unpinning",
+				zap.Error(err),
+				zap.Binary("cid", pin.CID))
+			return fmt.Errorf("failed to parse CID: %w", err)
+		}
+
+		hash := internal.NewIPFSHash(cidToUnpin)
+		if err := s.pinSvc.DeletePinByHash(hash, pin.UserID); err != nil {
+			s.logger.Error("Failed to unpin CID in core",
+				zap.Error(err),
+				zap.Stringer("cid", cidToUnpin),
+				zap.Uint("user_id", pin.UserID))
+			return fmt.Errorf("failed to unpin CID in core: %w", err)
+		}
+
+		s.logger.Debug("Core unpin operation completed",
+			zap.Stringer("cid", cidToUnpin),
+			zap.Uint("user_id", pin.UserID))
+	}
+
+	// Always soft-delete the IPFSPin record
+	err = db.RetryableTransaction(s.ctx, s.db, func(g *gorm.DB) *gorm.DB {
 		if err := g.WithContext(ctx).
 			Where("request_id = ?", requestID).
 			Delete(&pluginDb.IPFSPin{}).
@@ -219,8 +268,10 @@ func (s *PinServiceDefault) DeletePin(ctx context.Context, requestID types.Binar
 		return err
 	}
 
-	s.logger.Debug("Deleted pin",
-		zap.String("request_id", requestID.String()))
+	s.logger.Debug("Deleted pin record",
+		zap.String("request_id", requestID.String()),
+		zap.Uint("user_id", pin.UserID),
+		zap.Int64("other_pins_count", otherPinsCount))
 	return nil
 }
 
@@ -265,6 +316,24 @@ func (s *PinServiceDefault) UpdatePinStatus(ctx context.Context, requestID types
 		zap.String("status", string(status)),
 		zap.Int64("rows_affected", rowsAffected))
 	return nil
+}
+
+// countUserPinsByCID counts active pin records for a specific user and CID, excluding a specific request ID
+func (s *PinServiceDefault) countUserPinsByCID(ctx context.Context, userID uint, cidBytes []byte, excludeRequestID types.BinaryUUID) (int64, error) {
+	var count int64
+
+	err := db.RetryableTransaction(s.ctx, s.db, func(g *gorm.DB) *gorm.DB {
+		query := g.WithContext(ctx).Model(&pluginDb.IPFSPin{}).
+			Where("user_id = ? AND cid = ? AND request_id != ?", userID, cidBytes, excludeRequestID)
+
+		return query.Count(&count)
+	})
+
+	if err != nil {
+		return 0, fmt.Errorf("failed to count user pins by CID: %w", err)
+	}
+
+	return count, nil
 }
 
 // addDelegateAddresses retrieves delegate addresses and marshals them to JSON, then sets them on the pin model

--- a/internal/service/pin/pin.go
+++ b/internal/service/pin/pin.go
@@ -18,6 +18,7 @@ import (
 	"go.uber.org/zap"
 	"gorm.io/datatypes"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 // PinServiceDefault implements the IPFSPinService interface
@@ -203,75 +204,64 @@ func (s *PinServiceDefault) ReplacePin(ctx context.Context, _ uint, _ string, ol
 
 // DeletePin soft-deletes a pin job by its RequestID.
 func (s *PinServiceDefault) DeletePin(ctx context.Context, requestID types.BinaryUUID) error {
-	// First, get the pin record being deleted to extract UserID and CID
-	pin, err := s.GetPinByRequestID(ctx, requestID)
-	if err != nil {
-		return err
-	}
-
-	// If pin doesn't exist, nothing to do
-	if pin == nil {
-		return nil
-	}
-
-	// Count other active pins by the same user for the same CID
-	otherPinsCount, err := s.countUserPinsByCID(ctx, pin.UserID, pin.CID, requestID)
-	if err != nil {
-		s.logger.Error("Failed to count other user pins for CID",
-			zap.Error(err),
-			zap.Uint("user_id", pin.UserID),
-			zap.Binary("cid", pin.CID),
-			zap.String("request_id", requestID.String()))
-		return err
-	}
-
-	// Only call core unpin operation if there are no other active pins for this user/CID combination
-	if otherPinsCount == 0 {
-		cidToUnpin, err := cid.Parse(pin.CID)
-		if err != nil {
-			s.logger.Error("Failed to parse CID for unpinning",
-				zap.Error(err),
-				zap.Binary("cid", pin.CID))
-			return fmt.Errorf("failed to parse CID: %w", err)
+	// load + delete + re-check inside one txn with row lock; unpin after commit
+	var (
+		pin         pluginDb.IPFSPin
+		shouldUnpin bool
+	)
+	err := db.RetryableTransaction(s.ctx, s.db, func(g *gorm.DB) *gorm.DB {
+		// Lock the target row to serialize concurrent deletes on same request
+		if err := g.WithContext(ctx).
+			Clauses(clause.Locking{Strength: "UPDATE"}).
+			Where("request_id = ?", requestID).
+			First(&pin).Error; err != nil {
+			if err == gorm.ErrRecordNotFound {
+				// If pin doesn't exist, nothing to do
+				return g
+			}
+			_ = g.AddError(err)
 		}
-
-		hash := internal.NewIPFSHash(cidToUnpin)
-		if err := s.pinSvc.DeletePinByHash(hash, pin.UserID); err != nil {
-			s.logger.Error("Failed to unpin CID in core",
-				zap.Error(err),
-				zap.Stringer("cid", cidToUnpin),
-				zap.Uint("user_id", pin.UserID))
-			return fmt.Errorf("failed to unpin CID in core: %w", err)
-		}
-
-		s.logger.Debug("Core unpin operation completed",
-			zap.Stringer("cid", cidToUnpin),
-			zap.Uint("user_id", pin.UserID))
-	}
-
-	// Always soft-delete the IPFSPin record
-	err = db.RetryableTransaction(s.ctx, s.db, func(g *gorm.DB) *gorm.DB {
+		// Soft-delete the target
 		if err := g.WithContext(ctx).
 			Where("request_id = ?", requestID).
-			Delete(&pluginDb.IPFSPin{}).
-			Error; err != nil {
-			_ = g.AddError(fmt.Errorf("failed to delete pin: %w", err))
-			return g
+			Delete(&pluginDb.IPFSPin{}).Error; err != nil {
+			_ = g.AddError(err)
 		}
+		// Check if any other active pins remain for (user_id, cid)
+		var cnt int64
+		if err := g.WithContext(ctx).
+			Model(&pluginDb.IPFSPin{}).
+			Where("user_id = ? AND cid = ? AND request_id != ?", pin.UserID, pin.CID, requestID).
+			Limit(1).Count(&cnt).Error; err != nil {
+			_ = g.AddError(err)
+		}
+		shouldUnpin = (cnt == 0)
 		return g
 	})
-
 	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil
+		}
 		s.logger.Error("Failed to delete pin",
 			zap.Error(err),
 			zap.String("request_id", requestID.String()))
 		return err
 	}
-
-	s.logger.Debug("Deleted pin record",
-		zap.String("request_id", requestID.String()),
-		zap.Uint("user_id", pin.UserID),
-		zap.Int64("other_pins_count", otherPinsCount))
+	if shouldUnpin {
+		c, err := cid.Cast(pin.CID)
+		if err != nil {
+			return fmt.Errorf("cid cast: %w", err)
+		}
+		if err := s.pinSvc.DeletePinByHash(internal.NewIPFSHash(c), pin.UserID); err != nil {
+			s.logger.Error("Failed to unpin CID in core",
+				zap.Error(err),
+				zap.Stringer("cid", c),
+				zap.Uint("user_id", pin.UserID))
+			return fmt.Errorf("failed to unpin CID in core: %w", err)
+		}
+		s.logger.Debug("Core unpin operation completed", zap.Stringer("cid", c), zap.Uint("user_id", pin.UserID))
+	}
+	s.logger.Debug("Deleted pin record", zap.String("request_id", requestID.String()), zap.Uint("user_id", pin.UserID))
 	return nil
 }
 

--- a/internal/service/pin/pin.go
+++ b/internal/service/pin/pin.go
@@ -232,11 +232,8 @@ func (s *PinServiceDefault) DeletePin(ctx context.Context, requestID types.Binar
 			return g
 		}
 		// Check if any other active pins remain for (user_id, cid)
-		var cnt int64
-		if err := g.WithContext(ctx).
-			Model(&pluginDb.IPFSPin{}).
-			Where("user_id = ? AND cid = ? AND request_id != ?", pin.UserID, pin.CID, requestID).
-			Limit(1).Count(&cnt).Error; err != nil {
+		cnt, err := s.countUserPinsByCID(ctx, pin.UserID, pin.CID, requestID)
+		if err != nil {
 			_ = g.AddError(err)
 			return g
 		}

--- a/internal/service/pin/pin.go
+++ b/internal/service/pin/pin.go
@@ -208,6 +208,7 @@ func (s *PinServiceDefault) DeletePin(ctx context.Context, requestID types.Binar
 	var (
 		pin         pluginDb.IPFSPin
 		shouldUnpin bool
+		loaded      bool
 	)
 	err := db.RetryableTransaction(s.ctx, s.db, func(g *gorm.DB) *gorm.DB {
 		// Lock the target row to serialize concurrent deletes on same request
@@ -220,12 +221,15 @@ func (s *PinServiceDefault) DeletePin(ctx context.Context, requestID types.Binar
 				return g
 			}
 			_ = g.AddError(err)
+			return g
 		}
+		loaded = true
 		// Soft-delete the target
 		if err := g.WithContext(ctx).
 			Where("request_id = ?", requestID).
 			Delete(&pluginDb.IPFSPin{}).Error; err != nil {
 			_ = g.AddError(err)
+			return g
 		}
 		// Check if any other active pins remain for (user_id, cid)
 		var cnt int64
@@ -234,19 +238,22 @@ func (s *PinServiceDefault) DeletePin(ctx context.Context, requestID types.Binar
 			Where("user_id = ? AND cid = ? AND request_id != ?", pin.UserID, pin.CID, requestID).
 			Limit(1).Count(&cnt).Error; err != nil {
 			_ = g.AddError(err)
+			return g
 		}
 		shouldUnpin = (cnt == 0)
 		return g
 	})
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
-			return nil
-		}
 		s.logger.Error("Failed to delete pin",
 			zap.Error(err),
 			zap.String("request_id", requestID.String()))
 		return err
 	}
+	
+	if !loaded {
+		return nil
+	}
+
 	if shouldUnpin {
 		c, err := cid.Cast(pin.CID)
 		if err != nil {

--- a/internal/service/upload/upload.go
+++ b/internal/service/upload/upload.go
@@ -76,20 +76,6 @@ func (s *UploadServiceDefault) HandleUpload(ctx context.Context, reader io.ReadS
 		return cid.Undef, "", err
 	}
 
-	// TODO: check if we need to prevent duplication here or in AddPin
-	_, err = s.pin.AddPin(ctx, &pluginDb.IPFSPin{
-		UserID:    userId,
-		CID:       roots[0].Bytes(),
-		Name:      "",
-		Origins:   nil,
-		Meta:      nil,
-		Delegates: nil,
-		Info:      nil,
-	})
-	if err != nil {
-		return cid.Undef, "", err
-	}
-
 	return roots[0], uploadId, nil
 }
 

--- a/internal/service/upload/upload.go
+++ b/internal/service/upload/upload.go
@@ -123,12 +123,25 @@ func (s *UploadServiceDefault) ProcessCIDs(ctx context.Context, cids []cid.Cid, 
 			UserID:   uploadMeta.UserID,
 		}
 
-		// Create the upload record
+		// Create the core pin record
 		_, err = s.corePin.CreatePin(ctx, pinMeta, nil)
 		if err != nil {
 			return fmt.Errorf("failed to create pin record: %w", err)
 		}
 
+		// Create the IPFS pin record
+		_, err = s.pin.AddPin(ctx, &pluginDb.IPFSPin{
+			UserID:    userId,
+			CID:       _cid.Bytes(),
+			Name:      "",
+			Origins:   nil,
+			Meta:      nil,
+			Delegates: nil,
+			Info:      nil,
+		})
+		if err != nil {
+			return fmt.Errorf("failed to create IPFS pin record: %w", err)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
- Add core.PinService dependency to PinServiceDefault
- Modify DeletePin to only unpin from core if no other active pins exist for the same user/CID
- Add CountUserPinsByCID method to count active pins excluding a specific request ID
- Create IPFS pin records in ProcessCIDs in addition to core pin records

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Prevents unintended unpinning when deleting a pin by ensuring deletion checks for other active pins for the same content and user before unpinning; deletion now handles missing pins gracefully and logs outcomes.
  - Uploads now fail fast with clear errors if creating an IPFS pin cannot be completed, avoiding partial or inconsistent states.
- Chores
  - Stronger transactional safeguards and enhanced logging during pin deletion to aid troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->