### PR TITLE
fix(file_manager): handle root path case in GetBreadcrumbs

### DIFF
--- a/internal/service/file_manager/file_manager.go
+++ b/internal/service/file_manager/file_manager.go
@@ -131,6 +131,11 @@ func (s *FileManagerServiceDefault) GetBreadcrumbs(ctx context.Context, userID u
 		return nil, fmt.Errorf("path must start with '/'")
 	}
 	
+	// Special case for root path - return empty breadcrumbs
+	if path == pluginDb.RootPath {
+		return []*pluginDb.FilePath{}, nil
+	}
+	
 	// Check if path exists for the given user
 	var existingPath pluginDb.FilePath
 	err := db.RetryableTransaction(s.ctx, s.db, func(g *gorm.DB) *gorm.DB {


### PR DESCRIPTION
*   Added special case handling for the root path (`/`) in the `GetBreadcrumbs` method
*   Now returns an empty slice of breadcrumbs when the root path is requested
*   Fixes potential errors or unexpected behavior when navigating to the root directory

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Breadcrumbs are now correctly hidden at the root directory.
  * Prevents unnecessary checks and potential errors when navigating to the root.
  * Improves navigation consistency and responsiveness at the top level.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->