### PR TITLE
fix(protocol): add new file path workflow

### DIFF
--- a/internal/protocol/op_file_path.go
+++ b/internal/protocol/op_file_path.go
@@ -419,5 +419,5 @@ func NewFilePathOperation(ctx core.Context) core.Operation {
 }
 
 func FilePathOperationName() string {
-	return "ipfs.file.path"
+	return FILE_PATH_WORKFLOW
 }

--- a/internal/protocol/protocol.go
+++ b/internal/protocol/protocol.go
@@ -90,6 +90,17 @@ func (p Protocol) Workflows() []core.WorkflowDefinition {
 		p.newPinChildBlockWorkflow(),
 		p.newUploadWorkflow(),
 		p.newTUSUploadWorkflow(),
+		p.newFilePathWorkflow(),
+	}
+}
+
+func (p Protocol) newFilePathWorkflow() core.WorkflowDefinition {
+	return core.WorkflowDefinition{
+		Name:                 FilePathOperationName(),
+		AutoTriggerFirstStep: true,
+		Steps: []core.OperationStep{
+			p.newRetryStep(FilePathOperationName()),
+		},
 	}
 }
 

--- a/internal/protocol/workflows.go
+++ b/internal/protocol/workflows.go
@@ -9,6 +9,7 @@ const (
 	PIN_CHILD_BLOCK_WORKFLOW = "ipfs.network.pin.children"
 	UPLOAD_WORKFLOW          = "ipfs.upload"
 	TUS_UPLOAD_WORKFLOW      = "ipfs.tus.upload"
+	FILE_PATH_WORKFLOW       = "ipfs.file.path"
 )
 
 type PinWorkflowData struct {


### PR DESCRIPTION
- Introduce FILE_PATH_WORKFLOW constant for file path operations
- Implement newFilePathWorkflow to define the file path workflow with auto-triggered first step
- Update FilePathOperationName to return the new workflow constant

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced an automated workflow for file path operations with auto-start and built-in retry, improving reliability and responsiveness.
- Bug Fixes
  - Standardized the user-facing operation name for file path actions to ensure consistent behavior across integrations and logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->