### PR TITLE
fix(db): add default timestamps and engine specification to mysql migration schema

### DIFF
--- a/internal/db/migrations/mysql/20250702025738_init.sql
+++ b/internal/db/migrations/mysql/20250702025738_init.sql
@@ -4,7 +4,7 @@ CREATE TABLE IF NOT EXISTS ipfs_pins (
     id INTEGER PRIMARY KEY AUTO_INCREMENT,
     request_id BINARY(16) UNIQUE,
     user_id INTEGER,
-    status TEXT,
+    status VARCHAR(50),
     cid VARBINARY(64),
     name TEXT,
     origins TEXT,
@@ -12,21 +12,21 @@ CREATE TABLE IF NOT EXISTS ipfs_pins (
     delegates TEXT,
     info TEXT,
     parent_request_id BINARY(16),
-    created_at TIMESTAMP,
-    updated_at TIMESTAMP,
-    deleted_at TIMESTAMP
-);
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    deleted_at TIMESTAMP NULL DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE IF NOT EXISTS ipfs_blocks (
     id INTEGER PRIMARY KEY AUTO_INCREMENT,
     cid VARBINARY(64) UNIQUE,
     size INTEGER,
-    last_announcement TIMESTAMP,
+    last_announcement TIMESTAMP NULL DEFAULT NULL,
     ready BOOLEAN DEFAULT FALSE,
-    created_at TIMESTAMP,
-    updated_at TIMESTAMP,
-    deleted_at TIMESTAMP
-);
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    deleted_at TIMESTAMP NULL DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE INDEX idx_ipfs_blocks_last_announcement ON ipfs_blocks (last_announcement);
 CREATE INDEX idx_ipfs_blocks_cid_last_announcement ON ipfs_blocks (cid, last_announcement);
@@ -40,23 +40,23 @@ CREATE TABLE IF NOT EXISTS ipfs_linked_blocks (
     parent_id INTEGER,
     child_id INTEGER,
     link_index INTEGER,
-    created_at TIMESTAMP,
-    updated_at TIMESTAMP,
-    deleted_at TIMESTAMP,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    deleted_at TIMESTAMP NULL DEFAULT NULL,
     FOREIGN KEY (parent_id) REFERENCES ipfs_blocks(id),
     FOREIGN KEY (child_id) REFERENCES ipfs_blocks(id),
     UNIQUE (parent_id, child_id, link_index)
-);
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE IF NOT EXISTS ipfs_requests (
     id INTEGER PRIMARY KEY AUTO_INCREMENT,
     request_id BIGINT UNSIGNED UNIQUE,
     pin_request_id VARBINARY(64),
     parent_pin_request_id VARBINARY(64),
-    created_at TIMESTAMP,
-    updated_at TIMESTAMP,
-    deleted_at TIMESTAMP
-);
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    deleted_at TIMESTAMP NULL DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE INDEX idx_ipfs_requests_pin_request_id ON ipfs_requests (pin_request_id);
 CREATE INDEX idx_ipfs_requests_parent_pin_request_id ON ipfs_requests (parent_pin_request_id);
@@ -68,11 +68,11 @@ CREATE TABLE IF NOT EXISTS ipfs_unixfs_nodes (
     type INTEGER,
     block_size INTEGER,
     child_cid TEXT,
-    created_at TIMESTAMP,
-    updated_at TIMESTAMP,
-    deleted_at TIMESTAMP,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    deleted_at TIMESTAMP NULL DEFAULT NULL,
     FOREIGN KEY (block_id) REFERENCES ipfs_blocks(id)
-);
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE IF NOT EXISTS ipfs_file_paths (
     id INTEGER PRIMARY KEY AUTO_INCREMENT,
@@ -88,26 +88,24 @@ CREATE TABLE IF NOT EXISTS ipfs_file_paths (
     is_orphan BOOLEAN DEFAULT FALSE,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    deleted_at TIMESTAMP,
+    deleted_at TIMESTAMP NULL DEFAULT NULL,
     
-    UNIQUE KEY (user_id, cid, path, deleted_at),
-    KEY (user_id, path),
-    KEY (user_id, parent_path),
-    KEY (user_id, parent_path, name),
+    UNIQUE KEY (user_id, cid, path(500), deleted_at),
+    KEY (user_id, path(500)),
+    KEY (user_id, parent_path(500)),
+    KEY (user_id, parent_path(500), name),
     KEY (user_id, is_directory, depth),
     KEY (user_id, is_orphan),
     KEY idx_ipfs_file_paths_deleted_at (deleted_at)
-);
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 -- +goose StatementEnd
 
 -- +goose Down
 -- +goose StatementBegin
-
-
-DROP TABLE ipfs_linked_blocks;
-DROP TABLE ipfs_unixfs_nodes;
-DROP TABLE ipfs_file_paths;
-DROP TABLE ipfs_pins;
-DROP TABLE ipfs_requests;
-DROP TABLE ipfs_blocks;
+DROP TABLE IF EXISTS ipfs_linked_blocks;
+DROP TABLE IF EXISTS ipfs_unixfs_nodes;
+DROP TABLE IF EXISTS ipfs_file_paths;
+DROP TABLE IF EXISTS ipfs_pins;
+DROP TABLE IF EXISTS ipfs_requests;
+DROP TABLE IF EXISTS ipfs_blocks;
 -- +goose StatementEnd


### PR DESCRIPTION
* Changed `status` column in `ipfs_pins` table from TEXT to VARCHAR(50)
* Added default values for `created_at` and `updated_at` columns across multiple tables
* Specified InnoDB engine and utf8mb4 charset for all tables
* Added IF EXISTS clause to DROP TABLE statements in down migration
* Added index length limitations for long VARCHAR columns in file paths table

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None

- Refactor
  - Standardized timestamps with sensible defaults for better consistency.
  - Made soft-delete fields nullable to improve data handling.
  - Tightened status field to a fixed length for improved data integrity.
  - Optimized indexing on large path fields to enhance query performance.

- Chores
  - Improved downgrade safety for database migrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->