### PR TITLE
fix(db): goose statements are choking the parser/queries?

### DIFF
--- a/internal/db/migrations/mysql/20250702025738_init.sql
+++ b/internal/db/migrations/mysql/20250702025738_init.sql
@@ -1,5 +1,4 @@
 -- +goose Up
--- +goose StatementBegin
 CREATE TABLE IF NOT EXISTS ipfs_pins (
     id INTEGER PRIMARY KEY AUTO_INCREMENT,
     request_id BINARY(16) UNIQUE,
@@ -98,14 +97,11 @@ CREATE TABLE IF NOT EXISTS ipfs_file_paths (
     KEY (user_id, is_orphan),
     KEY idx_ipfs_file_paths_deleted_at (deleted_at)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
--- +goose StatementEnd
 
 -- +goose Down
--- +goose StatementBegin
 DROP TABLE IF EXISTS ipfs_linked_blocks;
 DROP TABLE IF EXISTS ipfs_unixfs_nodes;
 DROP TABLE IF EXISTS ipfs_file_paths;
 DROP TABLE IF EXISTS ipfs_pins;
 DROP TABLE IF EXISTS ipfs_requests;
 DROP TABLE IF EXISTS ipfs_blocks;
--- +goose StatementEnd


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined database migration scripts to use plain SQL blocks, removing wrapper markers. No changes to table structures, indexes, or constraints, and no impact on application behavior.
  * This is an internal cleanup; no user-facing changes or actions required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->