### PR TITLE
fix(protocol): trying to log the block error after having reset it, causes nil ptr

### DIFF
--- a/internal/protocol/block_processor.go
+++ b/internal/protocol/block_processor.go
@@ -92,12 +92,12 @@ func (bp *BlockProcessor) queueBlock(block blocks.Block, parentCid cid.Cid) erro
 
 		bp.wp.Submit(func() {
 			err := bp.processBlock(bp.ctx, job)
-			job.reset()
-			blockJobPool.Put(job) // Release the blockJob back to the pool
 			if err != nil {
 				bp.logger.Error("Block processing failed", zap.Error(err), zap.String("CID", job.Block.Cid().String()))
 				bp.handleError(err) // Just log the error, don't cancel context
 			}
+			job.reset()
+			blockJobPool.Put(job) // Release the blockJob back to the pool
 		})
 		return nil
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures errors are fully handled and logged before background tasks are recycled, preventing missed logs and improving diagnostic clarity during failures. This reduces the chance of inconsistent states under error conditions.

* **Refactor**
  * Adjusted the internal processing order for pooled task cleanup to improve robustness and reliability. No functional changes are expected for end-users, but behavior under failure scenarios is more predictable and stable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->