### PR TITLE
fix(api): validate download quota before fetching block data

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -772,6 +772,14 @@ func (a API) handleRawBlockRequest(ctx httputil.RequestContext, _cid cid.Cid, w 
 	// Check download quota if quota service is available
 	userID := upload.UserID
 
+	if err := quota.ValidateDownloadQuota(a.ctx, userID, upload.Size); err != nil {
+		a.logger.Warn("Download quota validation failed", zap.Uint("user_id", userID), zap.Error(err))
+		apiErr := NewError(ErrKeyDownloadQuotaExceeded, err)
+		_ = ctx.Error(apiErr, http.StatusTooManyRequests)
+		return apiErr
+	}
+
+	// Only fetch block data after quota validation passes
 	block, err := a.ipfs.GetNode().GetBlock(reqCtx, _cid)
 	if err != nil {
 		a.logger.Error("Failed to get block", zap.Error(err))
@@ -780,19 +788,7 @@ func (a API) handleRawBlockRequest(ctx httputil.RequestContext, _cid cid.Cid, w 
 		return apiErr
 	}
 
-	// Use actual block size for quota validation and events
-	actualBlockSize := uint64(len(block.RawData()))
-
-	if err := quota.ValidateDownloadQuota(a.ctx, userID, actualBlockSize); err != nil {
-		a.logger.Warn("Download quota validation failed", zap.Uint("user_id", userID), zap.Error(err))
-		apiErr := NewError(ErrKeyDownloadQuotaExceeded, err)
-		_ = ctx.Error(apiErr, http.StatusTooManyRequests)
-		return apiErr
-	}
-
-	// Emit download completion event for quota tracking
-
-	// Get client IP
+	// Get client IP for quota tracking
 	ip := c.RealIP()
 
 	a.setTrustlessHeaders(w, r, _cid.String())


### PR DESCRIPTION
- Move download quota validation before fetching block data to prevent unnecessary operations
- Use upload size for quota validation instead of actual block size
- Maintain client IP extraction for quota tracking purposes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced download quota validation by checking limits earlier in the request processing pipeline for more efficient handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->