### PR TITLE
feat: add QUIC v1 and WebSocket announcement addresses

### DIFF
--- a/internal/protocol/ipfs/node.go
+++ b/internal/protocol/ipfs/node.go
@@ -357,8 +357,15 @@ func AnnouncementAddresses() ([]multiaddr.Multiaddr, error) {
 	}
 
 	unspecAddrs := []multiaddr.Multiaddr{
+		// TCP
 		multiaddr.StringCast("/ip4/0.0.0.0/tcp/4001"),
 		multiaddr.StringCast("/ip6/::/tcp/4001"),
+		// QUIC v1
+		multiaddr.StringCast("/ip4/0.0.0.0/udp/4001/quic-v1"),
+		multiaddr.StringCast("/ip6/::/udp/4001/quic-v1"),
+		// WebSocket
+		multiaddr.StringCast("/ip4/0.0.0.0/tcp/4002/ws"),
+		multiaddr.StringCast("/ip6/::/tcp/4002/ws"),
 	}
 
 	announcementAddrs, err := manet.ResolveUnspecifiedAddresses(unspecAddrs, nil)


### PR DESCRIPTION
- Add QUIC v1 addresses for UDP 4001 (IPv4 and IPv6)
- Add WebSocket addresses for TCP 4002 (IPv4 and IPv6)


---

<!-- kody-pr-summary:start -->
Adds QUIC v1 and WebSocket announcement addresses to the IPFS node. This change enables the node to announce its availability and accept connections over QUIC v1 (UDP port 4001) and WebSockets (TCP port 4002) for both IPv4 and IPv6, in addition to the existing TCP announcements.
<!-- kody-pr-summary:end -->