### PR TITLE
ci: add secrets inherit

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,3 +9,4 @@ on:
 jobs:
   build:
     uses: LumeWeb/workflows/.github/workflows/build-plugin.yml@develop
+    secrets: inherit


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request updates the GitHub Actions build workflow configuration to enable secret inheritance for the reusable workflow. By adding the `secrets: inherit` directive to the build job, all secrets defined in the current repository are now passed to the external workflow located in `LumeWeb/workflows`. This ensures that the automated build process has access to necessary credentials or sensitive information required for execution.
<!-- kody-pr-summary:end -->