### PR TITLE
fix: use mapstructures Unmarshaler properly

### DIFF
--- a/internal/config/bootstrap_peer.go
+++ b/internal/config/bootstrap_peer.go
@@ -11,8 +11,8 @@ import (
 )
 
 var (
-	_ yaml.Marshaler                     = (*IPFSPeer)(nil)
-	_ mapstructure.UnmarshalMapstructure = (*IPFSPeer)(nil)
+	_ yaml.Marshaler           = (*IPFSPeer)(nil)
+	_ mapstructure.Unmarshaler = (*IPFSPeer)(nil)
 )
 
 func init() {
@@ -25,7 +25,7 @@ type IPFSPeer struct {
 	ai peer.AddrInfo
 }
 
-func (pi IPFSPeer) MarshalYAML() (interface{}, error) {
+func (pi IPFSPeer) MarshalYAML() (any, error) {
 	addrs, err := peer.AddrInfoToP2pAddrs(&pi.ai)
 	if err != nil {
 		return nil, err
@@ -38,7 +38,7 @@ func (pi IPFSPeer) MarshalYAML() (interface{}, error) {
 	return addrs[0].String(), nil
 }
 
-func (pi *IPFSPeer) DecodeMapstructure(value interface{}) error {
+func (pi *IPFSPeer) UnmarshalMapstructure(value any) error {
 	var addr *peer.AddrInfo
 	var err error
 


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request fixes the implementation of the mapstructures Unmarshaler interface for the IPFSPeer type. The changes correct the interface implementation by replacing the deprecated `DecodeMapstructure` method with the proper `UnmarshalMapstructure` method, and updates the type assertion to use the correct `Unmarshaler` interface. Additionally, the return type in `MarshalYAML` is updated to use the more modern `any` type alias instead of `interface{}`. These changes ensure proper unmarshaling of IPFS peer configuration data.
<!-- kody-pr-summary:end -->