### PR TITLE
fix: prevent nil pointer panic in IPNS republisher

### DIFF
--- a/internal/protocol/ipfs/node.go
+++ b/internal/protocol/ipfs/node.go
@@ -346,6 +346,8 @@ func NewNode(ctx core.Context, cfg *config.ProtocolConfig, rs pluginCore.Reprovi
 
 	// Create boxo keystore for IPNS key management
 	boxoKeystore := keystore.NewMemKeystore()
+	// Wrap with safe keystore to prevent nil keys from being stored
+	safeKeystore := NewSafeKeystore(boxoKeystore, ctx.Logger())
 
 	// Create boxo IPNS publisher
 	boxoPublisher := namesys.NewIPNSPublisher(frt, ds)
@@ -360,7 +362,7 @@ func NewNode(ctx core.Context, cfg *config.ProtocolConfig, rs pluginCore.Reprovi
 		reprovider:       rp,
 		reproviderCancel: reproviderCancel,
 		datastore:        ds,
-		keystore:         boxoKeystore,
+		keystore:         safeKeystore,
 		publisher:        boxoPublisher,
 	}, nil
 }

--- a/internal/protocol/ipfs/safe_keystore.go
+++ b/internal/protocol/ipfs/safe_keystore.go
@@ -1,0 +1,96 @@
+package ipfs
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/ipfs/boxo/keystore"
+	ic "github.com/libp2p/go-libp2p/core/crypto"
+	"go.lumeweb.com/portal/core"
+	"go.uber.org/zap"
+)
+
+// SafeKeystore wraps a keystore.Keystore to prevent nil keys from being stored
+// This is a defensive wrapper around the vendor's MemKeystore which doesn't validate nil keys
+type SafeKeystore struct {
+	inner keystore.Keystore
+	log   *core.Logger
+}
+
+// NewSafeKeystore creates a new safe keystore wrapper
+func NewSafeKeystore(inner keystore.Keystore, log *core.Logger) *SafeKeystore {
+	return &SafeKeystore{
+		inner: inner,
+		log:   log,
+	}
+}
+
+// Has returns whether or not a key exists in the Keystore
+func (sk *SafeKeystore) Has(name string) (bool, error) {
+	return sk.inner.Has(name)
+}
+
+// Put stores a key in the Keystore with nil validation
+// Returns an error if the key is nil
+func (sk *SafeKeystore) Put(name string, k ic.PrivKey) error {
+	if k == nil {
+		sk.log.Error("Refusing to put nil key into keystore",
+			zap.String("key_name", name),
+		)
+		return errors.New("cannot put nil key into keystore")
+	}
+	return sk.inner.Put(name, k)
+}
+
+// Get retrieves a key from the Keystore
+// Returns the key if it exists, and ErrNoSuchKey otherwise
+func (sk *SafeKeystore) Get(name string) (ic.PrivKey, error) {
+	key, err := sk.inner.Get(name)
+	if err != nil {
+		return nil, err
+	}
+	// Defensive check: even though we prevent nil keys from being stored,
+	// validate on retrieval as well to catch any edge cases
+	if key == nil {
+		sk.log.Error("Retrieved nil key from keystore",
+			zap.String("key_name", name),
+		)
+		return nil, fmt.Errorf("key %s exists but is nil in keystore", name)
+	}
+	return key, nil
+}
+
+// Delete removes a key from the Keystore
+func (sk *SafeKeystore) Delete(name string) error {
+	return sk.inner.Delete(name)
+}
+
+// List returns a list of key identifiers
+func (sk *SafeKeystore) List() ([]string, error) {
+	names, err := sk.inner.List()
+	if err != nil {
+		return nil, err
+	}
+
+	// Validate that all listed keys are non-nil
+	// This is a defensive check to catch any corruption
+	for _, name := range names {
+		key, err := sk.Get(name)
+		if err != nil {
+			sk.log.Warn("Failed to get key during list validation",
+				zap.String("key_name", name),
+				zap.Error(err),
+			)
+			// Continue to list other keys, but log the issue
+		}
+		if key == nil {
+			sk.log.Error("Found nil key during list, attempting to delete",
+				zap.String("key_name", name),
+			)
+			// Try to delete the corrupted entry
+			_ = sk.Delete(name)
+		}
+	}
+
+	return names, nil
+}

--- a/internal/protocol/ipfs/safe_keystore_test.go
+++ b/internal/protocol/ipfs/safe_keystore_test.go
@@ -1,0 +1,102 @@
+package ipfs
+
+import (
+	"testing"
+
+	"github.com/ipfs/boxo/keystore"
+	"github.com/libp2p/go-libp2p/core/crypto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.lumeweb.com/portal/core"
+)
+
+func TestSafeKeystore_RejectsNilKeys(t *testing.T) {
+	inner := keystore.NewMemKeystore()
+	logger := core.NewLogger(zap.NewNop(), zap.NewNop().AtomicLevel())
+	safeKS := NewSafeKeystore(inner, logger)
+
+	// Attempt to put a nil key
+	err := safeKS.Put("test-key", nil)
+	assert.Error(t, err, "Should reject nil key")
+	assert.Contains(t, err.Error(), "cannot put nil key")
+
+	// Verify the key was not stored
+	has, err := safeKS.Has("test-key")
+	require.NoError(t, err)
+	assert.False(t, has, "Nil key should not be stored")
+}
+
+func TestSafeKeystore_AllowsValidKeys(t *testing.T) {
+	inner := keystore.NewMemKeystore()
+	logger := core.NewLogger(zap.NewNop(), zap.NewNop().AtomicLevel())
+	safeKS := NewSafeKeystore(inner, logger)
+
+	// Generate a valid key
+	privKey, _, err := crypto.GenerateEd25519Key(crypto.RandSource)
+	require.NoError(t, err)
+
+	// Put the valid key
+	err = safeKS.Put("test-key", privKey)
+	assert.NoError(t, err, "Should accept valid key")
+
+	// Verify the key was stored
+	has, err := safeKS.Has("test-key")
+	require.NoError(t, err)
+	assert.True(t, has, "Valid key should be stored")
+
+	// Verify we can retrieve it
+	retrieved, err := safeKS.Get("test-key")
+	require.NoError(t, err)
+	assert.NotNil(t, retrieved, "Retrieved key should not be nil")
+}
+
+func TestSafeKeystore_ListValidatesKeys(t *testing.T) {
+	inner := keystore.NewMemKeystore()
+	logger := core.NewLogger(zap.NewNop(), zap.NewNop().AtomicLevel())
+	safeKS := NewSafeKeystore(inner, logger)
+
+	// Add a valid key
+	privKey, _, err := crypto.GenerateEd25519Key(crypto.RandSource)
+	require.NoError(t, err)
+	err = safeKS.Put("valid-key", privKey)
+	require.NoError(t, err)
+
+	// List keys
+	names, err := safeKS.List()
+	require.NoError(t, err)
+	assert.Contains(t, names, "valid-key", "Should list valid key")
+}
+
+func TestSafeKeystore_GetValidatesNonNil(t *testing.T) {
+	// This test verifies the defensive check in Get() catches any edge cases
+	// where nil keys might exist in the underlying keystore
+	inner := keystore.NewMemKeystore()
+	logger := core.NewLogger(zap.NewNop(), zap.NewNop().AtomicLevel())
+	safeKS := NewSafeKeystore(inner, logger)
+
+	// Try to get a non-existent key
+	_, err := safeKS.Get("non-existent-key")
+	assert.Error(t, err, "Should return error for non-existent key")
+}
+
+func TestSafeKeystore_Delete(t *testing.T) {
+	inner := keystore.NewMemKeystore()
+	logger := core.NewLogger(zap.NewNop(), zap.NewNop().AtomicLevel())
+	safeKS := NewSafeKeystore(inner, logger)
+
+	// Add a valid key
+	privKey, _, err := crypto.GenerateEd25519Key(crypto.RandSource)
+	require.NoError(t, err)
+	err = safeKS.Put("test-key", privKey)
+	require.NoError(t, err)
+
+	// Delete the key
+	err = safeKS.Delete("test-key")
+	assert.NoError(t, err)
+
+	// Verify it's gone
+	has, err := safeKS.Has("test-key")
+	require.NoError(t, err)
+	assert.False(t, has)
+}

--- a/internal/service/ipns_key/ipns_key.go
+++ b/internal/service/ipns_key/ipns_key.go
@@ -402,6 +402,15 @@ func (s *IPNSKeyServiceDefault) syncKeyToBoxoKeystore(ctx context.Context, key *
 		return nil
 	}
 
+	// Validate private key is not nil before putting in keystore
+	if privKey == nil {
+		s.Logger().Error("Private key is nil, cannot sync to keystore",
+			zap.Uint("key_id", key.ID),
+			zap.Stringer("peer_id", key.PeerID()),
+		)
+		return fmt.Errorf("private key is nil")
+	}
+
 	// Import into boxo keystore
 	err = boxoKS.Put(keyName, privKey)
 	if err != nil {
@@ -482,6 +491,15 @@ func (s *IPNSKeyServiceDefault) SyncToBoxoKeystore(ctx context.Context) error {
 		if err != nil {
 			s.Logger().Error("Failed to decrypt private key for sync",
 				zap.Error(err),
+				zap.Uint("key_id", key.ID),
+				zap.Stringer("peer_id", key.PeerID()),
+			)
+			continue
+		}
+
+		// Validate private key is not nil before putting in keystore
+		if privKey == nil {
+			s.Logger().Error("Decrypted private key is nil, cannot sync to keystore",
 				zap.Uint("key_id", key.ID),
 				zap.Stringer("peer_id", key.PeerID()),
 			)


### PR DESCRIPTION
- Add SafeKeystore wrapper to validate keys before storage
- Add nil validation in syncKeyToBoxoKeystore
- Add nil validation in SyncToBoxoKeystore
- Add comprehensive tests for SafeKeystore
