### PR TITLE
fix(ipns): prevent nil pointer panic in IPNS republisher

### DIFF
--- a/core/ipns_key.go
+++ b/core/ipns_key.go
@@ -29,6 +29,7 @@ type IPNSNodeAccess interface {
 	GetPublisher() *namesys.IPNSPublisher
 	GetKeystore() keystore.Keystore
 	GetDatastore() datastore.Datastore
+	GetPrivateKey() crypto.PrivKey
 }
 
 // IPNSBoxoServices provides access to Boxo IPNS services

--- a/internal/api/api_blocks_test.go
+++ b/internal/api/api_blocks_test.go
@@ -16,7 +16,8 @@ import (
 	"github.com/stretchr/testify/mock"
 	"go.lumeweb.com/portal-plugin-ipfs/internal"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/api/dto"
-	"go.lumeweb.com/portal-plugin-ipfs/internal/testing/mocks"
+	"go.lumeweb.com/portal-plugin-ipfs/internal/testing/mocks/protocol" "protocol"
+	"go.lumeweb.com/portal-plugin-ipfs/internal/testing/mocks" "mocks"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/testing/util"
 	coreMocks "go.lumeweb.com/portal/core/testing/mocks"
 	"go.lumeweb.com/portal/core"
@@ -107,7 +108,7 @@ func TestAPI_handleIPFSGet(t *testing.T) {
 		token, _, testCID, _ := helper.SetupAuthenticatedTest()
 
 		// Setup IPFS node mock expectations for HasBlock
-		protoMock := core.GetProtocol(internal.ProtocolName).(*mocks.MockProtoNode)
+		protoMock := core.GetProtocol(internal.ProtocolName).(*protocol.MockProtoNode)
 		mockIPFSNode := protoMock.GetNode().(*mocks.MockIPFSNode)
 
 		// Mock HasBlock to return true for the test CID

--- a/internal/protocol/ipfs/node.go
+++ b/internal/protocol/ipfs/node.go
@@ -64,6 +64,7 @@ type IPFSNode interface {
 	GetPublisher() *namesys.IPNSPublisher
 	GetKeystore() keystore.Keystore
 	GetDatastore() datastore.Datastore
+	GetPrivateKey() crypto.PrivKey
 }
 
 // NopExchange wraps an exchange.Interface and disables NotifyNewBlocks.
@@ -430,6 +431,11 @@ func (n *Node) GetPublisher() *namesys.IPNSPublisher {
 // GetDatastore returns the node's datastore
 func (n *Node) GetDatastore() datastore.Datastore {
 	return n.datastore
+}
+
+// GetPrivateKey returns the node's private key
+func (n *Node) GetPrivateKey() crypto.PrivKey {
+	return n.host.Peerstore().PrivKey(n.host.ID())
 }
 
 func isIPv4PrivateRange(addr multiaddr.Multiaddr) bool {

--- a/internal/protocol/ipfs/provide_test.go
+++ b/internal/protocol/ipfs/provide_test.go
@@ -42,13 +42,13 @@ func TestReprovider_Run(t *testing.T) {
 		{CID: cid.Cid{}, LastAnnouncement: time.Now().Add(-2 * interval)},
 		{CID: cid.Cid{}, LastAnnouncement: time.Now().Add(-2 * interval)},
 	}
-	mockStore.EXPECT().ProvideCIDs(batchSize).Return(testCIDs, nil).Times(2)
+	mockStore.EXPECT().ProvideCIDs(mock.Anything, batchSize).Return(testCIDs, nil).Times(2)
 
 	// Mock provider ProvideMany - expect multiple calls
 	mockProvider.EXPECT().ProvideMany(mock.Anything, mock.Anything).Return(nil).Times(2)
 
 	// Mock store SetLastAnnouncement - expect multiple calls
-	mockStore.EXPECT().SetLastAnnouncement(mock.Anything, mock.Anything).Return(nil).Times(2)
+	mockStore.EXPECT().SetLastAnnouncement(mock.Anything, mock.Anything, mock.Anything).Return(nil).Times(2)
 
 	go reprovider.Run(ctx, interval, timeout, batchSize)
 
@@ -90,7 +90,7 @@ func TestReprovider_Run_ProvideCIDsError(t *testing.T) {
 	mockProvider.EXPECT().Ready().Return(true)
 
 	// Mock store returning error
-	mockStore.EXPECT().ProvideCIDs(batchSize).Return(nil, errors.New("test error")).Once()
+	mockStore.EXPECT().ProvideCIDs(mock.Anything, batchSize).Return(nil, errors.New("test error")).Once()
 
 	go reprovider.Run(ctx, interval, timeout, batchSize)
 
@@ -116,7 +116,7 @@ func TestReprovider_Run_ProvideManyError(t *testing.T) {
 		{CID: cid.Cid{}, LastAnnouncement: time.Now().Add(-2 * interval)},
 		{CID: cid.Cid{}, LastAnnouncement: time.Now().Add(-2 * interval)},
 	}
-	mockStore.EXPECT().ProvideCIDs(batchSize).Return(testCIDs, nil).Once()
+	mockStore.EXPECT().ProvideCIDs(mock.Anything, batchSize).Return(testCIDs, nil).Once()
 
 	// Mock provider ProvideMany returning error
 	mockProvider.EXPECT().ProvideMany(mock.Anything, mock.Anything).Return(errors.New("test error")).Once()
@@ -145,13 +145,13 @@ func TestReprovider_Run_SetLastAnnouncementError(t *testing.T) {
 		{CID: cid.Cid{}, LastAnnouncement: time.Now().Add(-2 * interval)},
 		{CID: cid.Cid{}, LastAnnouncement: time.Now().Add(-2 * interval)},
 	}
-	mockStore.EXPECT().ProvideCIDs(batchSize).Return(testCIDs, nil).Once()
+	mockStore.EXPECT().ProvideCIDs(mock.Anything, batchSize).Return(testCIDs, nil).Once()
 
 	// Mock provider ProvideMany
 	mockProvider.EXPECT().ProvideMany(mock.Anything, mock.Anything).Return(nil).Once()
 
 	// Mock store SetLastAnnouncement returning error
-	mockStore.EXPECT().SetLastAnnouncement(mock.Anything, mock.Anything).Return(errors.New("test error")).Once()
+	mockStore.EXPECT().SetLastAnnouncement(mock.Anything, mock.Anything, mock.Anything).Return(errors.New("test error")).Once()
 
 	go reprovider.Run(ctx, interval, timeout, batchSize)
 
@@ -181,13 +181,13 @@ func TestReprovider_Trigger(t *testing.T) {
 		{CID: cid.Cid{}, LastAnnouncement: time.Now().Add(-2 * interval)},
 		{CID: cid.Cid{}, LastAnnouncement: time.Now().Add(-2 * interval)},
 	}
-	mockStore.EXPECT().ProvideCIDs(batchSize).Return(testCIDs, nil).Times(2)
+	mockStore.EXPECT().ProvideCIDs(mock.Anything, batchSize).Return(testCIDs, nil).Times(2)
 
 	// Mock provider ProvideMany
 	mockProvider.EXPECT().ProvideMany(mock.Anything, mock.Anything).Return(nil).Times(2)
 
 	// Mock store SetLastAnnouncement
-	mockStore.EXPECT().SetLastAnnouncement(mock.Anything, mock.Anything).Return(nil).Times(2)
+	mockStore.EXPECT().SetLastAnnouncement(mock.Anything, mock.Anything, mock.Anything).Return(nil).Times(2)
 
 	go reprovider.Run(ctx, interval, timeout, batchSize)
 
@@ -233,7 +233,7 @@ func TestReprovider_performProvide_NoCIDs(t *testing.T) {
 	}
 
 	// Mock store returning no CIDs
-	mockStore.EXPECT().ProvideCIDs(batchSize).Return([]core.PinnedCID{}, nil).Once()
+	mockStore.EXPECT().ProvideCIDs(mock.Anything, batchSize).Return([]core.PinnedCID{}, nil).Once()
 
 	sleepDuration := reprovider.performProvide(ctx, interval, timeout, batchSize)
 
@@ -262,7 +262,7 @@ func TestReprovider_performProvide_ProvideCIDsError(t *testing.T) {
 	}
 
 	// Mock store returning error
-	mockStore.EXPECT().ProvideCIDs(batchSize).Return(nil, errors.New("test error")).Once()
+	mockStore.EXPECT().ProvideCIDs(mock.Anything, batchSize).Return(nil, errors.New("test error")).Once()
 
 	sleepDuration := reprovider.performProvide(ctx, interval, timeout, batchSize)
 
@@ -293,7 +293,7 @@ func TestReprovider_performProvide_WaitingForNextInterval(t *testing.T) {
 	// Mock store returning CIDs with future LastAnnouncement
 	futureTime := time.Now().Add(2 * interval)
 	testCIDs := []core.PinnedCID{{CID: cid.Cid{}, LastAnnouncement: futureTime}}
-	mockStore.EXPECT().ProvideCIDs(batchSize).Return(testCIDs, nil).Once()
+	mockStore.EXPECT().ProvideCIDs(mock.Anything, batchSize).Return(testCIDs, nil).Once()
 
 	sleepDuration := reprovider.performProvide(ctx, interval, timeout, batchSize)
 
@@ -326,13 +326,13 @@ func TestReprovider_performProvide_Success(t *testing.T) {
 		{CID: cid.Cid{}, LastAnnouncement: time.Now().Add(-2 * interval)},
 		{CID: cid.Cid{}, LastAnnouncement: time.Now().Add(-2 * interval)},
 	}
-	mockStore.EXPECT().ProvideCIDs(batchSize).Return(testCIDs, nil).Once()
+	mockStore.EXPECT().ProvideCIDs(mock.Anything, batchSize).Return(testCIDs, nil).Once()
 
 	// Mock provider ProvideMany
 	mockProvider.EXPECT().ProvideMany(mock.Anything, mock.Anything).Return(nil).Once()
 
 	// Mock store SetLastAnnouncement
-	mockStore.EXPECT().SetLastAnnouncement(mock.Anything, mock.Anything).Return(nil).Once()
+	mockStore.EXPECT().SetLastAnnouncement(mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
 
 	sleepDuration := reprovider.performProvide(ctx, interval, timeout, batchSize)
 
@@ -366,13 +366,13 @@ func TestReprovider_performProvide_Success_NotAllAnnounced(t *testing.T) {
 		{CID: cid.Cid{}, LastAnnouncement: time.Now().Add(-2 * interval)},
 		{CID: cid.Cid{}, LastAnnouncement: time.Now().Add(2 * interval)}, // Future announcement
 	}
-	mockStore.EXPECT().ProvideCIDs(batchSize).Return(testCIDs, nil).Once()
+	mockStore.EXPECT().ProvideCIDs(mock.Anything, batchSize).Return(testCIDs, nil).Once()
 
 	// Mock provider ProvideMany
 	mockProvider.EXPECT().ProvideMany(mock.Anything, mock.Anything).Return(nil).Once()
 
 	// Mock store SetLastAnnouncement
-	mockStore.EXPECT().SetLastAnnouncement(mock.Anything, mock.Anything).Return(nil).Once()
+	mockStore.EXPECT().SetLastAnnouncement(mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
 
 	sleepDuration := reprovider.performProvide(ctx, interval, timeout, batchSize)
 
@@ -405,7 +405,7 @@ func TestReprovider_performProvide_ProvideManyError(t *testing.T) {
 		{CID: cid.Cid{}, LastAnnouncement: time.Now().Add(-2 * interval)},
 		{CID: cid.Cid{}, LastAnnouncement: time.Now().Add(-2 * interval)},
 	}
-	mockStore.EXPECT().ProvideCIDs(batchSize).Return(testCIDs, nil).Once()
+	mockStore.EXPECT().ProvideCIDs(mock.Anything, batchSize).Return(testCIDs, nil).Once()
 
 	// Mock provider ProvideMany returning error
 	mockProvider.EXPECT().ProvideMany(mock.Anything, mock.Anything).Return(errors.New("test error")).Once()
@@ -441,13 +441,13 @@ func TestReprovider_performProvide_SetLastAnnouncementError(t *testing.T) {
 		{CID: cid.Cid{}, LastAnnouncement: time.Now().Add(-2 * interval)},
 		{CID: cid.Cid{}, LastAnnouncement: time.Now().Add(-2 * interval)},
 	}
-	mockStore.EXPECT().ProvideCIDs(batchSize).Return(testCIDs, nil).Once()
+	mockStore.EXPECT().ProvideCIDs(mock.Anything, batchSize).Return(testCIDs, nil).Once()
 
 	// Mock provider ProvideMany
 	mockProvider.EXPECT().ProvideMany(mock.Anything, mock.Anything).Return(nil).Once()
 
 	// Mock store SetLastAnnouncement returning error
-	mockStore.EXPECT().SetLastAnnouncement(mock.Anything, mock.Anything).Return(errors.New("test error")).Once()
+	mockStore.EXPECT().SetLastAnnouncement(mock.Anything, mock.Anything, mock.Anything).Return(errors.New("test error")).Once()
 
 	sleepDuration := reprovider.performProvide(ctx, interval, timeout, batchSize)
 
@@ -480,13 +480,13 @@ func TestReprovider_performProvide_MinAnnouncement(t *testing.T) {
 		{CID: cid.Cid{}, LastAnnouncement: time.Now().Add(-2 * interval)},
 		{CID: cid.Cid{}, LastAnnouncement: time.Now().Add(-2 * interval)},
 	}
-	mockStore.EXPECT().ProvideCIDs(batchSize).Return(testCIDs, nil).Once()
+	mockStore.EXPECT().ProvideCIDs(mock.Anything, batchSize).Return(testCIDs, nil).Once()
 
 	// Mock provider ProvideMany
 	mockProvider.EXPECT().ProvideMany(mock.Anything, mock.Anything).Return(nil).Once()
 
 	// Mock store SetLastAnnouncement
-	mockStore.EXPECT().SetLastAnnouncement(mock.Anything, mock.Anything).Return(nil).Once()
+	mockStore.EXPECT().SetLastAnnouncement(mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
 
 	sleepDuration := reprovider.performProvide(ctx, interval, timeout, batchSize)
 
@@ -520,13 +520,13 @@ func TestReprovider_performProvide_MinAnnouncement_NotAllAnnounced(t *testing.T)
 		{CID: cid.Cid{}, LastAnnouncement: time.Now().Add(-2 * interval)},
 		{CID: cid.Cid{}, LastAnnouncement: time.Now().Add(2 * interval)}, // Future announcement
 	}
-	mockStore.EXPECT().ProvideCIDs(batchSize).Return(testCIDs, nil).Once()
+	mockStore.EXPECT().ProvideCIDs(mock.Anything, batchSize).Return(testCIDs, nil).Once()
 
 	// Mock provider ProvideMany
 	mockProvider.EXPECT().ProvideMany(mock.Anything, mock.Anything).Return(nil).Once()
 
 	// Mock store SetLastAnnouncement
-	mockStore.EXPECT().SetLastAnnouncement(mock.Anything, mock.Anything).Return(nil).Once()
+	mockStore.EXPECT().SetLastAnnouncement(mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
 
 	sleepDuration := reprovider.performProvide(ctx, interval, timeout, batchSize)
 

--- a/internal/protocol/tests/op_file_path_test.go
+++ b/internal/protocol/tests/op_file_path_test.go
@@ -17,7 +17,8 @@ import (
 	"go.lumeweb.com/portal-plugin-ipfs/internal/protocol"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/service/block"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/service/file_manager"
-	"go.lumeweb.com/portal-plugin-ipfs/internal/testing/mocks"
+	"go.lumeweb.com/portal-plugin-ipfs/internal/testing/mocks/protocol" "protocol"
+	"go.lumeweb.com/portal-plugin-ipfs/internal/testing/mocks" "mocks"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/testing/util"
 	"go.lumeweb.com/portal/core"
 	coreTesting "go.lumeweb.com/portal/core/testing"
@@ -186,7 +187,7 @@ func TestFilePathOperationHandler_Execute_WithIncompleteMetadata(t *testing.T) {
 		workflowSvc.On("UpdateWorkflowDataStruct", ctx, req.ID, mock.AnythingOfType("protocol.FilePathWorkflowData"), "json").Return(nil)
 
 		// Mock the IPFS node's GetBlockstore method to prevent the unexpected call error
-		protoMock := core.GetProtocol(internal.ProtocolName).(*mocks.MockProtoNode)
+		protoMock := core.GetProtocol(internal.ProtocolName).(*protocol.MockProtoNode)
 		mockIPFSNode := protoMock.GetNode().(*mocks.MockIPFSNode)
 		mockBlockstore := mocks.NewMockMockBlockstore(t)
 		mockIPFSNode.EXPECT().GetBlockstore().Return(mockBlockstore).Maybe()
@@ -244,7 +245,7 @@ func TestFilePathOperationHandler_Execute_WithMissingMetadata(t *testing.T) {
 		workflowSvc.On("UpdateWorkflowDataStruct", ctx, req.ID, mock.AnythingOfType("protocol.FilePathWorkflowData"), "json").Return(nil)
 
 		// Mock the IPFS node's GetBlockstore method to prevent the unexpected call error
-		protoMock := core.GetProtocol(internal.ProtocolName).(*mocks.MockProtoNode)
+		protoMock := core.GetProtocol(internal.ProtocolName).(*protocol.MockProtoNode)
 		mockIPFSNode := protoMock.GetNode().(*mocks.MockIPFSNode)
 		mockBlockstore := mocks.NewMockMockBlockstore(t)
 		mockIPFSNode.EXPECT().GetBlockstore().Return(mockBlockstore).Maybe()
@@ -280,7 +281,7 @@ func TestFilePathOperationHandler_CreateOrphanEntriesForPins(t *testing.T) {
 		}
 
 		// Mock the IPFS node's GetBlockstore method to prevent the unexpected call error
-		protoMock := core.GetProtocol(internal.ProtocolName).(*mocks.MockProtoNode)
+		protoMock := core.GetProtocol(internal.ProtocolName).(*protocol.MockProtoNode)
 		mockIPFSNode := protoMock.GetNode().(*mocks.MockIPFSNode)
 		mockBlockstore := mocks.NewMockMockBlockstore(t)
 		mockIPFSNode.EXPECT().GetBlockstore().Return(mockBlockstore).Maybe()

--- a/internal/service/boxo/republisher.go
+++ b/internal/service/boxo/republisher.go
@@ -153,10 +153,16 @@ func NewIPNSRepublisherService() (core.Service, []core.ContextBuilderOption, err
 			// This prevents the republisher from crashing on corrupted keystore entries
 			safeKS := NewSafeRepublisherKeystore(ks, ctx.Logger())
 
+			// Get the node's private key for the republisher's self key
+			// The vendor code always tries to republish the self key first
+			selfKey := node.GetPrivateKey()
+			if selfKey == nil {
+				return fmt.Errorf("node private key is nil")
+			}
+
 			// Create the boxo republisher with default settings
-			// Note: We pass nil for selfKey since we don't need to republish the node's own record
-			// The republisher will still republish all keys from the keystore
-			repub := boxoRepublisher.NewRepublisher(publisher, ds, nil, safeKS)
+			// Pass the node's private key as the self key to satisfy vendor code requirements
+			repub := boxoRepublisher.NewRepublisher(publisher, ds, selfKey, safeKS)
 
 			// Configure with defaults (4-hour interval, 24-hour record lifetime)
 			repub.Interval = boxoRepublisher.DefaultRebroadcastInterval

--- a/internal/testing/mocks/MockIPFSNode.go
+++ b/internal/testing/mocks/MockIPFSNode.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-datastore"
 	"github.com/ipfs/go-ipld-format"
+	"github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/multiformats/go-multiaddr"
 	mock "github.com/stretchr/testify/mock"
@@ -545,6 +546,52 @@ func (_c *MockIPFSNode_GetKeystore_Call) Return(keystore1 keystore.Keystore) *Mo
 }
 
 func (_c *MockIPFSNode_GetKeystore_Call) RunAndReturn(run func() keystore.Keystore) *MockIPFSNode_GetKeystore_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetPrivateKey provides a mock function for the type MockIPFSNode
+func (_mock *MockIPFSNode) GetPrivateKey() crypto.PrivKey {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetPrivateKey")
+	}
+
+	var r0 crypto.PrivKey
+	if returnFunc, ok := ret.Get(0).(func() crypto.PrivKey); ok {
+		r0 = returnFunc()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(crypto.PrivKey)
+		}
+	}
+	return r0
+}
+
+// MockIPFSNode_GetPrivateKey_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetPrivateKey'
+type MockIPFSNode_GetPrivateKey_Call struct {
+	*mock.Call
+}
+
+// GetPrivateKey is a helper method to define mock.On call
+func (_e *MockIPFSNode_Expecter) GetPrivateKey() *MockIPFSNode_GetPrivateKey_Call {
+	return &MockIPFSNode_GetPrivateKey_Call{Call: _e.mock.On("GetPrivateKey")}
+}
+
+func (_c *MockIPFSNode_GetPrivateKey_Call) Run(run func()) *MockIPFSNode_GetPrivateKey_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockIPFSNode_GetPrivateKey_Call) Return(privKey crypto.PrivKey) *MockIPFSNode_GetPrivateKey_Call {
+	_c.Call.Return(privKey)
+	return _c
+}
+
+func (_c *MockIPFSNode_GetPrivateKey_Call) RunAndReturn(run func() crypto.PrivKey) *MockIPFSNode_GetPrivateKey_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/testing/mocks/protocol/MockProtoNode.go
+++ b/internal/testing/mocks/protocol/MockProtoNode.go
@@ -2,7 +2,7 @@
 // github.com/vektra/mockery
 // template: testify
 
-package mocks
+package protocol
 
 import (
 	"io"

--- a/internal/testing/util/util.go
+++ b/internal/testing/util/util.go
@@ -15,6 +15,7 @@ import (
 	pluginDb "go.lumeweb.com/portal-plugin-ipfs/internal/db"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/protocol/ipfs"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/testing/mocks"
+	protocol "go.lumeweb.com/portal-plugin-ipfs/internal/testing/mocks/protocol"
 	"go.lumeweb.com/portal/core"
 	coreTesting "go.lumeweb.com/portal/core/testing"
 	"go.lumeweb.com/portal/db"
@@ -118,7 +119,7 @@ func CreateTestBlockAndNode(t *testing.T, ctx coreTesting.TestContext, cid cid.C
 
 func GetProtocolMock() coreTesting.TestContextBuilderOption {
 	return coreTesting.WithCustomMockProtocol(internal.ProtocolName, func(ctx coreTesting.TestContext) core.Protocol {
-		protoMock := mocks.NewMockProtoNode(ctx.T())
+		protoMock := protocol.NewMockProtoNode(ctx.T())
 		protoMock.EXPECT().GetConfig().Return(&config.ProtocolConfig{}).Maybe()
 		protoMock.EXPECT().Workflows().Return(nil).Maybe()
 		ipfsNode := mocks.NewMockIPFSNode(ctx.T())


### PR DESCRIPTION
The boxo republisher always tries to republish the node's own IPNS
record first using the self key parameter. Previously we passed nil,
which caused a nil pointer dereference panic in the vendor code.

The IPFS node already generates its own identity key from the portal
identity seed during initialization. This change exposes that key via
a new GetPrivateKey() method on IPNSNodeAccess and IPFSNode interfaces,
and uses it as the republisher's self key.

Changes:
- Add GetPrivateKey() method to IPNSNodeAccess interface (core/ipns_key.go)
- Add GetPrivateKey() method to IPFSNode interface (internal/protocol/ipfs/node.go)
- Implement GetPrivateKey() in Node struct using host.Peerstore().PrivKey(host.ID())
- Update republisher to retrieve and use the node's private key instead of nil
- Move MockProtoNode to internal/testing/mocks/protocol/ to resolve import cycle
  (MockProtoNode imports ipfs.IPFSNode, creating a cycle with provide_test.go)
- Regenerate mocks with mockery
- Fix test mock expectations to match updated mock signatures

This fixes the panic by using the node's real identity key while avoiding
the need to generate a dummy key.
