### PR TITLE
fix(db): separate SQL statements in MySQL migration

### DIFF
--- a/internal/db/migrations/mysql/20260207010815_add_ipns_keys_and_websites_tables.sql
+++ b/internal/db/migrations/mysql/20260207010815_add_ipns_keys_and_websites_tables.sql
@@ -13,7 +13,9 @@ CREATE TABLE IF NOT EXISTS ipfs_ipns_keys (
     KEY idx_ipfs_ipns_keys_user_id (user_id),
     KEY idx_ipfs_ipns_keys_deleted_at (deleted_at)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+-- +goose StatementEnd
 
+-- +goose StatementBegin
 CREATE TABLE IF NOT EXISTS ipfs_websites (
     id INTEGER PRIMARY KEY AUTO_INCREMENT,
     user_id INTEGER NOT NULL,
@@ -46,5 +48,8 @@ CREATE TABLE IF NOT EXISTS ipfs_websites (
 -- +goose Down
 -- +goose StatementBegin
 DROP TABLE IF EXISTS ipfs_websites;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
 DROP TABLE IF EXISTS ipfs_ipns_keys;
 -- +goose StatementEnd


### PR DESCRIPTION
Split multiple CREATE TABLE and DROP TABLE statements into individual
goose statement blocks to resolve MySQL syntax error 1064.


---

<!-- kody-pr-summary:start -->
 This PR fixes the MySQL migration script by properly separating multiple SQL statements using Goose migration directives.

**Changes Made:**
- Added `-- +goose StatementEnd` and `-- +goose StatementBegin` boundaries between the `ipfs_ipns_keys` and `ipfs_websites` table creation statements in the Up migration
- Applied the same separation to the Down migration (rollback) section between the `DROP TABLE` statements

**Functional Impact:**
Ensures that table creation and deletion operations execute as distinct migration statements rather than a single combined operation. This prevents potential execution errors during database migrations where the migration tool might improperly handle multiple DDL statements without explicit statement boundaries, ensuring reliable schema updates and rollbacks.
<!-- kody-pr-summary:end -->