### PR TITLE
fix(db): change INTEGER to BIGINT UNSIGNED for foreign key compatibility

### DIFF
--- a/internal/db/migrations/mysql/20250702025738_init.sql
+++ b/internal/db/migrations/mysql/20250702025738_init.sql
@@ -1,8 +1,8 @@
 -- +goose Up
 CREATE TABLE IF NOT EXISTS ipfs_pins (
-    id INTEGER PRIMARY KEY AUTO_INCREMENT,
+    id BIGINT UNSIGNED PRIMARY KEY AUTO_INCREMENT,
     request_id BINARY(16) UNIQUE,
-    user_id INTEGER,
+    user_id BIGINT UNSIGNED,
     status VARCHAR(50),
     cid VARBINARY(64),
     name TEXT,
@@ -17,7 +17,7 @@ CREATE TABLE IF NOT EXISTS ipfs_pins (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE IF NOT EXISTS ipfs_blocks (
-    id INTEGER PRIMARY KEY AUTO_INCREMENT,
+    id BIGINT UNSIGNED PRIMARY KEY AUTO_INCREMENT,
     cid VARBINARY(64) UNIQUE,
     size INTEGER,
     last_announcement TIMESTAMP NULL DEFAULT NULL,
@@ -35,9 +35,9 @@ CREATE INDEX idx_ipfs_pins_created_at ON ipfs_pins (created_at);
 CREATE INDEX idx_ipfs_pins_status_user_created_at ON ipfs_pins (status, user_id, created_at);
 
 CREATE TABLE IF NOT EXISTS ipfs_linked_blocks (
-    id INTEGER PRIMARY KEY AUTO_INCREMENT,
-    parent_id INTEGER,
-    child_id INTEGER,
+    id BIGINT UNSIGNED PRIMARY KEY AUTO_INCREMENT,
+    parent_id BIGINT UNSIGNED,
+    child_id BIGINT UNSIGNED,
     link_index INTEGER,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
@@ -48,7 +48,7 @@ CREATE TABLE IF NOT EXISTS ipfs_linked_blocks (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE IF NOT EXISTS ipfs_requests (
-    id INTEGER PRIMARY KEY AUTO_INCREMENT,
+    id BIGINT UNSIGNED PRIMARY KEY AUTO_INCREMENT,
     request_id BIGINT UNSIGNED UNIQUE,
     pin_request_id VARBINARY(64),
     parent_pin_request_id VARBINARY(64),
@@ -61,8 +61,8 @@ CREATE INDEX idx_ipfs_requests_pin_request_id ON ipfs_requests (pin_request_id);
 CREATE INDEX idx_ipfs_requests_parent_pin_request_id ON ipfs_requests (parent_pin_request_id);
 
 CREATE TABLE IF NOT EXISTS ipfs_unixfs_nodes (
-    id INTEGER PRIMARY KEY AUTO_INCREMENT,
-    block_id INTEGER UNIQUE,
+    id BIGINT UNSIGNED PRIMARY KEY AUTO_INCREMENT,
+    block_id BIGINT UNSIGNED UNIQUE,
     name TEXT,
     type INTEGER,
     block_size INTEGER,
@@ -74,8 +74,8 @@ CREATE TABLE IF NOT EXISTS ipfs_unixfs_nodes (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE IF NOT EXISTS ipfs_file_paths (
-    id INTEGER PRIMARY KEY AUTO_INCREMENT,
-    user_id INTEGER NOT NULL,
+    id BIGINT UNSIGNED PRIMARY KEY AUTO_INCREMENT,
+    user_id BIGINT UNSIGNED NOT NULL,
     cid VARBINARY(64) NOT NULL,
     path VARCHAR(1000) NOT NULL,
     name VARCHAR(255) NOT NULL,

--- a/internal/db/migrations/mysql/20260207010815_add_ipns_keys_and_websites_tables.sql
+++ b/internal/db/migrations/mysql/20260207010815_add_ipns_keys_and_websites_tables.sql
@@ -1,8 +1,8 @@
 -- +goose Up
 -- +goose StatementBegin
 CREATE TABLE IF NOT EXISTS ipfs_ipns_keys (
-    id INTEGER PRIMARY KEY AUTO_INCREMENT,
-    user_id INTEGER NOT NULL,
+    id BIGINT UNSIGNED PRIMARY KEY AUTO_INCREMENT,
+    user_id BIGINT UNSIGNED NOT NULL,
     name VARCHAR(255) NOT NULL,
     peer_id_multihash VARBINARY(64) NOT NULL,
     private_key_encrypted BLOB NOT NULL,
@@ -17,8 +17,8 @@ CREATE TABLE IF NOT EXISTS ipfs_ipns_keys (
 
 -- +goose StatementBegin
 CREATE TABLE IF NOT EXISTS ipfs_websites (
-    id INTEGER PRIMARY KEY AUTO_INCREMENT,
-    user_id INTEGER NOT NULL,
+    id BIGINT UNSIGNED PRIMARY KEY AUTO_INCREMENT,
+    user_id BIGINT UNSIGNED NOT NULL,
     domain VARCHAR(255) NOT NULL,
     target_type VARCHAR(50) NOT NULL,
     target_multihash VARBINARY(64) NOT NULL,

--- a/internal/db/migrations/mysql/20260226193115_add_dns_zones_table.sql
+++ b/internal/db/migrations/mysql/20260226193115_add_dns_zones_table.sql
@@ -1,8 +1,8 @@
 -- +goose Up
 -- +goose StatementBegin
 CREATE TABLE IF NOT EXISTS ipfs_dns_zones (
-    id INTEGER PRIMARY KEY AUTO_INCREMENT,
-    user_id INTEGER NOT NULL,
+    id BIGINT UNSIGNED PRIMARY KEY AUTO_INCREMENT,
+    user_id BIGINT UNSIGNED NOT NULL,
     domain VARCHAR(255) NOT NULL,
     status VARCHAR(50) NOT NULL,
     powerdns_zone_id VARCHAR(255),
@@ -22,7 +22,7 @@ CREATE TABLE IF NOT EXISTS ipfs_dns_zones (
 -- +goose StatementEnd
 
 -- +goose StatementBegin
-ALTER TABLE ipfs_websites ADD COLUMN dns_zone_id INTEGER NULL;
+ALTER TABLE ipfs_websites ADD COLUMN dns_zone_id BIGINT UNSIGNED NULL;
 CREATE INDEX idx_websites_dns_zone_id ON ipfs_websites(dns_zone_id);
 ALTER TABLE ipfs_websites ADD CONSTRAINT fk_websites_dns_zone FOREIGN KEY (dns_zone_id) REFERENCES ipfs_dns_zones(id);
 -- +goose StatementEnd


### PR DESCRIPTION
Fixes foreign key constraint error where IPFS plugin tables used INTEGER
for id/user_id columns while the users table uses BIGINT UNSIGNED for id.


---

<!-- kody-pr-summary:start -->
 This pull request updates MySQL database migrations to change integer column types from `INTEGER` to `BIGINT UNSIGNED` across multiple tables to ensure foreign key compatibility and support larger ID ranges.

**Key Changes:**
- Modified primary key columns (`id`) in `ipfs_pins`, `ipfs_blocks`, `ipfs_linked_blocks`, `ipfs_requests`, `ipfs_unixfs_nodes`, `ipfs_file_paths`, `ipfs_ipns_keys`, `ipfs_websites`, and `ipfs_dns_zones` tables
- Updated foreign key columns (`user_id`, `parent_id`, `child_id`, `block_id`, `dns_zone_id`) to use `BIGINT UNSIGNED`
- Applied consistent data type changes to both initial schema creation and subsequent migration files (including IPNS keys, websites, and DNS zones tables)

**Functional Impact:**
- Ensures type consistency between related tables for proper foreign key constraint enforcement
- Expands supported value range for auto-incrementing IDs and user references to accommodate larger datasets
- Resolves potential data type mismatches in database relationships
<!-- kody-pr-summary:end -->