### PR TITLE
fix(db): separate SQL statements into individual goose blocks

### DIFF
--- a/internal/db/migrations/mysql/20260226193115_add_dns_zones_table.sql
+++ b/internal/db/migrations/mysql/20260226193115_add_dns_zones_table.sql
@@ -23,14 +23,26 @@ CREATE TABLE IF NOT EXISTS ipfs_dns_zones (
 
 -- +goose StatementBegin
 ALTER TABLE ipfs_websites ADD COLUMN dns_zone_id BIGINT UNSIGNED NULL;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
 CREATE INDEX idx_websites_dns_zone_id ON ipfs_websites(dns_zone_id);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
 ALTER TABLE ipfs_websites ADD CONSTRAINT fk_websites_dns_zone FOREIGN KEY (dns_zone_id) REFERENCES ipfs_dns_zones(id);
 -- +goose StatementEnd
 
 -- +goose Down
 -- +goose StatementBegin
 ALTER TABLE ipfs_websites DROP FOREIGN KEY fk_websites_dns_zone;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
 DROP INDEX IF EXISTS idx_websites_dns_zone_id ON ipfs_websites;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
 ALTER TABLE ipfs_websites DROP COLUMN dns_zone_id;
 -- +goose StatementEnd
 


### PR DESCRIPTION
Each SQL statement must have its own -- +goose StatementBegin/StatementEnd
block to be executed separately by goose. Multiple statements in one block
causes MySQL syntax error 1064.


---

<!-- kody-pr-summary:start -->
 This pull request fixes database migration execution by restructuring SQL migration blocks in the DNS zones migration file.

**Changes Made:**
- Split multiple SQL statements within single `-- +goose StatementBegin/End` blocks into separate, individual goose blocks
- **Up migration**: Separated the `ALTER TABLE` (add column), `CREATE INDEX`, and `ALTER TABLE` (add foreign key) operations into three distinct transaction blocks
- **Down migration**: Separated the `DROP FOREIGN KEY`, `DROP INDEX`, and `DROP COLUMN` operations into three distinct transaction blocks

**Functional Impact:**
Ensures database schema migrations execute reliably when using the Goose migration tool. By isolating each DDL statement into its own transaction block, the migration can properly track individual statement execution, handle failures granularly, and maintain cleaner rollback capabilities when modifying the `ipfs_websites` table to support DNS zone associations.
<!-- kody-pr-summary:end -->