### PR TITLE
fix(dns): register DNS service with correct ID and add as website dependency

### DIFF
--- a/internal/service/dns/dns_service.go
+++ b/internal/service/dns/dns_service.go
@@ -4,13 +4,10 @@ import (
 	"fmt"
 
 	"go.lumeweb.com/portal/core"
+	pluginCore "go.lumeweb.com/portal-plugin-ipfs/core"
 	"go.lumeweb.com/portal-plugin-ipfs/internal"
 	pluginConfig "go.lumeweb.com/portal-plugin-ipfs/internal/config"
 	"go.uber.org/zap"
-)
-
-const (
-	DNS_SERVICE = "dns_service"
 )
 
 // DNSServiceOptions holds configuration options for DNSService
@@ -95,7 +92,7 @@ func NewDNSServiceWithOptions(options ...DNSServiceOption) (core.Service, []core
 }
 
 func (s *DNSService) ID() string {
-	return DNS_SERVICE
+	return pluginCore.DNS_SERVICE
 }
 
 // SetPowerDNSClient sets the PowerDNS client (for testing)

--- a/ipfs.go
+++ b/ipfs.go
@@ -17,6 +17,7 @@ import (
 	"go.lumeweb.com/portal-plugin-ipfs/internal/protocol"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/service/block"
 	boxo "go.lumeweb.com/portal-plugin-ipfs/internal/service/boxo"
+	"go.lumeweb.com/portal-plugin-ipfs/internal/service/dns"
 	filemanager "go.lumeweb.com/portal-plugin-ipfs/internal/service/file_manager"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/service/ipns_key"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/service/pin"
@@ -105,7 +106,11 @@ func init() {
 				{
 					ID:      pluginCore.WEBSITE_SERVICE,
 					Factory: website.NewWebsiteService,
-					Depends: []string{pluginCore.PIN_SERVICE, pluginCore.IPNS_KEY_SERVICE},
+					Depends: []string{pluginCore.PIN_SERVICE, pluginCore.IPNS_KEY_SERVICE, pluginCore.DNS_SERVICE},
+				},
+				{
+					ID:      pluginCore.DNS_SERVICE,
+					Factory: dns.NewDNSService,
 				},
 			}, nil
 		},
@@ -124,6 +129,7 @@ func init() {
 			&db.UnixFSNode{},
 			&db.IPFSIPNSKey{},
 			&db.Website{},
+			&db.DNSZone{},
 		},
 		Metrics: GetCollectors(),
 		Migrations: core.DBMigration{


### PR DESCRIPTION
- Fix DNS service ID() method to return pluginCore.DNS_SERVICE instead of local constant
- Register DNS service in plugin services list
- Add DNS service as dependency of website service
- Add DNSZone model to plugin models


---

<!-- kody-pr-summary:start -->
 Based on the code changes, this pull request fixes the DNS service integration within the IPFS plugin by ensuring proper service registration and dependency management.

**Changes Made:**

1. **Fixed DNS Service ID Reference**: Updated the DNS service to use the canonical service identifier (`DNS_SERVICE`) defined in the plugin's core package instead of a locally defined constant, ensuring consistency across the codebase.

2. **Registered DNS Service**: Added the DNS service to the plugin's service registry with its proper factory function, enabling the service to be initialized and managed by the portal framework.

3. **Added Service Dependency**: Configured the Website service to depend on the DNS service, ensuring the DNS service initializes before the Website service during application startup.

4. **Registered Database Model**: Added the `DNSZone` database model to the plugin's entity registration, enabling persistence for DNS-related data.
<!-- kody-pr-summary:end -->