### PR TITLE
fix(api): remove duplicate tags from SSL status webhook endpoint

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -760,7 +760,7 @@ See also:.*`),
 Internal webhook called by Caddy when SSL certificates are issued or updated. Requires X-Gateway-Secret header for authentication.
 
 See also:.*`),
-				router.WithTags("internal", "webhooks"),
+				router.WithTags("internal"),
 				router.WithPathParam("domain", "Domain name for the website. Example: example.com", ""),
 				router.WithRequestBody(&dto.SSLStatusUpdateRequest{}, "SSL status update", true),
 				router.WithSuccessResponse(http.StatusOK, "SSL status updated", router.WithJSONContent(dto.WebsiteResponse{})),


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
 This PR fixes duplicate tagging in the API documentation for the SSL status webhook endpoint by removing the "webhooks" tag. The endpoint was previously categorized under both "internal" and "webhooks" tags, causing it to appear in multiple groups in the Swagger documentation. With this change, the endpoint is now properly grouped only under the "internal" tag.
<!-- kody-pr-summary:end -->