### PR TITLE
fix(api): remove placeholder contact and terms of service

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -209,9 +209,7 @@ API requests are rate-limited based on user account tier. See Portal documentati
 
 For detailed API usage examples and integration guides, visit the Portal documentation website.
 `).
-		Contact("support@lumeweb.com", "LumeWeb Support").
-		License("MIT", "https://opensource.org/licenses/MIT").
-		TermsOfService("https://lumeweb.com/terms")
+		License("MIT", "https://opensource.org/licenses/MIT")
 }
 
 func (a *API) Configure(r router.Router, accessSvc core.AccessService) error {


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
 Removes placeholder contact information and Terms of Service URL from the API documentation configuration. The Swagger/OpenAPI specification will no longer display the support email contact (support@lumeweb.com) or the Terms of Service link (https://lumeweb.com/terms), while retaining the MIT license declaration.
<!-- kody-pr-summary:end -->