### PR TITLE
feat(ipns): add GetKeyByName method to IPNSKeyService

### DIFF
--- a/core/ipns_key.go
+++ b/core/ipns_key.go
@@ -53,6 +53,9 @@ type IPNSKeyService interface {
 	// ListKeys lists all IPNS keys for a user
 	ListKeys(ctx context.Context, userID uint) ([]pluginDb.IPFSIPNSKey, error)
 
+	// GetKeyByName retrieves a single IPNS key by name for a user
+	GetKeyByName(ctx context.Context, userID uint, name string) (*pluginDb.IPFSIPNSKey, error)
+
 	// GetKeyByID retrieves a single IPNS key by ID
 	GetKeyByID(ctx context.Context, userID uint, keyID uint) (*pluginDb.IPFSIPNSKey, error)
 

--- a/internal/service/ipns_key/ipns_key.go
+++ b/internal/service/ipns_key/ipns_key.go
@@ -257,6 +257,26 @@ func (s *IPNSKeyServiceDefault) ListKeys(ctx context.Context, userID uint) ([]pl
 	return keys, nil
 }
 
+// GetKeyByName retrieves a single IPNS key by name for a user
+func (s *IPNSKeyServiceDefault) GetKeyByName(ctx context.Context, userID uint, name string) (*pluginDb.IPFSIPNSKey, error) {
+	ctx, span := core.TraceMethod(ctx, "IPNSKeyServiceDefault.GetKeyByName")
+	defer span.End()
+
+	var key pluginDb.IPFSIPNSKey
+	err := db.RetryableComponentTransaction(s, ctx, func(tx *gorm.DB) *gorm.DB {
+		return tx.Where("user_id = ? AND name = ? AND deleted_at IS NULL", userID, name).First(&key)
+	})
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil // Key not found, return nil
+		}
+		s.Logger().Error("Failed to get IPNS key by name", zap.Error(err), zap.Uint("user_id", userID), zap.String("name", name))
+		return nil, fmt.Errorf("failed to get IPNS key by name: %w", err)
+	}
+
+	return &key, nil
+}
+
 // GetKeyByID retrieves a single IPNS key by ID
 func (s *IPNSKeyServiceDefault) GetKeyByID(ctx context.Context, userID uint, keyID uint) (*pluginDb.IPFSIPNSKey, error) {
 	ctx, span := core.TraceMethod(ctx, "IPNSKeyServiceDefault.GetKeyByID")


### PR DESCRIPTION
- Add GetKeyByName interface method to IPNSKeyService
- Implement GetKeyByName in IPNSKeyServiceDefault
- Allows looking up IPNS keys by name for a user
- Returns nil if key not found (not an error)


---

<!-- kody-pr-summary:start -->
 This pull request adds a new `GetKeyByName` method to the IPNS key service, enabling retrieval of a specific IPNS key using its human-readable name rather than its database ID.

**Changes Made:**
- Extended the `IPNSKeyService` interface with a new `GetKeyByName` method that accepts a user ID and key name
- Implemented the method in the default service to query the database by user ID and key name while respecting soft-delete constraints
- Returns the matching IPNS key if found, or nil if no matching key exists for the specified user

**Functional Impact:**
Users and dependent services can now look up IPNS keys using meaningful names (e.g., "website-key", "app-data") instead of requiring knowledge of internal database IDs, improving usability for key management workflows.
<!-- kody-pr-summary:end -->