### PR TITLE
feat(ipns): add GetKeyByName method to IPNSKeyService

### DIFF
--- a/core/ipns_key.go
+++ b/core/ipns_key.go
@@ -53,6 +53,9 @@ type IPNSKeyService interface {
 	// ListKeys lists all IPNS keys for a user
 	ListKeys(ctx context.Context, userID uint) ([]pluginDb.IPFSIPNSKey, error)
 
+	// GetKeyByName retrieves a single IPNS key by name for a user
+	GetKeyByName(ctx context.Context, userID uint, name string) (*pluginDb.IPFSIPNSKey, error)
+
 	// GetKeyByID retrieves a single IPNS key by ID
 	GetKeyByID(ctx context.Context, userID uint, keyID uint) (*pluginDb.IPFSIPNSKey, error)
 

--- a/internal/service/ipns_key/ipns_key.go
+++ b/internal/service/ipns_key/ipns_key.go
@@ -257,6 +257,26 @@ func (s *IPNSKeyServiceDefault) ListKeys(ctx context.Context, userID uint) ([]pl
 	return keys, nil
 }
 
+// GetKeyByName retrieves a single IPNS key by name for a user
+func (s *IPNSKeyServiceDefault) GetKeyByName(ctx context.Context, userID uint, name string) (*pluginDb.IPFSIPNSKey, error) {
+	ctx, span := core.TraceMethod(ctx, "IPNSKeyServiceDefault.GetKeyByName")
+	defer span.End()
+
+	var key pluginDb.IPFSIPNSKey
+	err := db.RetryableComponentTransaction(s, ctx, func(tx *gorm.DB) *gorm.DB {
+		return tx.Where("user_id = ? AND name = ? AND deleted_at IS NULL", userID, name).First(&key)
+	})
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil // Key not found, return nil
+		}
+		s.Logger().Error("Failed to get IPNS key by name", zap.Error(err), zap.Uint("user_id", userID), zap.String("name", name))
+		return nil, fmt.Errorf("failed to get IPNS key by name: %w", err)
+	}
+
+	return &key, nil
+}
+
 // GetKeyByID retrieves a single IPNS key by ID
 func (s *IPNSKeyServiceDefault) GetKeyByID(ctx context.Context, userID uint, keyID uint) (*pluginDb.IPFSIPNSKey, error) {
 	ctx, span := core.TraceMethod(ctx, "IPNSKeyServiceDefault.GetKeyByID")


### PR DESCRIPTION
feat(ipns): add GetKeyByName method to IPNSKeyService

- Add GetKeyByName interface method to IPNSKeyService
- Implement GetKeyByName in IPNSKeyServiceDefault
- Allows looking up IPNS keys by name for a user
- Returns nil if key not found (not an error)

---

<!-- kody-pr-summary:start -->
 This pull request adds a new `GetKeyByName` method to the `IPNSKeyService` interface and its implementation, enabling retrieval of IPNS keys using their human-readable name instead of database ID.

**Changes:**
- Added `GetKeyByName(ctx context.Context, userID uint, name string)` method signature to the `IPNSKeyService` interface in `core/ipns_key.go`
- Implemented the method in `internal/service/ipns_key/ipns_key.go` with the following behavior:
  - Retrieves a single IPNS key scoped to the specified user ID and key name
  - Respects soft-delete semantics (excludes records where `deleted_at` is not null)
  - Returns `nil` when no matching key exists (distinguishing "not found" from actual errors)
  - Includes OpenTelemetry tracing and structured error logging consistent with existing service methods

**Functional Impact:**
This change supports name-based lookup of IPNS keys, allowing users or API consumers to reference keys by their assigned names rather than internal database IDs. This facilitates more intuitive key management workflows where human-readable identifiers are preferred for lookups and operations.
<!-- kody-pr-summary:end -->