### PR TITLE
feat(ipns): add GetKeyByName method to IPNSKeyService

### DIFF
--- a/core/ipns_key.go
+++ b/core/ipns_key.go
@@ -53,6 +53,9 @@ type IPNSKeyService interface {
 	// ListKeys lists all IPNS keys for a user
 	ListKeys(ctx context.Context, userID uint) ([]pluginDb.IPFSIPNSKey, error)
 
+	// GetKeyByName retrieves a single IPNS key by name for a user
+	GetKeyByName(ctx context.Context, userID uint, name string) (*pluginDb.IPFSIPNSKey, error)
+
 	// GetKeyByID retrieves a single IPNS key by ID
 	GetKeyByID(ctx context.Context, userID uint, keyID uint) (*pluginDb.IPFSIPNSKey, error)
 

--- a/internal/service/ipns_key/ipns_key.go
+++ b/internal/service/ipns_key/ipns_key.go
@@ -257,6 +257,26 @@ func (s *IPNSKeyServiceDefault) ListKeys(ctx context.Context, userID uint) ([]pl
 	return keys, nil
 }
 
+// GetKeyByName retrieves a single IPNS key by name for a user
+func (s *IPNSKeyServiceDefault) GetKeyByName(ctx context.Context, userID uint, name string) (*pluginDb.IPFSIPNSKey, error) {
+	ctx, span := core.TraceMethod(ctx, "IPNSKeyServiceDefault.GetKeyByName")
+	defer span.End()
+
+	var key pluginDb.IPFSIPNSKey
+	err := db.RetryableComponentTransaction(s, ctx, func(tx *gorm.DB) *gorm.DB {
+		return tx.Where("user_id = ? AND name = ? AND deleted_at IS NULL", userID, name).First(&key)
+	})
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil // Key not found, return nil
+		}
+		s.Logger().Error("Failed to get IPNS key by name", zap.Error(err), zap.Uint("user_id", userID), zap.String("name", name))
+		return nil, fmt.Errorf("failed to get IPNS key by name: %w", err)
+	}
+
+	return &key, nil
+}
+
 // GetKeyByID retrieves a single IPNS key by ID
 func (s *IPNSKeyServiceDefault) GetKeyByID(ctx context.Context, userID uint, keyID uint) (*pluginDb.IPFSIPNSKey, error) {
 	ctx, span := core.TraceMethod(ctx, "IPNSKeyServiceDefault.GetKeyByID")


### PR DESCRIPTION
Add GetKeyByName method to IPNSKeyService

---

<!-- kody-pr-summary:start -->
 Adds a `GetKeyByName` method to the IPNS key service that retrieves a single IPNS key by its human-readable name for a specific user. This provides an alternative lookup mechanism alongside the existing ID-based retrieval (`GetKeyByID`), enabling applications to fetch IPNS keys using user-friendly identifiers rather than database IDs. The implementation ensures user-scoped access control, respects soft-delete semantics, and returns nil for non-existent keys rather than errors.
<!-- kody-pr-summary:end -->