### PR TITLE
ci: remove branch restrictions from build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,7 @@ name: Build
 
 on:
   push:
-    branches: [ master, develop ]
   pull_request:
-    branches: [ master, develop ]
 
 jobs:
   build:


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
 Based on the code changes, here is a precise description for this pull request:

**Summary**
This pull request modifies the CI build workflow configuration to remove branch restrictions, allowing the build process to trigger on push and pull request events across all branches rather than being limited to only `master` and `develop`.

**Changes Made**
- **`.github/workflows/build.yml`**: Removed the `branches` filter constraints from both `push` and `pull_request` event triggers in the GitHub Actions workflow configuration.

**Functional Impact**
- The build workflow will now execute automatically when code is pushed to any branch (including feature branches, hotfix branches, and other working branches), not just `master` or `develop`.
- Pull requests targeting any branch will now trigger the build workflow, expanding CI coverage beyond the previously restricted target branches.
- This ensures continuous integration validation occurs consistently across the entire repository branch structure, improving code quality visibility during development workflows.
<!-- kody-pr-summary:end -->