### PR TITLE
ci: add git town workflow

### DIFF
--- a/.github/workflows/git-town.yml
+++ b/.github/workflows/git-town.yml
@@ -1,0 +1,19 @@
+name: Git Town
+
+on:
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+  git-town:
+    name: Display the branch stack
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: git-town/action@v1


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
 Adds a Git Town workflow to automatically display the branch stack information on pull requests. 

This integration runs on all pull requests to visualize the hierarchy and dependency chain of stacked branches, helping contributors understand the relationship between branches when using Git Town's stacked pull request workflow. The workflow posts the branch stack details as a comment on pull requests to improve code review context and navigation through dependent changes.
<!-- kody-pr-summary:end -->