### PR TITLE
ci: add workflow_dispatch trigger to build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,7 @@ name: Build
 on:
   push:
   pull_request:
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
 This pull request adds the `workflow_dispatch` trigger to the build workflow, enabling manual execution of the workflow from the GitHub Actions interface or API. 

**Changes:**
- Added `workflow_dispatch:` event trigger to `.github/workflows/build.yml`

**Impact:**
- Maintainers can now manually trigger build jobs on-demand without requiring a push or pull request
- Existing automated triggers (`push` and `pull_request`) remain unchanged and functional
- Useful for running builds on specific branches or debugging workflow issues without code commits
<!-- kody-pr-summary:end -->