### PR TITLE
refactor: use errors.AsType for type-safe error assertions

### DIFF
--- a/internal/api/api_upload.go
+++ b/internal/api/api_upload.go
@@ -49,8 +49,8 @@ func (a *API) handleUpload(c echo.Context) error {
 		// Handle specific error types with appropriate HTTP status codes
 		var apiErr *IPFSError
 
-		// Check if it's an UploadError and extract the error type
-		if uploadErr, ok := err.(*uploadpkg.UploadError); ok {
+		// Check if it's an UploadError and extract the error type using the helper function
+		if uploadErr, ok := uploadpkg.AsUploadError(err); ok {
 			// Map upload error type to API error type using the helper function
 			apiErr = NewError(pluginErrors.MapUploadErrorType(uploadErr.Type), uploadErr)
 		} else {

--- a/internal/service/upload/upload.go
+++ b/internal/service/upload/upload.go
@@ -106,8 +106,8 @@ func (s *UploadServiceDefault) HandleUploadWithMode(ctx context.Context, reader 
 
 			rootCID, uploadID, err := processor.Process(ctx, reader)
 			if err != nil {
-				// If it's already an UploadError, return it as-is
-				if _, ok := err.(*upload.UploadError); ok {
+				// If it's already an UploadError, return it as-is using the helper function
+				if _, ok := upload.AsUploadError(err); ok {
 					return UploadResult{}, err
 				}
 				// Otherwise wrap it in a generic processing error

--- a/internal/upload/errors.go
+++ b/internal/upload/errors.go
@@ -1,6 +1,7 @@
 package upload
 
 import (
+	stderrors "errors"
 	"fmt"
 
 	"go.lumeweb.com/portal-plugin-ipfs/internal/errors"
@@ -95,8 +96,8 @@ func IsUploadErrorType(err error, errorType string) bool {
 		return false
 	}
 
-	// Check if it's an UploadError with matching type
-	if uploadErr, ok := err.(*UploadError); ok {
+	// Check if it's an UploadError with matching type using errors.AsType for type safety
+	if uploadErr, ok := stderrors.AsType[*UploadError](err); ok {
 		return uploadErr.Type == errorType
 	}
 
@@ -109,10 +110,15 @@ func GetUploadErrorType(err error) string {
 		return ""
 	}
 
-	// Check if it's an UploadError
-	if uploadErr, ok := err.(*UploadError); ok {
+	// Check if it's an UploadError using errors.AsType for type safety
+	if uploadErr, ok := stderrors.AsType[*UploadError](err); ok {
 		return uploadErr.Type
 	}
 
 	return ""
+}
+
+// AsUploadError extracts an UploadError from an error using type-safe assertion
+func AsUploadError(err error) (*UploadError, bool) {
+	return stderrors.AsType[*UploadError](err)
 }


### PR DESCRIPTION
Replace unsafe type assertions (comma-ok pattern) with Go 1.26's errors.AsType
for type-safe error checking. This improves code safety and prevents panics
from incorrect type assertions.

Changes:

- internal/api/api\_upload.go: Use errors.AsType for UploadError type checking
- internal/upload/errors.go: Use errors.AsType in helper functions
- internal/service/upload/upload.go: Use errors.AsType for processor error handling

* `develop` <!-- branch-stack -->
  - \#328 :point\_left:

***

<!-- kody-pr-summary:start -->

This pull request refactors error type assertions across the IPFS upload handling codebase to use `errors.AsType` instead of direct type assertions.

**Changes:**

- Replaced direct type assertions (e.g., `err.(*UploadError)`) with `errors.AsType[*UploadError](err)` in:
  - Upload API error handling (`internal/api/api_upload.go`)
  - Upload service processing logic (`internal/service/upload/upload.go`)
  - Upload error utility functions (`internal/upload/errors.go`)

**Impact:**
This change provides type-safe error assertions that properly handle wrapped errors, improving the robustness of error type checking when errors are propagated through multiple layers of the application stack. The refactoring maintains existing functionality while adopting a safer pattern for error type inspection.

<!-- kody-pr-summary:end -->
