### PR TITLE
fix(protocol): use directory name without file extension for LevelDB datastore

### DIFF
--- a/internal/protocol/protocol.go
+++ b/internal/protocol/protocol.go
@@ -366,7 +366,7 @@ func NewProtocol() (core.Protocol, []core.ContextBuilderOption, error) {
 				return fmt.Errorf("failed to create virtual blockstore: %w", err)
 			}
 
-			_ds, dsErr = levelds.NewDatastore(filepath.Join(ctx.Config().ConfigDir(), internal.ProtocolName, "p2p.ldb"), nil)
+			_ds, dsErr = levelds.NewDatastore(filepath.Join(ctx.Config().ConfigDir(), internal.ProtocolName, "p2p"), nil)
 			if dsErr != nil {
 				ctx.Logger().Fatal("failed to open leveldb datastore", zap.Error(dsErr))
 			}


### PR DESCRIPTION
Change p2p.ldb to p2p as the LevelDB directory name, since levelds.NewDatastore expects a directory path where LevelDB stores its database files, not a path with a file extension.

- `develop` <!-- branch-stack -->
  - \#334 :point\_left:


---

<!-- kody-pr-summary:start -->
 Fix the LevelDB datastore directory path by removing the `.ldb` file extension from the directory name. LevelDB requires a directory path (not a file path) to store its database files, and the previous naming incorrectly implied a single file rather than a data directory. This change updates the P2P datastore path from `p2p.ldb` to `p2p` to ensure proper directory structure for the datastore.
<!-- kody-pr-summary:end -->