### PR TITLE
test: skip flaky context cancellation test

### DIFF
--- a/internal/protocol/tests/block_processor_file_integration_test.go
+++ b/internal/protocol/tests/block_processor_file_integration_test.go
@@ -281,6 +281,8 @@ func TestFileBlockProcessor_Integration_FileTypes(t *testing.T) {
 }
 
 func TestFileBlockProcessor_Integration_ContextCancellation(t *testing.T) {
+	t.Skip("Context cancellation test disabled - flaky test behavior, needs investigation")
+
 	// Create test context
 	testCtx, err := coreTesting.NewTestContext(t)
 	require.NoError(t, err)


### PR DESCRIPTION
Skip TestFileBlockProcessor\_Integration\_ContextCancellation due to unstable behavior. Test exhibits inconsistent results and needs further investigation to determine root cause.

- `develop` <!-- branch-stack -->
  - \#355 :point\_left:


---

<!-- kody-pr-summary:start -->
This pull request temporarily disables the `TestFileBlockProcessor_Integration_ContextCancellation` integration test in the file block processor test suite.

**Changes Made:**
- Added `t.Skip()` directive to skip the context cancellation integration test due to flaky behavior that requires further investigation

**Impact:**
- Removes unstable test execution from the CI pipeline to prevent intermittent failures while maintaining the rest of the integration test suite
- The test logic remains in the codebase for future debugging and stabilization efforts
<!-- kody-pr-summary:end -->