### PR TITLE
fix(api): move pins endpoint to root level

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -237,7 +237,7 @@ Use this to:
 - Search for specific pins
 - Monitor pinning status
 
-See also: POST /api/pins (add pin), GET /api/pins/{id} (get pin details)`),
+See also: POST /pins (add pin), GET /pins/{id} (get pin details)`),
 				router.WithTags("Pinning"),
 				router.WithQueryParam("cid", "Filter by content identifier. Supports multiple CIDs for batch queries. Example: QmHash1, QmHash2", []string{}),
 				router.WithQueryParam("name", "Filter by pin name. Supports partial matching for search functionality.", ""),
@@ -260,7 +260,7 @@ Creates a new pin object for the specified CID. Content will be pinned to the IP
 
 Prerequisites: CID must be valid IPFS content identifier
 
-See also: GET /api/pins (list pins), GET /api/pins/{id} (get pin details)`),
+See also: GET /pins (list pins), GET /pins/{id} (get pin details)`),
 				router.WithTags("Pinning"),
 				router.WithRequestBody(&dto.PinRequest{}, "Pin object", true),
 				router.WithSuccessResponse(http.StatusAccepted, "Successful response", router.WithJSONContent(dto.PinStatusResponse{})),
@@ -359,13 +359,14 @@ See also:.*`),
 		),
 	)
 
+	// Register pin routes at root level to match IPFS pinning service API specification
+	if err := router.RegisterRoutes(r, accessSvc, a.Subdomain(), pinRoutes, router.WithMiddlewares(authMw), router.WithCors()); err != nil {
+		return fmt.Errorf("failed to register pin routes: %w", err)
+	}
+
 	apiGroup, err := r.Group("/api")
 	if err != nil {
 		return fmt.Errorf("failed to create api group: %w", err)
-	}
-
-	if err := router.RegisterRoutes(apiGroup, accessSvc, a.Subdomain(), pinRoutes, router.WithMiddlewares(authMw), router.WithCors()); err != nil {
-		return fmt.Errorf("failed to register pin routes: %w", err)
 	}
 
 	if err := router.RegisterRoutes(apiGroup, accessSvc, a.Subdomain(), fileManagerRoutes, router.WithMiddlewares(authMw), router.WithCors()); err != nil {

--- a/internal/api/api_pins_test.go
+++ b/internal/api/api_pins_test.go
@@ -92,3 +92,28 @@ func TestAPI_deletePin(t *testing.T) {
 		assert.Equal(t, http.StatusAccepted, rec.Code)
 	}, TestOptions)
 }
+
+func TestAPI_listPins_requiresAuthentication(t *testing.T) {
+	coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		helper := newMockHelper(t, ctx)
+
+		rec := helper.makeRequest(http.MethodGet, "/pins", nil)
+
+		assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	}, TestOptions)
+}
+
+func TestAPI_listPins_pathIsolation(t *testing.T) {
+	coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		helper := newMockHelper(t, ctx)
+		token, _, _, _ := helper.SetupAuthenticatedTest()
+
+		// Verify root-level path works
+		rec := helper.makeAuthenticatedRequest(http.MethodGet, "/pins", token, nil)
+		assert.Equal(t, http.StatusOK, rec.Code)
+
+		// Verify API group path does NOT work (ensures route isolation)
+		rec2 := helper.makeAuthenticatedRequest(http.MethodGet, "/api/pins", token, nil)
+		assert.Equal(t, http.StatusNotFound, rec2.Code)
+	}, TestOptions)
+}

--- a/internal/api/api_pins_test.go
+++ b/internal/api/api_pins_test.go
@@ -17,7 +17,7 @@ func TestAPI_listPins(t *testing.T) {
 		helper := newMockHelper(t, ctx)
 		token, _, _, _ := helper.SetupAuthenticatedTest()
 
-		rec := helper.makeAuthenticatedRequest(http.MethodGet, "/api/pins", token, nil)
+		rec := helper.makeAuthenticatedRequest(http.MethodGet, "/pins", token, nil)
 
 		assert.Equal(t, http.StatusOK, rec.Code)
 		var response dto.PinResultsResponse
@@ -34,7 +34,7 @@ func TestAPI_addPin(t *testing.T) {
 		token, _, _, _ := helper.SetupAuthenticatedTest()
 
 		reqBody := fmt.Sprintf(`{"cid":"%s","name":"test"}`, TestCID)
-		rec := helper.makeAuthenticatedRequest(http.MethodPost, "/api/pins", token, []byte(reqBody))
+		rec := helper.makeAuthenticatedRequest(http.MethodPost, "/pins", token, []byte(reqBody))
 
 		assert.Equal(t, http.StatusAccepted, rec.Code)
 		var response dto.PinStatusResponse
@@ -51,7 +51,7 @@ func TestAPI_getPin(t *testing.T) {
 		helper := newMockHelper(t, ctx)
 		token, _, _, pinID := helper.SetupAuthenticatedTest()
 
-		rec := helper.makeAuthenticatedRequest(http.MethodGet, fmt.Sprintf("/api/pins/%s", pinID.String()), token, nil)
+		rec := helper.makeAuthenticatedRequest(http.MethodGet, fmt.Sprintf("/pins/%s", pinID.String()), token, nil)
 
 		assert.Equal(t, http.StatusOK, rec.Code)
 		var response dto.PinStatusResponse
@@ -70,7 +70,7 @@ func TestAPI_replacePin(t *testing.T) {
 		token, _, _, pinID := helper.SetupAuthenticatedTest()
 
 		reqBody := fmt.Sprintf(`{"cid":"%s","name":"test"}`, TestCID)
-		rec := helper.makeAuthenticatedRequest(http.MethodPost, fmt.Sprintf("/api/pins/%s", pinID.String()), token, []byte(reqBody))
+		rec := helper.makeAuthenticatedRequest(http.MethodPost, fmt.Sprintf("/pins/%s", pinID.String()), token, []byte(reqBody))
 
 		assert.Equal(t, http.StatusAccepted, rec.Code)
 		var response dto.PinStatusResponse
@@ -87,7 +87,7 @@ func TestAPI_deletePin(t *testing.T) {
 		helper := newMockHelper(t, ctx)
 		token, _, _, pinID := helper.SetupAuthenticatedTest()
 
-		rec := helper.makeAuthenticatedRequest(http.MethodDelete, fmt.Sprintf("/api/pins/%s", pinID.String()), token, nil)
+		rec := helper.makeAuthenticatedRequest(http.MethodDelete, fmt.Sprintf("/pins/%s", pinID.String()), token, nil)
 
 		assert.Equal(t, http.StatusAccepted, rec.Code)
 	}, TestOptions)


### PR DESCRIPTION
Move pin routes from /api/pins to /pins to match IPFS pinning service API specification. The endpoints are now registered at the root level instead of under the /api group, maintaining the same authentication and CORS middleware.

Changes:

- Register pin routes on root router instead of apiGroup
- Update swagger documentation URLs from /api/pins to /pins
- Update test URLs accordingly

* `develop` <!-- branch-stack -->
  - \#359 :point\_left:

***

<!-- kody-pr-summary:start -->

This PR moves the IPFS pinning service API endpoints from `/api/pins` to the root level `/pins` to comply with the IPFS pinning service API specification.

**Changes:**

- Relocated all pin-related endpoints (`GET /pins`, `POST /pins`, `GET /pins/{id}`, `POST /pins/{id}`, `DELETE /pins/{id}`) from the `/api` path prefix to the root path
- Updated API documentation and "See also" references to reflect the new endpoint paths
- Modified test cases to use the updated root-level paths

This ensures compatibility with standard IPFS pinning service clients that expect these endpoints at the root level rather than under an `/api` prefix.

<!-- kody-pr-summary:end -->
