### PR TITLE
fix(api): make /api/info endpoint publicly accessible

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -415,18 +415,6 @@ See also:.*`),
 				router.WithRequestBody(&dto.GetBlockMetaBatchRequest{}, "Batch request for block metadata", true),
 			),
 		),
-		router.NewRoute(http.MethodGet, "/info", a.handleGetInfo,
-			router.WithSwagger(
-				router.WithSummary("Get node information"),
-				router.WithDescription(`Retrieves information about the IPFS node.
-
-Returns node identity (peer ID) and network connection addresses. Useful for diagnostics and verifying node connectivity.
-
-See also:.*`),
-				router.WithTags("Content"),
-				router.WithSuccessResponse(http.StatusOK, "Node information", router.WithJSONContent(dto.InfoResponse{})),
-			),
-		),
 	)
 
 	if err := router.RegisterRoutes(apiGroup, accessSvc, a.Subdomain(), ipfsRoutes, router.WithMiddlewares(authMw), router.WithCors()); err != nil {
@@ -936,6 +924,26 @@ See also:.*`),
 
 	if err := router.RegisterRoutes(r, accessSvc, a.Subdomain(), gatewayRoutes, router.WithMiddlewares(gatewayAuthMw), router.WithCors()); err != nil {
 		return fmt.Errorf("failed to register gateway routes: %w", err)
+	}
+
+	// Public info endpoint
+	publicInfoRoutes := router.DefineRoutes(
+		router.NewRoute(http.MethodGet, "/info", a.handleGetInfo,
+			router.WithSwagger(
+				router.WithSummary("Get node information"),
+				router.WithDescription(`Retrieves information about the IPFS node.
+
+Returns node identity (peer ID) and network connection addresses. Useful for diagnostics and verifying node connectivity.
+
+See also:.*`),
+				router.WithTags("Content"),
+				router.WithSuccessResponse(http.StatusOK, "Node information", router.WithJSONContent(dto.InfoResponse{})),
+			),
+		),
+	)
+
+	if err := router.RegisterRoutes(apiGroup, accessSvc, a.Subdomain(), publicInfoRoutes, router.WithCors()); err != nil {
+		return fmt.Errorf("failed to register public info routes: %w", err)
 	}
 
 	// SSL status routes

--- a/internal/api/api_blocks_test.go
+++ b/internal/api/api_blocks_test.go
@@ -1,6 +1,6 @@
 package api
 
-// Note: These tests use helper.makeAuthenticatedRequest() which internally
+// Note: These tests use helper.makeAuthenticatedRequest() or helper.makeRequest() which internally
 // uses ctx.Router() and httpSvc.APISubdomain() as required by the specification.
 // This maintains consistency with api_pins_test.go, api_files_test.go, and
 // api_upload_test.go which all use the same helper pattern.
@@ -18,7 +18,6 @@ import (
 	"go.lumeweb.com/portal-plugin-ipfs/internal/api/dto"
 	protocol "go.lumeweb.com/portal-plugin-ipfs/internal/protocol/mock_tests"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/testing/mocks"
-	"go.lumeweb.com/portal-plugin-ipfs/internal/testing/util"
 	coreMocks "go.lumeweb.com/portal/core/testing/mocks"
 	"go.lumeweb.com/portal/core"
 	coreTesting "go.lumeweb.com/portal/core/testing"
@@ -76,9 +75,8 @@ func TestAPI_handleGetBlockMetaBatch(t *testing.T) {
 func TestAPI_handleGetInfo(t *testing.T) {
 	coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 		helper := newMockHelper(t, ctx)
-		token, _ := helper.SetupAuthenticatedTestWithCID(util.GenerateTestCID(t, "test data"))
 
-		rec := helper.makeAuthenticatedRequest(http.MethodGet, "/api/info", token, nil)
+		rec := helper.makeRequest(http.MethodGet, "/api/info", nil)
 
 		assert.Equal(t, http.StatusOK, rec.Code)
 		var response dto.InfoResponse


### PR DESCRIPTION
- `develop` <!-- branch-stack -->
  - \#363 :point\_left:


---

<!-- kody-pr-summary:start -->
 This pull request makes the `/api/info` endpoint publicly accessible without requiring authentication.

**Changes:**
- Moved the `/api/info` endpoint from authenticated routes to a new public route group, allowing unauthenticated access to node information
- Updated the corresponding test to use unauthenticated requests instead of authenticated ones

**Functional Impact:**
Users and external services can now retrieve IPFS node information (including peer ID and network connection addresses) without needing authentication credentials. This facilitates easier diagnostics and connectivity verification for public node discovery.
<!-- kody-pr-summary:end -->