### PR TITLE
fix(protocol): update pin status to pinned after POST upload

### DIFF
--- a/internal/protocol/op_post_upload.go
+++ b/internal/protocol/op_post_upload.go
@@ -121,6 +121,23 @@ func (h *PostUploadOperationHandler) Execute(ctx context.Context, req *models.Re
 		return err
 	}
 
+	// Set progress - updating pin status
+	if err := tracker.SetProgress(80); err != nil {
+		h.Logger().Warn("Failed to update progress", zap.Error(err))
+	}
+
+	// Update pin status to pinned
+	pinSvc := core.GetService[pluginCore.IPFSPinService](h.Context(), pluginCore.PIN_SERVICE)
+	if pinSvc != nil {
+		err = pinSvc.UpdatePinStatus(ctx, ipfsPin.RequestID, db.PinningStatusPinned, nil)
+		if err != nil {
+			h.Logger().Error("Failed to update pin status to pinned", zap.Error(err))
+			// Don't fail the whole operation for this
+		}
+	} else {
+		h.Logger().Warn("Pin service not available for status update")
+	}
+
 	err = h.updateWorkflow(ctx, req.ID, rootCids, ipfsPin)
 	if err != nil {
 		return err

--- a/internal/protocol/tests/op_post_upload_test.go
+++ b/internal/protocol/tests/op_post_upload_test.go
@@ -4,9 +4,13 @@ import (
 	"bytes"
 	"testing"
 
+	pluginCore "go.lumeweb.com/portal-plugin-ipfs/core"
+	"go.lumeweb.com/portal-plugin-ipfs/internal/db"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/protocol"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/upload"
 	"go.lumeweb.com/portal/core"
+	"go.lumeweb.com/queryutil"
+	"go.lumeweb.com/queryutil/filter"
 	coreTesting "go.lumeweb.com/portal/core/testing"
 )
 
@@ -128,5 +132,44 @@ func testFileUpload(t *testing.T, fileContent string, filename string) {
 
 		// Run the upload workflow test
 		testPostUploadWorkflow(t, ctx, universalReader, upload.FormatFile, upload.ArchiveConvert)
+	}, GetStandardTestOptions()...)
+}
+
+// TestPostUploadOperation_PinStatus verifies that pin status transitions from queued to pinned
+func TestPostUploadOperation_PinStatus(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		fileContent := "Test content for pin status verification"
+		fileReader := bytes.NewReader([]byte(fileContent))
+		universalReader := upload.NewUniversalReader(fileReader)
+
+		// Run the upload workflow
+		testPostUploadWorkflow(t, ctx, universalReader, upload.FormatFile, upload.ArchiveConvert)
+
+		// Retrieve the pin service
+		pinSvc := core.GetService[pluginCore.IPFSPinService](ctx, pluginCore.PIN_SERVICE)
+		if pinSvc == nil {
+			t.Fatal("Pin service not available")
+		}
+
+		// Get the most recent pin for this user
+		sort := []filter.Sort{
+			{Field: "created_at", Order: filter.OrderDesc},
+		}
+		pins, total, err := pinSvc.ListPins(ctx, nil, sort, queryutil.DefaultPagination)
+		if err != nil {
+			t.Fatalf("Failed to list pins: %v", err)
+		}
+
+		if total == 0 || len(pins) == 0 {
+			t.Fatal("No pins found")
+		}
+
+		// Get the most recent pin (pins should be ordered by created_at desc)
+		pin := pins[0]
+
+		// Verify the pin status is "pinned"
+		if pin.Status != db.PinningStatusPinned {
+			t.Errorf("Expected pin status to be 'pinned', got '%s'", pin.Status)
+		}
 	}, GetStandardTestOptions()...)
 }


### PR DESCRIPTION
- Add UpdatePinStatus call in PostUploadOperationHandler.Execute
- Set progress to 80% for pin status update step
- Add TestPostUploadOperation\_PinStatus to verify status transition

* `develop` <!-- branch-stack -->
  - \#364 :point\_left:


---

<!-- kody-pr-summary:start -->
 This PR fixes an issue where the IPFS pin status was not being properly updated to reflect successful completion after a POST upload operation.

**Changes:**
- Updates the pin status to "pinned" after successful completion of the POST upload workflow, ensuring the status accurately reflects that content is now available in the IPFS network
- Adds progress tracking (80%) during the pin status update phase to provide better visibility into the upload process
- Implements graceful error handling that logs status update failures without failing the entire upload operation
- Adds comprehensive test coverage (`TestPostUploadOperation_PinStatus`) to verify that pins correctly transition to "pinned" status after upload completion

This resolves a bug where uploaded content would remain in an intermediate state (e.g., "queued") even after the upload successfully finished, ensuring users can accurately track the availability of their pinned content.
<!-- kody-pr-summary:end -->