### PR TITLE
chore: update queryutil

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -50,7 +50,7 @@ require (
 	go.lumeweb.com/portal-plugin-dashboard v0.2.7-0.20260312042836-d9dfa043a80d
 	go.lumeweb.com/portal-plugin-quota v0.0.0-20251229183341-d3147a18bb0f
 	go.lumeweb.com/portal-router v0.6.13
-	go.lumeweb.com/queryutil v0.3.15
+	go.lumeweb.com/queryutil v0.3.16
 	go.lumeweb.com/web/go/portal-plugin-ipfs v0.0.0-20260123053442-479cd558a2fc
 	go.uber.org/zap v1.27.1
 	golang.org/x/crypto v0.49.0

--- a/go.sum
+++ b/go.sum
@@ -1417,6 +1417,8 @@ go.lumeweb.com/portal-router v0.6.13 h1:WqBNN4naPuERAwLqjCwxpAhpvzBxom8w8KqdP+Eo
 go.lumeweb.com/portal-router v0.6.13/go.mod h1:4tb+XYa0GYiFVraMoossGgMBTN9z4U54v8SL+EOBvbs=
 go.lumeweb.com/queryutil v0.3.15 h1:R2l6GAAne8rCgh1rGy5HQ54zvs8JJw3gRLjhmkd8SHk=
 go.lumeweb.com/queryutil v0.3.15/go.mod h1:nLkIuXzugX8Ln24wsAbfTafvNmaTHLJhIUKWC1693G4=
+go.lumeweb.com/queryutil v0.3.16 h1:4ShUZdaov+jBRWTkABaa8j1QnDSUv1AtVDJd6IbPO3Y=
+go.lumeweb.com/queryutil v0.3.16/go.mod h1:nLkIuXzugX8Ln24wsAbfTafvNmaTHLJhIUKWC1693G4=
 go.lumeweb.com/web/go/portal-dashboard v0.0.0-20260123053442-479cd558a2fc h1:75sjqoO6sy15ONcUO9P+gRsu3CyYA+fbfoER3YLPBTk=
 go.lumeweb.com/web/go/portal-dashboard v0.0.0-20260123053442-479cd558a2fc/go.mod h1:vMRQ9Q+5VbGjXNAOgIhpFwWAo5yoZjgUbVJXXJ1y3qI=
 go.lumeweb.com/web/go/portal-plugin-core v0.0.0-20260123053442-479cd558a2fc h1:md3+r8pqklmj8Lb9Iqj3fZQXYQ1oaaDnKnPeJmja+is=

--- a/internal/protocol/tests/debug_config_test.go
+++ b/internal/protocol/tests/debug_config_test.go
@@ -1,0 +1,34 @@
+package tests
+
+import (
+	"testing"
+
+	"go.lumeweb.com/portal/config"
+	coreTesting "go.lumeweb.com/portal/core/testing"
+)
+
+func TestDebugConfigDir(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		tb.Helper()
+		
+		// Debug: print the config directory
+		cfg := ctx.Config()
+		configDir := cfg.ConfigDir()
+		
+		t.Logf("ConfigDir: %s", configDir)
+		t.Logf("Config type: %T", cfg)
+		
+		// Check if it's a mock or real config
+		if mockCfg, ok := cfg.(*config.MockManager); ok {
+			t.Logf("Mock config detected")
+			t.Logf("Mock ConfigDir: %s", mockCfg.ConfigDir())
+		} else if realCfg, ok := cfg.(*config.ManagerDefault); ok {
+			t.Logf("Real config detected")
+			t.Logf("Real ConfigDir: %s", realCfg.ConfigDir())
+			// Try to get the config file
+			t.Logf("ConfigFile: %s", realCfg.ConfigFile())
+		} else {
+			t.Logf("Unknown config type: %T", cfg)
+		}
+	})
+}


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
 Add debug test for configuration directory detection in test environment

Adds a diagnostic test (`TestDebugConfigDir`) to identify and log the configuration manager type and directory paths used during test execution. The test determines whether the test context is using a mock configuration manager (`config.MockManager`) or the real default manager (`config.ManagerDefault`), and logs the corresponding configuration directory and file paths to assist with troubleshooting configuration-related issues in the test suite.
<!-- kody-pr-summary:end -->