### PR TITLE
fix: add user isolation to pins API and DB service

### DIFF
--- a/core/ipfs_pin.go
+++ b/core/ipfs_pin.go
@@ -40,5 +40,17 @@ type IPFSPinService interface {
 	// GetPinByCIDAndUser retrieves a pin by CID and user ID
 	GetPinByCIDAndUser(ctx context.Context, c cid.Cid, userID uint) (*db.IPFSPin, error)
 
+	// ListPinsForUser retrieves a paginated and filtered list of pin jobs for a specific user.
+	ListPinsForUser(ctx context.Context, userID uint, filter []queryutil.CrudFilter, sort []filter.Sort, pagination queryutil.Pagination) ([]*db.IPFSPin, int64, error)
+
+	// GetPinByRequestIDForUser retrieves a single pin job by its RequestID for a specific user.
+	GetPinByRequestIDForUser(ctx context.Context, userID uint, requestID types.BinaryUUID) (*db.IPFSPin, error)
+
+	// DeletePinForUser soft-deletes a pin job by its RequestID for a specific user.
+	DeletePinForUser(ctx context.Context, userID uint, requestID types.BinaryUUID) error
+
+	// ReplacePinForUser creates a new pin job to replace an old one, verifying ownership.
+	ReplacePinForUser(ctx context.Context, userID uint, userIp string, oldRequestID types.BinaryUUID, newPin *db.IPFSPin) (*db.IPFSPin, error)
+
 	core.Service
 }

--- a/internal/api/api_pins.go
+++ b/internal/api/api_pins.go
@@ -41,6 +41,10 @@ func (a *API) startPinWorkflow(ctx httputil.RequestContext, c echo.Context, user
 func (a *API) listPins(c echo.Context) error {
 	ctx := httputil.Context(c)
 	reqCtx := ctx.Context.Request().Context()
+	user, err := mcontext.GetUserID(c)
+	if err != nil {
+		return err
+	}
 
 	filter := dto.IPFSPinFilter{}
 	if _, ok := httputil.DecodeAndValidateRequest(ctx, &filter); !ok {
@@ -62,7 +66,9 @@ func (a *API) listPins(c echo.Context) error {
 		apiErr := NewError(ErrKeyFileProcessingFailed, err)
 		return ctx.Error(apiErr, apiErr.HttpStatus())
 	}
-	pins, total, err := a.pinService.ListPins(reqCtx, filters, sort, pagination)
+	
+	// Use ForUser variant to ensure user isolation
+	pins, total, err := a.pinService.ListPinsForUser(reqCtx, user, filters, sort, pagination)
 	if err != nil {
 		a.Logger().Error("Failed to list pins", zap.Error(err))
 		apiErr := NewError(ErrKeyFileProcessingFailed, err)
@@ -93,6 +99,9 @@ func (a *API) addPin(c echo.Context) error {
 		return nil
 	}
 
+	// Set the user_id on the model to ensure user isolation
+	model.UserID = user
+
 	_pin, err := a.pinService.AddPin(reqCtx, model)
 	if err != nil {
 		a.Logger().Error("Failed to add pin", zap.Error(err))
@@ -118,6 +127,10 @@ func (a *API) addPin(c echo.Context) error {
 func (a *API) getPin(c echo.Context) error {
 	ctx := httputil.Context(c)
 	reqCtx := ctx.Context.Request().Context()
+	user, err := mcontext.GetUserID(c)
+	if err != nil {
+		return err
+	}
 
 	_uuid, err := uuid.Parse(c.Param("requestid"))
 	if err != nil {
@@ -127,7 +140,8 @@ func (a *API) getPin(c echo.Context) error {
 
 	requestID := types.FromUUID(_uuid)
 
-	_pin, err := a.pinService.GetPinByRequestID(reqCtx, requestID)
+	// Use ForUser variant to ensure user isolation
+	_pin, err := a.pinService.GetPinByRequestIDForUser(reqCtx, user, requestID)
 	if err != nil {
 		a.Logger().Error("Failed to get pin", zap.Error(err))
 		apiErr := NewError(ErrKeyPinFetchFailed, err)
@@ -166,9 +180,11 @@ func (a *API) replacePin(c echo.Context) error {
 		return nil
 	}
 
-	// TODO: Clarify meaning of hardcoded 0 and "" parameters
-	// Consider: a.pinService.ReplacePin(reqCtx, accountID, name, requestID, model)
-	_pin, err := a.pinService.ReplacePin(reqCtx, 0, "", requestID, model)
+	// Set the user_id on the model to ensure user isolation
+	model.UserID = user
+
+	// Use ForUser variant to ensure user isolation
+	_pin, err := a.pinService.ReplacePinForUser(reqCtx, user, c.RealIP(), requestID, model)
 	if err != nil {
 		a.Logger().Error("Failed to replace pin", zap.Error(err))
 		apiErr := NewError(ErrKeyFileProcessingFailed, err)
@@ -194,6 +210,10 @@ func (a *API) deletePin(c echo.Context) error {
 	ctx := httputil.Context(c)
 	reqCtx := ctx.Context.Request().Context()
 	reqCtx = store.ClientIPOption(reqCtx, c.RealIP())
+	user, err := mcontext.GetUserID(c)
+	if err != nil {
+		return err
+	}
 
 	_uuid, err := uuid.Parse(c.Param("requestid"))
 	if err != nil {
@@ -203,7 +223,8 @@ func (a *API) deletePin(c echo.Context) error {
 
 	requestID := types.FromUUID(_uuid)
 
-	if err := a.pinService.DeletePin(reqCtx, requestID); err != nil {
+	// Use ForUser variant to ensure user isolation
+	if err := a.pinService.DeletePinForUser(reqCtx, user, requestID); err != nil {
 		a.Logger().Error("Failed to delete pin", zap.Error(err))
 		apiErr := NewError(ErrKeyFileProcessingFailed, err)
 		return ctx.Error(apiErr, apiErr.HttpStatus())

--- a/internal/api/api_pins.go
+++ b/internal/api/api_pins.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"fmt"
 	"net/http"
 
 	"github.com/google/uuid"
@@ -146,11 +145,6 @@ func (a *API) getPin(c echo.Context) error {
 		a.Logger().Error("Failed to get pin", zap.Error(err))
 		apiErr := NewError(ErrKeyPinFetchFailed, err)
 		return ctx.Error(apiErr, apiErr.HttpStatus())
-	}
-
-	if _pin == nil {
-		apiErr := NewError(ErrKeyPinFetchFailed, fmt.Errorf("pin not found"))
-		return ctx.Error(apiErr, http.StatusNotFound)
 	}
 
 	return httputil.EncodeResponse(ctx, _pin, &dto.PinStatusResponse{})

--- a/internal/api/test_helpers_test.go
+++ b/internal/api/test_helpers_test.go
@@ -122,17 +122,20 @@ func (m *mockHelper) SetupPinServiceMocks(userID uint, testCID cid.Cid, pinID ty
 	// Setup GetPinByRequestID expectation
 	mockPinService.EXPECT().GetPinByRequestID(mock.Anything, pinID).Return(createMockIPFSPin(userID, testCID, pinID, pluginDb.PinningStatusPinned), nil).Maybe()
 
-	// Setup ListPins expectation
-	mockPinService.EXPECT().ListPins(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]*pluginDb.IPFSPin{createMockIPFSPin(userID, testCID, pinID, pluginDb.PinningStatusPinned)}, int64(1), nil).Maybe()
+	// Setup ListPinsForUser expectation
+	mockPinService.EXPECT().ListPinsForUser(mock.Anything, userID, mock.Anything, mock.Anything, mock.Anything).Return([]*pluginDb.IPFSPin{createMockIPFSPin(userID, testCID, pinID, pluginDb.PinningStatusPinned)}, int64(1), nil).Maybe()
 
-	// Setup DeletePin expectation
-	mockPinService.EXPECT().DeletePin(mock.Anything, pinID).Return(nil).Maybe()
+	// Setup DeletePinForUser expectation
+	mockPinService.EXPECT().DeletePinForUser(mock.Anything, userID, pinID).Return(nil).Maybe()
 
-	// Setup ReplacePin expectation
-	mockPinService.EXPECT().ReplacePin(mock.Anything, mock.AnythingOfType("uint"), mock.AnythingOfType("string"), pinID, mock.AnythingOfType("*db.IPFSPin")).Return(createMockIPFSPin(userID, testCID, pinID, pluginDb.PinningStatusPinned), nil).Maybe()
+	// Setup ReplacePinForUser expectation
+	mockPinService.EXPECT().ReplacePinForUser(mock.Anything, userID, mock.AnythingOfType("string"), pinID, mock.AnythingOfType("*db.IPFSPin")).Return(createMockIPFSPin(userID, testCID, pinID, pluginDb.PinningStatusPinned), nil).Maybe()
 
 	// Setup GetPinByCIDAndUser expectation
 	mockPinService.EXPECT().GetPinByCIDAndUser(mock.Anything, mock.AnythingOfType("cid.Cid"), userID).Return(createMockIPFSPin(userID, testCID, pinID, pluginDb.PinningStatusPinned), nil).Maybe()
+
+	// Setup GetPinByRequestIDForUser expectation
+	mockPinService.EXPECT().GetPinByRequestIDForUser(mock.Anything, userID, pinID).Return(createMockIPFSPin(userID, testCID, pinID, pluginDb.PinningStatusPinned), nil).Maybe()
 
 	return mockPinService
 }

--- a/internal/api/test_helpers_test.go
+++ b/internal/api/test_helpers_test.go
@@ -128,14 +128,23 @@ func (m *mockHelper) SetupPinServiceMocks(userID uint, testCID cid.Cid, pinID ty
 	// Setup DeletePinForUser expectation
 	mockPinService.EXPECT().DeletePinForUser(mock.Anything, userID, pinID).Return(nil).Maybe()
 
+	// Setup DeletePinForUser error expectation for 404 cases
+	mockPinService.EXPECT().DeletePinForUser(mock.Anything, mock.Anything, pinID).Return(fmt.Errorf("pin not found for user")).Maybe()
+
 	// Setup ReplacePinForUser expectation
 	mockPinService.EXPECT().ReplacePinForUser(mock.Anything, userID, mock.AnythingOfType("string"), pinID, mock.AnythingOfType("*db.IPFSPin")).Return(createMockIPFSPin(userID, testCID, pinID, pluginDb.PinningStatusPinned), nil).Maybe()
+
+	// Setup ReplacePinForUser error expectation for 404 cases
+	mockPinService.EXPECT().ReplacePinForUser(mock.Anything, mock.Anything, mock.AnythingOfType("string"), pinID, mock.AnythingOfType("*db.IPFSPin")).Return(nil, fmt.Errorf("pin not found for user")).Maybe()
 
 	// Setup GetPinByCIDAndUser expectation
 	mockPinService.EXPECT().GetPinByCIDAndUser(mock.Anything, mock.AnythingOfType("cid.Cid"), userID).Return(createMockIPFSPin(userID, testCID, pinID, pluginDb.PinningStatusPinned), nil).Maybe()
 
 	// Setup GetPinByRequestIDForUser expectation
 	mockPinService.EXPECT().GetPinByRequestIDForUser(mock.Anything, userID, pinID).Return(createMockIPFSPin(userID, testCID, pinID, pluginDb.PinningStatusPinned), nil).Maybe()
+
+	// Setup GetPinByRequestIDForUser error expectation for 404 cases
+	mockPinService.EXPECT().GetPinByRequestIDForUser(mock.Anything, mock.Anything, pinID).Return(nil, fmt.Errorf("pin not found for user")).Maybe()
 
 	return mockPinService
 }

--- a/internal/api/test_helpers_test.go
+++ b/internal/api/test_helpers_test.go
@@ -125,26 +125,26 @@ func (m *mockHelper) SetupPinServiceMocks(userID uint, testCID cid.Cid, pinID ty
 	// Setup ListPinsForUser expectation
 	mockPinService.EXPECT().ListPinsForUser(mock.Anything, userID, mock.Anything, mock.Anything, mock.Anything).Return([]*pluginDb.IPFSPin{createMockIPFSPin(userID, testCID, pinID, pluginDb.PinningStatusPinned)}, int64(1), nil).Maybe()
 
+	// Setup DeletePinForUser error expectation for 404 cases (wrong user or not found)
+	mockPinService.EXPECT().DeletePinForUser(mock.Anything, userID+1, pinID).Return(fmt.Errorf("pin not found for user")).Maybe()
+
 	// Setup DeletePinForUser expectation
 	mockPinService.EXPECT().DeletePinForUser(mock.Anything, userID, pinID).Return(nil).Maybe()
 
-	// Setup DeletePinForUser error expectation for 404 cases
-	mockPinService.EXPECT().DeletePinForUser(mock.Anything, mock.Anything, pinID).Return(fmt.Errorf("pin not found for user")).Maybe()
+	// Setup ReplacePinForUser error expectation for 404 cases (wrong user or not found)
+	mockPinService.EXPECT().ReplacePinForUser(mock.Anything, userID+1, mock.AnythingOfType("string"), pinID, mock.AnythingOfType("*db.IPFSPin")).Return(nil, fmt.Errorf("pin not found for user")).Maybe()
 
 	// Setup ReplacePinForUser expectation
 	mockPinService.EXPECT().ReplacePinForUser(mock.Anything, userID, mock.AnythingOfType("string"), pinID, mock.AnythingOfType("*db.IPFSPin")).Return(createMockIPFSPin(userID, testCID, pinID, pluginDb.PinningStatusPinned), nil).Maybe()
 
-	// Setup ReplacePinForUser error expectation for 404 cases
-	mockPinService.EXPECT().ReplacePinForUser(mock.Anything, mock.Anything, mock.AnythingOfType("string"), pinID, mock.AnythingOfType("*db.IPFSPin")).Return(nil, fmt.Errorf("pin not found for user")).Maybe()
-
 	// Setup GetPinByCIDAndUser expectation
 	mockPinService.EXPECT().GetPinByCIDAndUser(mock.Anything, mock.AnythingOfType("cid.Cid"), userID).Return(createMockIPFSPin(userID, testCID, pinID, pluginDb.PinningStatusPinned), nil).Maybe()
 
+	// Setup GetPinByRequestIDForUser error expectation for 404 cases (wrong user or not found)
+	mockPinService.EXPECT().GetPinByRequestIDForUser(mock.Anything, userID+1, pinID).Return(nil, fmt.Errorf("pin not found for user")).Maybe()
+
 	// Setup GetPinByRequestIDForUser expectation
 	mockPinService.EXPECT().GetPinByRequestIDForUser(mock.Anything, userID, pinID).Return(createMockIPFSPin(userID, testCID, pinID, pluginDb.PinningStatusPinned), nil).Maybe()
-
-	// Setup GetPinByRequestIDForUser error expectation for 404 cases
-	mockPinService.EXPECT().GetPinByRequestIDForUser(mock.Anything, mock.Anything, pinID).Return(nil, fmt.Errorf("pin not found for user")).Maybe()
 
 	return mockPinService
 }

--- a/internal/service/pin/pin.go
+++ b/internal/service/pin/pin.go
@@ -583,3 +583,77 @@ func (s *PinServiceDefault) getDelegatesJSON() ([]byte, error) {
 
 	return delegatesJSON, nil
 }
+
+// ListPinsForUser retrieves a paginated and filtered list of pin jobs for a specific user.
+func (s *PinServiceDefault) ListPinsForUser(ctx context.Context, userID uint, filters []queryutil.CrudFilter, sort []filter.Sort, pagination queryutil.Pagination) ([]*pluginDb.IPFSPin, int64, error) {
+	ctx, span := core.TraceMethod(ctx, "PinServiceDefault.ListPinsForUser")
+	defer span.End()
+
+	// Add user_id filter to ensure user isolation
+	userFilter := filter.NewLogicalFilter("user_id", filter.OpEq, userID)
+	allFilters := append([]queryutil.CrudFilter{userFilter}, filters...)
+
+	return s.ListPins(ctx, allFilters, sort, pagination)
+}
+
+// GetPinByRequestIDForUser retrieves a single pin job by its RequestID for a specific user.
+func (s *PinServiceDefault) GetPinByRequestIDForUser(ctx context.Context, userID uint, requestID types.BinaryUUID) (*pluginDb.IPFSPin, error) {
+	ctx, span := core.TraceMethod(ctx, "PinServiceDefault.GetPinByRequestIDForUser")
+	defer span.End()
+
+	pin, err := s.GetPinByRequestID(ctx, requestID)
+	if err != nil {
+		return nil, err
+	}
+	if pin == nil {
+		return nil, nil
+	}
+	if pin.UserID != userID {
+		return nil, nil
+	}
+	return pin, nil
+}
+
+// DeletePinForUser soft-deletes a pin job by its RequestID for a specific user.
+func (s *PinServiceDefault) DeletePinForUser(ctx context.Context, userID uint, requestID types.BinaryUUID) error {
+	ctx, span := core.TraceMethod(ctx, "PinServiceDefault.DeletePinForUser")
+	defer span.End()
+
+	// Verify pin exists and belongs to user before proceeding
+	var pin pluginDb.IPFSPin
+	err := db.RetryableComponentTransaction(s, ctx, func(tx *gorm.DB) *gorm.DB {
+		return tx.Where("request_id = ? AND user_id = ?", requestID, userID).First(&pin)
+	})
+	
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return fmt.Errorf("pin not found for user")
+		}
+		return err
+	}
+
+	// Delegate to DeletePin for the actual deletion logic
+	return s.DeletePin(ctx, requestID)
+}
+
+// ReplacePinForUser creates a new pin job to replace an old one, verifying ownership.
+func (s *PinServiceDefault) ReplacePinForUser(ctx context.Context, userID uint, userIp string, oldRequestID types.BinaryUUID, newPin *pluginDb.IPFSPin) (*pluginDb.IPFSPin, error) {
+	ctx, span := core.TraceMethod(ctx, "PinServiceDefault.ReplacePinForUser")
+	defer span.End()
+
+	// Verify the old pin exists and belongs to user
+	var oldPin pluginDb.IPFSPin
+	err := db.RetryableComponentTransaction(s, ctx, func(tx *gorm.DB) *gorm.DB {
+		return tx.Where("request_id = ? AND user_id = ?", oldRequestID, userID).First(&oldPin)
+	})
+	
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, fmt.Errorf("pin not found for user")
+		}
+		return nil, err
+	}
+
+	// Delegate to ReplacePin for the actual replacement logic
+	return s.ReplacePin(ctx, userID, userIp, oldRequestID, newPin)
+}

--- a/internal/service/pin/pin.go
+++ b/internal/service/pin/pin.go
@@ -606,10 +606,10 @@ func (s *PinServiceDefault) GetPinByRequestIDForUser(ctx context.Context, userID
 		return nil, err
 	}
 	if pin == nil {
-		return nil, nil
+		return nil, fmt.Errorf("pin not found for user")
 	}
 	if pin.UserID != userID {
-		return nil, nil
+		return nil, fmt.Errorf("pin not found for user")
 	}
 	return pin, nil
 }

--- a/internal/service/pin/pin_test.go
+++ b/internal/service/pin/pin_test.go
@@ -287,3 +287,311 @@ func TestPinService_UpdatePinStatus_NotFound(t *testing.T) {
 		assert.Contains(tb, err.Error(), fmt.Sprintf("no pin found with request ID: %s", nonExistentRequestID.String()))
 	}, TestOptions)
 }
+
+func TestPinService_ListPinsForUser(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		// Arrange
+		pinService := core.GetService[pluginCore.IPFSPinService](ctx, pluginCore.PIN_SERVICE)
+
+		user1 := uint(100)
+		user2 := uint(200)
+
+		// Generate CIDs
+		testString1 := "test data user 1"
+		testCID1 := util.GenerateTestCID(t, testString1)
+		testString2 := "test data user 2"
+		testCID2 := util.GenerateTestCID(t, testString2)
+		testString3 := "test data user 1 extra"
+		testCID3 := util.GenerateTestCID(t, testString3)
+
+		// Create pins for user 1
+		pin1 := &pluginDb.IPFSPin{
+			CID:       testCID1.Bytes(),
+			RequestID: types.NewBinUUID(),
+			UserID:    user1,
+		}
+		pin3 := &pluginDb.IPFSPin{
+			CID:       testCID3.Bytes(),
+			RequestID: types.NewBinUUID(),
+			UserID:    user1,
+		}
+
+		// Create pins for user 2
+		pin2 := &pluginDb.IPFSPin{
+			CID:       testCID2.Bytes(),
+			RequestID: types.NewBinUUID(),
+			UserID:    user2,
+		}
+
+		// Add pins to database
+		result := ctx.DB().Create(pin1)
+		require.NoError(tb, result.Error)
+		result = ctx.DB().Create(pin2)
+		require.NoError(tb, result.Error)
+		result = ctx.DB().Create(pin3)
+		require.NoError(tb, result.Error)
+
+		// Act - Get pins for user 1
+		pins, total, err := pinService.ListPinsForUser(context.Background(), user1, nil, nil, queryutil.DefaultPagination)
+
+		// Assert - Should only return user1's pins
+		require.NoError(tb, err)
+		assert.Len(tb, pins, 2)
+		assert.Equal(tb, int64(2), total)
+		
+		// Verify all pins belong to user 1
+		for _, pin := range pins {
+			assert.Equal(tb, user1, pin.UserID)
+		}
+
+		// Act - Get pins for user 2
+		pins2, total2, err2 := pinService.ListPinsForUser(context.Background(), user2, nil, nil, queryutil.DefaultPagination)
+
+		// Assert - Should only return user2's pins
+		require.NoError(tb, err2)
+		assert.Len(tb, pins2, 1)
+		assert.Equal(tb, int64(1), total2)
+		assert.Equal(tb, user2, pins2[0].UserID)
+	}, TestOptions)
+}
+
+func TestPinService_GetPinByRequestIDForUser_Success(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		// Arrange
+		pinService := core.GetService[pluginCore.IPFSPinService](ctx, pluginCore.PIN_SERVICE)
+
+		user1 := uint(100)
+		user2 := uint(200)
+
+		testString := "test data"
+		testCID := util.GenerateTestCID(t, testString)
+
+		pin1 := &pluginDb.IPFSPin{
+			CID:       testCID.Bytes(),
+			RequestID: types.NewBinUUID(),
+			UserID:    user1,
+		}
+
+		// Add pin to database
+		result := ctx.DB().Create(pin1)
+		require.NoError(tb, result.Error)
+
+		// Act - Get pin for correct user
+		retrievedPin, err := pinService.GetPinByRequestIDForUser(context.Background(), user1, pin1.RequestID)
+
+		// Assert
+		require.NoError(tb, err)
+		assert.NotNil(tb, retrievedPin)
+		assert.Equal(tb, pin1.CID, retrievedPin.CID)
+		assert.Equal(tb, user1, retrievedPin.UserID)
+
+		// Act - Try to get pin for wrong user
+		retrievedPin2, err2 := pinService.GetPinByRequestIDForUser(context.Background(), user2, pin1.RequestID)
+
+		// Assert - Should return nil because pin belongs to user1
+		require.NoError(tb, err2)
+		assert.Nil(tb, retrievedPin2)
+	}, TestOptions)
+}
+
+func TestPinService_GetPinByRequestIDForUser_NotFound(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		// Arrange
+		pinService := core.GetService[pluginCore.IPFSPinService](ctx, pluginCore.PIN_SERVICE)
+
+		user := uint(100)
+		nonExistentRequestID := types.NewBinUUID()
+
+		// Act
+		retrievedPin, err := pinService.GetPinByRequestIDForUser(context.Background(), user, nonExistentRequestID)
+
+		// Assert
+		require.NoError(tb, err)
+		assert.Nil(tb, retrievedPin)
+	}, TestOptions)
+}
+
+func TestPinService_DeletePinForUser_Success(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		// Arrange
+		pinService := core.GetService[pluginCore.IPFSPinService](ctx, pluginCore.PIN_SERVICE)
+		corePinService := core.GetService[*coreMocks.MockPinService](ctx, core.PIN_SERVICE)
+		fileManagerService := core.GetService[*mocks.MockFileManagerService](ctx, pluginCore.FILE_MANAGER_SERVICE)
+
+		userID := uint(100)
+
+		testString := "test data"
+		testCID := util.GenerateTestCID(t, testString)
+
+		pin1 := &pluginDb.IPFSPin{
+			CID:       testCID.Bytes(),
+			RequestID: types.NewBinUUID(),
+			UserID:    userID,
+		}
+
+		// Setup mock expectations
+		hash := internal.NewIPFSHash(testCID)
+		corePinService.EXPECT().GetPinByHash(mock.Anything, hash, userID).Return(nil, nil).Maybe()
+		corePinService.EXPECT().DeletePinByHash(mock.Anything, hash, userID).Return(nil).Maybe()
+		fileManagerService.EXPECT().DeleteFilePathSmart(mock.Anything, userID, testCID.Bytes()).Return(nil).Maybe()
+
+		// Add pin to database
+		result := ctx.DB().Create(pin1)
+		require.NoError(tb, result.Error)
+
+		// Act - Delete pin for correct user
+		err := pinService.DeletePinForUser(context.Background(), userID, pin1.RequestID)
+
+		// Assert
+		require.NoError(tb, err)
+
+		// Verify pin is deleted
+		var retrievedPin pluginDb.IPFSPin
+		result = ctx.DB().Where("request_id = ?", pin1.RequestID).First(&retrievedPin)
+		assert.Error(tb, result.Error) // Should be deleted
+	}, TestOptions)
+}
+
+func TestPinService_DeletePinForUser_WrongUser(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		// Arrange
+		pinService := core.GetService[pluginCore.IPFSPinService](ctx, pluginCore.PIN_SERVICE)
+
+		user1 := uint(100)
+		user2 := uint(200)
+
+		testString := "test data"
+		testCID := util.GenerateTestCID(t, testString)
+
+		pin1 := &pluginDb.IPFSPin{
+			CID:       testCID.Bytes(),
+			RequestID: types.NewBinUUID(),
+			UserID:    user1,
+		}
+
+		// Add pin to database
+		result := ctx.DB().Create(pin1)
+		require.NoError(tb, result.Error)
+
+		// Act - Try to delete pin for wrong user
+		err := pinService.DeletePinForUser(context.Background(), user2, pin1.RequestID)
+
+		// Assert - Should fail because pin doesn't belong to user2
+		assert.Error(tb, err)
+		assert.Contains(tb, err.Error(), "pin not found for user")
+
+		// Verify pin still exists in database
+		var retrievedPin pluginDb.IPFSPin
+		result = ctx.DB().Where("request_id = ?", pin1.RequestID).First(&retrievedPin)
+		require.NoError(tb, result.Error)
+		assert.Equal(tb, pin1.CID, retrievedPin.CID)
+	}, TestOptions)
+}
+
+func TestPinService_DeletePinForUser_NotFound(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		// Arrange
+		pinService := core.GetService[pluginCore.IPFSPinService](ctx, pluginCore.PIN_SERVICE)
+
+		user := uint(100)
+		nonExistentRequestID := types.NewBinUUID()
+
+		// Act
+		err := pinService.DeletePinForUser(context.Background(), user, nonExistentRequestID)
+
+		// Assert
+		assert.Error(tb, err)
+		assert.Contains(tb, err.Error(), "pin not found for user")
+	}, TestOptions)
+}
+
+func TestPinService_ReplacePinForUser_Success(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		// Arrange
+		pinService := core.GetService[pluginCore.IPFSPinService](ctx, pluginCore.PIN_SERVICE)
+
+		userID := uint(100)
+
+		testString1 := "test data 1"
+		testCID1 := util.GenerateTestCID(t, testString1)
+		testString2 := "test data 2"
+		testCID2 := util.GenerateTestCID(t, testString2)
+
+		oldPin := &pluginDb.IPFSPin{
+			CID:       testCID1.Bytes(),
+			RequestID: types.NewBinUUID(),
+			UserID:    userID,
+		}
+
+		newPin := &pluginDb.IPFSPin{
+			CID:       testCID2.Bytes(),
+			RequestID: types.NewBinUUID(),
+			UserID:    userID,
+		}
+
+		// Add old pin to database
+		result := ctx.DB().Create(oldPin)
+		require.NoError(tb, result.Error)
+
+		// Act - Replace pin for correct user
+		replacedPin, err := pinService.ReplacePinForUser(context.Background(), userID, "127.0.0.1", oldPin.RequestID, newPin)
+
+		// Assert
+		require.NoError(tb, err)
+		assert.NotNil(tb, replacedPin)
+		assert.Equal(tb, newPin.CID, replacedPin.CID)
+
+		// Verify old pin is deleted
+		var retrievedOldPin pluginDb.IPFSPin
+		result = ctx.DB().Where("request_id = ?", oldPin.RequestID).First(&retrievedOldPin)
+		assert.Error(tb, result.Error) // Should be deleted
+
+		// Verify new pin exists
+		var retrievedNewPin pluginDb.IPFSPin
+		result = ctx.DB().Where("request_id = ?", newPin.RequestID).First(&retrievedNewPin)
+		require.NoError(tb, result.Error)
+		assert.Equal(tb, newPin.CID, retrievedNewPin.CID)
+	}, TestOptions)
+}
+
+func TestPinService_ReplacePinForUser_WrongUser(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		// Arrange
+		pinService := core.GetService[pluginCore.IPFSPinService](ctx, pluginCore.PIN_SERVICE)
+
+		user1 := uint(100)
+		user2 := uint(200)
+
+		testString := "test data"
+		testCID := util.GenerateTestCID(t, testString)
+
+		oldPin := &pluginDb.IPFSPin{
+			CID:       testCID.Bytes(),
+			RequestID: types.NewBinUUID(),
+			UserID:    user1,
+		}
+
+		newPin := &pluginDb.IPFSPin{
+			CID:       testCID.Bytes(),
+			RequestID: types.NewBinUUID(),
+			UserID:    user2,
+		}
+
+		// Add old pin to database
+		result := ctx.DB().Create(oldPin)
+		require.NoError(tb, result.Error)
+
+		// Act - Try to replace pin for wrong user
+		_, err := pinService.ReplacePinForUser(context.Background(), user2, "127.0.0.1", oldPin.RequestID, newPin)
+
+		// Assert - Should fail because pin belongs to user1
+		assert.Error(tb, err)
+		assert.Contains(tb, err.Error(), "pin not found for user")
+
+		// Verify old pin still exists
+		var retrievedOldPin pluginDb.IPFSPin
+		result = ctx.DB().Where("request_id = ?", oldPin.RequestID).First(&retrievedOldPin)
+		require.NoError(tb, result.Error)
+		assert.Equal(tb, oldPin.CID, retrievedOldPin.CID)
+	}, TestOptions)
+}

--- a/internal/service/pin/pin_test.go
+++ b/internal/service/pin/pin_test.go
@@ -388,9 +388,10 @@ func TestPinService_GetPinByRequestIDForUser_Success(t *testing.T) {
 		// Act - Try to get pin for wrong user
 		retrievedPin2, err2 := pinService.GetPinByRequestIDForUser(context.Background(), user2, pin1.RequestID)
 
-		// Assert - Should return nil because pin belongs to user1
-		require.NoError(tb, err2)
+		// Assert - Should return error because pin belongs to user1
+		require.Error(tb, err2)
 		assert.Nil(tb, retrievedPin2)
+		assert.Contains(tb, err2.Error(), "pin not found for user")
 	}, TestOptions)
 }
 
@@ -406,8 +407,9 @@ func TestPinService_GetPinByRequestIDForUser_NotFound(t *testing.T) {
 		retrievedPin, err := pinService.GetPinByRequestIDForUser(context.Background(), user, nonExistentRequestID)
 
 		// Assert
-		require.NoError(tb, err)
+		require.Error(tb, err)
 		assert.Nil(tb, retrievedPin)
+		assert.Contains(tb, err.Error(), "pin not found for user")
 	}, TestOptions)
 }
 

--- a/internal/testing/mocks/MockIPFSPinService.go
+++ b/internal/testing/mocks/MockIPFSPinService.go
@@ -309,6 +309,69 @@ func (_c *MockIPFSPinService_DeletePin_Call) RunAndReturn(run func(ctx context.C
 	return _c
 }
 
+// DeletePinForUser provides a mock function for the type MockIPFSPinService
+func (_mock *MockIPFSPinService) DeletePinForUser(ctx context.Context, userID uint, requestID types.BinaryUUID) error {
+	ret := _mock.Called(ctx, userID, requestID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeletePinForUser")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uint, types.BinaryUUID) error); ok {
+		r0 = returnFunc(ctx, userID, requestID)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockIPFSPinService_DeletePinForUser_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeletePinForUser'
+type MockIPFSPinService_DeletePinForUser_Call struct {
+	*mock.Call
+}
+
+// DeletePinForUser is a helper method to define mock.On call
+//   - ctx context.Context
+//   - userID uint
+//   - requestID types.BinaryUUID
+func (_e *MockIPFSPinService_Expecter) DeletePinForUser(ctx interface{}, userID interface{}, requestID interface{}) *MockIPFSPinService_DeletePinForUser_Call {
+	return &MockIPFSPinService_DeletePinForUser_Call{Call: _e.mock.On("DeletePinForUser", ctx, userID, requestID)}
+}
+
+func (_c *MockIPFSPinService_DeletePinForUser_Call) Run(run func(ctx context.Context, userID uint, requestID types.BinaryUUID)) *MockIPFSPinService_DeletePinForUser_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 uint
+		if args[1] != nil {
+			arg1 = args[1].(uint)
+		}
+		var arg2 types.BinaryUUID
+		if args[2] != nil {
+			arg2 = args[2].(types.BinaryUUID)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockIPFSPinService_DeletePinForUser_Call) Return(err error) *MockIPFSPinService_DeletePinForUser_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockIPFSPinService_DeletePinForUser_Call) RunAndReturn(run func(ctx context.Context, userID uint, requestID types.BinaryUUID) error) *MockIPFSPinService_DeletePinForUser_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetPinByCIDAndUser provides a mock function for the type MockIPFSPinService
 func (_mock *MockIPFSPinService) GetPinByCIDAndUser(ctx context.Context, c cid.Cid, userID uint) (*db.IPFSPin, error) {
 	ret := _mock.Called(ctx, c, userID)
@@ -451,6 +514,80 @@ func (_c *MockIPFSPinService_GetPinByRequestID_Call) RunAndReturn(run func(ctx c
 	return _c
 }
 
+// GetPinByRequestIDForUser provides a mock function for the type MockIPFSPinService
+func (_mock *MockIPFSPinService) GetPinByRequestIDForUser(ctx context.Context, userID uint, requestID types.BinaryUUID) (*db.IPFSPin, error) {
+	ret := _mock.Called(ctx, userID, requestID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetPinByRequestIDForUser")
+	}
+
+	var r0 *db.IPFSPin
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uint, types.BinaryUUID) (*db.IPFSPin, error)); ok {
+		return returnFunc(ctx, userID, requestID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uint, types.BinaryUUID) *db.IPFSPin); ok {
+		r0 = returnFunc(ctx, userID, requestID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*db.IPFSPin)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, uint, types.BinaryUUID) error); ok {
+		r1 = returnFunc(ctx, userID, requestID)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockIPFSPinService_GetPinByRequestIDForUser_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetPinByRequestIDForUser'
+type MockIPFSPinService_GetPinByRequestIDForUser_Call struct {
+	*mock.Call
+}
+
+// GetPinByRequestIDForUser is a helper method to define mock.On call
+//   - ctx context.Context
+//   - userID uint
+//   - requestID types.BinaryUUID
+func (_e *MockIPFSPinService_Expecter) GetPinByRequestIDForUser(ctx interface{}, userID interface{}, requestID interface{}) *MockIPFSPinService_GetPinByRequestIDForUser_Call {
+	return &MockIPFSPinService_GetPinByRequestIDForUser_Call{Call: _e.mock.On("GetPinByRequestIDForUser", ctx, userID, requestID)}
+}
+
+func (_c *MockIPFSPinService_GetPinByRequestIDForUser_Call) Run(run func(ctx context.Context, userID uint, requestID types.BinaryUUID)) *MockIPFSPinService_GetPinByRequestIDForUser_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 uint
+		if args[1] != nil {
+			arg1 = args[1].(uint)
+		}
+		var arg2 types.BinaryUUID
+		if args[2] != nil {
+			arg2 = args[2].(types.BinaryUUID)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockIPFSPinService_GetPinByRequestIDForUser_Call) Return(iPFSPin *db.IPFSPin, err error) *MockIPFSPinService_GetPinByRequestIDForUser_Call {
+	_c.Call.Return(iPFSPin, err)
+	return _c
+}
+
+func (_c *MockIPFSPinService_GetPinByRequestIDForUser_Call) RunAndReturn(run func(ctx context.Context, userID uint, requestID types.BinaryUUID) (*db.IPFSPin, error)) *MockIPFSPinService_GetPinByRequestIDForUser_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ID provides a mock function for the type MockIPFSPinService
 func (_mock *MockIPFSPinService) ID() string {
 	ret := _mock.Called()
@@ -577,6 +714,98 @@ func (_c *MockIPFSPinService_ListPins_Call) Return(iPFSPins []*db.IPFSPin, n int
 }
 
 func (_c *MockIPFSPinService_ListPins_Call) RunAndReturn(run func(ctx context.Context, filter1 []queryutil.CrudFilter, sort []filter.Sort, pagination queryutil.Pagination) ([]*db.IPFSPin, int64, error)) *MockIPFSPinService_ListPins_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ListPinsForUser provides a mock function for the type MockIPFSPinService
+func (_mock *MockIPFSPinService) ListPinsForUser(ctx context.Context, userID uint, filter1 []queryutil.CrudFilter, sort []filter.Sort, pagination queryutil.Pagination) ([]*db.IPFSPin, int64, error) {
+	ret := _mock.Called(ctx, userID, filter1, sort, pagination)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListPinsForUser")
+	}
+
+	var r0 []*db.IPFSPin
+	var r1 int64
+	var r2 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uint, []queryutil.CrudFilter, []filter.Sort, queryutil.Pagination) ([]*db.IPFSPin, int64, error)); ok {
+		return returnFunc(ctx, userID, filter1, sort, pagination)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uint, []queryutil.CrudFilter, []filter.Sort, queryutil.Pagination) []*db.IPFSPin); ok {
+		r0 = returnFunc(ctx, userID, filter1, sort, pagination)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*db.IPFSPin)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, uint, []queryutil.CrudFilter, []filter.Sort, queryutil.Pagination) int64); ok {
+		r1 = returnFunc(ctx, userID, filter1, sort, pagination)
+	} else {
+		r1 = ret.Get(1).(int64)
+	}
+	if returnFunc, ok := ret.Get(2).(func(context.Context, uint, []queryutil.CrudFilter, []filter.Sort, queryutil.Pagination) error); ok {
+		r2 = returnFunc(ctx, userID, filter1, sort, pagination)
+	} else {
+		r2 = ret.Error(2)
+	}
+	return r0, r1, r2
+}
+
+// MockIPFSPinService_ListPinsForUser_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListPinsForUser'
+type MockIPFSPinService_ListPinsForUser_Call struct {
+	*mock.Call
+}
+
+// ListPinsForUser is a helper method to define mock.On call
+//   - ctx context.Context
+//   - userID uint
+//   - filter1 []queryutil.CrudFilter
+//   - sort []filter.Sort
+//   - pagination queryutil.Pagination
+func (_e *MockIPFSPinService_Expecter) ListPinsForUser(ctx interface{}, userID interface{}, filter1 interface{}, sort interface{}, pagination interface{}) *MockIPFSPinService_ListPinsForUser_Call {
+	return &MockIPFSPinService_ListPinsForUser_Call{Call: _e.mock.On("ListPinsForUser", ctx, userID, filter1, sort, pagination)}
+}
+
+func (_c *MockIPFSPinService_ListPinsForUser_Call) Run(run func(ctx context.Context, userID uint, filter1 []queryutil.CrudFilter, sort []filter.Sort, pagination queryutil.Pagination)) *MockIPFSPinService_ListPinsForUser_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 uint
+		if args[1] != nil {
+			arg1 = args[1].(uint)
+		}
+		var arg2 []queryutil.CrudFilter
+		if args[2] != nil {
+			arg2 = args[2].([]queryutil.CrudFilter)
+		}
+		var arg3 []filter.Sort
+		if args[3] != nil {
+			arg3 = args[3].([]filter.Sort)
+		}
+		var arg4 queryutil.Pagination
+		if args[4] != nil {
+			arg4 = args[4].(queryutil.Pagination)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+			arg4,
+		)
+	})
+	return _c
+}
+
+func (_c *MockIPFSPinService_ListPinsForUser_Call) Return(iPFSPins []*db.IPFSPin, n int64, err error) *MockIPFSPinService_ListPinsForUser_Call {
+	_c.Call.Return(iPFSPins, n, err)
+	return _c
+}
+
+func (_c *MockIPFSPinService_ListPinsForUser_Call) RunAndReturn(run func(ctx context.Context, userID uint, filter1 []queryutil.CrudFilter, sort []filter.Sort, pagination queryutil.Pagination) ([]*db.IPFSPin, int64, error)) *MockIPFSPinService_ListPinsForUser_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -709,6 +938,92 @@ func (_c *MockIPFSPinService_ReplacePin_Call) Return(iPFSPin *db.IPFSPin, err er
 }
 
 func (_c *MockIPFSPinService_ReplacePin_Call) RunAndReturn(run func(ctx context.Context, userId uint, userIp string, oldRequestID types.BinaryUUID, newPin *db.IPFSPin) (*db.IPFSPin, error)) *MockIPFSPinService_ReplacePin_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ReplacePinForUser provides a mock function for the type MockIPFSPinService
+func (_mock *MockIPFSPinService) ReplacePinForUser(ctx context.Context, userID uint, userIp string, oldRequestID types.BinaryUUID, newPin *db.IPFSPin) (*db.IPFSPin, error) {
+	ret := _mock.Called(ctx, userID, userIp, oldRequestID, newPin)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ReplacePinForUser")
+	}
+
+	var r0 *db.IPFSPin
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uint, string, types.BinaryUUID, *db.IPFSPin) (*db.IPFSPin, error)); ok {
+		return returnFunc(ctx, userID, userIp, oldRequestID, newPin)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uint, string, types.BinaryUUID, *db.IPFSPin) *db.IPFSPin); ok {
+		r0 = returnFunc(ctx, userID, userIp, oldRequestID, newPin)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*db.IPFSPin)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, uint, string, types.BinaryUUID, *db.IPFSPin) error); ok {
+		r1 = returnFunc(ctx, userID, userIp, oldRequestID, newPin)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockIPFSPinService_ReplacePinForUser_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ReplacePinForUser'
+type MockIPFSPinService_ReplacePinForUser_Call struct {
+	*mock.Call
+}
+
+// ReplacePinForUser is a helper method to define mock.On call
+//   - ctx context.Context
+//   - userID uint
+//   - userIp string
+//   - oldRequestID types.BinaryUUID
+//   - newPin *db.IPFSPin
+func (_e *MockIPFSPinService_Expecter) ReplacePinForUser(ctx interface{}, userID interface{}, userIp interface{}, oldRequestID interface{}, newPin interface{}) *MockIPFSPinService_ReplacePinForUser_Call {
+	return &MockIPFSPinService_ReplacePinForUser_Call{Call: _e.mock.On("ReplacePinForUser", ctx, userID, userIp, oldRequestID, newPin)}
+}
+
+func (_c *MockIPFSPinService_ReplacePinForUser_Call) Run(run func(ctx context.Context, userID uint, userIp string, oldRequestID types.BinaryUUID, newPin *db.IPFSPin)) *MockIPFSPinService_ReplacePinForUser_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 uint
+		if args[1] != nil {
+			arg1 = args[1].(uint)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		var arg3 types.BinaryUUID
+		if args[3] != nil {
+			arg3 = args[3].(types.BinaryUUID)
+		}
+		var arg4 *db.IPFSPin
+		if args[4] != nil {
+			arg4 = args[4].(*db.IPFSPin)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+			arg4,
+		)
+	})
+	return _c
+}
+
+func (_c *MockIPFSPinService_ReplacePinForUser_Call) Return(iPFSPin *db.IPFSPin, err error) *MockIPFSPinService_ReplacePinForUser_Call {
+	_c.Call.Return(iPFSPin, err)
+	return _c
+}
+
+func (_c *MockIPFSPinService_ReplacePinForUser_Call) RunAndReturn(run func(ctx context.Context, userID uint, userIp string, oldRequestID types.BinaryUUID, newPin *db.IPFSPin) (*db.IPFSPin, error)) *MockIPFSPinService_ReplacePinForUser_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
Add ForUser service variants that inject user\_id filters to prevent cross-user access to pins. Fixes security vulnerability where any user could list, view, replace, or delete pins belonging to other users.

Changes:

- Add ListPinsForUser(), GetPinByRequestIDForUser(), DeletePinForUser(), ReplacePinForUser() to IPFSPinService interface
- Implement ForUser methods in PinServiceDefault following DRY pattern:
  - ListPinsForUser injects user\_id filter via filter.NewLogicalFilter()
  - GetPinByRequestIDForUser wraps GetPinByRequestID and verifies ownership
  - DeletePinForUser/ReplacePinForUser verify ownership before delegating
- Update API handlers to use ForUser variants:
  - listPins() uses ListPinsForUser()
  - addPin() sets model.UserID
  - getPin() uses GetPinByRequestIDForUser()
  - deletePin() uses DeletePinForUser()
  - replacePin() uses ReplacePinForUser() with actual user/IP
- Add comprehensive user isolation tests verifying:
  - Users can only list their own pins
  - Users can only get their own pins by requestID
  - Users can only delete their own pins
  - Users can only replace their own pins

* `develop` <!-- branch-stack -->
  - **fix: add user isolation to pins API and DB service** :point\_left:

***

<!-- kody-pr-summary:start -->

This pull request implements user isolation for the IPFS pins API and database service to prevent cross-user data access.

**Key Changes:**

- **Added user-scoped service methods**: Introduced `ListPinsForUser`, `GetPinByRequestIDForUser`, `DeletePinForUser`, and `ReplacePinForUser` methods that enforce user ownership verification before allowing access to pin data.

- **Updated API endpoints**: Modified all pin management endpoints (`listPins`, `getPin`, `addPin`, `replacePin`, `deletePin`) to extract the authenticated user ID and use the new user-isolated service methods, ensuring users can only view and manage their own pins.

- **Enforced ownership validation**: Service implementations now verify that pins belong to the requesting user before returning, updating, or deleting records, returning "not found" errors when users attempt to access other users' pins.

- **Fixed authorization gaps**: Eliminated hardcoded parameters in the replace pin operation and added explicit user ID assignment when creating new pins to ensure proper ownership tracking.

- **Added comprehensive test coverage**: Included test cases verifying that users cannot list, retrieve, delete, or replace pins belonging to other users, confirming proper isolation boundaries.

This fix addresses a security vulnerability where the pins API previously allowed potential access to other users' pin data by enforcing strict user-based filtering and ownership checks across all pin operations.

<!-- kody-pr-summary:end -->
