### PR TITLE
fix: return 404 instead of 500 when fetching replaced pins

### DIFF
--- a/internal/api/api_pins.go
+++ b/internal/api/api_pins.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/google/uuid"
@@ -145,6 +146,11 @@ func (a *API) getPin(c echo.Context) error {
 		a.Logger().Error("Failed to get pin", zap.Error(err))
 		apiErr := NewError(ErrKeyPinFetchFailed, err)
 		return ctx.Error(apiErr, apiErr.HttpStatus())
+	}
+
+	if _pin == nil {
+		apiErr := NewError(ErrKeyPinFetchFailed, fmt.Errorf("pin not found"))
+		return ctx.Error(apiErr, http.StatusNotFound)
 	}
 
 	return httputil.EncodeResponse(ctx, _pin, &dto.PinStatusResponse{})

--- a/internal/api/test_helpers_test.go
+++ b/internal/api/test_helpers_test.go
@@ -140,8 +140,8 @@ func (m *mockHelper) SetupPinServiceMocks(userID uint, testCID cid.Cid, pinID ty
 	// Setup GetPinByCIDAndUser expectation
 	mockPinService.EXPECT().GetPinByCIDAndUser(mock.Anything, mock.AnythingOfType("cid.Cid"), userID).Return(createMockIPFSPin(userID, testCID, pinID, pluginDb.PinningStatusPinned), nil).Maybe()
 
-	// Setup GetPinByRequestIDForUser error expectation for 404 cases (wrong user or not found)
-	mockPinService.EXPECT().GetPinByRequestIDForUser(mock.Anything, userID+1, pinID).Return(nil, fmt.Errorf("pin not found for user")).Maybe()
+	// Setup GetPinByRequestIDForUser expectation for 404 cases (wrong user or not found)
+	mockPinService.EXPECT().GetPinByRequestIDForUser(mock.Anything, userID+1, pinID).Return(nil, nil).Maybe()
 
 	// Setup GetPinByRequestIDForUser expectation
 	mockPinService.EXPECT().GetPinByRequestIDForUser(mock.Anything, userID, pinID).Return(createMockIPFSPin(userID, testCID, pinID, pluginDb.PinningStatusPinned), nil).Maybe()

--- a/internal/service/pin/pin.go
+++ b/internal/service/pin/pin.go
@@ -603,15 +603,15 @@ func (s *PinServiceDefault) GetPinByRequestIDForUser(ctx context.Context, userID
 
 	pin, err := s.GetPinByRequestID(ctx, requestID)
 	if err != nil {
-		// Any error (including gorm.ErrRecordNotFound from GetPinByRequestID
-		// or errors from ReplacePin) indicates the pin doesn't exist.
-		// Return nil, nil to let API return 404.
-		return nil, nil
+		// Propagate non-record-not-found errors (connection, timeout, etc.)
+		return nil, err
 	}
 	if pin == nil {
+		// Record not found - return nil, nil for 404
 		return nil, nil
 	}
 	if pin.UserID != userID {
+		// Not this user's pin - return nil, nil for 404
 		return nil, nil
 	}
 	return pin, nil

--- a/internal/service/pin/pin.go
+++ b/internal/service/pin/pin.go
@@ -603,13 +603,16 @@ func (s *PinServiceDefault) GetPinByRequestIDForUser(ctx context.Context, userID
 
 	pin, err := s.GetPinByRequestID(ctx, requestID)
 	if err != nil {
-		return nil, err
+		// Any error (including gorm.ErrRecordNotFound from GetPinByRequestID
+		// or errors from ReplacePin) indicates the pin doesn't exist.
+		// Return nil, nil to let API return 404.
+		return nil, nil
 	}
 	if pin == nil {
-		return nil, fmt.Errorf("pin not found for user")
+		return nil, nil
 	}
 	if pin.UserID != userID {
-		return nil, fmt.Errorf("pin not found for user")
+		return nil, nil
 	}
 	return pin, nil
 }

--- a/internal/service/pin/pin_test.go
+++ b/internal/service/pin/pin_test.go
@@ -388,10 +388,9 @@ func TestPinService_GetPinByRequestIDForUser_Success(t *testing.T) {
 		// Act - Try to get pin for wrong user
 		retrievedPin2, err2 := pinService.GetPinByRequestIDForUser(context.Background(), user2, pin1.RequestID)
 
-		// Assert - Should return error because pin belongs to user1
-		require.Error(tb, err2)
+		// Assert - Should return nil, nil because pin belongs to user1
+		require.NoError(tb, err2)
 		assert.Nil(tb, retrievedPin2)
-		assert.Contains(tb, err2.Error(), "pin not found for user")
 	}, TestOptions)
 }
 
@@ -407,9 +406,8 @@ func TestPinService_GetPinByRequestIDForUser_NotFound(t *testing.T) {
 		retrievedPin, err := pinService.GetPinByRequestIDForUser(context.Background(), user, nonExistentRequestID)
 
 		// Assert
-		require.Error(tb, err)
+		require.NoError(tb, err)
 		assert.Nil(tb, retrievedPin)
-		assert.Contains(tb, err.Error(), "pin not found for user")
 	}, TestOptions)
 }
 


### PR DESCRIPTION
Fix compliance test failure where GET /pins/{requestid} was returning HTTP 500 instead of 404 for replaced/soft-deleted pins.

Root cause:

- GetPinByRequestIDForUser was returning fmt.Errorf('pin not found') instead of (nil, nil) for unreachable pins
- API handler tried to encode nil pointer, causing panic
- Or returned 500 via ErrKeyPinFetchFailed error mapping

Changes:

- GetPinByRequestIDForUser now returns (nil, nil) for non-existent/ deleted/wrong-user pins, allowing clean 404 handling
- API handler checks for nil pin and returns 404 with error body before attempting to encode
- Updated mocks and tests to expect (nil, nil) instead of errors

This restores the original design pattern where GET /pins/{requestid} returns 404 on not found, not 500 with an error response.

- `develop` <!-- branch-stack -->
  - **fix: return 404 instead of 500 when fetching replaced pins** :point\_left:

***

<!-- kody-pr-summary:start -->

Fixes error handling to return HTTP 404 Not Found instead of HTTP 500 Internal Server Error when fetching pins that have been replaced, do not exist, or belong to other users.

This change ensures proper user isolation by preventing users from accessing pins owned by other accounts while providing accurate HTTP status codes for missing resources. The service layer now returns `nil` without errors for these cases, allowing the API layer to respond with appropriate 404 status codes rather than internal server errors.

<!-- kody-pr-summary:end -->
