### PR TITLE
fix(ipns): extract CID from path instead of passing full path to PublishWithKey

### DIFF
--- a/internal/api/api_ipns.go
+++ b/internal/api/api_ipns.go
@@ -398,8 +398,16 @@ func (a *API) republishIPNS(c echo.Context) error {
 			return ctx.Error(apiErr, apiErr.HttpStatus())
 		}
 
+		// Extract CID from the path
+		pathSegments := valuePath.Segments()
+		if len(pathSegments) < 2 {
+			apiErr := NewError(ErrKeyInvalidRequest, fmt.Errorf("invalid IPNS record path format"))
+			return ctx.Error(apiErr, apiErr.HttpStatus())
+		}
+		cidStr := pathSegments[1]
+
 		// Republish with the same value
-		err = ipnsKeyService.PublishWithKey(reqCtx, privKey, valuePath.String(), 0)
+		err = ipnsKeyService.PublishWithKey(reqCtx, privKey, cidStr, 0)
 		if err != nil {
 			a.Logger().Error("Failed to republish IPNS record", zap.Error(err), zap.String("peer_id", key.PeerID().String()))
 			apiErr := NewError(ErrKeyFileProcessingFailed, fmt.Errorf("failed to republish IPNS record: %w", err))
@@ -432,7 +440,15 @@ func (a *API) republishIPNS(c echo.Context) error {
 				continue
 			}
 
-			err = ipnsKeyService.PublishWithKey(reqCtx, privKey, valuePath.String(), 0)
+			// Extract CID from the path
+			pathSegments := valuePath.Segments()
+			if len(pathSegments) < 2 {
+				a.Logger().Warn("Invalid IPNS record path format, skipping", zap.String("peer_id", peerID))
+				continue
+			}
+			cidStr := pathSegments[1]
+
+			err = ipnsKeyService.PublishWithKey(reqCtx, privKey, cidStr, 0)
 			if err != nil {
 				a.Logger().Warn("Failed to republish IPNS record, skipping", zap.Error(err), zap.String("peer_id", peerID))
 				continue

--- a/internal/api/api_ipns.go
+++ b/internal/api/api_ipns.go
@@ -22,6 +22,24 @@ import (
 // KeyTypeEd25519 is the key type identifier for Ed25519 keys.
 const KeyTypeEd25519 = 1
 
+// ipfsPathSegment is the expected first segment for IPFS paths
+const ipfsPathSegment = "ipfs"
+
+// extractCIDFromIPNSPath extracts the CID from an IPNS record path.
+// The path should be formatted as /ipfs/{cid}, where the CID is at segment 1.
+// Returns an error if the path format is invalid or doesn't start with "ipfs".
+func extractCIDFromIPNSPath(valuePath path.Path) (string, error) {
+	pathSegments := valuePath.Segments()
+	if len(pathSegments) < 2 {
+		return "", fmt.Errorf("invalid IPNS record path format: expected at least 2 segments, got %d", len(pathSegments))
+	}
+	// Validate first segment is "ipfs" to ensure we're extracting the right component
+	if pathSegments[0] != ipfsPathSegment {
+		return "", fmt.Errorf("unexpected path protocol: %s", pathSegments[0])
+	}
+	return pathSegments[1], nil
+}
+
 // IPNS Key Handlers
 
 // createIPNSKey creates or imports an IPNS key for the authenticated user.
@@ -399,12 +417,11 @@ func (a *API) republishIPNS(c echo.Context) error {
 		}
 
 		// Extract CID from the path
-		pathSegments := valuePath.Segments()
-		if len(pathSegments) < 2 {
-			apiErr := NewError(ErrKeyInvalidRequest, fmt.Errorf("invalid IPNS record path format"))
+		cidStr, err := extractCIDFromIPNSPath(valuePath)
+		if err != nil {
+			apiErr := NewError(ErrKeyInvalidRequest, err)
 			return ctx.Error(apiErr, apiErr.HttpStatus())
 		}
-		cidStr := pathSegments[1]
 
 		// Republish with the same value
 		err = ipnsKeyService.PublishWithKey(reqCtx, privKey, cidStr, 0)
@@ -441,12 +458,11 @@ func (a *API) republishIPNS(c echo.Context) error {
 			}
 
 			// Extract CID from the path
-			pathSegments := valuePath.Segments()
-			if len(pathSegments) < 2 {
-				a.Logger().Warn("Invalid IPNS record path format, skipping", zap.String("peer_id", peerID))
+			cidStr, err := extractCIDFromIPNSPath(valuePath)
+			if err != nil {
+				a.Logger().Warn("Invalid IPNS record path format, skipping", zap.Error(err), zap.String("peer_id", peerID))
 				continue
 			}
-			cidStr := pathSegments[1]
 
 			err = ipnsKeyService.PublishWithKey(reqCtx, privKey, cidStr, 0)
 			if err != nil {

--- a/internal/api/api_ipns_test.go
+++ b/internal/api/api_ipns_test.go
@@ -12,7 +12,6 @@ import (
 	mh "github.com/multiformats/go-multihash"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/ipfs/boxo/ipns"
-	"github.com/ipfs/boxo/path"
 	"github.com/ipfs/go-cid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -510,9 +509,6 @@ func TestAPI_RepublishIPNS(t *testing.T) {
 
 			mockIPNSKeyService := helper.SetupIPNSServiceMocksNoDefaults(userID)
 
-			targetCID := cid.MustParse(TestCID)
-			ipnsPath := path.FromCid(targetCID)
-
 			// Create a valid IPNS record with a value
 			mockRecord := createMockIPNSRecord(t, TestCID)
 			ipnsName, _ := ipns.NameFromString(TestIPNSName)
@@ -522,7 +518,7 @@ func TestAPI_RepublishIPNS(t *testing.T) {
 
 			mockIPNSKeyService.EXPECT().ListPublished(mock.Anything).Return(records, nil)
 			mockIPNSKeyService.EXPECT().GetPrivateKeyByPeerID(mock.Anything, ipnsName.Peer().String()).Return(nil, userID, nil).Times(1)
-			mockIPNSKeyService.EXPECT().PublishWithKey(mock.Anything, nil, ipnsPath.String(), mock.AnythingOfType("time.Duration")).Return(nil)
+			mockIPNSKeyService.EXPECT().PublishWithKey(mock.Anything, nil, TestCID, mock.AnythingOfType("time.Duration")).Return(nil)
 
 			rec := helper.makeAuthenticatedRequest(http.MethodPost, "/api/ipns/republish", token, nil)
 
@@ -544,16 +540,13 @@ func TestAPI_RepublishIPNS(t *testing.T) {
 
 			mockKey := createTestIPNSKey(1, userID, "test-key", TestPeerID)
 
-			targetCID := cid.MustParse(TestCID)
-			ipnsPath := path.FromCid(targetCID)
-
 			// Create a valid IPNS record with a value
 			mockRecord := createMockIPNSRecord(t, TestCID)
 
 			mockIPNSKeyService.EXPECT().GetKeyByID(mock.Anything, userID, uint(1)).Return(&mockKey, nil)
 			mockIPNSKeyService.EXPECT().GetPublished(mock.Anything, mockKey.PeerID().String(), false).Return(mockRecord, nil)
 			mockIPNSKeyService.EXPECT().GetPrivateKeyByPeerID(mock.Anything, mockKey.PeerID().String()).Return(nil, userID, nil)
-			mockIPNSKeyService.EXPECT().PublishWithKey(mock.Anything, nil, ipnsPath.String(), mock.AnythingOfType("time.Duration")).Return(nil)
+			mockIPNSKeyService.EXPECT().PublishWithKey(mock.Anything, nil, TestCID, mock.AnythingOfType("time.Duration")).Return(nil)
 
 			reqBody := `{"key_id":1}`
 			rec := helper.makeAuthenticatedRequest(http.MethodPost, "/api/ipns/republish", token, []byte(reqBody))
@@ -604,6 +597,69 @@ func TestAPI_RepublishIPNS(t *testing.T) {
 			rec := httptest.NewRecorder()
 			ctx.Router().ServeHTTP(rec, req)
 			assert.Equal(t, http.StatusUnauthorized, rec.Code)
+		}, TestOptions)
+	})
+
+	t.Run("regression_path_extraction_single_key", func(t *testing.T) {
+		// Regression test: Ensures CID is extracted from path, not full path string passed to PublishWithKey
+		// This tests the fix for the bug where valuePath.String() was passed instead of just the CID
+		coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+			helper := newMockHelper(t, ctx)
+			token, userID := helper.SetupAuthenticatedTestWithCID(cid.MustParse(TestCID))
+
+			mockIPNSKeyService := helper.SetupIPNSServiceMocks(userID)
+
+			mockKey := createTestIPNSKey(1, userID, "test-key", TestPeerID)
+
+			// Create a mock IPNS record that will return a path like /ipfs/{cid}
+			mockRecord := createMockIPNSRecord(t, TestCID)
+
+			mockIPNSKeyService.EXPECT().GetKeyByID(mock.Anything, userID, uint(1)).Return(&mockKey, nil)
+			mockIPNSKeyService.EXPECT().GetPublished(mock.Anything, mockKey.PeerID().String(), false).Return(mockRecord, nil)
+			mockIPNSKeyService.EXPECT().GetPrivateKeyByPeerID(mock.Anything, mockKey.PeerID().String()).Return(nil, userID, nil)
+			// Important: This test expects the CID string, NOT the full path string (/ipfs/{cid})
+			mockIPNSKeyService.EXPECT().PublishWithKey(mock.Anything, nil, TestCID, mock.AnythingOfType("time.Duration")).Return(nil)
+
+			reqBody := `{"key_id":1}`
+			rec := helper.makeAuthenticatedRequest(http.MethodPost, "/api/ipns/republish", token, []byte(reqBody))
+
+			assert.Equal(t, http.StatusOK, rec.Code)
+
+			var response dto.IPNSRepublishResponse
+			err := json.Unmarshal(rec.Body.Bytes(), &response)
+			require.NoError(t, err)
+			assert.Equal(t, 1, response.Count)
+		}, TestOptions)
+	})
+
+	t.Run("regression_path_extraction_bulk_keys", func(t *testing.T) {
+		// Regression test: Ensures CID extraction from path works correctly in bulk republish loop
+		coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+			helper := newMockHelper(t, ctx)
+			token, userID := helper.SetupAuthenticatedTestWithCID(cid.MustParse(TestCID))
+
+			mockIPNSKeyService := helper.SetupIPNSServiceMocksNoDefaults(userID)
+
+			// Create a mock IPNS record
+			mockRecord := createMockIPNSRecord(t, TestCID)
+			ipnsName, _ := ipns.NameFromString(TestIPNSName)
+			records := map[ipns.Name]*ipns.Record{
+				ipnsName: mockRecord,
+			}
+
+			mockIPNSKeyService.EXPECT().ListPublished(mock.Anything).Return(records, nil)
+			mockIPNSKeyService.EXPECT().GetPrivateKeyByPeerID(mock.Anything, ipnsName.Peer().String()).Return(nil, userID, nil).Times(1)
+			// Important: This test expects the CID string, NOT the full path string (/ipfs/{cid})
+			mockIPNSKeyService.EXPECT().PublishWithKey(mock.Anything, nil, TestCID, mock.AnythingOfType("time.Duration")).Return(nil)
+
+			rec := helper.makeAuthenticatedRequest(http.MethodPost, "/api/ipns/republish", token, nil)
+
+			assert.Equal(t, http.StatusOK, rec.Code)
+
+			var response dto.IPNSRepublishResponse
+			err := json.Unmarshal(rec.Body.Bytes(), &response)
+			require.NoError(t, err)
+			assert.Equal(t, 1, response.Count)
 		}, TestOptions)
 	})
 }


### PR DESCRIPTION
The IPNS republish functions were passing the full IPFS path string (e.g., /ipfs/{cid}) to PublishWithKey() instead of just the CID string (e.g., {cid}). This caused cid.Decode() to fail with "invalid cid: selected encoding not supported" error.

Fixed both republishIPNS() code paths:

- Single key republish (line 402): Extract CID using path.Segments()\[1]
- Bulk republish loop (line 443): Extract CID with validation for invalid paths

Added regression tests to verify CID extraction works correctly for both single and bulk republish scenarios.

Closes e2e test failures where IPNS republish would fail with invalid CID error.

- `develop` <!-- branch-stack -->
  - **fix(ipns): extract CID from path instead of passing full path to PublishWithKey** :point\_left:

***

<!-- kody-pr-summary:start -->

Fix IPNS republishing to correctly extract the CID from the IPFS path before publishing, instead of passing the full path string to the `PublishWithKey` method.

The changes modify the `republishIPNS` function to parse the IPFS path (format: `/ipfs/{cid}`), validate it has the expected segments, and extract only the CID component to pass to the publishing service. This resolves a bug where the full path string was being used instead of just the CID, which caused incorrect IPNS record values.

The fix is applied to both single key republishing and bulk republishing code paths. Tests are updated to expect CID-only strings and include regression tests to prevent future occurrences of this issue.

<!-- kody-pr-summary:end -->
