### PR TITLE
fix(api): add nil record checks to prevent nil pointer dereference

### DIFF
--- a/internal/api/api_ipns.go
+++ b/internal/api/api_ipns.go
@@ -318,6 +318,13 @@ func (a *API) resolveIPNS(c echo.Context) error {
 		return ctx.Error(apiErr, apiErr.HttpStatus())
 	}
 
+	// Check if record is nil (key not yet published)
+	if record == nil {
+		a.Logger().Debug("IPNS record not found", zap.String("name", name))
+		apiErr := NewError(ErrKeyPinFetchFailed, fmt.Errorf("IPNS name not found: %s", name))
+		return ctx.Error(apiErr, apiErr.HttpStatus())
+	}
+
 	// Convert IPNS record to response
 	valuePath, err := record.Value()
 	if err != nil {

--- a/internal/api/api_ipns_test.go
+++ b/internal/api/api_ipns_test.go
@@ -499,6 +499,22 @@ func TestAPI_ResolveIPNS(t *testing.T) {
 			assert.Equal(t, http.StatusUnauthorized, rec.Code)
 		}, TestOptions)
 	})
+
+	t.Run("error_nil_record", func(t *testing.T) {
+		coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+			helper := newMockHelper(t, ctx)
+			token, _ := helper.SetupAuthenticatedTestWithCID(cid.MustParse(TestCID))
+
+			mockIPNSKeyService := helper.SetupIPNSServiceMocks(1)
+
+			// Return nil record to simulate key not yet published
+			mockIPNSKeyService.EXPECT().GetPublished(mock.Anything, TestIPNSName, false).Return((*ipns.Record)(nil), nil)
+
+			rec := helper.makeAuthenticatedRequest(http.MethodGet, fmt.Sprintf("/api/ipns/resolve/%s", TestIPNSName), token, nil)
+
+			assert.Equal(t, http.StatusInternalServerError, rec.Code)
+		}, TestOptions)
+	})
 }
 
 func TestAPI_RepublishIPNS(t *testing.T) {

--- a/internal/service/website/janitor.go
+++ b/internal/service/website/janitor.go
@@ -289,6 +289,19 @@ func (j *WebsiteJanitorJob) validateIPNSTarget(ctx context.Context, website *plu
 		return nil
 	}
 
+	// Check if record is nil (key not yet published)
+	if record == nil {
+		j.logger.Warn("IPNS record not found",
+			zap.Uint("website_id", website.ID),
+			zap.String("domain", website.Domain),
+			zap.String("peer_id", website.TargetHash()),
+		)
+		website.Status = string(pluginDb.WebsiteStatusBroken)
+		now := time.Now()
+		website.LastCheckedAt = &now
+		return nil
+	}
+
 	// Extract CID from record
 	recordCID, err := record.Value()
 	if err != nil {


### PR DESCRIPTION
Add nil checks after retrieving IPNS records to prevent panics when a key exists but hasn't been published yet. This fixes runtime panics that occur when calling methods on nil IPNS Record objects.

Changes:

- Add nil check in api\_ipns.go resolveIPNS() after GetPublished()
- Add nil check in janitor.go validateIPNSTarget() after GetPublished()
- Add test case for nil record scenario in api\_ipns\_test.go

Fixes panic: runtime error: invalid memory address or nil pointer dereference at github.com/ipfs/boxo/ipns.(\*Record).Value()

- `develop` <!-- branch-stack -->
  - **fix(api): add nil record checks to prevent nil pointer dereference** :point\_left:


---

<!-- kody-pr-summary:start -->
 This pull request fixes nil pointer dereference errors that occur when attempting to resolve IPNS names that have not yet been published.

**Changes Made:**

1. **IPNS Resolution API (`internal/api/api_ipns.go`)**: Added a nil check after fetching IPNS records to handle cases where a key exists but has no published record. Instead of crashing when attempting to access the record value, the API now returns a proper "IPNS name not found" error response.

2. **Website Janitor Service (`internal/service/website/janitor.go`)**: Added defensive nil checking when validating IPNS targets during the janitor's cleanup process. If an IPNS record is not found for a website's target hash, the service now logs a warning, marks the website status as "broken", and continues processing rather than causing a panic.

3. **Test Coverage (`internal/api/api_ipns_test.go`)**: Added a test case to verify the API correctly handles nil record responses by returning an appropriate HTTP 500 error.

**Impact:**
- Prevents application crashes when resolving unpublished IPNS keys
- Improves error handling by providing meaningful feedback to API consumers
- Ensures the website janitor can gracefully handle broken or unpublished IPNS references without interrupting the cleanup process
<!-- kody-pr-summary:end -->