### PR TITLE
fix: add canonical domain handling and HTTP error checking for PowerDNS

### DIFF
--- a/internal/service/dns/powerdns_client.go
+++ b/internal/service/dns/powerdns_client.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
+	"strings"
 
 	"go.lumeweb.com/portal/core"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/dns/powerdns"
@@ -37,8 +39,15 @@ func NewPowerDNSClient(baseURL, apiKey string, logger *core.Logger) (*PowerDNSCl
 func (c *PowerDNSClient) CreateZone(ctx context.Context, domain string, nameservers []string) (*powerdns.Zone, error) {
 	serverID := "localhost"
 
+	// PowerDNS requires canonical zone names with trailing dots
+	canonicalDomain := strings.TrimSuffix(domain, ".") + "."
+	c.logger.Debug("Creating zone in PowerDNS",
+		zap.String("domain", domain),
+		zap.String("canonical_domain", canonicalDomain),
+		zap.Strings("nameservers", nameservers))
+
 	zoneCreate := powerdns.ZoneCreate{
-		Name:        domain,
+		Name:        canonicalDomain,
 		Nameservers: &nameservers,
 	}
 
@@ -50,6 +59,12 @@ func (c *PowerDNSClient) CreateZone(ctx context.Context, domain string, nameserv
 		return nil, fmt.Errorf("failed to create zone: %w", err)
 	}
 	defer resp.Body.Close()
+
+	// Check HTTP status code
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		bodyBytes, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("PowerDNS API returned status %d, body: %s", resp.StatusCode, string(bodyBytes))
+	}
 
 	var zone powerdns.Zone
 	if err := json.NewDecoder(resp.Body).Decode(&zone); err != nil {

--- a/internal/service/dns/powerdns_client_test.go
+++ b/internal/service/dns/powerdns_client_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"go.lumeweb.com/portal/core"
@@ -514,6 +515,189 @@ func TestDeleteZoneIntegration(t *testing.T) {
 
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestCreateZoneCanonicalDomain(t *testing.T) {
+	tests := []struct {
+		name         string
+		inputDomain  string
+		expectedBody string
+		expectError  bool
+	}{
+		{
+			name:         "canonicalize domain without trailing dot",
+			inputDomain:  "example.com",
+			expectedBody: `{"name":"example.com."}`,
+			expectError:  false,
+		},
+		{
+			name:         "preserve existing trailing dot",
+			inputDomain:  "example.com.",
+			expectedBody: `{"name":"example.com."}`,
+			expectError:  false,
+		},
+		{
+			name:         "canonicalize subdomain without trailing dot",
+			inputDomain:  "test.example.com",
+			expectedBody: `{"name":"test.example.com."}`,
+			expectError:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				var body powerdns.ZoneCreate
+				if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+					t.Errorf("failed to decode request body: %v", err)
+				}
+
+				if body.Name != "example.com." && body.Name != "test.example.com." {
+					t.Errorf("expected canonical domain, got '%s'", body.Name)
+				}
+
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusCreated)
+				json.NewEncoder(w).Encode(powerdns.Zone{
+					Id:   strPtr(body.Name),
+					Name: strPtr(body.Name),
+					Kind: (*powerdns.ZoneKind)(strPtr("Native")),
+				})
+			}))
+			defer server.Close()
+
+			logger := zap.NewNop()
+			coreLogger := &core.Logger{Logger: logger}
+			client, err := NewPowerDNSClient(server.URL, "test-api-key", coreLogger)
+			if err != nil {
+				t.Fatalf("NewPowerDNSClient failed: %v", err)
+			}
+
+			ctx := context.Background()
+			zone, err := client.CreateZone(ctx, tt.inputDomain, []string{})
+
+			if tt.expectError && err == nil {
+				t.Error("expected error but got nil")
+			}
+
+			if !tt.expectError && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+
+			if !tt.expectError && zone != nil {
+				if zone.Name == nil {
+					t.Errorf("expected zone name, got nil")
+				} else if !strings.HasSuffix(*zone.Name, ".") {
+					t.Errorf("expected zone name to have trailing dot, got '%s'", *zone.Name)
+				}
+			}
+		})
+	}
+}
+
+func TestCreateZoneHTTPErrorHandling(t *testing.T) {
+	tests := []struct {
+		name          string
+		statusCode    int
+		errorBody     string
+		expectedError string
+	}{
+		{
+			name:          "HTTP 422 unprocessable entity with error message",
+			statusCode:    http.StatusUnprocessableEntity,
+			errorBody:     `{"error": "DNS Name 'test.example.com' is not canonical"}`,
+			expectedError: "PowerDNS API returned status 422",
+		},
+		{
+			name:          "HTTP 400 bad request",
+			statusCode:    http.StatusBadRequest,
+			errorBody:     `{"error": "Invalid request"}`,
+			expectedError: "PowerDNS API returned status 400",
+		},
+		{
+			name:          "HTTP 500 internal server error",
+			statusCode:    http.StatusInternalServerError,
+			errorBody:     `Internal Server Error`,
+			expectedError: "PowerDNS API returned status 500",
+		},
+		{
+			name:          "HTTP 404 not found",
+			statusCode:    http.StatusNotFound,
+			errorBody:     `{"error": "Not found"}`,
+			expectedError: "PowerDNS API returned status 404",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tt.statusCode)
+				w.Write([]byte(tt.errorBody))
+			}))
+			defer server.Close()
+
+			logger := zap.NewNop()
+			coreLogger := &core.Logger{Logger: logger}
+			client, err := NewPowerDNSClient(server.URL, "test-api-key", coreLogger)
+			if err != nil {
+				t.Fatalf("NewPowerDNSClient failed: %v", err)
+			}
+
+			ctx := context.Background()
+			zone, err := client.CreateZone(ctx, "example.com", []string{})
+
+			if err == nil {
+				t.Error("expected error but got nil")
+			}
+
+			if !strings.Contains(err.Error(), tt.expectedError) {
+				t.Errorf("expected error to contain %q, got %v", tt.expectedError, err)
+			}
+
+			if zone != nil {
+				t.Errorf("expected nil zone on error, got %v", zone)
+			}
+
+			if strings.Contains(err.Error(), tt.errorBody) {
+				t.Logf("✓ Error body included in error message: %v", err)
+			}
+		})
+	}
+}
+
+func TestCreateZoneErrorResponseBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		w.Write([]byte(`{"error": "DNS Name is not canonical", "details": "must end with a dot"}`))
+	}))
+	defer server.Close()
+
+	logger := zap.NewNop()
+	coreLogger := &core.Logger{Logger: logger}
+	client, err := NewPowerDNSClient(server.URL, "test-api-key", coreLogger)
+	if err != nil {
+		t.Fatalf("NewPowerDNSClient failed: %v", err)
+	}
+
+	ctx := context.Background()
+	zone, err := client.CreateZone(ctx, "invalid-domain", []string{})
+
+	if err == nil {
+		t.Fatal("expected error but got nil")
+	}
+
+	if zone != nil {
+		t.Errorf("expected nil zone on error, got %v", zone)
+	}
+
+	// Verify the error message includes the HTTP status and body
+	if !strings.Contains(err.Error(), "422") {
+		t.Errorf("expected error to contain status code 422, got %v", err)
+	}
+
+	if !strings.Contains(err.Error(), "DNS Name is not canonical") {
+		t.Errorf("expected error to contain PowerDNS error message, got %v", err)
 	}
 }
 

--- a/internal/service/dns/powerdns_client_test.go
+++ b/internal/service/dns/powerdns_client_test.go
@@ -528,19 +528,19 @@ func TestCreateZoneCanonicalDomain(t *testing.T) {
 		{
 			name:         "canonicalize domain without trailing dot",
 			inputDomain:  "example.com",
-			expectedBody: `{"name":"example.com."}`,
+			expectedBody: `{"kind":"Native","name":"example.com.","nameservers":[]}`,
 			expectError:  false,
 		},
 		{
 			name:         "preserve existing trailing dot",
 			inputDomain:  "example.com.",
-			expectedBody: `{"name":"example.com."}`,
+			expectedBody: `{"kind":"Native","name":"example.com.","nameservers":[]}`,
 			expectError:  false,
 		},
 		{
 			name:         "canonicalize subdomain without trailing dot",
 			inputDomain:  "test.example.com",
-			expectedBody: `{"name":"test.example.com."}`,
+			expectedBody: `{"kind":"Native","name":"test.example.com.","nameservers":[]}`,
 			expectError:  false,
 		},
 	}
@@ -548,8 +548,26 @@ func TestCreateZoneCanonicalDomain(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				// Read raw request body to compare with expectedBody
+				bodyBytes, err := io.ReadAll(r.Body)
+				if err != nil {
+					t.Errorf("failed to read request body: %v", err)
+				}
+
+				// Compare actual body with expected body
+				actualBody := string(bodyBytes)
+				expectedBody := tt.expectedBody
+
+				// Normalize whitespace for comparison
+				actualNormalized := strings.ReplaceAll(actualBody, " ", "")
+				expectedNormalized := strings.ReplaceAll(expectedBody, " ", "")
+
+				if !tt.expectError && actualNormalized != expectedNormalized {
+					t.Errorf("expected request body %q, got %q", expectedBody, actualBody)
+				}
+
 				var body powerdns.ZoneCreate
-				if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				if err := json.Unmarshal(bodyBytes, &body); err != nil {
 					t.Errorf("failed to decode request body: %v", err)
 				}
 


### PR DESCRIPTION
- Ensure PowerDNS zone names have trailing dots by canonicalizing input
- Add HTTP status code validation for CreateZone API responses
- Include response body in error messages for better debugging
- Add comprehensive tests for canonical domain handling
- Add tests for HTTP error status handling across various scenarios

* `develop` <!-- branch-stack -->
  - **fix: add canonical domain handling and HTTP error checking for PowerDNS** :point\_left:

***

<!-- kody-pr-summary:start -->

Fixes DNS zone creation issues with PowerDNS by ensuring domain names are properly canonicalized and improving error handling for API failures.

**Changes:**

- **Canonical Domain Formatting**: Ensures all domain names are converted to canonical format (with trailing dot) before sending to PowerDNS API, resolving "DNS Name is not canonical" validation errors
- **HTTP Error Handling**: Adds explicit checking for non-2xx HTTP status codes when creating zones, returning detailed error messages that include the HTTP status code and response body for improved debugging
- **Observability**: Adds debug logging to track domain canonicalization during zone creation

**Testing:**

- Added comprehensive test coverage for domain canonicalization scenarios (domains with/without trailing dots, subdomains)
- Added tests for HTTP error handling across various status codes (400, 404, 422, 500) to verify error messages include both status code and response body content

<!-- kody-pr-summary:end -->
