### PR TITLE
fix(powerdns): normalize nameserver format and DRY client implementation

### DIFF
--- a/internal/service/dns/powerdns_client.go
+++ b/internal/service/dns/powerdns_client.go
@@ -13,6 +13,9 @@ import (
 	"go.uber.org/zap"
 )
 
+// Default PowerDNS server ID for single-server deployments
+const defaultServerID = "localhost"
+
 // PowerDNSClient wraps the generated PowerDNS client
 type PowerDNSClient struct {
 	client *powerdns.Client
@@ -35,40 +38,59 @@ func NewPowerDNSClient(baseURL, apiKey string, logger *core.Logger) (*PowerDNSCl
 	}, nil
 }
 
+// handleResponse processes HTTP response, checking status code and decoding JSON
+// It safely closes the response body and returns an error if the status code is not 2xx
+func handleResponse[T any](resp *http.Response) (*T, error) {
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		bodyBytes, _ := io.ReadAll(resp.Body)
+		var zero T
+		return &zero, fmt.Errorf("PowerDNS API returned status %d, body: %s", resp.StatusCode, string(bodyBytes))
+	}
+
+	var result T
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		var zero T
+		return &zero, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return &result, nil
+}
+
 // CreateZone creates a new zone in PowerDNS
 func (c *PowerDNSClient) CreateZone(ctx context.Context, domain string, nameservers []string) (*powerdns.Zone, error) {
-	serverID := "localhost"
-
 	// PowerDNS requires canonical zone names with trailing dots
 	canonicalDomain := strings.TrimSuffix(domain, ".") + "."
+
+	// Normalize nameservers to canonical form (with trailing dots)
+	canonicalNameservers := make([]string, len(nameservers))
+	for i, ns := range nameservers {
+		canonicalNameservers[i] = strings.TrimSuffix(ns, ".") + "."
+	}
+
 	c.logger.Debug("Creating zone in PowerDNS",
 		zap.String("domain", domain),
 		zap.String("canonical_domain", canonicalDomain),
-		zap.Strings("nameservers", nameservers))
+		zap.Strings("nameservers", nameservers),
+		zap.Strings("canonical_nameservers", canonicalNameservers))
 
 	zoneCreate := powerdns.ZoneCreate{
 		Name:        canonicalDomain,
-		Nameservers: &nameservers,
+		Nameservers: &canonicalNameservers,
 	}
 
 	kind := powerdns.ZoneCreateKindNative
 	zoneCreate.Kind = &kind
 
-	resp, err := c.client.CreateZone(ctx, serverID, zoneCreate)
+	resp, err := c.client.CreateZone(ctx, defaultServerID, zoneCreate)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create zone: %w", err)
 	}
-	defer resp.Body.Close()
 
-	// Check HTTP status code
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		bodyBytes, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("PowerDNS API returned status %d, body: %s", resp.StatusCode, string(bodyBytes))
-	}
-
-	var zone powerdns.Zone
-	if err := json.NewDecoder(resp.Body).Decode(&zone); err != nil {
-		return nil, fmt.Errorf("failed to decode zone response: %w", err)
+	zone, err := handleResponse[powerdns.Zone](resp)
+	if err != nil {
+		return nil, err
 	}
 
 	if zone.Id == nil {
@@ -79,40 +101,32 @@ func (c *PowerDNSClient) CreateZone(ctx context.Context, domain string, nameserv
 		zap.String("domain", domain),
 		zap.String("zone_id", *zone.Id))
 
-	return &zone, nil
+	return zone, nil
 }
 
 // GetZone retrieves a zone from PowerDNS
 func (c *PowerDNSClient) GetZone(ctx context.Context, zoneID string) (*powerdns.Zone, error) {
-	serverID := "localhost"
-
-	resp, err := c.client.GetZone(ctx, serverID, zoneID)
+	resp, err := c.client.GetZone(ctx, defaultServerID, zoneID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get zone: %w", err)
 	}
-	defer resp.Body.Close()
 
-	var zone powerdns.Zone
-	if err := json.NewDecoder(resp.Body).Decode(&zone); err != nil {
-		return nil, fmt.Errorf("failed to decode zone response: %w", err)
-	}
-
-	return &zone, nil
+	return handleResponse[powerdns.Zone](resp)
 }
 
 // UpdateZoneRRSets updates RRsets in a zone
 func (c *PowerDNSClient) UpdateZoneRRSets(ctx context.Context, zoneID string, rrsets []powerdns.RRSet) error {
-	serverID := "localhost"
-
 	zonePatch := powerdns.ZonePatch{
 		Rrsets: &rrsets,
 	}
 
-	resp, err := c.client.UpdateZoneRRSets(ctx, serverID, zoneID, zonePatch)
+	resp, err := c.client.UpdateZoneRRSets(ctx, defaultServerID, zoneID, zonePatch)
 	if err != nil {
 		return fmt.Errorf("failed to update zone: %w", err)
 	}
-	defer resp.Body.Close()
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 
 	c.logger.Info("Zone RRsets updated in PowerDNS",
 		zap.String("zone_id", zoneID),
@@ -123,9 +137,7 @@ func (c *PowerDNSClient) UpdateZoneRRSets(ctx context.Context, zoneID string, rr
 
 // DeleteZone deletes a zone from PowerDNS
 func (c *PowerDNSClient) DeleteZone(ctx context.Context, zoneID string) error {
-	serverID := "localhost"
-
-	resp, err := c.client.DeleteZone(ctx, serverID, zoneID)
+	resp, err := c.client.DeleteZone(ctx, defaultServerID, zoneID)
 	if err != nil {
 		return fmt.Errorf("failed to delete zone: %w", err)
 	}

--- a/internal/service/dns/powerdns_client_test.go
+++ b/internal/service/dns/powerdns_client_test.go
@@ -613,6 +613,132 @@ func TestCreateZoneCanonicalDomain(t *testing.T) {
 		})
 	}
 }
+func TestCreateZoneCanonicalNameservers(t *testing.T) {
+	tests := []struct {
+		name           string
+		domain         string
+		nameservers    []string
+		expectedNS     []string
+		expectError    bool
+	}{
+		{
+			name:        "normalize nameservers without trailing dots",
+			domain:      "example.com",
+			nameservers: []string{"ns1.example.com", "ns2.example.com"},
+			expectedNS:  []string{"ns1.example.com.", "ns2.example.com."},
+			expectError: false,
+		},
+		{
+			name:        "preserve nameservers with trailing dots",
+			domain:      "example.com",
+			nameservers: []string{"ns1.example.com.", "ns2.example.com."},
+			expectedNS:  []string{"ns1.example.com.", "ns2.example.com."},
+			expectError: false,
+		},
+		{
+			name:        "mix of normalized and non-normalized nameservers",
+			domain:      "example.com",
+			nameservers: []string{"ns1.example.com", "ns2.example.com.", "ns3.example.com"},
+			expectedNS:  []string{"ns1.example.com.", "ns2.example.com.", "ns3.example.com."},
+			expectError: false,
+		},
+		{
+			name:        "single nameserver without trailing dot",
+			domain:      "example.com",
+			nameservers: []string{"ns1.example.com"},
+			expectedNS:  []string{"ns1.example.com."},
+			expectError: false,
+		},
+		{
+			name:        "empty nameserver list",
+			domain:      "example.com",
+			nameservers: []string{},
+			expectedNS:  []string{},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var capturedBody powerdns.ZoneCreate
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				// Read and parse request body
+				bodyBytes, err := io.ReadAll(r.Body)
+				if err != nil {
+					t.Errorf("failed to read request body: %v", err)
+				}
+
+				if err := json.Unmarshal(bodyBytes, &capturedBody); err != nil {
+					t.Errorf("failed to decode request body: %v", err)
+				}
+
+				// Verify nameservers are normalized
+				if capturedBody.Nameservers == nil {
+					t.Errorf("expected nameservers to be set, got nil")
+				}
+
+				actualNameservers := *capturedBody.Nameservers
+
+				if len(actualNameservers) != len(tt.expectedNS) {
+					t.Errorf("expected %d nameservers, got %d", len(tt.expectedNS), len(actualNameservers))
+				}
+
+				for i, expected := range tt.expectedNS {
+					if i >= len(actualNameservers) {
+						t.Errorf("missing nameserver at index %d", i)
+						break
+					}
+					if actualNameservers[i] != expected {
+						t.Errorf("expected nameserver[%d] to be %q, got %q", i, expected, actualNameservers[i])
+					}
+				}
+
+				// Verify all nameservers have trailing dots
+				for _, ns := range actualNameservers {
+					if !strings.HasSuffix(ns, ".") {
+						t.Errorf("expected nameserver '%s' to have trailing dot", ns)
+					}
+				}
+
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusCreated)
+				json.NewEncoder(w).Encode(powerdns.Zone{
+					Id:   strPtr(capturedBody.Name),
+					Name: strPtr(capturedBody.Name),
+					Kind: (*powerdns.ZoneKind)(strPtr("Native")),
+				})
+			}))
+			defer server.Close()
+
+			logger := zap.NewNop()
+			coreLogger := &core.Logger{Logger: logger}
+			client, err := NewPowerDNSClient(server.URL, "test-api-key", coreLogger)
+			if err != nil {
+				t.Fatalf("NewPowerDNSClient failed: %v", err)
+			}
+
+			ctx := context.Background()
+			zone, err := client.CreateZone(ctx, tt.domain, tt.nameservers)
+
+			if tt.expectError && err == nil {
+				t.Error("expected error but got nil")
+			}
+
+			if !tt.expectError && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+
+			if !tt.expectError && zone != nil {
+				if zone.Name == nil {
+					t.Errorf("expected zone name, got nil")
+				} else if !strings.HasSuffix(*zone.Name, ".") {
+					t.Errorf("expected zone name to have trailing dot, got '%s'", *zone.Name)
+				}
+			}
+		})
+	}
+}
 
 func TestCreateZoneHTTPErrorHandling(t *testing.T) {
 	tests := []struct {

--- a/internal/service/dns/powerdns_client_test.go
+++ b/internal/service/dns/powerdns_client_test.go
@@ -675,7 +675,7 @@ func TestCreateZoneCanonicalNameservers(t *testing.T) {
 
 				// Verify nameservers are normalized
 				if capturedBody.Nameservers == nil {
-					t.Errorf("expected nameservers to be set, got nil")
+					t.Fatalf("expected nameservers to be set, got nil")
 				}
 
 				actualNameservers := *capturedBody.Nameservers


### PR DESCRIPTION
- Normalize nameservers to canonical form (with trailing dots) in CreateZone
- Add comprehensive tests for nameserver normalization
- Refactor to reduce duplication:
  - Extract defaultServerID constant
  - Add generic handleResponse helper for response processing
- All methods now use consistent error handling patterns

* `develop` <!-- branch-stack -->
  - **fix(powerdns): normalize nameserver format and DRY client implementation** :point\_left:

***

<!-- kody-pr-summary:start -->

This pull request fixes nameserver format handling in the PowerDNS client and refactors the implementation to reduce code duplication.

**Key Changes:**

1. **Nameserver Normalization**: Fixed an issue where nameservers without trailing dots could cause DNS configuration problems. The client now automatically normalizes all nameservers to canonical format (with trailing dots) when creating zones, ensuring consistent DNS records regardless of input format.

2. **DRY Response Handling**: Extracted repetitive HTTP response processing logic into a reusable generic `handleResponse` function. This eliminates duplicate code across `CreateZone`, `GetZone`, and other methods while maintaining proper error handling and JSON decoding.

3. **Code Cleanup**: Replaced hardcoded "localhost" server ID references with a constant and added null safety checks for HTTP responses in zone update operations.

The changes include comprehensive test coverage verifying that nameservers are correctly normalized across various input scenarios (with/without trailing dots, mixed formats, single and multiple nameservers).

<!-- kody-pr-summary:end -->
