### PR TITLE
fix: add concrete DTOs for list responses in swagger docs

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -698,7 +698,7 @@ Returns paginated list of zones with filtering support.
 
 See also:.*`),
 				router.WithTags("DNS", "Zones"),
-				router.WithSuccessResponse(http.StatusOK, "List of zones", router.WithJSONContent(queryutil.Response[dto.ZoneListResponse]{})),
+				router.WithSuccessResponse(http.StatusOK, "List of zones", router.WithJSONContent(dto.ZoneListResponseResponse{})),
 			),
 		),
 		router.NewRoute(http.MethodGet, "/dns/zones/:id", a.getZone,
@@ -783,7 +783,7 @@ Returns paginated list of records with filtering support.
 See also:.*`),
 				router.WithTags("DNS", "Records"),
 				router.WithPathParam("id", "Zone ID", ""),
-				router.WithSuccessResponse(http.StatusOK, "List of records", router.WithJSONContent(queryutil.Response[dto.RecordResponse]{})),
+				router.WithSuccessResponse(http.StatusOK, "List of records", router.WithJSONContent(dto.RecordResponseResponse{})),
 			),
 		),
 		router.NewRoute(http.MethodGet, "/dns/zones/:id/records/:name/:type", a.getRecord,

--- a/internal/api/dto/dns.go
+++ b/internal/api/dto/dns.go
@@ -96,6 +96,19 @@ type ZoneListRequest struct {
 	Domain string `json:"domain,omitempty"` // Filter by domain (partial match)
 }
 
+// ZoneListResponseResponse is a swagger-only DTO that represents the paginated response for DNS zones.
+// It merges the generic queryutil.Response[*dto.ZoneListResponse] for OpenAPI documentation.
+//
+// This struct exists due to a TODO bug where queryutil.Response generics are not getting detected
+// properly as an array type in the swagger documentation generation. By providing a concrete struct,
+// we ensure the swagger docs correctly show the data field as an array of ZoneListResponse items.
+//
+// Note: This struct is only used for swagger documentation, not for actual encoding.
+type ZoneListResponseResponse struct {
+	Data  []ZoneListResponse `json:"data"`
+	Total int64              `json:"total"`
+}
+
 func (r ZoneListRequest) Schema() *zog.StructSchema {
 	return zog.Struct(zog.Shape{
 		"Status": config.ZogStringLike[string]().OneOf([]string{
@@ -184,6 +197,19 @@ type RecordListRequest struct {
 	Type  string `json:"type,omitempty"`  // Filter by record type
 	Name  string `json:"name,omitempty"`  // Filter by name (partial match)
 	Limit uint   `json:"limit,omitempty"` // Maximum number of records to return
+}
+
+// RecordResponseResponse is a swagger-only DTO that represents the paginated response for DNS records.
+// It merges the generic queryutil.Response[*dto.RecordResponse] for OpenAPI documentation.
+//
+// This struct exists due to a TODO bug where queryutil.Response generics are not getting detected
+// properly as an array type in the swagger documentation generation. By providing a concrete struct,
+// we ensure the swagger docs correctly show the data field as an array of RecordResponse items.
+//
+// Note: This struct is only used for swagger documentation, not for actual encoding.
+type RecordResponseResponse struct {
+	Data  []RecordResponse `json:"data"`
+	Total int64            `json:"total"`
 }
 
 func (r RecordListRequest) Schema() *zog.StructSchema {


### PR DESCRIPTION
Add concrete ZoneListResponseResponse and RecordResponseResponse structs to fix type mismatches in client code generation. The queryutil.Response\[T] generic type gets detected as a single object instead of an array in swagger docs, so these concrete structs ensure correct array type representation.

Changes:

- Add ZoneListResponseResponse with Data \[]ZoneListResponse (array)
- Add RecordResponseResponse with Data \[]RecordResponse (array)
- Update listZones route to use ZoneListResponseResponse
- Update listRecords route to use RecordResponseResponse

* `develop` <!-- branch-stack -->
  - **fix: add concrete DTOs for list responses in swagger docs** :point\_left:


---

<!-- kody-pr-summary:start -->
 Fix Swagger/OpenAPI documentation generation for DNS list endpoints by introducing concrete DTOs to replace generic response types.

**Changes:**
- Added `ZoneListResponseResponse` and `RecordResponseResponse` concrete structs to properly represent paginated list responses in Swagger documentation
- Updated DNS zones list endpoint (`/dns/zones`) and DNS records list endpoint (`/dns/zones/:id/records`) to use the new concrete response types for API documentation

**Purpose:**
Resolves a documentation generation issue where `queryutil.Response` generic types were not being properly detected as array types in the Swagger docs. The concrete DTOs ensure the generated OpenAPI specification correctly shows the `data` field as an array of zone or record items, while maintaining the existing paginated response structure (`data` array + `total` count) in the actual API responses.
<!-- kody-pr-summary:end -->