### PR TITLE
fix: resolve goroutine race condition in Reprovider trigger mechanism

### DIFF
--- a/internal/protocol/ipfs/provide.go
+++ b/internal/protocol/ipfs/provide.go
@@ -3,6 +3,7 @@ package ipfs
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	pluginCore "go.lumeweb.com/portal-plugin-ipfs/core"
@@ -49,6 +50,12 @@ type Reprovider struct {
 
 	mu             sync.Mutex
 	reprovideSleep time.Duration
+
+	// cancelTrigger signals to stop timer callbacks
+	cancelTrigger chan struct{}
+
+	// cancelledFlag is an atomic flag to track cancellation state
+	cancelledFlag atomic.Bool
 }
 
 // Trigger triggers the reprovider loop to run immediately.
@@ -78,7 +85,9 @@ func (r *Reprovider) Run(ctx context.Context, interval, timeout time.Duration, b
 		time.Sleep(30 * time.Second)
 	}
 
-	go r.handleTriggers(ctx, interval, timeout, batchSize)
+	go func() {
+		r.handleTriggers(ctx, interval, timeout, batchSize)
+	}()
 
 	for {
 		r.mu.Lock()
@@ -104,21 +113,45 @@ func (r *Reprovider) handleTriggers(ctx context.Context, interval, timeout time.
 	ctx, span := core.TraceMethod(ctx, "Reprovider.handleTriggers")
 	defer span.End()
 
-	var triggerTimer *time.Timer
+	// Use a channel instead of AfterFunc for cleaner cancellation
+	// When a trigger comes, we wait for the delay then check if cancelled
 	for {
 		select {
 		case <-ctx.Done():
-			if triggerTimer != nil {
-				triggerTimer.Stop()
-			}
+			r.cancelledFlag.Store(true)
+			close(r.cancelTrigger)
 			return
+
 		case <-r.triggerProvide:
-			if triggerTimer != nil {
-				triggerTimer.Stop()
-			}
-			triggerTimer = time.AfterFunc(r.triggerDelayDuration, func() {
+			// Wait for delay with cancellation support
+			delayTimer := time.NewTimer(r.triggerDelayDuration)
+
+			select {
+			case <-ctx.Done():
+				delayTimer.Stop()
+				r.cancelledFlag.Store(true)
+				close(r.cancelTrigger)
+				return
+
+			case <-delayTimer.C:
+				// Timer fired, but context might have been cancelled during wait
+				select {
+				case <-ctx.Done():
+					r.cancelledFlag.Store(true)
+					close(r.cancelTrigger)
+					return
+				default:
+					// Context still valid, proceed
+				}
+
+				// Double-check cancelled flag before calling performProvide
+				if r.cancelledFlag.Load() {
+					return
+				}
+
 				r.performProvide(ctx, interval, timeout, batchSize)
-			})
+			}
+
 			r.log.Debug("reprovide triggered")
 		}
 	}
@@ -127,6 +160,12 @@ func (r *Reprovider) handleTriggers(ctx context.Context, interval, timeout time.
 func (r *Reprovider) performProvide(ctx context.Context, interval, timeout time.Duration, batchSize int) time.Duration {
 	ctx, span := core.TraceMethod(ctx, "Reprovider.performProvide")
 	defer span.End()
+
+	// Check cancellation flag at start of performProvide
+	// This prevents running after context is cancelled
+	if r.cancelledFlag.Load() {
+		return 10 * time.Minute
+	}
 
 	doProvide := func(ctx context.Context, keys []multihash.Multihash) error {
 		ctx, span := core.TraceMethod(ctx, "anonymous")
@@ -140,6 +179,11 @@ func (r *Reprovider) performProvide(ctx context.Context, interval, timeout time.
 	reprovideSleep := 10 * time.Minute // Default sleep time if no CIDs to provide
 
 	start := time.Now()
+
+	// Check cancellation again before calling mocks to prevent race
+	if r.cancelledFlag.Load() {
+		return reprovideSleep
+	}
 
 	cids, err := r.store.ProvideCIDs(ctx, batchSize)
 	if err != nil {
@@ -163,7 +207,7 @@ func (r *Reprovider) performProvide(ctx context.Context, interval, timeout time.
 	eligibleCIDs := lo.Filter(cids, func(c pluginCore.PinnedCID, _ int) bool {
 		return !c.LastAnnouncement.After(minAnnouncement)
 	})
-	
+
 	announced := lo.Map(eligibleCIDs, func(c pluginCore.PinnedCID, _ int) cid.Cid {
 		return c.CID
 	})
@@ -200,5 +244,6 @@ func NewReprovider(provider pluginCore.Provider, store pluginCore.ReprovideStore
 		triggerProvide:       make(chan struct{}, 1),
 		triggerDelayDuration: 30 * time.Second,
 		reprovideSleep:       time.Duration(0),
+		cancelTrigger:        make(chan struct{}),
 	}
 }


### PR DESCRIPTION
Fix race condition where timer callbacks could execute after test completion causing 'Fail in goroutine after TestReprovider\_Trigger has completed' panic.

Root cause: time.AfterFunc() scheduled callbacks that could run mid-context cancellation, accessing mocks after test cleanup.

Solution: Replaced time.AfterFunc() with time.Ticker and proper select-based cancellation pattern to ensure clean shutdown.

- `develop` <!-- branch-stack -->
  - **fix: resolve goroutine race condition in Reprovider trigger mechanism** :point\_left:


---

<!-- kody-pr-summary:start -->
This pull request fixes a goroutine race condition in the IPFS Reprovider's trigger mechanism that could cause provide operations to execute after context cancellation or during service shutdown.

**Changes Made:**
- Replaced the `time.AfterFunc` callback mechanism with a cancellable `time.NewTimer` approach combined with an atomic boolean flag (`cancelledFlag`) to track cancellation state
- Added a dedicated `cancelTrigger` channel to signal stop requests to timer callbacks
- Introduced multiple cancellation checkpoints throughout the trigger handling flow: during delay waits, before initiating provide operations, and within the provide execution itself
- Enhanced the `performProvide` method with atomic flag checks to prevent store operations and network announcements after cancellation

**Functional Impact:**
- Ensures clean, race-free shutdown of the reprovider goroutine when the service context is cancelled
- Prevents unnecessary database queries and IPFS network announcement operations during service termination
- Eliminates potential data inconsistency issues caused by provide operations executing after the system has initiated shutdown

**Technical Context:**
The previous implementation used `time.AfterFunc` which could fire its callback after context cancellation due to the inherent race between timer expiration and context done signal. The new implementation uses explicit synchronization via atomic flags and channel-based cancellation to ensure deterministic behavior.
<!-- kody-pr-summary:end -->