### PR TITLE
fix(dns): return proper HTTP status codes for DNS records API

### DIFF
--- a/internal/api/api_dns.go
+++ b/internal/api/api_dns.go
@@ -327,7 +327,7 @@ func (a *API) createRecord(c echo.Context) error {
 	record, err := a.dnsService.CreateRecord(reqCtx, zoneID, req.Name, req.Type, req.Content, ttl)
 	if err != nil {
 		a.Logger().Error("Failed to create DNS record", zap.Error(err), zap.Uint("zone_id", zoneID))
-		apiErr := NewError(mapDNSErrorToAPIError(err), err)
+		apiErr := NewError(mapDNSErrorToAPIError(err, "record"), err)
 		return ctx.Error(apiErr, apiErr.HttpStatus())
 	}
 
@@ -363,7 +363,7 @@ func (a *API) updateRecord(c echo.Context) error {
 	records, err := a.dnsService.UpdateRecord(reqCtx, zoneID, name, recordType, []string{req.Content}, ttl)
 	if err != nil {
 		a.Logger().Error("Failed to update DNS record", zap.Error(err), zap.String("name", name), zap.String("type", recordType))
-		apiErr := NewError(mapDNSErrorToAPIError(err), err)
+		apiErr := NewError(mapDNSErrorToAPIError(err, "record"), err)
 		return ctx.Error(apiErr, apiErr.HttpStatus())
 	}
 
@@ -396,7 +396,7 @@ func (a *API) deleteRecord(c echo.Context) error {
 	err = a.dnsService.DeleteRecord(reqCtx, zoneID, name, recordType)
 	if err != nil {
 		a.Logger().Error("Failed to delete DNS record", zap.Error(err), zap.String("name", name), zap.String("type", recordType))
-		apiErr := NewError(mapDNSErrorToAPIError(err), err)
+		apiErr := NewError(mapDNSErrorToAPIError(err, "record"), err)
 		return ctx.Error(apiErr, apiErr.HttpStatus())
 	}
 

--- a/internal/api/api_dns.go
+++ b/internal/api/api_dns.go
@@ -327,7 +327,7 @@ func (a *API) createRecord(c echo.Context) error {
 	record, err := a.dnsService.CreateRecord(reqCtx, zoneID, req.Name, req.Type, req.Content, ttl)
 	if err != nil {
 		a.Logger().Error("Failed to create DNS record", zap.Error(err), zap.Uint("zone_id", zoneID))
-		apiErr := NewError(ErrKeyDuplicateRecord, err)
+		apiErr := NewError(mapDNSErrorToAPIError(err), err)
 		return ctx.Error(apiErr, apiErr.HttpStatus())
 	}
 
@@ -363,7 +363,7 @@ func (a *API) updateRecord(c echo.Context) error {
 	records, err := a.dnsService.UpdateRecord(reqCtx, zoneID, name, recordType, []string{req.Content}, ttl)
 	if err != nil {
 		a.Logger().Error("Failed to update DNS record", zap.Error(err), zap.String("name", name), zap.String("type", recordType))
-		apiErr := NewError(ErrKeyRecordNotFound, err)
+		apiErr := NewError(mapDNSErrorToAPIError(err), err)
 		return ctx.Error(apiErr, apiErr.HttpStatus())
 	}
 
@@ -396,7 +396,7 @@ func (a *API) deleteRecord(c echo.Context) error {
 	err = a.dnsService.DeleteRecord(reqCtx, zoneID, name, recordType)
 	if err != nil {
 		a.Logger().Error("Failed to delete DNS record", zap.Error(err), zap.String("name", name), zap.String("type", recordType))
-		apiErr := NewError(ErrKeyRecordNotFound, err)
+		apiErr := NewError(mapDNSErrorToAPIError(err), err)
 		return ctx.Error(apiErr, apiErr.HttpStatus())
 	}
 

--- a/internal/api/dns_helpers.go
+++ b/internal/api/dns_helpers.go
@@ -2,13 +2,16 @@ package api
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/labstack/echo/v4"
 	"github.com/samber/lo"
 	"go.lumeweb.com/httputil"
 	mcontext "go.lumeweb.com/portal-middleware/context"
+	"go.lumeweb.com/portal/core"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/db"
 	"gorm.io/gorm"
 )
@@ -88,4 +91,61 @@ func parseZoneIDParamWithResponse(c echo.Context) (uint, error) {
 // handleNoContent returns a 204 No Content response
 func handleNoContent(c echo.Context) error {
 	return c.NoContent(http.StatusNoContent)
+}
+
+// mapDNSErrorToAPIError converts DNS service errors to appropriate API error types
+// Returns the correct error key to ensure proper HTTP status codes:
+// - ErrKeyZoneNotFound (404): when the zone or zone-related resource is not found
+// - ErrKeyDuplicateRecord (409): when PowerDNS returns a 409 Conflict
+// - ErrKeyValidationFailed (422): when PowerDNS returns a 422 Unprocessable Entity
+// - ErrKeyUpdateFailed (500): for all other internal errors
+func mapDNSErrorToAPIError(err error) core.ErrorType {
+	if err == nil {
+		return ErrKeyUpdateFailed
+	}
+
+	// Check for gorm.ErrRecordNotFound (zone not found in database)
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return ErrKeyZoneNotFound
+	}
+
+	// Check for PowerDNS API errors by examining the error message
+	// The handleResponse function in powerdns_client.go includes the HTTP status code
+	errMsg := err.Error()
+
+	// Check for HTTP 409 Conflict (duplicate record)
+	if containsStatusCode(errMsg, 409) {
+		return ErrKeyDuplicateRecord
+	}
+
+	// Check for HTTP 404 Not Found from PowerDNS
+	if containsStatusCode(errMsg, 404) {
+		return ErrKeyZoneNotFound
+	}
+
+	// Check for HTTP 422 Unprocessable Entity (validation error)
+	if containsStatusCode(errMsg, 422) {
+		return ErrKeyValidationFailed
+	}
+
+	// For all other errors, return 500 Internal Server Error
+	return ErrKeyUpdateFailed
+}
+
+// containsStatusCode checks if an error message contains a specific HTTP status code
+func containsStatusCode(errMsg string, statusCode int) bool {
+	// Look for patterns like "status 409", "returned 409", "HTTP 409", etc.
+	patterns := []string{
+		fmt.Sprintf("status %d", statusCode),
+		fmt.Sprintf("returned %d", statusCode),
+		fmt.Sprintf("HTTP %d", statusCode),
+		fmt.Sprintf("%d", statusCode),
+	}
+
+	for _, pattern := range patterns {
+		if strings.Contains(errMsg, pattern) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/api/dns_helpers.go
+++ b/internal/api/dns_helpers.go
@@ -95,17 +95,25 @@ func handleNoContent(c echo.Context) error {
 
 // mapDNSErrorToAPIError converts DNS service errors to appropriate API error types
 // Returns the correct error key to ensure proper HTTP status codes:
-// - ErrKeyZoneNotFound (404): when the zone or zone-related resource is not found
+// - ErrKeyZoneNotFound (404): when zone is not found
+// - ErrKeyRecordNotFound (404): when DNS record is not found
 // - ErrKeyDuplicateRecord (409): when PowerDNS returns a 409 Conflict
 // - ErrKeyValidationFailed (422): when PowerDNS returns a 422 Unprocessable Entity
 // - ErrKeyUpdateFailed (500): for all other internal errors
-func mapDNSErrorToAPIError(err error) core.ErrorType {
+//
+// The resourceType parameter distinguishes between zone and record not found errors:
+// - "zone": returns ErrKeyZoneNotFound for gorm.ErrRecordNotFound
+// - "record": returns ErrKeyRecordNotFound for gorm.ErrRecordNotFound
+func mapDNSErrorToAPIError(err error, resourceType string) core.ErrorType {
 	if err == nil {
 		return ErrKeyUpdateFailed
 	}
 
-	// Check for gorm.ErrRecordNotFound (zone not found in database)
+	// Check for gorm.ErrRecordNotFound - distinguish based on resource type
 	if errors.Is(err, gorm.ErrRecordNotFound) {
+		if resourceType == "record" {
+			return ErrKeyRecordNotFound
+		}
 		return ErrKeyZoneNotFound
 	}
 
@@ -134,12 +142,12 @@ func mapDNSErrorToAPIError(err error) core.ErrorType {
 
 // containsStatusCode checks if an error message contains a specific HTTP status code
 func containsStatusCode(errMsg string, statusCode int) bool {
-	// Look for patterns like "status 409", "returned 409", "HTTP 409", etc.
+	// Look for specific status code patterns with word boundaries to avoid false positives
 	patterns := []string{
 		fmt.Sprintf("status %d", statusCode),
 		fmt.Sprintf("returned %d", statusCode),
 		fmt.Sprintf("HTTP %d", statusCode),
-		fmt.Sprintf("%d", statusCode),
+		fmt.Sprintf("code %d", statusCode),
 	}
 
 	for _, pattern := range patterns {

--- a/internal/api/dns_helpers_test.go
+++ b/internal/api/dns_helpers_test.go
@@ -13,53 +13,74 @@ func TestMapDNSErrorToAPIError(t *testing.T) {
 	tests := []struct {
 		name         string
 		err          error
+		resourceType string
 		expectedKey  core.ErrorType
 	}{
 		{
-			name:        "nil error",
-			err:         nil,
-			expectedKey: ErrKeyUpdateFailed,
+			name:         "nil error",
+			err:          nil,
+			resourceType: "zone",
+			expectedKey:  ErrKeyUpdateFailed,
 		},
 		{
-			name:        "gorm record not found",
-			err:         gorm.ErrRecordNotFound,
-			expectedKey: ErrKeyZoneNotFound,
+			name:         "gorm zone not found",
+			err:          gorm.ErrRecordNotFound,
+			resourceType: "zone",
+			expectedKey:  ErrKeyZoneNotFound,
 		},
 		{
-			name:        "wrapped gorm error",
-			err:         fmt.Errorf("wrapped: %w", gorm.ErrRecordNotFound),
-			expectedKey: ErrKeyZoneNotFound,
+			name:         "gorm record not found",
+			err:          gorm.ErrRecordNotFound,
+			resourceType: "record",
+			expectedKey:  ErrKeyRecordNotFound,
 		},
 		{
-			name:        "powerdns 409 conflict",
-			err:         fmt.Errorf("PowerDNS API returned status 409, body: error"),
-			expectedKey: ErrKeyDuplicateRecord,
+			name:         "wrapped gorm error for record",
+			err:          fmt.Errorf("wrapped: %w", gorm.ErrRecordNotFound),
+			resourceType: "record",
+			expectedKey:  ErrKeyRecordNotFound,
 		},
 		{
-			name:        "powerdns 404 not found",
-			err:         fmt.Errorf("PowerDNS API returned status 404, body: zone not found"),
-			expectedKey: ErrKeyZoneNotFound,
+			name:         "wrapped gorm error for zone",
+			err:          fmt.Errorf("wrapped: %w", gorm.ErrRecordNotFound),
+			resourceType: "zone",
+			expectedKey:  ErrKeyZoneNotFound,
 		},
 		{
-			name:        "powerdns 422 validation error",
-			err:         fmt.Errorf("PowerDNS API returned status 422, body: validation failed"),
-			expectedKey: ErrKeyValidationFailed,
+			name:         "powerdns 409 conflict",
+			err:          fmt.Errorf("PowerDNS API returned status 409, body: error"),
+			resourceType: "record",
+			expectedKey:  ErrKeyDuplicateRecord,
 		},
 		{
-			name:        "internal server error",
-			err:         fmt.Errorf("internal error"),
-			expectedKey: ErrKeyUpdateFailed,
+			name:         "powerdns 404 not found",
+			err:          fmt.Errorf("PowerDNS API returned status 404, body: zone not found"),
+			resourceType: "zone",
+			expectedKey:  ErrKeyZoneNotFound,
 		},
 		{
-			name:        "powerdns 500 error",
-			err:         fmt.Errorf("PowerDNS API returned status 500, body: server error"),
-			expectedKey: ErrKeyUpdateFailed,
+			name:         "powerdns 422 validation error",
+			err:          fmt.Errorf("PowerDNS API returned status 422, body: validation failed"),
+			resourceType: "record",
+			expectedKey:  ErrKeyValidationFailed,
+		},
+		{
+			name:         "internal server error",
+			err:          fmt.Errorf("internal error"),
+			resourceType: "zone",
+			expectedKey:  ErrKeyUpdateFailed,
+		},
+		{
+			name:         "powerdns 500 error",
+			err:          fmt.Errorf("PowerDNS API returned status 500, body: server error"),
+			resourceType: "record",
+			expectedKey:  ErrKeyUpdateFailed,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := mapDNSErrorToAPIError(tt.err)
+			result := mapDNSErrorToAPIError(tt.err, tt.resourceType)
 			assert.Equal(t, tt.expectedKey, result)
 		})
 	}
@@ -91,10 +112,22 @@ func TestContainsStatusCode(t *testing.T) {
 			expected:   true,
 		},
 		{
-			name:       "plain 500 in message",
+			name:       "code 500 in message",
 			errMsg:     "error code 500",
 			statusCode: 500,
 			expected:   true,
+		},
+		{
+			name:       "number 409 in timeout should not false positive",
+			errMsg:     "timeout after 4090ms",
+			statusCode: 409,
+			expected:   false,
+		},
+		{
+			name:       "number 404 in ID should not false positive",
+			errMsg:     "record id 4041 not found",
+			statusCode: 404,
+			expected:   false,
 		},
 		{
 			name:       "no status code",

--- a/internal/api/dns_helpers_test.go
+++ b/internal/api/dns_helpers_test.go
@@ -1,0 +1,119 @@
+package api
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.lumeweb.com/portal/core"
+	"gorm.io/gorm"
+)
+
+func TestMapDNSErrorToAPIError(t *testing.T) {
+	tests := []struct {
+		name         string
+		err          error
+		expectedKey  core.ErrorType
+	}{
+		{
+			name:        "nil error",
+			err:         nil,
+			expectedKey: ErrKeyUpdateFailed,
+		},
+		{
+			name:        "gorm record not found",
+			err:         gorm.ErrRecordNotFound,
+			expectedKey: ErrKeyZoneNotFound,
+		},
+		{
+			name:        "wrapped gorm error",
+			err:         fmt.Errorf("wrapped: %w", gorm.ErrRecordNotFound),
+			expectedKey: ErrKeyZoneNotFound,
+		},
+		{
+			name:        "powerdns 409 conflict",
+			err:         fmt.Errorf("PowerDNS API returned status 409, body: error"),
+			expectedKey: ErrKeyDuplicateRecord,
+		},
+		{
+			name:        "powerdns 404 not found",
+			err:         fmt.Errorf("PowerDNS API returned status 404, body: zone not found"),
+			expectedKey: ErrKeyZoneNotFound,
+		},
+		{
+			name:        "powerdns 422 validation error",
+			err:         fmt.Errorf("PowerDNS API returned status 422, body: validation failed"),
+			expectedKey: ErrKeyValidationFailed,
+		},
+		{
+			name:        "internal server error",
+			err:         fmt.Errorf("internal error"),
+			expectedKey: ErrKeyUpdateFailed,
+		},
+		{
+			name:        "powerdns 500 error",
+			err:         fmt.Errorf("PowerDNS API returned status 500, body: server error"),
+			expectedKey: ErrKeyUpdateFailed,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := mapDNSErrorToAPIError(tt.err)
+			assert.Equal(t, tt.expectedKey, result)
+		})
+	}
+}
+
+func TestContainsStatusCode(t *testing.T) {
+	tests := []struct {
+		name       string
+		errMsg     string
+		statusCode int
+		expected   bool
+	}{
+		{
+			name:       "status 409 in message",
+			errMsg:     "PowerDNS API returned status 409, body: conflict",
+			statusCode: 409,
+			expected:   true,
+		},
+		{
+			name:       "returned 404 in message",
+			errMsg:     "API returned 404 not found",
+			statusCode: 404,
+			expected:   true,
+		},
+		{
+			name:       "HTTP 422 in message",
+			errMsg:     "HTTP 422 unprocessable entity",
+			statusCode: 422,
+			expected:   true,
+		},
+		{
+			name:       "plain 500 in message",
+			errMsg:     "error code 500",
+			statusCode: 500,
+			expected:   true,
+		},
+		{
+			name:       "no status code",
+			errMsg:     "general error",
+			statusCode: 409,
+			expected:   false,
+		},
+		{
+			name:       "different status code",
+			errMsg:     "status 404",
+			statusCode: 409,
+			expected:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := containsStatusCode(tt.errMsg, tt.statusCode)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
The createRecord, updateRecord, and deleteRecord handlers were returning correct 409 Conflict regardless of the actual error type. This commit introduces proper error code mapping to ensure the correct HTTP status codes are returned:

- 404 (Not Found): when zone or record is not found
- 409 (Conflict): when PowerDNS returns actual duplicate error
- 422 (Unprocessable Entity): validation errors from PowerDNS
- 500 (Internal Server Error): all other internal errors

Changes:

- Add mapDNSErrorToAPIError() helper to map errors to appropriate API error types
- Add containsStatusCode() helper to parse PowerDNS HTTP status codes from errors
- Update createRecord, updateRecord, deleteRecord to use mapDNSErrorToAPIError()
- Add comprehensive tests for error mapping helper functions

This ensures clients receive accurate HTTP status codes that reflect the actual error conditions, improving API error handling and debugging.

- `develop` <!-- branch-stack -->
  - **fix(dns): return proper HTTP status codes for DNS records API** :point\_left:

***

<!-- kody-pr-summary:start -->

**fix(dns): return proper HTTP status codes for DNS records API**

**Description:**

Fixes the DNS records API endpoints (`createRecord`, `updateRecord`, `deleteRecord`) to return accurate HTTP status codes based on the actual error condition, rather than returning generic or incorrect status codes.

**Changes:**

- **Error Mapping**: Introduced a centralized error mapping function that translates DNS service errors (including PowerDNS API responses and database errors) to appropriate API error types:
  - `404 Not Found` for missing zones or zone-related resources
  - `409 Conflict` for duplicate DNS records
  - `422 Unprocessable Entity` for validation failures
  - `500 Internal Server Error` for other internal errors

- **API Endpoints Updated**: Modified `createRecord`, `updateRecord`, and `deleteRecord` handlers to use the new error mapping logic instead of hardcoded error keys.

- **Test Coverage**: Added comprehensive unit tests validating the error mapping logic for various error scenarios including database record-not-found errors, wrapped errors, and PowerDNS API error responses (409, 404, 422, 500).

**Impact:**

Clients of the DNS records API will now receive semantically correct HTTP status codes that accurately reflect the nature of the error, enabling better error handling and debugging on the client side.

<!-- kody-pr-summary:end -->
