### PR TITLE
fix: RRSet not found error by canonicalizing DNS names with trailing dots

### DIFF
--- a/internal/service/dns/dns_helpers.go
+++ b/internal/service/dns/dns_helpers.go
@@ -36,11 +36,26 @@ func (s *DNSServiceDefault) getZoneWithPowerDNS(ctx context.Context, zoneID uint
 }
 
 // buildFullName constructs the full DNS record name from a name and domain
+// Returns a canonical DNS name (with trailing dot) as required by PowerDNS API
 func buildFullName(name, domain string) string {
-	if name != domain && !strings.HasSuffix(name, "."+domain) {
-		return name + "." + domain
+	// Normalize both name and domain (strip trailing dots for comparison)
+	nameNoDot := strings.TrimSuffix(name, ".")
+	domainNoDot := strings.TrimSuffix(domain, ".")
+	
+	// If name is the zone apex (equals domain), return canonical domain
+	if nameNoDot == domainNoDot {
+		return domainNoDot + "."
 	}
-	return name
+	
+	// If name already contains the domain
+	if strings.HasSuffix(nameNoDot, "."+domainNoDot) {
+		// Return it canonically normalized (with trailing dot)
+		return nameNoDot + "."
+	}
+	
+	// Otherwise, construct the full name and canonicalize
+	fullName := nameNoDot + "." + domainNoDot
+	return fullName + "."
 }
 
 // stripDomain removes the domain suffix from a full DNS name

--- a/internal/service/dns/dns_helpers_test.go
+++ b/internal/service/dns/dns_helpers_test.go
@@ -1,6 +1,7 @@
 package dns
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -112,4 +113,393 @@ $TTL 3600
 	assert.Error(t, err)
 	assert.Nil(t, records)
 	assert.Contains(t, err.Error(), "no resource records")
+}
+
+// TestBuildFullName_RelativeName tests building full names from relative record names
+func TestBuildFullName_RelativeName(t *testing.T) {
+	tests := []struct {
+		name     string
+		domain   string
+		expected string
+	}{
+		{
+			name:     "www",
+			domain:   "example.com",
+			expected: "www.example.com.",
+		},
+		{
+			name:     "api",
+			domain:   "test.org",
+			expected: "api.test.org.",
+		},
+		{
+			name:     "mail",
+			domain:   "sub.example.com",
+			expected: "mail.sub.example.com.",
+		},
+		{
+			name:     "test-record",
+			domain:   "7a9dcb27.example.com",
+			expected: "test-record.7a9dcb27.example.com.",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := buildFullName(tt.name, tt.domain)
+			assert.Equal(t, tt.expected, result, "buildFullName(%q, %q)", tt.name, tt.domain)
+		})
+	}
+}
+
+// TestBuildFullName_EdgeCases tests edge cases and boundary conditions
+func TestBuildFullName_EdgeCases(t *testing.T) {
+	tests := []struct {
+		name     string
+		domain   string
+		expected string
+	}{
+		{
+			name:     "a",
+			domain:   "b.com",
+			expected: "a.b.com.",
+		},
+		{
+			name:     "a",
+			domain:   "b.c.d.com",
+			expected: "a.b.c.d.com.",
+		},
+		{
+			name:     "*",
+			domain:   "example.com",
+			expected: "*.example.com.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := buildFullName(tt.name, tt.domain)
+			assert.Equal(t, tt.expected, result, "buildFullName(%q, %q)", tt.name, tt.domain)
+		})
+	}
+}
+
+// TestBuildFullName_CaseSensitivity tests that function is case-preserving but DNS is case-insensitive
+func TestBuildFullName_CaseSensitivity(t *testing.T) {
+	name := "WWW"
+	domain := "EXAMPLE.COM"
+	result := buildFullName(name, domain)
+
+	// The result should preserve the input case
+	assert.Equal(t, "WWW.EXAMPLE.COM.", result)
+}
+
+// TestStripDomain tests removal of domain suffix from full DNS names
+func TestStripDomain(t *testing.T) {
+	tests := []struct {
+		name     string
+		domain   string
+		expected string
+	}{
+		{
+			name:     "www.example.com",
+			domain:   "example.com",
+			expected: "www",
+		},
+		{
+			name:     "api.test.org",
+			domain:   "test.org",
+			expected: "api",
+		},
+		{
+			name:     "sub.sub.domain.example.com",
+			domain:   "example.com",
+			expected: "sub.sub.domain",
+		},
+		{
+			name:     "example.com",
+			domain:   "example.com",
+			expected: "example.com",
+		},
+		{
+			name:     "www",
+			domain:   "example.com",
+			expected: "www",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := stripDomain(tt.name, tt.domain)
+			assert.Equal(t, tt.expected, result, "stripDomain(%q, %q)", tt.name, tt.domain)
+		})
+	}
+}
+
+// TestBuildFullNameIdentity tests that buildFullName followed by stripDomain returns original name
+func TestBuildFullNameIdentity(t *testing.T) {
+	tests := []struct {
+		relativeName string
+		domainBase   string
+	}{
+		{"www", "example.com"},
+		{"api", "test.org"},
+		{"mail", "sub.example.com"},
+		{"a.b.c", "example.com"},
+		{"api.v1", "service.example.com"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.relativeName, func(t *testing.T) {
+			fullName := buildFullName(tt.relativeName, tt.domainBase)
+			// stripDomain needs the full name without trailing dot to properly match
+			strippedName := stripDomain(strings.TrimSuffix(fullName, "."), tt.domainBase)
+			assert.Equal(t, tt.relativeName, strippedName,
+				"When stripping domain from buildFullName result, should get original name: %q -> buildFullName -> %q -> stripDomain -> %q",
+				tt.relativeName, fullName, strippedName)
+		})
+	}
+}
+
+// TestGetDefaultTTL tests the default TTL helper function
+func TestGetDefaultTTL(t *testing.T) {
+	tests := []struct {
+		ttl      uint
+		expected uint
+	}{
+		{0, 3600},
+		{1800, 1800},
+		{3600, 3600},
+		{86400, 86400},
+	}
+	for _, tt := range tests {
+		t.Run("", func(t *testing.T) {
+			result := getDefaultTTL(tt.ttl)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// TestBuildFullNameRoundTrip verifies that buildFullName followed by stripDomain returns original name
+func TestBuildFullNameRoundTrip(t *testing.T) {
+	testCases := []struct {
+		name   string
+		domain string
+	}{
+		{"www", "example.com"},
+		{"api", "test.org"},
+		{"deep.sub", "example.com"},
+		{"a.b.c", "example.com"},
+		{"mail", "sub.example.com"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			full := buildFullName(tc.name, tc.domain)
+			// stripDomain needs the full name without trailing dot to properly match
+			relative := stripDomain(strings.TrimSuffix(full, "."), tc.domain)
+
+			assert.Equal(t, tc.name, relative,
+				"Round trip through buildFullName and stripDomain should return original name")
+		})
+	}
+}
+
+// TestBuildFullName_AbsoluteName tests building full names from absolute record names (already include domain)
+func TestBuildFullName_AbsoluteName(t *testing.T) {
+	tests := []struct {
+		name     string
+		domain   string
+		expected string
+	}{
+		{
+			name:     "www.example.com",
+			domain:   "example.com",
+			expected: "www.example.com.",
+		},
+		{
+			name:     "www.example.com.",
+			domain:   "example.com",
+			expected: "www.example.com.",
+		},
+		{
+			name:     "api.test.org",
+			domain:   "test.org",
+			expected: "api.test.org.",
+		},
+		{
+			name:     "deep.sub.domain.example.com",
+			domain:   "example.com",
+			expected: "deep.sub.domain.example.com.",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := buildFullName(tt.name, tt.domain)
+			assert.Equal(t, tt.expected, result, "buildFullName(%q, %q)", tt.name, tt.domain)
+		})
+	}
+}
+
+// TestBuildFullName_ZoneApex tests handling of zone apex (base domain)
+func TestBuildFullName_ZoneApex(t *testing.T) {
+	tests := []struct {
+		name     string
+		domain   string
+		expected string
+	}{
+		{
+			name:     "example.com",
+			domain:   "example.com",
+			expected: "example.com.",
+		},
+		{
+			name:     "example.com.",
+			domain:   "example.com.",
+			expected: "example.com.",
+		},
+		{
+			name:     "test.example.com",
+			domain:   "test.example.com",
+			expected: "test.example.com.",
+		},
+		{
+			name:     "test.example.com.",
+			domain:   "test.example.com.",
+			expected: "test.example.com.",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := buildFullName(tt.name, tt.domain)
+			assert.Equal(t, tt.expected, result, "buildFullName(%q, %q)", tt.name, tt.domain)
+		})
+	}
+}
+
+// TestBuildFullName_SubdomainLevels tests building names with multiple subdomain levels
+func TestBuildFullName_SubdomainLevels(t *testing.T) {
+	tests := []struct {
+		name     string
+		domain   string
+		expected string
+	}{
+		{
+			name:     "a.b.c",
+			domain:   "example.com",
+			expected: "a.b.c.example.com.",
+		},
+		{
+			name:     "api.v1.service",
+			domain:   "production.example.com",
+			expected: "api.v1.service.production.example.com.",
+		},
+		{
+			name:     "sub.sub.sub.domain",
+			domain:   "example.org",
+			expected: "sub.sub.sub.domain.example.org.",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := buildFullName(tt.name, tt.domain)
+			assert.Equal(t, tt.expected, result, "buildFullName(%q, %q)", tt.name, tt.domain)
+		})
+	}
+}
+
+// TestBuildFullName_DomainWithTrailingDot tests domains with trailing dots
+func TestBuildFullName_DomainWithTrailingDot(t *testing.T) {
+	tests := []struct {
+		name     string
+		domain   string
+		expected string
+	}{
+		{
+			name:     "www",
+			domain:   "example.com.",
+			expected: "www.example.com.",
+		},
+		{
+			name:     "api",
+			domain:   "test.org.",
+			expected: "api.test.org.",
+		},
+		{
+			name:     "mail",
+			domain:   "sub.example.com.",
+			expected: "mail.sub.example.com.",
+		},
+		{
+			name:     "www.example.com",
+			domain:   "example.com.",
+			expected: "www.example.com.",
+		},
+		{
+			name:     "www.example.com",
+			domain:   "example.com",
+			expected: "www.example.com.",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := buildFullName(tt.name, tt.domain)
+			assert.Equal(t, tt.expected, result, "buildFullName(%q, %q)", tt.name, tt.domain)
+		})
+	}
+}
+
+// TestBuildFullName_CanonicalAllResults tests that all results have trailing dots
+func TestBuildFullName_CanonicalAllResults(t *testing.T) {
+	tests := []struct {
+		name   string
+		domain string
+	}{
+		{"www", "example.com"},
+		{"www.example.com", "example.com"},
+		{"www.example.com.", "example.com"},
+		{"example.com", "example.com"},
+		{"example.com.", "example.com."},
+		{"a.b.c", "example.com"},
+		{"deep.sub.example.com", "example.com"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := buildFullName(tt.name, tt.domain)
+			assert.True(t, strings.HasSuffix(result, "."),
+				"Result should have trailing dot: buildFullName(%q, %q) = %q", tt.name, tt.domain, result)
+		})
+	}
+}
+
+// TestBuildFullName_RealWorldScenarios tests real-world naming scenarios from the codebase
+func TestBuildFullName_RealWorldScenarios(t *testing.T) {
+	tests := []struct {
+		name     string
+		domain   string
+		expected string
+	}{
+		// From DNS service record creation
+		{
+			name:     "test-db3471b9",
+			domain:   "7a9dcb27.example.com",
+			expected: "test-db3471b9.7a9dcb27.example.com.",
+		},
+		// From website DNS records
+		{
+			name:     "_dnslink",
+			domain:   "example.com",
+			expected: "_dnslink.example.com.",
+		},
+		{
+			name:     "www",
+			domain:   "example.com",
+			expected: "www.example.com.",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := buildFullName(tt.name, tt.domain)
+			assert.Equal(t, tt.expected, result, "buildFullName(%q, %q)", tt.name, tt.domain)
+		})
+	}
 }


### PR DESCRIPTION
PowerDNS API requires canonical names but buildFullName returned non-canonical names, causing record creation failures and subsequent retrieval errors.

Refactored buildFullName() to:

- Always return canonical names with trailing dots
- Handle relative names, subdomains, and zone apex scenarios
- Normalize input names and domains regardless of trailing dot presence

* `develop` <!-- branch-stack -->
  - **fix: RRSet not found error by canonicalizing DNS names with trailing dots** :point\_left:


---

<!-- kody-pr-summary:start -->
**Fix RRSet not found errors by canonicalizing DNS names with trailing dots**

This PR resolves "RRSet not found" errors that occurred when interacting with the PowerDNS API by ensuring all DNS names are properly canonicalized with trailing dots.

**Changes:**
- Modified `buildFullName()` to always return canonical DNS names (with trailing dot) as required by the PowerDNS API
- Enhanced handling for various input formats including names with/without trailing dots, relative names, absolute names already containing the domain, and zone apex cases (when record name equals the domain)
- Added comprehensive test coverage for DNS name construction, edge cases, case sensitivity, and round-trip operations (buildFullName followed by stripDomain)

**Impact:**
DNS record operations now properly format record names for PowerDNS compatibility, eliminating RRSet lookup failures caused by missing trailing dots in DNS names. The function now robustly handles mixed input formats while ensuring consistent canonical output.
<!-- kody-pr-summary:end -->