### PR TITLE
fix: add WebsiteItemResponse for swagger generics

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -603,7 +603,7 @@ Returns paginated list of website configurations with status, domain, and target
 
 See also:.*`),
 				router.WithTags("Websites"),
-				router.WithSuccessResponse(http.StatusOK, "List of websites", router.WithJSONContent(queryutil.Response[dto.WebsiteItem]{})),
+				router.WithSuccessResponse(http.StatusOK, "List of websites", router.WithJSONContent(dto.WebsiteItemResponse{})),
 			),
 		),
 		router.NewRoute(http.MethodGet, "/websites/:id", a.getWebsite,

--- a/internal/api/dto/website.go
+++ b/internal/api/dto/website.go
@@ -253,6 +253,19 @@ type WebsiteValidateResponse struct {
 // WebsiteItem represents a website listing item (used in list responses)
 type WebsiteItem WebsiteResponse
 
+// WebsiteItemResponse is a swagger-only DTO that represents the paginated response for websites.
+// It merges the generic queryutil.Response[dto.WebsiteItem] for OpenAPI documentation.
+//
+// This struct exists due to a TODO bug where queryutil.Response generics are not getting detected
+// properly as an array type in the swagger documentation generation. By providing a concrete struct,
+// we ensure the swagger docs correctly show the data field as an array of WebsiteItem items.
+//
+// Note: This struct is only used for swagger documentation, not for actual encoding.
+type WebsiteItemResponse struct {
+	Data  []WebsiteItem `json:"data"`
+	Total int64         `json:"total"`
+}
+
 // WebsiteFilter represents filtering options for website listings
 type WebsiteFilter struct {
 	Domain     *string              `json:"domain,omitempty" query:"domain"`


### PR DESCRIPTION
Add concrete WebsiteItemResponse type to fix swagger documentation issues where queryutil.Response generics were not being detected as array types in OpenAPI documentation.

- Add WebsiteItemResponse struct with Data and Total fields
- Update listWebsites route to use WebsiteItemResponse instead of generic queryutil.Response\[dto.WebsiteItem]

This follows the same pattern used in DNS API with ZoneListResponseResponse and RecordResponseResponse.

- `develop` <!-- branch-stack -->
  - **fix: add WebsiteItemResponse for swagger generics** :point\_left:


---

<!-- kody-pr-summary:start -->
 This PR fixes Swagger/OpenAPI documentation generation for the website listing endpoint by introducing a concrete response type to replace a generic wrapper.

**Problem:**
The generic `queryutil.Response[dto.WebsiteItem]` type was not being properly detected as an array type in Swagger documentation generation (noted as a TODO bug), causing the API documentation to incorrectly represent the paginated response structure for website listings.

**Solution:**
- Added `WebsiteItemResponse` struct in `dto/website.go` that explicitly defines the paginated response with `Data []WebsiteItem` and `Total int64` fields
- Updated the websites list route in `api.go` to reference `dto.WebsiteItemResponse{}` instead of `queryutil.Response[dto.WebsiteItem]{}` for Swagger documentation purposes

**Impact:**
Ensures the Swagger/OpenAPI specification correctly displays the website listing endpoint response as an object containing a `data` array of `WebsiteItem` objects and a `total` count. This change affects documentation generation only and does not modify the actual API response encoding or runtime behavior.
<!-- kody-pr-summary:end -->