### PR TITLE
fix: respect user's dns_hosting_enabled setting in website creation

### DIFF
--- a/internal/api/api_websites.go
+++ b/internal/api/api_websites.go
@@ -75,10 +75,6 @@ func (a *API) createWebsite(c echo.Context) error {
 	// Set user ID
 	model.UserID = user
 
-	// Ensure default enabled value regardless of DTO implementation details
-	// This provides defensive validation and creates a single source of truth
-	model.Enabled = model.Enabled || DefaultWebsiteEnabled
-
 	website, err := a.websiteService.CreateWebsite(reqCtx, model)
 	if err != nil {
 		a.Logger().Error("Failed to create website", zap.Error(err), zap.Uint("user_id", user), zap.String("domain", req.Domain))


### PR DESCRIPTION
The API handler was forcing model.Enabled to always be true, ignoring user input when dns\_hosting\_enabled=false was specified. This caused websites to auto-convert IPFS targets to IPNS even when DNS hosting was explicitly disabled.

Removed the erroneous defensive validation that overrode user input. The WebsiteRequest.ToModel() method already properly handles defaulting to true when DNSEnabled is nil, and respecting user input when specified.

- `develop` <!-- branch-stack -->
  - **fix: respect user's dns\_hosting\_enabled setting in website creation** :point\_left:


---

<!-- kody-pr-summary:start -->
This PR fixes an issue where the user's `dns_hosting_enabled` preference was being overridden during website creation. 

Previously, the code forced a default enabled value regardless of the user's input, which could result in DNS hosting being enabled even when the user explicitly disabled it in their request. 

The fix removes this forced default assignment, ensuring the system now respects the user's explicit choice for the DNS hosting enabled setting as provided in the website creation request.
<!-- kody-pr-summary:end -->