### PR TITLE
fix: accept valid IPNS peer IDs from IPNS publish

### DIFF
--- a/internal/service/website/validate_target_test.go
+++ b/internal/service/website/validate_target_test.go
@@ -62,7 +62,7 @@ func TestValidateTarget_IPNS_InvalidPeerID(t *testing.T) {
 		// Act & Assert
 		err := websiteService.(*WebsiteServiceDefault).validateTarget(string(pluginDb.WebsiteTargetTypeIPNS), invalidPeerID)
 		require.Error(tb, err, "Invalid peer ID should fail validation")
-		require.Contains(t, err.Error(), "invalid IPNS", "Error should mention IPNS validation failure")
+		require.Contains(tb, err.Error(), "invalid IPNS", "Error should mention IPNS validation failure")
 	}, TestOptions)
 }
 
@@ -78,7 +78,7 @@ func TestValidateTarget_IPNS_InvalidCID(t *testing.T) {
 		// Act & Assert
 		err := websiteService.(*WebsiteServiceDefault).validateTarget(string(pluginDb.WebsiteTargetTypeIPNS), invalidCID)
 		require.Error(tb, err, "Invalid CID should fail validation")
-		require.Contains(t, err.Error(), "invalid IPNS", "Error should mention IPNS validation failure")
+		require.Contains(tb, err.Error(), "invalid IPNS", "Error should mention IPNS validation failure")
 	}, TestOptions)
 }
 
@@ -95,7 +95,7 @@ func TestValidateTarget_IPNS_CIDNotLibp2pKey(t *testing.T) {
 		// Act & Assert
 		err := websiteService.(*WebsiteServiceDefault).validateTarget(string(pluginDb.WebsiteTargetTypeIPNS), nonLibp2pKeyCID)
 		require.Error(tb, err, "CID without libp2p-key codec should fail validation")
-		require.Contains(t, err.Error(), "invalid IPNS", "Error should mention IPNS validation failure")
+		require.Contains(tb, err.Error(), "invalid IPNS", "Error should mention IPNS validation failure")
 	}, TestOptions)
 }
 
@@ -126,7 +126,7 @@ func TestValidateTarget_IPFS_InvalidCID(t *testing.T) {
 		// Act & Assert
 		err := websiteService.(*WebsiteServiceDefault).validateTarget(string(pluginDb.WebsiteTargetTypeIPFS), invalidCID)
 		require.Error(tb, err, "Invalid CID should fail validation")
-		require.Contains(t, err.Error(), "invalid CID", "Error should mention CID validation failure")
+		require.Contains(tb, err.Error(), "invalid CID", "Error should mention CID validation failure")
 	}, TestOptions)
 }
 
@@ -142,7 +142,7 @@ func TestValidateTarget_UnknownType(t *testing.T) {
 		// Act & Assert
 		err := websiteService.(*WebsiteServiceDefault).validateTarget("unknown_type", anyHash)
 		require.Error(tb, err, "Unknown target type should fail validation")
-		require.Contains(t, err.Error(), "invalid target", "Error should mention invalid target type")
+		require.Contains(tb, err.Error(), "invalid target", "Error should mention invalid target type")
 	}, TestOptions)
 }
 

--- a/internal/service/website/validate_target_test.go
+++ b/internal/service/website/validate_target_test.go
@@ -1,0 +1,168 @@
+package website
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.lumeweb.com/portal/core"
+	pluginCore "go.lumeweb.com/portal-plugin-ipfs/core"
+	pluginDb "go.lumeweb.com/portal-plugin-ipfs/internal/db"
+	"go.lumeweb.com/portal-plugin-ipfs/internal/testing/util"
+	coreTesting "go.lumeweb.com/portal/core/testing"
+)
+
+const (
+	// TestPeerID1 is a valid libp2p ed25519 peer ID
+	TestPeerID1 = "12D3KooWRhWS6DXi1U1YnJ5r9E6KpSDHGbZAznXif4T9qDjHeEfE"
+	// TestPeerID2 is another valid libp2p ed25519 peer ID
+	TestPeerID2 = "12D3KooWR4Mq4DEB9Nhz41sDDRKtqnWHjB9qzTmnPogUJLjxTD8z"
+	// TestCIDv1Libp2pKey is a valid CIDv1 with libp2p-key codec
+	TestCIDv1Libp2pKey = "k51qzi5uqu5dlts3p5vfpw8kneqp5ye1ttb2jlt8qkt5mq9f2gvgmet6sec29r"
+)
+
+func TestValidateTarget_IPNS_PeerIDFirst(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		// Arrange
+		websiteService := core.GetService[pluginCore.WebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
+		require.NotNil(tb, websiteService)
+
+		// Use a valid peer ID (base36 encoding - the format from IPNS publish)
+		peerIDString := TestPeerID1
+
+		// Act & Assert
+		err := websiteService.(*WebsiteServiceDefault).validateTarget(string(pluginDb.WebsiteTargetTypeIPNS), peerIDString)
+		require.NoError(tb, err, "Valid peer ID should pass validation")
+	}, TestOptions)
+}
+
+func TestValidateTarget_IPNS_CIDv1Libp2pKey(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		// Arrange
+		websiteService := core.GetService[pluginCore.WebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
+		require.NotNil(tb, websiteService)
+
+		// Use a valid CIDv1 with libp2p-key codec
+		cidv1Key := TestCIDv1Libp2pKey
+
+		// Act & Assert
+		err := websiteService.(*WebsiteServiceDefault).validateTarget(string(pluginDb.WebsiteTargetTypeIPNS), cidv1Key)
+		require.NoError(tb, err, "Valid CIDv1 with libp2p-key codec should pass validation")
+	}, TestOptions)
+}
+
+func TestValidateTarget_IPNS_InvalidPeerID(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		// Arrange
+		websiteService := core.GetService[pluginCore.WebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
+		require.NotNil(tb, websiteService)
+
+		// Invalid peer ID string
+		invalidPeerID := "not-valid-peer-id"
+
+		// Act & Assert
+		err := websiteService.(*WebsiteServiceDefault).validateTarget(string(pluginDb.WebsiteTargetTypeIPNS), invalidPeerID)
+		require.Error(tb, err, "Invalid peer ID should fail validation")
+		require.Contains(t, err.Error(), "invalid IPNS", "Error should mention IPNS validation failure")
+	}, TestOptions)
+}
+
+func TestValidateTarget_IPNS_InvalidCID(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		// Arrange
+		websiteService := core.GetService[pluginCore.WebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
+		require.NotNil(tb, websiteService)
+
+		// Invalid CID that looks like CID but has unsupported encoding
+		invalidCID := "invalid-cid-format"
+
+		// Act & Assert
+		err := websiteService.(*WebsiteServiceDefault).validateTarget(string(pluginDb.WebsiteTargetTypeIPNS), invalidCID)
+		require.Error(tb, err, "Invalid CID should fail validation")
+		require.Contains(t, err.Error(), "invalid IPNS", "Error should mention IPNS validation failure")
+	}, TestOptions)
+}
+
+func TestValidateTarget_IPNS_CIDNotLibp2pKey(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		// Arrange
+		websiteService := core.GetService[pluginCore.WebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
+		require.NotNil(tb, websiteService)
+
+		// Valid CID but not libp2p-key codec (e.g., DagProtobuf CID)
+		// Qm... is CIDv0, bafkrei... is CIDv1 with raw codec
+		nonLibp2pKeyCID := "bafkreiem6tcea4zz7g2z4w4ocjp7t3ve5s7uoixxxdh2ikvmq3retdhsy"
+
+		// Act & Assert
+		err := websiteService.(*WebsiteServiceDefault).validateTarget(string(pluginDb.WebsiteTargetTypeIPNS), nonLibp2pKeyCID)
+		require.Error(tb, err, "CID without libp2p-key codec should fail validation")
+		require.Contains(t, err.Error(), "invalid IPNS", "Error should mention IPNS validation failure")
+	}, TestOptions)
+}
+
+func TestValidateTarget_IPFS_ValidCID(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		// Arrange
+		websiteService := core.GetService[pluginCore.WebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
+		require.NotNil(tb, websiteService)
+
+		// Valid CID (should pass IPFS validation) - use util helper
+		testCID := util.GenerateTestCID(t, "test-data-validation")
+
+		// Act & Assert
+		err := websiteService.(*WebsiteServiceDefault).validateTarget(string(pluginDb.WebsiteTargetTypeIPFS), testCID.String())
+		require.NoError(tb, err, "Valid CID should pass IPFS validation")
+	}, TestOptions)
+}
+
+func TestValidateTarget_IPFS_InvalidCID(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		// Arrange
+		websiteService := core.GetService[pluginCore.WebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
+		require.NotNil(tb, websiteService)
+
+		// Invalid CID
+		invalidCID := "not-a-valid-cid"
+
+		// Act & Assert
+		err := websiteService.(*WebsiteServiceDefault).validateTarget(string(pluginDb.WebsiteTargetTypeIPFS), invalidCID)
+		require.Error(tb, err, "Invalid CID should fail validation")
+		require.Contains(t, err.Error(), "invalid CID", "Error should mention CID validation failure")
+	}, TestOptions)
+}
+
+func TestValidateTarget_UnknownType(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		// Arrange
+		websiteService := core.GetService[pluginCore.WebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
+		require.NotNil(tb, websiteService)
+
+		// Any hash with unknown type should fail type validation
+		anyHash := "some-hash-value"
+
+		// Act & Assert
+		err := websiteService.(*WebsiteServiceDefault).validateTarget("unknown_type", anyHash)
+		require.Error(tb, err, "Unknown target type should fail validation")
+		require.Contains(t, err.Error(), "invalid target", "Error should mention invalid target type")
+	}, TestOptions)
+}
+
+func TestValidateTarget_IPNS_MultiplePeerIDFormats(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		// Arrange
+		websiteService := core.GetService[pluginCore.WebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
+		require.NotNil(tb, websiteService)
+
+		// Test multiple valid peer ID formats and CIDv1 libp2p-key formats
+		validPeerIDs := []string{
+			TestPeerID1,      // ed25519 peer ID (from IPNS publish)
+			TestPeerID2,      // Another valid ed25519 peer ID
+			TestCIDv1Libp2pKey, // CIDv1 libp2p-key (fallback)
+		}
+
+		// Act & Assert
+		for _, peerID := range validPeerIDs {
+			err := websiteService.(*WebsiteServiceDefault).validateTarget(string(pluginDb.WebsiteTargetTypeIPNS), peerID)
+			require.NoError(tb, err, "Peer ID %s should pass validation", peerID)
+		}
+	}, TestOptions)
+}

--- a/internal/service/website/website.go
+++ b/internal/service/website/website.go
@@ -972,11 +972,11 @@ func (s *WebsiteServiceDefault) validateTarget(targetType string, targetHash str
 			return fmt.Errorf("%w: %v", ErrInvalidCID, err)
 		}
 	case pluginDb.WebsiteTargetTypeIPNS:
-		// Validate IPNS name format (peer ID in base36 format)
-		_, err := cid.Decode(targetHash)
+		// Try peer ID decode first (IPNS uses libp2p peer IDs in base36)
+		_, err := peer.Decode(targetHash)
 		if err != nil {
-			// If CID decode fails, try peer ID decode
-			_, err = peer.Decode(targetHash)
+			// FALLBACK: Try CID decode (supports CIDv1 with libp2p-key codec)
+			_, err := cid.Decode(targetHash)
 			if err != nil {
 				return fmt.Errorf("%w: %v", ErrInvalidIPNS, err)
 			}


### PR DESCRIPTION
Previously, website updates to IPNS targets failed with "invalid cid: selected encoding not supported" because the validator tried to parse peer IDs as CIDs before attempting peer ID decode.

Now correctly accepts both:

- Base36 peer IDs (the format returned by IPNS publish)
- CIDv1 with libp2p-key codec

* `develop` <!-- branch-stack -->
  - **fix: accept valid IPNS peer IDs from IPNS publish** :point\_left:

***

<!-- kody-pr-summary:start -->

This PR fixes the IPNS target validation to properly accept valid peer IDs in base36 format, which is the standard format returned by IPNS publish operations.

**The Problem:**
The previous validation logic attempted to parse IPNS targets as CIDs first, causing valid peer IDs (in base36 format) to incorrectly fail validation when configuring website targets.

**The Solution:**
Reversed the validation order to check for peer ID format first, with CIDv1 libp2p-key format as a fallback. This ensures IPNS names generated from standard IPNS publish workflows are properly accepted while maintaining backward compatibility with CIDv1-encoded peer IDs.

**Changes:**

- Updated `validateTarget` in `internal/service/website/website.go` to prioritize peer ID decoding over CID decoding for IPNS targets
- Added comprehensive test suite in `validate_target_test.go` covering valid peer ID formats, CIDv1 libp2p-key validation, and error cases for invalid inputs

<!-- kody-pr-summary:end -->
