### PR TITLE
fix(website): Fix IPNS validation to use peer.Decode

### DIFF
--- a/internal/service/website/validate_target_test.go
+++ b/internal/service/website/validate_target_test.go
@@ -210,8 +210,8 @@ func TestValidateIPNSTarget_InvalidPeerID(t *testing.T) {
 
 		// Act & Assert
 		valid, err := websiteService.(*WebsiteServiceDefault).validateIPNSTarget(ctx, invalidPeerID)
-		require.Error(t, err, "Invalid peer ID should fail validation")
-		require.False(t, valid, "Invalid peer ID should return false")
+		require.Error(tb, err, "Invalid peer ID should fail validation")
+		require.False(tb, valid, "Invalid peer ID should return false")
 	}, TestOptions)
 }
 
@@ -226,8 +226,8 @@ func TestValidateIPNSTarget_InvalidCID(t *testing.T) {
 
 		// Act & Assert
 		valid, err := websiteService.(*WebsiteServiceDefault).validateIPNSTarget(ctx, invalidCID)
-		require.Error(t, err, "Invalid CID should fail validation")
-		require.False(t, valid, "Invalid CID should return false")
+		require.Error(tb, err, "Invalid CID should fail validation")
+		require.False(tb, valid, "Invalid CID should return false")
 	}, TestOptions)
 }
 
@@ -242,8 +242,8 @@ func TestValidateIPNSTarget_CIDNotLibp2pKey(t *testing.T) {
 
 		// Act & Assert
 		valid, err := websiteService.(*WebsiteServiceDefault).validateIPNSTarget(ctx, nonLibp2pKeyCID)
-		require.Error(t, err, "CID without libp2p-key codec should fail validation")
-		require.False(t, valid, "CID without libp2p-key codec should return false")
+		require.Error(tb, err, "CID without libp2p-key codec should fail validation")
+		require.False(tb, valid, "CID without libp2p-key codec should return false")
 	}, TestOptions)
 }
 

--- a/internal/service/website/validate_target_test.go
+++ b/internal/service/website/validate_target_test.go
@@ -154,9 +154,9 @@ func TestValidateTarget_IPNS_MultiplePeerIDFormats(t *testing.T) {
 
 		// Test multiple valid peer ID formats and CIDv1 libp2p-key formats
 		validPeerIDs := []string{
-			TestPeerID1,      // ed25519 peer ID (from IPNS publish)
-			TestPeerID2,      // Another valid ed25519 peer ID
-			TestCIDv1Libp2pKey, // CIDv1 libp2p-key (fallback)
+			TestPeerID1,         // ed25519 peer ID (from IPNS publish)
+			TestPeerID2,         // Another valid ed25519 peer ID
+			TestCIDv1Libp2pKey,  // CIDv1 libp2p-key (fallback)
 		}
 
 		// Act & Assert
@@ -166,3 +166,149 @@ func TestValidateTarget_IPNS_MultiplePeerIDFormats(t *testing.T) {
 		}
 	}, TestOptions)
 }
+
+func TestValidateIPNSTarget_ValidPeerID(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		// Arrange
+		websiteService := core.GetService[pluginCore.WebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
+		require.NotNil(tb, websiteService)
+
+		// Use a valid peer ID
+		peerIDString := TestPeerID1
+
+		// Act & Assert
+		valid, err := websiteService.(*WebsiteServiceDefault).validateIPNSTarget(ctx, peerIDString)
+		require.NoError(tb, err, "Valid peer ID should pass validation")
+		require.True(tb, valid, "Valid peer ID should return true")
+	}, TestOptions)
+}
+
+func TestValidateIPNSTarget_CIDv1Libp2pKey(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		// Arrange
+		websiteService := core.GetService[pluginCore.WebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
+		require.NotNil(tb, websiteService)
+
+		// Use a valid CIDv1 with libp2p-key codec
+		cidv1Key := TestCIDv1Libp2pKey
+
+		// Act & Assert
+		valid, err := websiteService.(*WebsiteServiceDefault).validateIPNSTarget(ctx, cidv1Key)
+		require.NoError(tb, err, "Valid CIDv1 with libp2p-key codec should pass validation")
+		require.True(tb, valid, "Valid CIDv1 should return true")
+	}, TestOptions)
+}
+
+func TestValidateIPNSTarget_InvalidPeerID(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		// Arrange
+		websiteService := core.GetService[pluginCore.WebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
+		require.NotNil(tb, websiteService)
+
+		// Invalid peer ID string
+		invalidPeerID := "not-valid-peer-id"
+
+		// Act & Assert
+		valid, err := websiteService.(*WebsiteServiceDefault).validateIPNSTarget(ctx, invalidPeerID)
+		require.Error(t, err, "Invalid peer ID should fail validation")
+		require.False(t, valid, "Invalid peer ID should return false")
+	}, TestOptions)
+}
+
+func TestValidateIPNSTarget_InvalidCID(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		// Arrange
+		websiteService := core.GetService[pluginCore.WebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
+		require.NotNil(tb, websiteService)
+
+		// Invalid CID format
+		invalidCID := "invalid-cid-format"
+
+		// Act & Assert
+		valid, err := websiteService.(*WebsiteServiceDefault).validateIPNSTarget(ctx, invalidCID)
+		require.Error(t, err, "Invalid CID should fail validation")
+		require.False(t, valid, "Invalid CID should return false")
+	}, TestOptions)
+}
+
+func TestValidateIPNSTarget_CIDNotLibp2pKey(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		// Arrange
+		websiteService := core.GetService[pluginCore.WebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
+		require.NotNil(tb, websiteService)
+
+		// Valid CID but not libp2p-key codec
+		nonLibp2pKeyCID := "bafkreiem6tcea4zz7g2z4w4ocjp7t3ve5s7uoixxxdh2ikvmq3retdhsy"
+
+		// Act & Assert
+		valid, err := websiteService.(*WebsiteServiceDefault).validateIPNSTarget(ctx, nonLibp2pKeyCID)
+		require.Error(t, err, "CID without libp2p-key codec should fail validation")
+		require.False(t, valid, "CID without libp2p-key codec should return false")
+	}, TestOptions)
+}
+
+func TestValidateIPNSTarget_MultipleValidFormats(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		// Arrange
+		websiteService := core.GetService[pluginCore.WebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
+		require.NotNil(tb, websiteService)
+
+		// Test multiple valid peer ID formats and CIDv1 libp2p-key formats
+		validTargets := []string{
+			TestPeerID1,        // ed25519 peer ID
+			TestPeerID2,        // Another valid ed25519 peer ID
+			TestCIDv1Libp2pKey, // CIDv1 libp2p-key
+		}
+
+		// Act & Assert
+		for _, target := range validTargets {
+			valid, err := websiteService.(*WebsiteServiceDefault).validateIPNSTarget(ctx, target)
+			require.NoError(tb, err, "Target %s should pass validation", target)
+			require.True(tb, valid, "Target %s should return true", target)
+		}
+	}, TestOptions)
+}
+
+func TestIsValidIPNSTarget_ValidPeerID(t *testing.T) {
+	// Valid peer ID should pass
+	require.True(t, isValidIPNSTarget(TestPeerID1), "Valid peer ID should return true")
+	require.True(t, isValidIPNSTarget(TestPeerID2), "Valid peer ID should return true")
+}
+
+func TestIsValidIPNSTarget_CIDv1Libp2pKey(t *testing.T) {
+	// Valid CIDv1 with libp2p-key codec should pass
+	require.True(t, isValidIPNSTarget(TestCIDv1Libp2pKey), "Valid CIDv1 libp2p-key should return true")
+}
+
+func TestIsValidIPNSTarget_InvalidPeerID(t *testing.T) {
+	// Invalid peer ID should fail
+	require.False(t, isValidIPNSTarget("not-valid-peer-id"), "Invalid peer ID should return false")
+	require.False(t, isValidIPNSTarget(""), "Empty string should return false")
+}
+
+func TestIsValidIPNSTarget_InvalidCID(t *testing.T) {
+	// Invalid CID format should fail
+	require.False(t, isValidIPNSTarget("invalid-cid-format"), "Invalid CID should return false")
+	require.False(t, isValidIPNSTarget("bogus"), "Bogus string should return false")
+}
+
+func TestIsValidIPNSTarget_CIDNotLibp2pKey(t *testing.T) {
+	// Valid CID but not libp2p-key codec should fail
+	nonLibp2pKeyCID := "bafkreiem6tcea4zz7g2z4w4ocjp7t3ve5s7uoixxxdh2ikvmq3retdhsy"
+	require.False(t, isValidIPNSTarget(nonLibp2pKeyCID), "CID without libp2p-key codec should return false")
+}
+
+func TestIsValidIPNSTarget_MultipleValidFormats(t *testing.T) {
+	// Test all valid formats
+	validTargets := []string{
+		TestPeerID1,
+		TestPeerID2,
+		TestCIDv1Libp2pKey,
+	}
+
+	for _, target := range validTargets {
+		require.True(t, isValidIPNSTarget(target), "Target %s should be valid", target)
+	}
+}
+
+

--- a/internal/service/website/website.go
+++ b/internal/service/website/website.go
@@ -962,6 +962,19 @@ func (s *WebsiteServiceDefault) validateDomain(domain string) error {
 	return nil
 }
 
+// isValidIPNSTarget checks if a target hash is a valid IPNS target
+// Returns true if the peer ID or CIDv1 with libp2p-key codec is valid
+func isValidIPNSTarget(targetHash string) bool {
+	// Try peer ID decode first (IPNS uses libp2p peer IDs in base36)
+	_, err := peer.Decode(targetHash)
+	if err != nil {
+		// FALLBACK: Try CID decode (supports CIDv1 with libp2p-key codec)
+		_, err = cid.Decode(targetHash)
+		return err == nil
+	}
+	return true
+}
+
 // validateTarget validates the target type and hash
 func (s *WebsiteServiceDefault) validateTarget(targetType string, targetHash string) error {
 	switch pluginDb.WebsiteTargetType(targetType) {
@@ -972,14 +985,9 @@ func (s *WebsiteServiceDefault) validateTarget(targetType string, targetHash str
 			return fmt.Errorf("%w: %v", ErrInvalidCID, err)
 		}
 	case pluginDb.WebsiteTargetTypeIPNS:
-		// Try peer ID decode first (IPNS uses libp2p peer IDs in base36)
-		_, err := peer.Decode(targetHash)
-		if err != nil {
-			// FALLBACK: Try CID decode (supports CIDv1 with libp2p-key codec)
-			_, err := cid.Decode(targetHash)
-			if err != nil {
-				return fmt.Errorf("%w: %v", ErrInvalidIPNS, err)
-			}
+		// Validate IPNS target (peer ID or CIDv1 libp2p-key codec)
+		if !isValidIPNSTarget(targetHash) {
+			return fmt.Errorf("%w: invalid IPNS target", ErrInvalidIPNS)
 		}
 	default:
 		return fmt.Errorf("%w: invalid type %s", ErrInvalidTarget, targetType)
@@ -1009,9 +1017,8 @@ func (s *WebsiteServiceDefault) validateIPFSTarget(ctx context.Context, targetHa
 func (s *WebsiteServiceDefault) validateIPNSTarget(ctx context.Context, targetHash string) (bool, error) {
 	// For Phase 1, we'll just check if the IPNS name is valid
 	// In production, we would check if the key exists in the database
-	_, err := cid.Decode(targetHash)
-	if err != nil {
-		return false, err
+	if !isValidIPNSTarget(targetHash) {
+		return false, fmt.Errorf("invalid IPNS target")
 	}
 
 	return true, nil

--- a/internal/service/website/website.go
+++ b/internal/service/website/website.go
@@ -969,8 +969,15 @@ func isValidIPNSTarget(targetHash string) bool {
 	_, err := peer.Decode(targetHash)
 	if err != nil {
 		// FALLBACK: Try CID decode (supports CIDv1 with libp2p-key codec)
-		_, err = cid.Decode(targetHash)
-		return err == nil
+		c, err := cid.Decode(targetHash)
+		if err != nil {
+			return false
+		}
+		// Validate that CID uses libp2p-key codec (0x72) for IPNS
+		if c.Type() != cid.Libp2pKey {
+			return false
+		}
+		return true
 	}
 	return true
 }


### PR DESCRIPTION
The validateIPNSTarget() function was incorrectly using cid.Decode() instead of peer.Decode() for IPNS target validation. This caused "invalid cid: selected encoding not supported" errors when creating or updating websites with IPNS peer ID targets.

Changes:

- Extract isValidIPNSTarget() helper function for shared validation logic
- Update validateIPNSTarget() to use peer.Decode() first, fallback to cid.Decode()
- Update validateTarget() to use isValidIPNSTarget() helper
- Add comprehensive tests for validateIPNSTarget()
- Add comprehensive tests for isValidIPNSTarget() helper

Fixes validation inconsistency between validateTarget() (correct) and validateIPNSTarget() (incorrect). Both now use identical logic with proper peer.Decode() first, then fallback to cid.Decode() for CIDv1 libp2p-key codec support.

- `develop` <!-- branch-stack -->
  - **fix(website): Fix IPNS validation to use peer.Decode** :point\_left:

***

<!-- kody-pr-summary:start -->

Fix IPNS validation to properly validate peer IDs using `peer.Decode` as the primary method, with CIDv1 libp2p-key format as fallback.

Extracts the IPNS validation logic into a dedicated `isValidIPNSTarget` helper function that first attempts peer ID decoding (for standard IPNS names in base36 format), then falls back to CID decoding for backward compatibility with CIDv1 libp2p-key encoded targets.

Updates both `validateTarget` and `validateIPNSTarget` methods to use the new validation helper, ensuring consistent IPNS target validation across the codebase.

Adds comprehensive test coverage for the IPNS validation logic, including tests for valid peer IDs, CIDv1 libp2p-key formats, invalid peer IDs, invalid CIDs, CIDs with non-libp2p-key codecs, and multiple valid format scenarios.

<!-- kody-pr-summary:end -->
