### PR TITLE
fix: auto-detect IPFS to IPNS conversion in UpdateWebsite

### DIFF
--- a/internal/service/website/website.go
+++ b/internal/service/website/website.go
@@ -39,11 +39,11 @@ var (
 // WebsiteServiceDefault implements the WebsiteService interface
 type WebsiteServiceDefault struct {
 	*core.BaseComponent
-	pinSvc           pluginCore.IPFSPinService
-	ipnsKeySvc       pluginCore.IPNSKeyService
-	mailerSvc        core.MailerService
-	dnsSvc           pluginCore.DNSService
-	config           *pluginConfig.WebsiteConfig
+	pinSvc     pluginCore.IPFSPinService
+	ipnsKeySvc pluginCore.IPNSKeyService
+	mailerSvc  core.MailerService
+	dnsSvc     pluginCore.DNSService
+	config     *pluginConfig.WebsiteConfig
 }
 
 // Ensure WebsiteServiceDefault implements the interface
@@ -409,7 +409,7 @@ func (s *WebsiteServiceDefault) ListWebsites(ctx context.Context, userID uint, f
 }
 
 // UpdateWebsite updates an existing website
-func (s *WebsiteServiceDefault) UpdateWebsite(ctx context.Context, userID uint, websiteID uint, updates map[string]interface{}) (*pluginDb.Website, error) {
+func (s *WebsiteServiceDefault) UpdateWebsite(ctx context.Context, userID uint, websiteID uint, updates map[string]any) (*pluginDb.Website, error) {
 	ctx, span := core.TraceMethod(ctx, "WebsiteServiceDefault.UpdateWebsite")
 	defer span.End()
 
@@ -454,6 +454,13 @@ func (s *WebsiteServiceDefault) UpdateWebsite(ctx context.Context, userID uint, 
 					targetType := website.TargetType
 					if tt, ok := updates["target_type"].(string); ok {
 						targetType = tt
+					}
+
+					// Auto-detect targetType if it's IPFS but target_hash is a peer ID
+					// This handles cases where user updates target_hash without updating target_type
+					if targetType == string(pluginDb.WebsiteTargetTypeIPFS) && isValidIPNSTarget(targetHashStr) {
+						targetType = string(pluginDb.WebsiteTargetTypeIPNS)
+						updates["target_type"] = targetType
 					}
 
 					// Validate target hash

--- a/internal/service/website/website_test.go
+++ b/internal/service/website/website_test.go
@@ -1934,3 +1934,39 @@ func TestWebsiteService_CreateWebsite_IPNSKeyAutoCreation_NoDuplicate(t *testing
 		assert.Equal(tb, string(pluginDb.WebsiteTargetTypeIPNS), createdWebsite2.TargetType, "Second website should use IPNS target")
 	}, TestOptions)
 }
+
+// TestWebsiteService_UpdateWebsite_ConvertIPFSToIPNS tests updating a website
+// from IPFS target to IPNS target when only target_hash is provided.
+// It validates that targetType is correctly auto-detected when target_hash
+// is a peer ID, avoiding the validation bug where cid.Decode() would be
+// called on a peer ID string.
+func TestWebsiteService_UpdateWebsite_ConvertIPFSToIPNS(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		// Arrange
+		websiteService := core.GetService[pluginCore.WebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
+		testCID := util.GenerateTestCID(t, "test data")
+		domain := "convert-test.com"
+
+		ipfsWebsite := createTestIPFSWebsite(testUserID1, domain, testCID.String())
+		createdWebsite, err := websiteService.CreateWebsite(context.Background(), ipfsWebsite)
+		require.NoError(tb, err)
+		require.NotNil(tb, createdWebsite)
+		assert.Equal(tb, string(pluginDb.WebsiteTargetTypeIPFS), createdWebsite.TargetType)
+
+		// Update to IPNS by changing target_hash to a peer ID
+		// targetType will be auto-detected as IPNS
+		testPeerID := "12D3KooWCqvCZqaG6LmG4mtoWZZwrvYB911DK8qqwE9gc25s4Hft"
+		updates := map[string]interface{}{
+			"target_hash": testPeerID,
+		}
+
+		// Act
+		updatedWebsite, err := websiteService.UpdateWebsite(context.Background(), testUserID1, createdWebsite.ID, updates)
+
+		// Assert
+		require.NoError(tb, err)
+		require.NotNil(tb, updatedWebsite)
+		assert.Equal(tb, string(pluginDb.WebsiteTargetTypeIPNS), updatedWebsite.TargetType)
+		assert.Equal(tb, testPeerID, updatedWebsite.TargetHash())
+	}, TestOptions)
+}


### PR DESCRIPTION
When updating a website's target\_hash to a peer ID without updating target\_type, the validation would fail because it treated the peer ID as a CID. This fix auto-detects targetType as IPNS when target\_hash is a valid IPNS target (peer ID or CIDv1 libp2p-key codec), allowing users to update target\_hash without explicitly setting target\_type.

The bug manifested as:
"invalid CID: invalid cid: selected encoding not supported"

The root cause was that validateTarget() received targetType="ipfs" instead of "ipns", causing cid.Decode() to be called on peer IDs.

Fixes validation bug when converting websites from IPFS to IPNS targets.

- `develop` <!-- branch-stack -->
  - **fix: auto-detect IPFS to IPNS conversion in UpdateWebsite** :point\_left:


---

<!-- kody-pr-summary:start -->
 This pull request fixes a validation issue in the `UpdateWebsite` method that occurred when users updated a website's target hash to an IPNS peer ID without explicitly changing the target type from IPFS to IPNS.

**Changes:**

1. **Auto-detection of IPNS targets** (`internal/service/website/website.go`): Added logic to automatically detect when a target hash is a valid IPNS peer ID (even when the target type is set to IPFS). When detected, the system automatically converts the target type to IPNS and updates the request parameters accordingly. This prevents validation failures that would occur when the system attempts to decode a peer ID string as a CID.

2. **Test coverage** (`internal/service/website/website_test.go`): Added `TestWebsiteService_UpdateWebsite_ConvertIPFSToIPNS` to validate the auto-conversion behavior, ensuring that updating a website with a peer ID target hash correctly transitions the target type from IPFS to IPNS.

**Functional Impact:**
- Users can now update a website from IPFS to IPNS targets by simply providing the peer ID in the `target_hash` field, without needing to explicitly set `target_type` to IPNS
- Eliminates validation errors when transitioning between IPFS CIDs and IPNS peer IDs
- Maintains backward compatibility with explicit target type specifications
<!-- kody-pr-summary:end -->