### PR TITLE
fix: remove duplicate GetCronJobIdentifier call from plugin cron job name

### DIFF
--- a/internal/plugin/info.go
+++ b/internal/plugin/info.go
@@ -81,7 +81,7 @@ func getPluginInfoWithoutTemplates() core.PluginInfo {
 		},
 		CronJobs: []core.PluginCronJob{
 			{
-				Name:    core.GetCronJobIdentifier(core.JobOriginPlugin, "ipfs.website_janitor"),
+				Name:    "website_janitor",
 				Factory: func() (core.CronJob, error) { return website.NewWebsiteJanitorJob(), nil },
 				Schedule: core.NewCronScheduleDefinition(core.CronScheduleTypeCron).
 					WithCronExpression("*/30 * * * *"),


### PR DESCRIPTION
The Name field in PluginCronJob was incorrectly calling GetCronJobIdentifier(), but RegisterPluginJobs() already handles the identifier construction. This caused double-conversion and malformed job types like 'plugin.ipfs.plugin.ipfs.website\_janitor'.

This fix changes the Name from an identifier call to a simple string, allowing RegisterPluginJobs() to properly construct the full job type as 'plugin.ipfs.website\_janitor'.

Fixes: Failed to register plugin cron jobs error for IPFS plugin

- `develop` <!-- branch-stack -->
  - **fix: remove duplicate GetCronJobIdentifier call from plugin cron job name** :point\_left:


---

<!-- kody-pr-summary:start -->
 This PR fixes a duplicate identifier generation issue in the plugin's cron job definition by removing the explicit `GetCronJobIdentifier` call.

**Changes:**
- Updated the cron job `Name` field from `core.GetCronJobIdentifier(core.JobOriginPlugin, "ipfs.website_janitor")` to just `"website_janitor"`

**Impact:**
The previous implementation manually constructed the full cron job identifier, which resulted in duplicate prefixing or namespacing since the core framework automatically applies identifier formatting when registering plugin cron jobs. This change provides the base job name only, allowing the core system to properly construct the unique identifier exactly once.
<!-- kody-pr-summary:end -->