### PR TITLE
fix: set correct SourceID for WebsiteJanitorJob

### DIFF
--- a/internal/service/website/janitor.go
+++ b/internal/service/website/janitor.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	JanitorJobSourceID = "ipfs.website_janitor"
+	JanitorJobSourceID = "ipfs"
 )
 
 // WebsiteJanitorJob implements core.CronJob for periodic website validation


### PR DESCRIPTION
The JanitorJobSourceID was incorrectly set to 'ipfs.website_janitor' instead of just 'ipfs'. For plugin jobs, SourceID must be the plugin ID itself, not the full job name.

This caused ValidateCronJob() to fail when checking whether the plugin exists, because PluginExists('ipfs.website_janitor') returns false instead of PluginExists('ipfs') which returns true.

The job.Type() is 'plugin.ipfs.website_janitor' which correctly matches the registered job type, but SourceID just needs to be the plugin ID for plugin jobs.

---

<!-- kody-pr-summary:start -->
This pull request fixes the source identifier constant used by the WebsiteJanitorJob. 

**Change Summary:**
- Updated the `JanitorJobSourceID` constant value from `"ipfs.website_janitor"` to `"ipfs"` in `internal/service/website/janitor.go`

This correction ensures the WebsiteJanitorJob uses the proper source identifier format expected by the cron job system.
<!-- kody-pr-summary:end -->