### PR TITLE
fix(cron): use WithExplicitJobType for website janitor

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/tus/tusd/v2 v2.9.2
 	go.lumeweb.com/httputil v0.5.4
-	go.lumeweb.com/portal v0.4.2-0.20260322154943-02f043cd006f
+	go.lumeweb.com/portal v0.4.2-0.20260323061814-0e9abd8e7ef1
 	go.lumeweb.com/portal-middleware v0.3.7
 	go.lumeweb.com/portal-plugin-core v0.0.0-20260109024150-b4ac33cb7c47
 	go.lumeweb.com/portal-plugin-dashboard v0.2.7-0.20260312042836-d9dfa043a80d

--- a/go.sum
+++ b/go.sum
@@ -1439,6 +1439,8 @@ go.lumeweb.com/portal v0.4.2-0.20260320233303-94340ff16f16 h1:AcQOQ/M0IRlSKstWzo
 go.lumeweb.com/portal v0.4.2-0.20260320233303-94340ff16f16/go.mod h1:hMq1Hez7Tw3DBa4BZdyl5iFvju7YbSJQ6ZPgpY2eukE=
 go.lumeweb.com/portal v0.4.2-0.20260322154943-02f043cd006f h1:YN6kzWyTZleoProJ2w+Mex7Hhdx+LWdkiWXEYv/VP6k=
 go.lumeweb.com/portal v0.4.2-0.20260322154943-02f043cd006f/go.mod h1:hMq1Hez7Tw3DBa4BZdyl5iFvju7YbSJQ6ZPgpY2eukE=
+go.lumeweb.com/portal v0.4.2-0.20260323061814-0e9abd8e7ef1 h1:TW9jsGVcqpEcNP/OfJB0vPhfIU/p4qk3UiTB9voZM1c=
+go.lumeweb.com/portal v0.4.2-0.20260323061814-0e9abd8e7ef1/go.mod h1:hMq1Hez7Tw3DBa4BZdyl5iFvju7YbSJQ6ZPgpY2eukE=
 go.lumeweb.com/portal-middleware v0.3.4 h1:A9/Ipo3giX449CCgbKGco97IqDxFG7Z1ppmM1IQBeDQ=
 go.lumeweb.com/portal-middleware v0.3.4/go.mod h1:3dHvOYXApc1b673I1UAoYBpyXg2c7ku4HqxXvef8dj8=
 go.lumeweb.com/portal-middleware v0.3.5 h1:QwW1cvw4VbSK3rfzW7TwbfezueUXNX80Y/WS97qfoyU=

--- a/internal/service/website/janitor.go
+++ b/internal/service/website/janitor.go
@@ -18,6 +18,7 @@ import (
 
 const (
 	JanitorJobSourceID = "ipfs"
+JanitorJobType     = "plugin.ipfs.website_janitor"
 )
 
 // WebsiteJanitorJob implements core.CronJob for periodic website validation
@@ -47,6 +48,7 @@ func NewWebsiteJanitorJob() core.CronJob {
 		"IPFS Website Janitor",
 		scheduleDef,
 		nil,
+		core.WithExplicitJobType(JanitorJobType),
 	)
 
 	return job


### PR DESCRIPTION
Add JanitorJobType constant and use core.WithExplicitJobType to explicitly set job type to 'plugin.ipfs.website\_janitor'. This resolves the design conflict where Type() computation failed for plugin jobs due to competing requirements for sourceID (validation) vs job type identification.

sourceID remains 'ipfs' for PluginExists() validation while explicit jobType ensures Type() returns the full identifier.

- `develop` <!-- branch-stack -->
  - **fix(cron): use WithExplicitJobType for website janitor** :point\_left:


---

<!-- kody-pr-summary:start -->
This pull request fixes the IPFS website janitor cron job to use an explicit job type identifier.

**Changes:**
- Added `JanitorJobType` constant (`plugin.ipfs.website_janitor`) to explicitly define the job type for the website janitor
- Updated the cron job configuration to use `core.WithExplicitJobType(JanitorJobType)` option when creating the job

This ensures the website janitor cron job is properly identified with a consistent, explicit type identifier rather than relying on default or auto-generated job type assignment.
<!-- kody-pr-summary:end -->