### PR TITLE
refactor(janitor): rename JanitorInterval to CheckInterval and set cron to every minute

### DIFF
--- a/internal/config/website.go
+++ b/internal/config/website.go
@@ -12,7 +12,7 @@ var _ config.Defaults = (*WebsiteConfig)(nil)
 type WebsiteConfig struct {
 	// Janitor configuration
 	JanitorEnabled      bool          `config:"janitor_enabled"`
-	JanitorInterval     time.Duration `config:"janitor_interval"`
+	CheckInterval       time.Duration `config:"check_interval"` // How often to re-validate individual websites
 	JanitorWorkerCount  int           `config:"janitor_worker_count"`
 	JanitorBatchSize    int           `config:"janitor_batch_size"`
 
@@ -27,10 +27,10 @@ type WebsiteConfig struct {
 
 func (c WebsiteConfig) Defaults() map[string]any {
 	return map[string]any{
-		"JanitorEnabled":       true,
-		"JanitorInterval":      30 * time.Minute,
-		"JanitorWorkerCount":   10,
-		"JanitorBatchSize":     500,
+		"JanitorEnabled":  true,
+		"CheckInterval":   30 * time.Minute,
+		"JanitorWorkerCount": 10,
+		"JanitorBatchSize":   500,
 		"ValidationTokenTTL":   24 * time.Hour,
 		"VerificationTokenKey": "lumeweb-verify",
 		"NotificationsEnabled": true,

--- a/internal/plugin/info.go
+++ b/internal/plugin/info.go
@@ -84,7 +84,7 @@ func getPluginInfoWithoutTemplates() core.PluginInfo {
 				Name:    "website_janitor",
 				Factory: func() (core.CronJob, error) { return website.NewWebsiteJanitorJob(), nil },
 				Schedule: core.NewCronScheduleDefinition(core.CronScheduleTypeCron).
-					WithCronExpression("*/30 * * * *"),
+					WithCronExpression("* * * * *"),
 			},
 		},
 		Models: []any{

--- a/internal/service/website/janitor.go
+++ b/internal/service/website/janitor.go
@@ -39,7 +39,7 @@ func NewWebsiteJanitorJob() core.CronJob {
 	// Initialize BaseCronJob with default values
 	jobID := uuid.New()
 	scheduleDef := core.NewCronScheduleDefinition(core.CronScheduleTypeCron).
-		WithCronExpression("*/30 * * * *") // Every 30 minutes (default)
+		WithCronExpression("* * * * *") // Every minute
 
 	job.BaseCronJob = core.NewBaseCronJob(
 		jobID,
@@ -72,7 +72,7 @@ func (j *WebsiteJanitorJob) Run(ctx core.Context, eventCtx context.Context) erro
 	}
 
 	j.logger.Info("Starting website janitor run",
-		zap.Duration("interval", j.config.JanitorInterval),
+		zap.Duration("check_interval", j.config.CheckInterval),
 		zap.Int("workers", j.config.JanitorWorkerCount),
 		zap.Int("batch_size", j.config.JanitorBatchSize))
 
@@ -80,7 +80,7 @@ func (j *WebsiteJanitorJob) Run(ctx core.Context, eventCtx context.Context) erro
 	var websites []*pluginDb.Website
 	err := j.db.WithContext(eventCtx).
 		Where("deleted_at IS NULL").
-		Where("last_checked_at IS NULL OR last_checked_at < ?", time.Now().Add(-j.config.JanitorInterval)).
+		Where("last_checked_at IS NULL OR last_checked_at < ?", time.Now().Add(-j.config.CheckInterval)).
 		Find(&websites).Error
 
 	if err != nil {


### PR DESCRIPTION
- Rename JanitorInterval config field to CheckInterval to better reflect its purpose (controls how often to re-validate individual websites based on last\_checked\_at)
- Set janitor cron schedule to run every minute instead of every 30 minutes
- The cron schedule and check interval are now decoupled:
  - Cron runs every minute to process pending work
  - CheckInterval determines which websites need re-validation

* `develop` <!-- branch-stack -->
  - **refactor(janitor): rename JanitorInterval to CheckInterval and set cron to every minute** :point\_left:


---

<!-- kody-pr-summary:start -->
 **Pull Request Description**

Refactors the website janitor configuration and scheduling to improve the responsiveness of website re-validation.

**Key Changes:**

1. **Configuration Clarification**: Renamed the configuration field `JanitorInterval` to `CheckInterval` to accurately reflect its purpose—defining how often individual websites should be re-validated (default: 30 minutes), distinct from the job execution frequency.

2. **Increased Job Frequency**: Changed the website janitor cron schedule from every 30 minutes (`*/30 * * * *`) to every minute (`* * * * *`). The job now runs every minute to check for and process websites that have exceeded the `CheckInterval` since their last validation.

3. **Updated References**: Modified the janitor service to use the renamed `CheckInterval` configuration field when querying for websites requiring validation.

**Functional Impact:**
The janitor process now evaluates the website queue every minute (rather than every 30 minutes), allowing websites to be re-validated more promptly once they become eligible based on the configured check interval.
<!-- kody-pr-summary:end -->