### PR TITLE
fix(janitor): extract CID from IPNS path before validation

### DIFF
--- a/internal/api/api_ipns.go
+++ b/internal/api/api_ipns.go
@@ -15,30 +15,13 @@ import (
 	pluginCore "go.lumeweb.com/portal-plugin-ipfs/core"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/api/dto"
 	pluginDb "go.lumeweb.com/portal-plugin-ipfs/internal/db"
+	"go.lumeweb.com/portal-plugin-ipfs/internal"
 	"go.uber.org/zap"
 	"gorm.io/gorm"
 )
 
 // KeyTypeEd25519 is the key type identifier for Ed25519 keys.
 const KeyTypeEd25519 = 1
-
-// ipfsPathSegment is the expected first segment for IPFS paths
-const ipfsPathSegment = "ipfs"
-
-// extractCIDFromIPNSPath extracts the CID from an IPNS record path.
-// The path should be formatted as /ipfs/{cid}, where the CID is at segment 1.
-// Returns an error if the path format is invalid or doesn't start with "ipfs".
-func extractCIDFromIPNSPath(valuePath path.Path) (string, error) {
-	pathSegments := valuePath.Segments()
-	if len(pathSegments) < 2 {
-		return "", fmt.Errorf("invalid IPNS record path format: expected at least 2 segments, got %d", len(pathSegments))
-	}
-	// Validate first segment is "ipfs" to ensure we're extracting the right component
-	if pathSegments[0] != ipfsPathSegment {
-		return "", fmt.Errorf("unexpected path protocol: %s", pathSegments[0])
-	}
-	return pathSegments[1], nil
-}
 
 // IPNS Key Handlers
 
@@ -424,7 +407,7 @@ func (a *API) republishIPNS(c echo.Context) error {
 		}
 
 		// Extract CID from the path
-		cidStr, err := extractCIDFromIPNSPath(valuePath)
+		cidStr, err := internal.ExtractCIDFromPathStrict(valuePath)
 		if err != nil {
 			apiErr := NewError(ErrKeyInvalidRequest, err)
 			return ctx.Error(apiErr, apiErr.HttpStatus())
@@ -465,7 +448,7 @@ func (a *API) republishIPNS(c echo.Context) error {
 			}
 
 			// Extract CID from the path
-			cidStr, err := extractCIDFromIPNSPath(valuePath)
+			cidStr, err := internal.ExtractCIDFromPathStrict(valuePath)
 			if err != nil {
 				a.Logger().Warn("Invalid IPNS record path format, skipping", zap.Error(err), zap.String("peer_id", peerID))
 				continue

--- a/internal/paths.go
+++ b/internal/paths.go
@@ -1,6 +1,46 @@
 package internal
 
+import (
+	"fmt"
+
+	"github.com/ipfs/boxo/path"
+)
+
 const (
 	IPFSPathPrefix = "/ipfs/"
 	IPNSPathPrefix = "/ipns/"
 )
+
+// extractCIDFromPath extracts a CID from an IPNS record path.
+// The path should be formatted as /ipfs/{cid}, where the CID is at segment 1.
+// Returns an error if the path format is invalid or doesn't start with "ipfs".
+func extractCIDFromPath(valuePath path.Path) (string, error) {
+	pathSegments := valuePath.Segments()
+	if len(pathSegments) < 2 {
+		return "", fmt.Errorf("invalid IPNS record path format: expected at least 2 segments, got %d", len(pathSegments))
+	}
+	if pathSegments[0] != "ipfs" {
+		return "", fmt.Errorf("unexpected path protocol: %s", pathSegments[0])
+	}
+	return pathSegments[1], nil
+}
+
+// ExtractCIDFromPathLenient extracts a CID from a path, with lenient fallback.
+// If the path is formatted as /ipfs/{cid}, returns the CID from the second segment.
+// If the path does not have the /ipfs/ prefix, treats the entire path as a CID string.
+// This is useful for validation where we want to be forgiving about path format.
+func ExtractCIDFromPathLenient(valuePath path.Path) string {
+	cid, err := extractCIDFromPath(valuePath)
+	if err != nil {
+		return valuePath.String()
+	}
+	return cid
+}
+
+// ExtractCIDFromPathStrict extracts a CID from a path, with strict validation.
+// The path must be formatted as /ipfs/{cid}, where the CID is at segment 1.
+// Returns an error if the path format is invalid or doesn't start with "ipfs".
+// Use this when path format errors should be propagated.
+func ExtractCIDFromPathStrict(valuePath path.Path) (string, error) {
+	return extractCIDFromPath(valuePath)
+}

--- a/internal/service/website/janitor.go
+++ b/internal/service/website/janitor.go
@@ -8,12 +8,13 @@ import (
 	"github.com/gammazero/workerpool"
 	"github.com/google/uuid"
 	"github.com/ipfs/go-cid"
-	pluginCore "go.lumeweb.com/portal-plugin-ipfs/core"
-	"go.lumeweb.com/portal-plugin-ipfs/internal/config"
-	pluginDb "go.lumeweb.com/portal-plugin-ipfs/internal/db"
 	"go.lumeweb.com/portal/core"
 	"go.uber.org/zap"
 	"gorm.io/gorm"
+	pluginCore "go.lumeweb.com/portal-plugin-ipfs/core"
+	"go.lumeweb.com/portal-plugin-ipfs/internal"
+	"go.lumeweb.com/portal-plugin-ipfs/internal/config"
+	pluginDb "go.lumeweb.com/portal-plugin-ipfs/internal/db"
 )
 
 const (
@@ -304,10 +305,10 @@ func (j *WebsiteJanitorJob) validateIPNSTarget(ctx context.Context, website *plu
 		return nil
 	}
 
-	// Extract CID from record
-	recordCID, err := record.Value()
+	// Extract target path from IPNS record
+	targetPath, err := record.Value()
 	if err != nil {
-		j.logger.Error("Failed to extract CID from IPNS record",
+		j.logger.Error("Failed to extract target path from IPNS record",
 			zap.Error(err),
 			zap.Uint("website_id", website.ID),
 			zap.String("domain", website.Domain),
@@ -319,14 +320,15 @@ func (j *WebsiteJanitorJob) validateIPNSTarget(ctx context.Context, website *plu
 		return nil
 	}
 
-	// Validate CID is pinned
-	cidValid, err := j.validateCIDTarget(ctx, recordCID.String())
+	// Extract CID from path using lenient matcher that handles both /ipfs/{cid} and plain CID strings
+	cidStr := internal.ExtractCIDFromPathLenient(targetPath)
+	cidValid, err := j.validateCIDTarget(ctx, cidStr)
 	if err != nil {
 		j.logger.Warn("Failed to validate resolved CID",
 			zap.Error(err),
 			zap.Uint("website_id", website.ID),
 			zap.String("domain", website.Domain),
-			zap.String("cid", recordCID.String()),
+			zap.String("cid", cidStr),
 		)
 		website.Status = string(pluginDb.WebsiteStatusBroken)
 		now := time.Now()
@@ -338,7 +340,7 @@ func (j *WebsiteJanitorJob) validateIPNSTarget(ctx context.Context, website *plu
 		j.logger.Warn("Resolved CID is not pinned",
 			zap.Uint("website_id", website.ID),
 			zap.String("domain", website.Domain),
-			zap.String("cid", recordCID.String()),
+			zap.String("cid", cidStr),
 		)
 		website.Status = string(pluginDb.WebsiteStatusBroken)
 		now := time.Now()

--- a/internal/service/website/janitor_test.go
+++ b/internal/service/website/janitor_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ipfs/boxo/path"
+	"github.com/ipfs/go-cid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	pluginCore "go.lumeweb.com/portal-plugin-ipfs/core"
@@ -79,7 +81,7 @@ func TestWebsiteJanitorJob_Run_NoWebsites(t *testing.T) {
 		// Configure janitor
 		websiteConfig := &pluginConfig.WebsiteConfig{
 			JanitorEnabled:     true,
-			JanitorInterval:    30 * time.Minute,
+			CheckInterval:      30 * time.Minute,
 			JanitorWorkerCount: 2,
 			JanitorBatchSize:   10,
 		}
@@ -132,13 +134,37 @@ func TestWebsiteJanitorJob_Origin(t *testing.T) {
 	assert.Equal(t, core.JobOriginPlugin, origin)
 }
 
-func TestWebsiteJanitorJob_SourceID(t *testing.T) {
-	// Arrange
-	job := NewWebsiteJanitorJob()
 
-	// Act
-	sourceID := job.SourceID()
+func TestWebsiteJanitorJob_ValidateIPNSTarget_FullPath(t *testing.T) {
+	// This test verifies that IPNS path prefixes are extracted correctly.
+	// When an IPNS record returns a path like "/ipfs/bafy...", the janitor should
+	// use internal.ExtractCIDFromPathLenient() to extract the CID.
 
-	// Assert
-	assert.Equal(t, "ipfs.website_janitor", sourceID)
+	tests := []struct {
+		name         string
+		cid          string
+	}{
+		{
+			name:         "Standard CID",
+			cid:          "bafybeieffnocaq7t4w4daagvydl32igft5oziyyaebqr6vx6rb3fwh2ab4",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Arrange - create path.Path from CID
+			// Decode CID and create path from it (which represents /ipfs/{cid})
+			targetCID, err := cid.Decode(tt.cid)
+			require.NoError(t, err, "CID should be valid")
+			targetPath := path.FromCid(targetCID)
+			
+			// Act - use the same helper as the production code
+			// The helper extracts CID from the path by examining segments
+			cidStr := internal.ExtractCIDFromPathLenient(targetPath)
+
+			// Assert - verify the CID was extracted correctly
+			assert.Equal(t, tt.cid, cidStr,
+				"CID should be extracted correctly from path")
+		})
+	}
 }


### PR DESCRIPTION
Fix cid.Decode() error when janitor validates IPNS-resolved targets that include protocol prefixes (e.g., /ipfs/{cid}).

Changes:

- Fix CID validation in website janitor to strip /ipfs/ prefix before parsing
- Extract path.CIDFromPathLenient() and path.CIDFromPathStrict() to internal/paths.go
- Refactor janitor to use new helper for CID extraction
- Refactor API IPNS republish to use shared helper (DRY)
- Add TestWebsiteJanitorJob\_ValidateIPNSTarget\_FullPath for path handling
- Delete outdated TestWebsiteJanitorJob\_SourceID test

The janitor now properly handles IPNS records that return full paths instead of just CID strings by extracting the CID using path.Segments().

- `develop` <!-- branch-stack -->
  - **fix(janitor): extract CID from IPNS path before validation** :point\_left:


---

<!-- kody-pr-summary:start -->
This pull request fixes a bug in the website janitor service where IPNS records containing path prefixes (e.g., `/ipfs/bafy...`) were failing validation because the code attempted to validate the entire path string as a CID.

**Key Changes:**

1. **Fixed IPNS validation in janitor**: Modified `validateIPNSTarget` to extract the actual CID from IPNS record paths using `ExtractCIDFromPathLenient` before validating against pinned content. This handles both `/ipfs/{cid}` formatted paths and raw CID strings.

2. **Refactored path extraction logic**: Moved CID extraction functions from the API layer to a shared `internal/paths.go` package, creating reusable `ExtractCIDFromPathStrict` (for API operations requiring strict validation) and `ExtractCIDFromPathLenient` (for janitor operations needing flexible parsing) functions.

3. **Updated API to use shared functions**: Replaced the local `extractCIDFromIPNSPath` function in `api_ipns.go` with calls to the centralized `ExtractCIDFromPathStrict`.

4. **Added test coverage**: Introduced `TestWebsiteJanitorJob_ValidateIPNSTarget_FullPath` to verify that CIDs are correctly extracted from `/ipfs/` prefixed paths.
<!-- kody-pr-summary:end -->