### PR TITLE
fix: use type-safe GORM Model for IPNS key website reference check

### DIFF
--- a/internal/service/ipns_key/ipns_key.go
+++ b/internal/service/ipns_key/ipns_key.go
@@ -436,7 +436,7 @@ func (s *IPNSKeyServiceDefault) DeleteKey(ctx context.Context, userID uint, keyI
 	checkErr := db.RetryableComponentTransaction(s, ctx, func(tx *gorm.DB) *gorm.DB {
 		return tx.Model(&pluginDb.Website{}).
 			Where("target_multihash = ? AND target_type = ? AND status = ?", 
-				 key.PeerIDMultihash, "ipns", "active").
+				 key.PeerIDMultihash, pluginDb.WebsiteTargetTypeIPNS, pluginDb.WebsiteStatusActive).
 			Count(&websiteCount)
 	})
 	if checkErr != nil {

--- a/internal/service/ipns_key/ipns_key.go
+++ b/internal/service/ipns_key/ipns_key.go
@@ -434,8 +434,9 @@ func (s *IPNSKeyServiceDefault) DeleteKey(ctx context.Context, userID uint, keyI
 	// Check if key is referenced by any active websites
 	var websiteCount int64
 	checkErr := db.RetryableComponentTransaction(s, ctx, func(tx *gorm.DB) *gorm.DB {
-		return tx.Table("ipfs_websites").
-			Where("target_multihash = ? AND target_type = ? AND status = ?", key.PeerIDMultihash, "ipns", "active").
+		return tx.Model(&pluginDb.Website{}).
+			Where("target_multihash = ? AND target_type = ? AND status = ?", 
+				 key.PeerIDMultihash, "ipns", "active").
 			Count(&websiteCount)
 	})
 	if checkErr != nil {

--- a/internal/service/ipns_key/ipns_key_test.go
+++ b/internal/service/ipns_key/ipns_key_test.go
@@ -14,6 +14,7 @@ import (
 	"go.lumeweb.com/portal-plugin-ipfs/internal"
 	pluginConfig "go.lumeweb.com/portal-plugin-ipfs/internal/config"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/db/migrations"
+	pluginDb "go.lumeweb.com/portal-plugin-ipfs/internal/db"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/testing/mocks"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/testing/util"
 	"go.lumeweb.com/portal/core"
@@ -366,6 +367,120 @@ func TestIPNSKeyService_DeleteKey_NotFound(t *testing.T) {
 		err := keyService.DeleteKey(context.Background(), userID, nonExistentKeyID)
 
 		// Assert
+		assert.Error(tb, err)
+	}, TestOptions)
+}
+
+func TestIPNSKeyService_DeleteKey_WithActiveWebsite(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		// Arrange
+		keyService := core.GetService[pluginCore.IPNSKeyService](ctx, pluginCore.IPNS_KEY_SERVICE)
+		require.NotNil(tb, keyService)
+
+		userID := uint(1)
+
+		// Create a key
+		createdKey, err := keyService.CreateKey(context.Background(), userID, "test-delete-key-active", KeyType_Ed25519)
+		require.NoError(tb, err)
+
+		// Create an active website that references this IPNS key
+		website := &pluginDb.Website{
+			UserID:          userID,
+			Domain:          "test.example.com",
+			TargetType:      string(pluginDb.WebsiteTargetTypeIPNS),
+			TargetMultihash: createdKey.PeerIDMultihash,
+			Status:          string(pluginDb.WebsiteStatusActive),
+			ValidationToken: "test-token-123",
+		}
+		
+		err = ctx.DB().Create(website).Error
+		require.NoError(tb, err)
+
+		// Act - Try to delete the key
+		err = keyService.DeleteKey(context.Background(), userID, createdKey.ID)
+
+		// Assert - Should fail because key is referenced by active website
+		assert.Error(tb, err)
+		assert.Contains(tb, err.Error(), "cannot delete IPNS key")
+		assert.Contains(tb, err.Error(), "referenced by 1 active website")
+
+		// Verify key still exists
+		_, err = keyService.GetKeyByID(context.Background(), userID, createdKey.ID)
+		assert.NoError(tb, err)
+	}, TestOptions)
+}
+
+func TestIPNSKeyService_DeleteKey_WithInactiveWebsite(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		// Arrange
+		keyService := core.GetService[pluginCore.IPNSKeyService](ctx, pluginCore.IPNS_KEY_SERVICE)
+		require.NotNil(tb, keyService)
+
+		userID := uint(1)
+
+		// Create a key
+		createdKey, err := keyService.CreateKey(context.Background(), userID, "test-delete-key-inactive", KeyType_Ed25519)
+		require.NoError(tb, err)
+
+		// Create an INACTIVE (broken) website that references this IPNS key
+		// This simulates the scenario where user wants to clean up a failed website and its key
+		website := &pluginDb.Website{
+			UserID:          userID,
+			Domain:          "test-broken.example.com",
+			TargetType:      string(pluginDb.WebsiteTargetTypeIPNS),
+			TargetMultihash: createdKey.PeerIDMultihash,
+			Status:          string(pluginDb.WebsiteStatusBroken),
+			ValidationToken: "test-token-456",
+		}
+		
+		err = ctx.DB().Create(website).Error
+		require.NoError(tb, err)
+
+		// Act - Try to delete the key
+		err = keyService.DeleteKey(context.Background(), userID, createdKey.ID)
+
+		// Assert - Should succeed because website is not active
+		require.NoError(tb, err)
+
+		// Verify key is soft-deleted
+		_, err = keyService.GetKeyByID(context.Background(), userID, createdKey.ID)
+		assert.Error(tb, err)
+	}, TestOptions)
+}
+
+func TestIPNSKeyService_DeleteKey_WithPendingWebsite(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		// Arrange
+		keyService := core.GetService[pluginCore.IPNSKeyService](ctx, pluginCore.IPNS_KEY_SERVICE)
+		require.NotNil(tb, keyService)
+
+		userID := uint(1)
+
+		// Create a key
+		createdKey, err := keyService.CreateKey(context.Background(), userID, "test-delete-key-pending", KeyType_Ed25519)
+		require.NoError(tb, err)
+
+		// Create a pending validation website that references this IPNS key
+		website := &pluginDb.Website{
+			UserID:          userID,
+			Domain:          "test-pending.example.com",
+			TargetType:      string(pluginDb.WebsiteTargetTypeIPNS),
+			TargetMultihash: createdKey.PeerIDMultihash,
+			Status:          string(pluginDb.WebsiteStatusPendingValidation),
+			ValidationToken: "test-token-789",
+		}
+		
+		err = ctx.DB().Create(website).Error
+		require.NoError(tb, err)
+
+		// Act - Try to delete the key
+		err = keyService.DeleteKey(context.Background(), userID, createdKey.ID)
+
+		// Assert - Should succeed because website is pending, not active
+		require.NoError(tb, err)
+
+		// Verify key is soft-deleted
+		_, err = keyService.GetKeyByID(context.Background(), userID, createdKey.ID)
 		assert.Error(tb, err)
 	}, TestOptions)
 }

--- a/internal/service/website/janitor_test.go
+++ b/internal/service/website/janitor_test.go
@@ -145,18 +145,23 @@ func TestWebsiteJanitorJob_ValidateIPNSTarget_FullPath(t *testing.T) {
 		cid          string
 	}{
 		{
-			name:         "Standard CID",
-			cid:          "bafybeieffnocaq7t4w4daagvydl32igft5oziyyaebqr6vx6rb3fwh2ab4",
+			name: "Path with /ipfs/ prefix",
+			cid:  "bafybeieffnocaq7t4w4daagvydl32igft5oziyyaebqr6vx6rb3fwh2ab4",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Arrange - create path.Path from CID
-			// Decode CID and create path from it (which represents /ipfs/{cid})
+			// Decode CID and create full path from it (which represents /ipfs/{cid})
+			// This is the format returned by ipns.Record.Value()
 			targetCID, err := cid.Decode(tt.cid)
 			require.NoError(t, err, "CID should be valid")
 			targetPath := path.FromCid(targetCID)
+
+			// Verify the path has the /ipfs/ prefix
+			assert.Equal(t, "/ipfs/"+tt.cid, targetPath.String(),
+				"path.FromCid() should create path with /ipfs/ prefix")
 			
 			// Act - use the same helper as the production code
 			// The helper extracts CID from the path by examining segments


### PR DESCRIPTION
Replace raw table name query with Model() for type safety and ensure correct table mapping. Add comprehensive tests for IPNS key deletion behavior with different website statuses.

- Change tx.Table("ipfs\_websites") to tx.Model(\&pluginDb.Website{})
- Add TestIPNSKeyService\_DeleteKey\_WithActiveWebsite (should fail)
- Add TestIPNSKeyService\_DeleteKey\_WithInactiveWebsite (should succeed)
- Add TestIPNSKeyService\_DeleteKey\_WithPendingWebsite (should succeed)
- Update janitor test comments for clarity

This ensures users can delete IPNS keys when wired websites are non-active (broken/pending) without errors.

- `develop` <!-- branch-stack -->
  - **fix: use type-safe GORM Model for IPNS key website reference check** :point\_left:

***

<!-- kody-pr-summary:start -->

This pull request implements type-safe database queries for IPNS key deletion checks and adds comprehensive test coverage for website reference validation.

**Key Changes:**

1. **Type-Safe GORM Model Usage**: Updated the IPNS key deletion logic to use `tx.Model(&pluginDb.Website{})` instead of the raw string `tx.Table("ipfs_websites")` when checking for active website references. This ensures compile-time type safety and better IDE support while maintaining the same functional behavior.

2. **IPNS Key Deletion Test Coverage**: Added three new test cases to verify the deletion behavior when IPNS keys are referenced by websites in different states:
   - **Active websites**: Deletion is blocked to prevent breaking live sites
   - **Inactive (broken) websites**: Deletion is allowed to enable cleanup of failed deployments
   - **Pending validation websites**: Deletion is allowed since the site is not yet live

3. **Test Documentation Improvements**: Enhanced test clarity in the website janitor tests with better naming and assertions to verify IPFS path formatting.

**Functional Impact:**

- IPNS keys referenced by active websites cannot be deleted (protects live sites)
- Users can clean up IPNS keys associated with failed or pending websites
- No behavioral changes to existing functionality - only implementation safety improvements and test coverage

<!-- kody-pr-summary:end -->
