### PR TITLE
fix(janitor): normalize CID for pin lookup and website creation

### DIFF
--- a/internal/api/dto/website.go
+++ b/internal/api/dto/website.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ipfs/go-cid"
 	"go.lumeweb.com/httputil"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/db"
+	"go.lumeweb.com/portal-plugin-ipfs/internal/protocol/encoding"
 	"go.lumeweb.com/portal/config"
 )
 
@@ -219,9 +220,14 @@ func (r *WebsiteRequest) ToModel() (*db.Website, error) {
 				},
 			}
 		}
-		website.TargetMultihash = c.Hash()
-		version := uint8(c.Version())
+
+		// Normalize to v1 for consistent storage
+		normalizedCid := encoding.NormalizeCid(c)
+		website.TargetMultihash = normalizedCid.Hash()
+		version := uint8(normalizedCid.Version())
 		website.CIDVersion = &version
+		codec := uint8(normalizedCid.Type())
+		website.CIDType = &codec
 	}
 
 	// Validate peer ID for IPNS targets

--- a/internal/service/website/janitor.go
+++ b/internal/service/website/janitor.go
@@ -15,6 +15,7 @@ import (
 	"go.lumeweb.com/portal-plugin-ipfs/internal"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/config"
 	pluginDb "go.lumeweb.com/portal-plugin-ipfs/internal/db"
+	"go.lumeweb.com/portal-plugin-ipfs/internal/protocol/encoding"
 )
 
 const (
@@ -220,11 +221,14 @@ func (j *WebsiteJanitorJob) validateCIDTarget(ctx context.Context, targetHash st
 		return false, fmt.Errorf("invalid CID: %w", err)
 	}
 
+	// Normalize to match database storage format (pins are stored as normalized CID v1)
+	normalizedCid := encoding.NormalizeCid(parsedCid)
+
 	// Check if CID is pinned for any user
 	// We need to scan through pins since GetPinByCIDAndUser requires a userID
 	var pins []*pluginDb.IPFSPin
 	err = j.db.WithContext(ctx).
-		Where("cid = ?", parsedCid.Bytes()).
+		Where("cid = ?", normalizedCid.Bytes()).
 		Where("deleted_at IS NULL").
 		Where("status = ?", pluginDb.PinningStatusPinned).
 		Limit(1).


### PR DESCRIPTION
Fixes CID comparison issues where janitor incorrectly marked websites as broken due to mismatched CID byte formats.

Changes:

- janitor.go: Normalize CID before querying database for pinned status The database stores normalized CID v1 bytes, but the query was using decoded CID bytes directly, causing false negatives.

- dto/website.go: Store CIDType (codec) during website creation Previously only CIDVersion was stored, causing TargetHash() to fall back to Raw codec when reconstructing CIDs.

Both fixes ensure consistent CID handling across storage, lookup, and reconstruction operations.

- `develop` <!-- branch-stack -->
  - **fix(janitor): normalize CID for pin lookup and website creation** :point\_left:


---

<!-- kody-pr-summary:start -->
This PR fixes CID format inconsistencies that caused pin lookup failures in the janitor service and ensures consistent CID storage for websites.

**Changes:**
- **Janitor Service**: Normalizes CIDs to v1 format before querying the database for pinned content, resolving mismatches between the lookup CID format and the normalized CID format stored in the pins table.
- **Website Creation**: Normalizes CIDs to v1 format when creating websites to ensure consistent storage, and adds support for persisting the CID codec/type in the database.

The normalization ensures that CIDs are stored and queried in a consistent format (CID v1), preventing validation failures when the janitor checks if a website's target CID is pinned.
<!-- kody-pr-summary:end -->