### PR TITLE
fix: normalize CID resolved from IPNS record

### DIFF
--- a/internal/api/api_ipns.go
+++ b/internal/api/api_ipns.go
@@ -315,6 +315,9 @@ func (a *API) resolveIPNS(c echo.Context) error {
 		return ctx.Error(apiErr, apiErr.HttpStatus())
 	}
 
+	// Normalize CID if the resolved value contains one
+	normalizedValue := internal.TryNormalizeCIDFromPath(valuePath)
+
 	sequence, err := record.Sequence()
 	if err != nil {
 		a.Logger().Error("Failed to get IPNS record sequence", zap.Error(err))
@@ -330,9 +333,9 @@ func (a *API) resolveIPNS(c echo.Context) error {
 
 	resp := dto.IPNSResolveResponse{
 		Name:     name,
-		Value:    valuePath.String(),
+		Value:    normalizedValue,
 		Sequence: sequence,
-		Path:     dto.IPFSPath(valuePath.String()),
+		Path:     dto.IPFSPath(normalizedValue),
 		Expired:  time.Now().After(validity),
 		Expires:  validity,
 	}

--- a/internal/paths.go
+++ b/internal/paths.go
@@ -52,6 +52,13 @@ func ExtractCIDFromPathStrict(valuePath path.Path) (string, error) {
 // If the path contains a valid CID, it will be normalized to v1 format.
 // If the path does not contain a valid CID, the original path string is returned unchanged.
 // This is useful when you want to normalize CIDs when possible but handle non-CID paths gracefully.
+//
+// The function includes defensive error handling:
+// - If CID parsing fails, returns the original path unchanged
+// - If normalization returns cid.Undef (unsupported CID version), returns the original path unchanged
+//
+// In practice, cid.Undef is rare as only v0 and v1 CIDs are supported and both normalize correctly.
+// This handling exists as a defensive measure for edge cases or future CID versions.
 func TryNormalizeCIDFromPath(valuePath path.Path) string {
 	// Try to extract CID string from the path
 	cidStr := ExtractCIDFromPathLenient(valuePath)

--- a/internal/paths.go
+++ b/internal/paths.go
@@ -3,7 +3,10 @@ package internal
 import (
 	"fmt"
 
+	"github.com/ipfs/go-cid"
 	"github.com/ipfs/boxo/path"
+
+	"go.lumeweb.com/portal-plugin-ipfs/internal/protocol/encoding"
 )
 
 const (
@@ -43,4 +46,36 @@ func ExtractCIDFromPathLenient(valuePath path.Path) string {
 // Use this when path format errors should be propagated.
 func ExtractCIDFromPathStrict(valuePath path.Path) (string, error) {
 	return extractCIDFromPath(valuePath)
+}
+
+// TryNormalizeCIDFromPath attempts to normalize a CID from a path.
+// If the path contains a valid CID, it will be normalized to v1 format.
+// If the path does not contain a valid CID, the original path string is returned unchanged.
+// This is useful when you want to normalize CIDs when possible but handle non-CID paths gracefully.
+func TryNormalizeCIDFromPath(valuePath path.Path) string {
+	// Try to extract CID string from the path
+	cidStr := ExtractCIDFromPathLenient(valuePath)
+	
+	// Try to parse it as a CID
+	parsedCid, err := cid.Parse(cidStr)
+	if err != nil {
+		// Not a valid CID, return the original path unchanged
+		return valuePath.String()
+	}
+	
+	// Normalize the CID
+	normalizedCid := encoding.NormalizeCid(parsedCid)
+	
+	// Reconstruct the path with the normalized CID
+	segments := valuePath.Segments()
+	if len(segments) > 0 && segments[0] == "ipfs" {
+		// This is /ipfs/{cid} format, reconstruct with normalized CID
+		return path.FromCid(normalizedCid).String()
+	} else if len(segments) == 0 {
+		// Just a CID without prefix, return normalized CID string
+		return normalizedCid.String()
+	}
+	
+	// Some other path format, return normalized as string
+	return normalizedCid.String()
 }

--- a/internal/paths.go
+++ b/internal/paths.go
@@ -62,20 +62,14 @@ func TryNormalizeCIDFromPath(valuePath path.Path) string {
 		// Not a valid CID, return the original path unchanged
 		return valuePath.String()
 	}
-	
+
 	// Normalize the CID
 	normalizedCid := encoding.NormalizeCid(parsedCid)
-	
-	// Reconstruct the path with the normalized CID
-	segments := valuePath.Segments()
-	if len(segments) > 0 && segments[0] == "ipfs" {
-		// This is /ipfs/{cid} format, reconstruct with normalized CID
-		return path.FromCid(normalizedCid).String()
-	} else if len(segments) == 0 {
-		// Just a CID without prefix, return normalized CID string
-		return normalizedCid.String()
+	if normalizedCid == cid.Undef {
+		// Unsupported CID version, return original path unchanged
+		return valuePath.String()
 	}
-	
-	// Some other path format, return normalized as string
-	return normalizedCid.String()
+
+	// Create a new path from the normalized CID
+	return path.FromCid(normalizedCid).String()
 }

--- a/internal/paths_test.go
+++ b/internal/paths_test.go
@@ -1,0 +1,48 @@
+package internal
+
+import (
+	"testing"
+
+	"github.com/ipfs/go-cid"
+	"github.com/stretchr/testify/require"
+	"github.com/ipfs/boxo/path"
+)
+
+func TestTryNormalizeCIDFromPath(t *testing.T) {
+	t.Run("v0_to_v1", func(t *testing.T) {
+		// Create a v0 CID
+		v0Cid, err := cid.Parse("QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG")
+		require.NoError(t, err)
+		
+		// Create a path from the v0 CID
+		valuePath := path.FromCid(v0Cid)
+		
+		// Normalize - should return v1 CID path
+		normalized := TryNormalizeCIDFromPath(valuePath)
+		
+		// Check that it's a v1 CID
+		parsedCid, err := cid.Parse(normalized)
+		require.NoError(t, err, "Should be able to parse normalized CID")
+		require.Equal(t, uint64(1), uint64(parsedCid.Version()), "Should be v1")
+	})
+
+	t.Run("v1_cid", func(t *testing.T) {
+		// Create a v1 CID
+		v1Cid, err := cid.Parse("bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi")
+		require.NoError(t, err)
+		
+		// Create a path from the v1 CID
+		valuePath := path.FromCid(v1Cid)
+		
+		// Normalize - should return the same v1 CID path
+		normalized := TryNormalizeCIDFromPath(valuePath)
+		
+		// Check that it's a v1 CID
+		parsedCid, err := cid.Parse(normalized)
+		require.NoError(t, err, "Should be able to parse normalized CID")
+		require.Equal(t, uint64(1), uint64(parsedCid.Version()), "Should be v1")
+		
+		// Check that it's the same CID
+		require.True(t, v1Cid.Equals(parsedCid), "Should be the same CID")
+	})
+}

--- a/internal/paths_test.go
+++ b/internal/paths_test.go
@@ -11,7 +11,7 @@ import (
 func TestTryNormalizeCIDFromPath(t *testing.T) {
 	t.Run("v0_to_v1", func(t *testing.T) {
 		// Create a v0 CID
-		v0Cid, err := cid.Parse("QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG")
+		v0Cid, err := cid.Parse("QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdD")
 		require.NoError(t, err)
 		
 		// Create a path from the v0 CID


### PR DESCRIPTION
Add CID normalization to the IPNS resolve endpoint to ensure all resolved CIDs are returned in v1 format for consistency.

- Add TryNormalizeCIDFromPath helper in internal/paths.go that attempts to normalize CIDs from paths when possible, but gracefully returns the original path unchanged if not a valid CID
- Update resolveIPNS endpoint to use the helper for normalization
- Add tests for the new helper function

This ensures consistency with other parts of the system that normalize CIDs (website creation, metadata storage) while being defensive about edge cases where the resolved value might not be a valid CID.

- `develop` <!-- branch-stack -->
  - **fix: normalize CID resolved from IPNS record** :point\_left:

***

<!-- kody-pr-summary:start -->

This PR fixes IPNS record resolution to normalize CIDs to v1 format. When resolving an IPNS name, the system now converts any v0 CIDs to v1 format while preserving v1 CIDs as-is. If the resolved value is not a valid CID, the original path is returned unchanged.

**Changes:**

- Added `TryNormalizeCIDFromPath` function to safely extract and normalize CIDs from paths, handling `/ipfs/{cid}` prefixes and bare CIDs
- Updated IPNS resolution endpoint (`resolveIPNS`) to return normalized CID values and paths in the response
- Added unit tests verifying v0 to v1 CID conversion and v1 CID preservation (idempotent normalization)

This ensures consistent CID representation in IPNS resolution responses, automatically upgrading legacy v0 CIDs to the modern v1 format while maintaining backward compatibility for non-CID paths.

<!-- kody-pr-summary:end -->
