### PR TITLE
fix: use direct TXT query for DNS validation token

### DIFF
--- a/internal/service/website/website.go
+++ b/internal/service/website/website.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"net"
 	"regexp"
 	"strings"
 	"time"
@@ -932,8 +933,8 @@ func (s *WebsiteServiceDefault) ValidateDNS(ctx context.Context, userID uint, we
 					return tx
 				}
 
-				// Query DNS for TXT records using dnslink library
-				// The library handles the _dnslink. prefix automatically
+				// Query DNS for DNSlink records using dnslink library
+				// Validation token is checked separately using direct TXT lookup
 				result, err := dnslink.Resolve(website.Domain)
 				if err != nil {
 					// Check if this is an NXDOMAIN error (no DNS records exist)
@@ -983,10 +984,19 @@ func (s *WebsiteServiceDefault) ValidateDNS(ctx context.Context, userID uint, we
 					}
 				}
 
-				// Check for validation token in raw TXT entries
+				// Check for validation token using direct TXT query
 				expectedTokenRecord := fmt.Sprintf("%s=%s", s.config.VerificationTokenKey, website.ValidationToken)
-				for _, txtEntry := range result.TxtEntries {
-					if strings.Contains(txtEntry.Value, expectedTokenRecord) {
+				txtRecords, err := net.LookupTXT(website.Domain)
+				if err != nil {
+					s.Logger().Debug("DNS TXT lookup failed for validation token",
+						zap.Error(err),
+						zap.String("domain", website.Domain))
+					_ = tx.AddError(fmt.Errorf("DNS TXT lookup failed for %s: %w", website.Domain, err))
+					return tx
+				}
+				
+				for _, txtRecord := range txtRecords {
+					if strings.Contains(txtRecord, expectedTokenRecord) {
 						hasToken = true
 						s.Logger().Debug("Found valid validation token",
 							zap.String("domain", website.Domain),


### PR DESCRIPTION
Replace DNS link TXT query with net.LookupTXT for validation token check to use system DNS instead of dnslink library. The DNS link record validation still uses dnslink.Resolve, but the verification token is now checked using standard DNS TXT lookup.

- Keep dnslink.Resolve for \_dnslink.domain.com validation
- Use net.LookupTXT for domain.com verification token check

* `develop` <!-- branch-stack -->
  - **fix: use direct TXT query for DNS validation token** :point\_left:


---

<!-- kody-pr-summary:start -->
This pull request fixes the DNS validation process by implementing a direct TXT record lookup for verification tokens.

**Changes:**
- Replaces the reliance on dnslink library's TXT entries for validation token verification with a direct DNS TXT query using `net.LookupTXT`
- Separates the concerns of DNSlink resolution (for content routing) from validation token verification (for domain ownership proof)
- Adds proper error handling for the direct TXT lookup operation

**Impact:**
The validation token is now retrieved through a standard DNS TXT query directly against the domain, ensuring the token is checked independently of the dnslink library's record processing. This provides more reliable detection of validation tokens during the domain verification process.
<!-- kody-pr-summary:end -->