### PR TITLE
fix(quota): skip quota checks for internal name resolution operations

### DIFF
--- a/internal/api/api_ipfs.go
+++ b/internal/api/api_ipfs.go
@@ -81,7 +81,11 @@ func (a API) handleRawBlockRequest(ctx httputil.RequestContext, _cid cid.Cid, w 
 	userID := upload.UserID
 
 	if err := quota.ValidateDownloadQuota(reqCtx, a.Context(), userID, upload.Size); err != nil {
-		a.Logger().Warn("Download quota validation failed", zap.Uint("user_id", userID), zap.Error(err))
+		a.Logger().Warn("Download quota validation failed",
+			zap.Uint("user_id", userID),
+			zap.Uint64("upload_size", upload.Size),
+			zap.Stringer("cid", _cid),
+			zap.Error(err))
 		apiErr := NewError(ErrKeyDownloadQuotaExceeded, err)
 		_ = ctx.Error(apiErr, http.StatusTooManyRequests)
 		return apiErr

--- a/internal/protocol/store/blockstore.go
+++ b/internal/protocol/store/blockstore.go
@@ -107,8 +107,11 @@ func (bs *BlockStore) Get(ctx context.Context, c cid.Cid) (blocks.Block, error) 
 
 	// Validate download quota - always anonymous (nil userID), unless skipped
 	if !IsQuotaCheckSkipped(ctx) {
+		bs.log.Debug("Performing anonymous download quota check",
+			zap.String("cid", c.String()),
+			zap.Uint64("size", size))
 		if err := quota.ValidateDownloadQuota(ctx, bs.ctx, 0, uint64(size)); err != nil {
-			bs.log.Debug("download quota validation failed", zap.String("cid", c.String()), zap.Error(err))
+			bs.log.Warn("Anonymous quota check failed", zap.String("cid", c.String()), zap.Error(err))
 			return nil, err
 		}
 	}

--- a/internal/protocol/store/metadata.go
+++ b/internal/protocol/store/metadata.go
@@ -215,7 +215,9 @@ func (s *MetadataStoreDefault) resolveNameFromParentWithBlock(childCid cid.Cid, 
 		zap.Stringer("parent_cid", parentCid))
 
 	// Get the parent block data
-	block, err := s.proto.GetNode().GetBlock(s.ctx, parentCid)
+	// Skip quota check for internal name resolution - this is metadata extraction from already-pinned data
+	getCtx := SkipQuotaCheckOption(s.ctx, true)
+	block, err := s.proto.GetNode().GetBlock(getCtx, parentCid)
 	if err != nil {
 		s.logger.Debug("Failed to get parent block",
 			zap.Stringer("child_cid", childCid),

--- a/internal/quota/quota.go
+++ b/internal/quota/quota.go
@@ -8,6 +8,7 @@ import (
 	"go.lumeweb.com/portal/core"
 	"go.lumeweb.com/portal/db/models"
 	"go.lumeweb.com/portal/event"
+	"go.uber.org/zap"
 )
 
 // WithQuotaService executes a function with quota service if available
@@ -89,9 +90,18 @@ func EmitStorageObjectUnpinned(cctx context.Context, ctx core.Context, pin *mode
 func ValidateUploadQuota(cctx context.Context, ctx core.Context, userID uint, requestedBytes uint64) error {
 	result, err := CheckUploadQuota(cctx, ctx, userID, requestedBytes)
 	if err != nil {
+		ctx.Logger().Warn("Upload quota check failed",
+			zap.Uint("user_id", userID),
+			zap.Uint64("requested_bytes", requestedBytes),
+			zap.Error(err))
 		return fmt.Errorf("quota check failed: %w", err)
 	}
 	if result != nil && !result.Allowed {
+		ctx.Logger().Debug("Upload quota exceeded",
+			zap.Uint("user_id", userID),
+			zap.Uint64("requested_bytes", requestedBytes),
+			zap.Uint64("current_usage", result.Details.CurrentUsage),
+			zap.Any("limit", result.Details.Limit))
 		return core.ErrUploadQuotaExceeded
 	}
 	return nil
@@ -101,9 +111,18 @@ func ValidateUploadQuota(cctx context.Context, ctx core.Context, userID uint, re
 func ValidateDownloadQuota(cctx context.Context, ctx core.Context, userID uint, requestedBytes uint64) error {
 	result, err := CheckDownloadQuota(cctx, ctx, userID, requestedBytes)
 	if err != nil {
+		ctx.Logger().Warn("Download quota check failed",
+			zap.Uint("user_id", userID),
+			zap.Uint64("requested_bytes", requestedBytes),
+			zap.Error(err))
 		return fmt.Errorf("quota check failed: %w", err)
 	}
 	if result != nil && !result.Allowed {
+		ctx.Logger().Debug("Download quota exceeded",
+			zap.Uint("user_id", userID),
+			zap.Uint64("requested_bytes", requestedBytes),
+			zap.Uint64("current_usage", result.Details.CurrentUsage),
+			zap.Any("limit", result.Details.Limit))
 		return core.ErrDownloadQuotaExceeded
 	}
 	return nil
@@ -113,9 +132,18 @@ func ValidateDownloadQuota(cctx context.Context, ctx core.Context, userID uint, 
 func ValidateStorageQuota(cctx context.Context, ctx core.Context, userID uint, requestedBytes uint64) error {
 	result, err := CheckStorageQuota(cctx, ctx, userID, requestedBytes)
 	if err != nil {
+		ctx.Logger().Warn("Storage quota check failed",
+			zap.Uint("user_id", userID),
+			zap.Uint64("requested_bytes", requestedBytes),
+			zap.Error(err))
 		return fmt.Errorf("quota check failed: %w", err)
 	}
 	if result != nil && !result.Allowed {
+		ctx.Logger().Debug("Storage quota exceeded",
+			zap.Uint("user_id", userID),
+			zap.Uint64("requested_bytes", requestedBytes),
+			zap.Uint64("current_usage", result.Details.CurrentUsage),
+			zap.Any("limit", result.Details.Limit))
 		return core.ErrStorageQuotaExceeded
 	}
 	return nil


### PR DESCRIPTION
- Add SkipQuotaCheckOption when retrieving parent blocks during UnixFS name resolution in MetadataStore
- Name resolution is an internal metadata extraction operation on already-pinned data that should not trigger quota validation
- Add comprehensive debug logging throughout quota validation pipeline
- Log quota check failures with context (user\_id, bytes, CID, size)
- Use Warn level for check failures, Debug level for quota exceeded conditions
- Improve error logging in API download handler

* `develop` <!-- branch-stack -->
  - **fix(quota): skip quota checks for internal name resolution operations** :point\_left:


---

<!-- kody-pr-summary:start -->
**Functional Summary:**
This pull request resolves an issue where internal metadata operations were incorrectly subject to quota validation, potentially causing failures during name resolution for already-pinned content. It also enhances observability across all quota validation flows.

**Key Changes:**

1. **Skip Quota Checks for Internal Operations** (`metadata.go`): Modified the name resolution process to bypass download quota validation when extracting metadata from parent blocks. Since this operation accesses already-pinned data during internal path resolution, quota enforcement was redundant and could block legitimate metadata retrieval.

2. **Enhanced Quota Logging** (`quota.go`, `api_ipfs.go`, `blockstore.go`): Added comprehensive structured logging across upload, download, and storage quota validation functions. Log entries now include user IDs, requested byte amounts, current usage statistics, limits, and content identifiers (CIDs) to improve diagnostic capabilities when quota violations occur.

3. **Improved Log Severity** (`blockstore.go`): Upgraded anonymous quota check failure logs from Debug to Warning level to ensure visibility of potential quota enforcement issues in production environments.

These changes ensure that internal system operations (such as IPFS path resolution and metadata extraction) function reliably without artificial quota constraints, while maintaining full quota enforcement for actual user-initiated upload and download requests.
<!-- kody-pr-summary:end -->