### PR TITLE
fix(blockstore): add proper quota tracking for upload and storage operations

### DIFF
--- a/internal/protocol/store/blockstore.go
+++ b/internal/protocol/store/blockstore.go
@@ -188,7 +188,7 @@ func (bs *BlockStore) Put(ctx context.Context, b blocks.Block) error {
 	}
 
 	// Validate upload quota for authenticated users if no existing upload
-	if userID > 0 && existingUpload == nil && !IsQuotaCheckSkipped(ctx) {
+	if IsValidUserID(userID) && existingUpload == nil && !IsQuotaCheckSkipped(ctx) {
 		if err := quota.ValidateUploadQuota(ctx, bs.ctx, userID, size); err != nil {
 			bs.log.Warn("Upload quota validation failed",
 				zap.Uint("user_id", userID),
@@ -202,7 +202,7 @@ func (bs *BlockStore) Put(ctx context.Context, b blocks.Block) error {
 		log.Debug("Upload already exists, skipping upload record creation",
 			zap.Stringer("cid", b.Cid()),
 			zap.Uint("existing_user_id", existingUpload.UserID))
-	} else if userID > 0 {
+	} else if IsValidUserID(userID) {
 		log.Debug("No existing upload, will create new record via storage upload",
 			zap.Stringer("cid", b.Cid()),
 			zap.Uint("user_id", userID))
@@ -223,10 +223,8 @@ func (bs *BlockStore) Put(ctx context.Context, b blocks.Block) error {
 	log.Debug("object uploaded", zap.Duration("elapsed", time.Since(start)))
 
 	// Emit upload completion event if we have an authenticated user and this is a new upload
-	if userID > 0 && existingUpload == nil && storageUpload != nil {
-		if clientIP == "" {
-			bs.log.Debug("Client IP not set in context for quota tracking", zap.Stringer("cid", b.Cid()))
-		}
+	if IsValidUserID(userID) && existingUpload == nil && storageUpload != nil {
+		LogIfClientIPMissing(ctx, bs.log, b.Cid())
 		quota.EmitUploadCompleted(ctx, bs.ctx, &userID, storageUpload.ID, size, clientIP)
 	}
 
@@ -250,11 +248,6 @@ func (bs *BlockStore) Put(ctx context.Context, b blocks.Block) error {
 		return fmt.Errorf("failed to pin block %q: %w", b.Cid(), err)
 	}
 
-	// Emit storage object pinned event for quota tracking
-	if clientIP == "" {
-		bs.log.Debug("Client IP not set in context for storage quota tracking", zap.Stringer("cid", b.Cid()))
-	}
-
 	// Use the upload record from storage or existing upload for quota tracking
 	storageUserID := userID
 	var storageUploadID uint
@@ -266,7 +259,8 @@ func (bs *BlockStore) Put(ctx context.Context, b blocks.Block) error {
 		storageUserID = existingUpload.UserID
 	}
 
-	if storageUserID > 0 {
+	if IsValidUserID(storageUserID) {
+		LogIfClientIPMissing(ctx, bs.log, b.Cid())
 		metaPin := &models.Pin{
 			UserID:   storageUserID,
 			UploadID: storageUploadID,

--- a/internal/protocol/store/blockstore.go
+++ b/internal/protocol/store/blockstore.go
@@ -11,6 +11,7 @@ import (
 	format "github.com/ipfs/go-ipld-format"
 	"github.com/multiformats/go-multicodec"
 	"github.com/multiformats/go-multihash"
+	"go.lumeweb.com/portal/db/models"
 	pluginCore "go.lumeweb.com/portal-plugin-ipfs/core"
 	"go.lumeweb.com/portal-plugin-ipfs/internal"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/protocol/encoding"
@@ -31,6 +32,7 @@ type (
 		metadata   pluginCore.MetadataStore
 		downloader pluginCore.BlockDownloader
 		storage    core.StorageService
+		upload     core.UploadService
 		proto      core.StorageProtocol
 	}
 )
@@ -175,8 +177,39 @@ func (bs *BlockStore) Put(ctx context.Context, b blocks.Block) error {
 	start := time.Now()
 
 	size := uint64(len(b.RawData()))
+	userID := GetUserID(ctx)
+	clientIP := GetClientIP(ctx)
 
-	_, err := bs.storage.UploadObject(ctx, service.NewStorageUploadRequest(
+	// Check if upload already exists: if so, skip quota checks and upload record creation
+	existingUpload, err := bs.upload.GetUpload(ctx, internal.NewIPFSHash(b.Cid()))
+	if err != nil {
+		log.Warn("Failed to check existing upload", zap.Error(err))
+		// Continue even if check fails - we'll get upload record from storage
+	}
+
+	// Validate upload quota for authenticated users if no existing upload
+	if userID > 0 && existingUpload == nil && !IsQuotaCheckSkipped(ctx) {
+		if err := quota.ValidateUploadQuota(ctx, bs.ctx, userID, size); err != nil {
+			bs.log.Warn("Upload quota validation failed",
+				zap.Uint("user_id", userID),
+				zap.Uint64("size", size),
+				zap.Error(err))
+			return fmt.Errorf("upload quota validation failed: %w", err)
+		}
+	}
+
+	if existingUpload != nil {
+		log.Debug("Upload already exists, skipping upload record creation",
+			zap.Stringer("cid", b.Cid()),
+			zap.Uint("existing_user_id", existingUpload.UserID))
+	} else if userID > 0 {
+		log.Debug("No existing upload, will create new record via storage upload",
+			zap.Stringer("cid", b.Cid()),
+			zap.Uint("user_id", userID))
+	}
+
+	// Upload to storage - this will return an upload record
+	storageUpload, err := bs.storage.UploadObject(ctx, service.NewStorageUploadRequest(
 		core.StorageUploadWithProtocol(bs.proto),
 		core.StorageUploadWithData(bytes.NewReader(b.RawData())),
 		core.StorageUploadWithSize(size),
@@ -188,6 +221,14 @@ func (bs *BlockStore) Put(ctx context.Context, b blocks.Block) error {
 	}
 
 	log.Debug("object uploaded", zap.Duration("elapsed", time.Since(start)))
+
+	// Emit upload completion event if we have an authenticated user and this is a new upload
+	if userID > 0 && existingUpload == nil && storageUpload != nil {
+		if clientIP == "" {
+			bs.log.Debug("Client IP not set in context for quota tracking", zap.Stringer("cid", b.Cid()))
+		}
+		quota.EmitUploadCompleted(ctx, bs.ctx, &userID, storageUpload.ID, size, clientIP)
+	}
 
 	node, err := encoding.DecodeBlock(ctx, b)
 	if err != nil {
@@ -208,6 +249,31 @@ func (bs *BlockStore) Put(ctx context.Context, b blocks.Block) error {
 		log.Debug("failed to pin block", zap.Error(err))
 		return fmt.Errorf("failed to pin block %q: %w", b.Cid(), err)
 	}
+
+	// Emit storage object pinned event for quota tracking
+	if clientIP == "" {
+		bs.log.Debug("Client IP not set in context for storage quota tracking", zap.Stringer("cid", b.Cid()))
+	}
+
+	// Use the upload record from storage or existing upload for quota tracking
+	storageUserID := userID
+	var storageUploadID uint
+	if storageUpload != nil {
+		storageUploadID = storageUpload.ID
+		storageUserID = storageUpload.UserID
+	} else if existingUpload != nil {
+		storageUploadID = existingUpload.ID
+		storageUserID = existingUpload.UserID
+	}
+
+	if storageUserID > 0 {
+		metaPin := &models.Pin{
+			UserID:   storageUserID,
+			UploadID: storageUploadID,
+		}
+		quota.EmitStorageObjectPinned(ctx, bs.ctx, metaPin, clientIP)
+	}
+
 	log.Debug("put block", zap.Duration("duration", time.Since(start)), zap.Error(err))
 	return nil
 }
@@ -296,12 +362,18 @@ func NewBlockStore(ctx core.Context, downloader pluginCore.BlockDownloader, meta
 		return nil, fmt.Errorf("storage service not initialized")
 	}
 
+	uploadSvc := core.GetService[core.UploadService](ctx, core.UPLOAD_SERVICE)
+	if uploadSvc == nil {
+		return nil, fmt.Errorf("upload service not initialized")
+	}
+
 	return &BlockStore{
 		ctx:        ctx,
 		log:        ctx.Logger(),
 		metadata:   metadata,
 		downloader: downloader,
 		storage:    storageSvc,
+		upload:     uploadSvc,
 		proto:      proto,
 	}, nil
 }

--- a/internal/protocol/store/store.go
+++ b/internal/protocol/store/store.go
@@ -2,10 +2,12 @@ package store
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/ipfs/go-cid"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/protocol/encoding"
 	"go.lumeweb.com/portal/core"
+	"go.uber.org/zap"
 )
 
 type (
@@ -115,4 +117,16 @@ func GetUserID(ctx context.Context) uint {
 		return 0
 	}
 	return value
+}
+
+// IsValidUserID checks if the user ID is valid (greater than 0)
+func IsValidUserID(userID uint) bool {
+	return userID > 0
+}
+
+// LogIfClientIPMissing logs a debug warning if client IP is not set in context
+func LogIfClientIPMissing(ctx context.Context, log *core.Logger, cid fmt.Stringer) {
+	if GetClientIP(ctx) == "" {
+		log.Debug("Client IP not set in context for quota tracking", zap.Stringer("cid", cid))
+	}
 }

--- a/internal/protocol/store/store.go
+++ b/internal/protocol/store/store.go
@@ -19,6 +19,7 @@ const (
 	DisableMetaCheck ContextKey = "disableMetaCheck"
 	ClientIPKey      ContextKey = "clientIP"
 	SkipQuotaCheck   ContextKey = "skipQuotaCheck"
+	UserIDKey        ContextKey = "userID"
 )
 
 // VirtualReadOption sets the virtual read option in the context
@@ -94,4 +95,24 @@ func IsQuotaCheckSkipped(ctx context.Context) bool {
 
 func cidKey(c cid.Cid) string {
 	return encoding.ToV1(c).String()
+}
+
+// UserOption sets user ID in the context
+func UserOption(ctx context.Context, userID uint) context.Context {
+	ctx, span := core.TraceMethod(ctx, "UserOption")
+	defer span.End()
+
+	return context.WithValue(ctx, UserIDKey, userID)
+}
+
+// GetUserID retrieves the user ID from the context
+func GetUserID(ctx context.Context) uint {
+	ctx, span := core.TraceMethod(ctx, "GetUserID")
+	defer span.End()
+
+	value, ok := ctx.Value(UserIDKey).(uint)
+	if !ok {
+		return 0
+	}
+	return value
 }

--- a/internal/protocol/store/tests/blockstore_test.go
+++ b/internal/protocol/store/tests/blockstore_test.go
@@ -6,23 +6,25 @@ import (
 	"testing"
 	"time"
 
-	blocks "github.com/ipfs/go-block-format"
+	"github.com/ipfs/go-block-format"
 	"github.com/ipfs/go-cid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	"go.lumeweb.com/portal-plugin-ipfs/internal"
-	"go.lumeweb.com/portal-plugin-ipfs/internal/protocol/store"
-	"go.lumeweb.com/portal-plugin-ipfs/internal/testing/mocks"
 	"go.lumeweb.com/portal/core"
 	coreTesting "go.lumeweb.com/portal/core/testing"
+	portalMocks "go.lumeweb.com/portal/core/testing/mocks"
+	"go.lumeweb.com/portal/db/models"
+	"go.lumeweb.com/portal-plugin-ipfs/internal"
+	"go.lumeweb.com/portal-plugin-ipfs/internal/protocol/store"
+	localMocks "go.lumeweb.com/portal-plugin-ipfs/internal/testing/mocks"
 )
 
 func TestBlockStore_Get(t *testing.T) {
 	coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 		// Arrange
-		mockDownloader := mocks.NewMockBlockDownloader(t)
-		mockMetadata := mocks.NewMockMetadataStore(t)
+		mockDownloader := localMocks.NewMockBlockDownloader(t)
+		mockMetadata := localMocks.NewMockMetadataStore(t)
 		bs, err := store.NewBlockStore(ctx, mockDownloader, mockMetadata)
 		require.NoError(tb, err)
 
@@ -48,8 +50,8 @@ func TestBlockStore_Get(t *testing.T) {
 func TestBlockStore_GetSize(t *testing.T) {
 	coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 		// Arrange
-		mockDownloader := mocks.NewMockBlockDownloader(t)
-		mockMetadata := mocks.NewMockMetadataStore(t)
+		mockDownloader := localMocks.NewMockBlockDownloader(t)
+		mockMetadata := localMocks.NewMockMetadataStore(t)
 		bs, err := store.NewBlockStore(ctx, mockDownloader, mockMetadata)
 		require.NoError(tb, err)
 
@@ -73,8 +75,8 @@ func TestBlockStore_GetSize(t *testing.T) {
 func TestBlockStore_GetSize_BlockExistsError(t *testing.T) {
 	coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 		// Arrange
-		mockDownloader := mocks.NewMockBlockDownloader(t)
-		mockMetadata := mocks.NewMockMetadataStore(t)
+		mockDownloader := localMocks.NewMockBlockDownloader(t)
+		mockMetadata := localMocks.NewMockMetadataStore(t)
 		bs, err := store.NewBlockStore(ctx, mockDownloader, mockMetadata)
 		require.NoError(tb, err)
 
@@ -97,8 +99,8 @@ func TestBlockStore_GetSize_BlockExistsError(t *testing.T) {
 func TestBlockStore_GetSize_SizeError(t *testing.T) {
 	coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 		// Arrange
-		mockDownloader := mocks.NewMockBlockDownloader(t)
-		mockMetadata := mocks.NewMockMetadataStore(t)
+		mockDownloader := localMocks.NewMockBlockDownloader(t)
+		mockMetadata := localMocks.NewMockMetadataStore(t)
 		bs, err := store.NewBlockStore(ctx, mockDownloader, mockMetadata)
 		require.NoError(tb, err)
 
@@ -122,8 +124,8 @@ func TestBlockStore_GetSize_SizeError(t *testing.T) {
 func TestBlockStore_Has(t *testing.T) {
 	coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 		// Arrange
-		mockDownloader := mocks.NewMockBlockDownloader(t)
-		mockMetadata := mocks.NewMockMetadataStore(t)
+		mockDownloader := localMocks.NewMockBlockDownloader(t)
+		mockMetadata := localMocks.NewMockMetadataStore(t)
 		bs, err := store.NewBlockStore(ctx, mockDownloader, mockMetadata)
 		require.NoError(tb, err)
 
@@ -145,8 +147,8 @@ func TestBlockStore_Has(t *testing.T) {
 func TestBlockStore_Has_NotFound(t *testing.T) {
 	coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 		// Arrange
-		mockDownloader := mocks.NewMockBlockDownloader(t)
-		mockMetadata := mocks.NewMockMetadataStore(t)
+		mockDownloader := localMocks.NewMockBlockDownloader(t)
+		mockMetadata := localMocks.NewMockMetadataStore(t)
 		bs, err := store.NewBlockStore(ctx, mockDownloader, mockMetadata)
 		require.NoError(tb, err)
 
@@ -170,9 +172,10 @@ func TestBlockStore_Has_NotFound(t *testing.T) {
 func TestBlockStore_Put(t *testing.T) {
 	coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 		// Arrange
-		mockDownloader := mocks.NewMockBlockDownloader(t)
-		mockMetadata := mocks.NewMockMetadataStore(t)
+		mockDownloader := localMocks.NewMockBlockDownloader(t)
+		mockMetadata := localMocks.NewMockMetadataStore(t)
 		mockStorage := core.GetService[*coreTesting.MockStorageService](ctx, core.STORAGE_SERVICE)
+		mockUpload := core.GetService[*portalMocks.MockUploadService](ctx, core.UPLOAD_SERVICE)
 
 		bs, err := store.NewBlockStore(ctx, mockDownloader, mockMetadata)
 		require.NoError(tb, err)
@@ -182,8 +185,12 @@ func TestBlockStore_Put(t *testing.T) {
 		testBlock, err := blocks.NewBlockWithCid([]byte(testData), testCid)
 		require.NoError(t, err)
 
-		// Mock the storage's UploadObject method
-		mockStorage.EXPECT().UploadObject(mock.Anything, mock.Anything).Return(nil, nil).Once()
+		// Mock the upload service GetUpload method (no existing upload)
+		mockUpload.EXPECT().GetUpload(mock.Anything, mock.Anything).Return(nil, core.ErrUploadNotFound).Once()
+
+		// Mock the storage's UploadObject method to return an upload record
+		uploadRecord := testUploadRecord(testCid)
+		mockStorage.EXPECT().UploadObject(mock.Anything, mock.Anything).Return(uploadRecord, nil).Once()
 
 		// Mock the metadata's Pin method
 		mockMetadata.EXPECT().Pin(mock.Anything, mock.Anything).Return(nil).Once()
@@ -199,9 +206,10 @@ func TestBlockStore_Put(t *testing.T) {
 func TestBlockStore_Put_UploadError(t *testing.T) {
 	coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 		// Arrange
-		mockDownloader := mocks.NewMockBlockDownloader(t)
-		mockMetadata := mocks.NewMockMetadataStore(t)
+		mockDownloader := localMocks.NewMockBlockDownloader(t)
+		mockMetadata := localMocks.NewMockMetadataStore(t)
 		mockStorage := core.GetService[*coreTesting.MockStorageService](ctx, core.STORAGE_SERVICE)
+		mockUpload := core.GetService[*portalMocks.MockUploadService](ctx, core.UPLOAD_SERVICE)
 
 		bs, err := store.NewBlockStore(ctx, mockDownloader, mockMetadata)
 		require.NoError(tb, err)
@@ -211,6 +219,9 @@ func TestBlockStore_Put_UploadError(t *testing.T) {
 		testBlock, err := blocks.NewBlockWithCid([]byte(testData), testCid)
 		require.NoError(t, err)
 		expectedError := errors.New("upload failed")
+
+		// Mock the upload service GetUpload method (no existing upload)
+		mockUpload.EXPECT().GetUpload(mock.Anything, mock.Anything).Return(nil, core.ErrUploadNotFound).Once()
 
 		// Mock the storage's UploadObject method to return an error
 		mockStorage.EXPECT().UploadObject(mock.Anything, mock.Anything).Return(nil, expectedError).Once()
@@ -227,9 +238,10 @@ func TestBlockStore_Put_UploadError(t *testing.T) {
 func TestBlockStore_Put_PinError(t *testing.T) {
 	coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 		// Arrange
-		mockDownloader := mocks.NewMockBlockDownloader(t)
-		mockMetadata := mocks.NewMockMetadataStore(t)
+		mockDownloader := localMocks.NewMockBlockDownloader(t)
+		mockMetadata := localMocks.NewMockMetadataStore(t)
 		mockStorage := core.GetService[*coreTesting.MockStorageService](ctx, core.STORAGE_SERVICE)
+		mockUpload := core.GetService[*portalMocks.MockUploadService](ctx, core.UPLOAD_SERVICE)
 
 		bs, err := store.NewBlockStore(ctx, mockDownloader, mockMetadata)
 		require.NoError(tb, err)
@@ -240,8 +252,12 @@ func TestBlockStore_Put_PinError(t *testing.T) {
 		require.NoError(t, err)
 		expectedError := errors.New("pin failed")
 
+		// Mock the upload service GetUpload method (no existing upload)
+		mockUpload.EXPECT().GetUpload(mock.Anything, mock.Anything).Return(nil, core.ErrUploadNotFound).Once()
+
 		// Mock the storage's UploadObject method
-		mockStorage.EXPECT().UploadObject(mock.Anything, mock.Anything).Return(nil, nil).Once()
+		uploadRecord := testUploadRecord(testCid)
+		mockStorage.EXPECT().UploadObject(mock.Anything, mock.Anything).Return(uploadRecord, nil).Once()
 
 		// Mock the metadata's Pin method to return an error
 		mockMetadata.EXPECT().Pin(mock.Anything, mock.Anything).Return(expectedError).Once()
@@ -258,8 +274,8 @@ func TestBlockStore_Put_PinError(t *testing.T) {
 func TestBlockStore_DeleteBlock(t *testing.T) {
 	coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 		// Arrange
-		mockDownloader := mocks.NewMockBlockDownloader(t)
-		mockMetadata := mocks.NewMockMetadataStore(t)
+		mockDownloader := localMocks.NewMockBlockDownloader(t)
+		mockMetadata := localMocks.NewMockMetadataStore(t)
 		mockStorage := core.GetService[*coreTesting.MockStorageService](ctx, core.STORAGE_SERVICE)
 
 		testData := "test data"
@@ -285,8 +301,8 @@ func TestBlockStore_DeleteBlock(t *testing.T) {
 func TestBlockStore_DeleteBlock_UnpinError(t *testing.T) {
 	coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 		// Arrange
-		mockDownloader := mocks.NewMockBlockDownloader(t)
-		mockMetadata := mocks.NewMockMetadataStore(t)
+		mockDownloader := localMocks.NewMockBlockDownloader(t)
+		mockMetadata := localMocks.NewMockMetadataStore(t)
 
 		testData := "test data"
 		testCid := generateCid(t, testData)
@@ -310,9 +326,10 @@ func TestBlockStore_DeleteBlock_UnpinError(t *testing.T) {
 func TestBlockStore_PutMany(t *testing.T) {
 	coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 		// Arrange
-		mockDownloader := mocks.NewMockBlockDownloader(t)
-		mockMetadata := mocks.NewMockMetadataStore(t)
+		mockDownloader := localMocks.NewMockBlockDownloader(t)
+		mockMetadata := localMocks.NewMockMetadataStore(t)
 		mockStorage := core.GetService[*coreTesting.MockStorageService](ctx, core.STORAGE_SERVICE)
+		mockUpload := core.GetService[*portalMocks.MockUploadService](ctx, core.UPLOAD_SERVICE)
 
 		bs, err := store.NewBlockStore(ctx, mockDownloader, mockMetadata)
 		require.NoError(tb, err)
@@ -328,6 +345,9 @@ func TestBlockStore_PutMany(t *testing.T) {
 		require.NoError(t, err)
 
 		_blocks := []blocks.Block{testBlock1, testBlock2}
+
+		// Mock the upload service GetUpload method for each block (no existing uploads)
+		mockUpload.EXPECT().GetUpload(mock.Anything, mock.Anything).Return(nil, core.ErrUploadNotFound).Times(2)
 
 		// Mock the storage's UploadObject method for each block
 		mockStorage.EXPECT().UploadObject(mock.Anything, mock.Anything).Return(nil, nil).Times(2)
@@ -346,9 +366,10 @@ func TestBlockStore_PutMany(t *testing.T) {
 func TestBlockStore_PutMany_PutError(t *testing.T) {
 	coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 		// Arrange
-		mockDownloader := mocks.NewMockBlockDownloader(t)
-		mockMetadata := mocks.NewMockMetadataStore(t)
+		mockDownloader := localMocks.NewMockBlockDownloader(t)
+		mockMetadata := localMocks.NewMockMetadataStore(t)
 		mockStorage := core.GetService[*coreTesting.MockStorageService](ctx, core.STORAGE_SERVICE)
+		mockUpload := core.GetService[*portalMocks.MockUploadService](ctx, core.UPLOAD_SERVICE)
 
 		bs, err := store.NewBlockStore(ctx, mockDownloader, mockMetadata)
 		require.NoError(tb, err)
@@ -366,6 +387,9 @@ func TestBlockStore_PutMany_PutError(t *testing.T) {
 		_blocks := []blocks.Block{testBlock1, testBlock2}
 		expectedError := errors.New("upload failed")
 
+		// Mock the upload service GetUpload method for the first block (no existing upload)
+		mockUpload.EXPECT().GetUpload(mock.Anything, mock.Anything).Return(nil, core.ErrUploadNotFound).Once()
+
 		// Mock the storage's UploadObject method to return an error for the first block
 		mockStorage.EXPECT().UploadObject(mock.Anything, mock.Anything).Return(nil, expectedError).Once()
 
@@ -381,8 +405,8 @@ func TestBlockStore_PutMany_PutError(t *testing.T) {
 func TestBlockStore_AllKeysChan(t *testing.T) {
 	coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 		// Arrange
-		mockDownloader := mocks.NewMockBlockDownloader(t)
-		mockMetadata := mocks.NewMockMetadataStore(t)
+		mockDownloader := localMocks.NewMockBlockDownloader(t)
+		mockMetadata := localMocks.NewMockMetadataStore(t)
 		bs, err := store.NewBlockStore(ctx, mockDownloader, mockMetadata)
 		require.NoError(tb, err)
 
@@ -414,8 +438,8 @@ func TestBlockStore_AllKeysChan(t *testing.T) {
 func TestBlockStore_AllKeysChan_MetadataError(t *testing.T) {
 	coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 		// Arrange
-		mockDownloader := mocks.NewMockBlockDownloader(t)
-		mockMetadata := mocks.NewMockMetadataStore(t)
+		mockDownloader := localMocks.NewMockBlockDownloader(t)
+		mockMetadata := localMocks.NewMockMetadataStore(t)
 		bs, err := store.NewBlockStore(ctx, mockDownloader, mockMetadata)
 		require.NoError(tb, err)
 
@@ -442,8 +466,8 @@ func TestBlockStore_AllKeysChan_MetadataError(t *testing.T) {
 func TestNewBlockStore_ProtocolNotFound(t *testing.T) {
 	coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 		// Create a mock MetadataStore and BlockDownloader
-		mockDownloader := mocks.NewMockBlockDownloader(t)
-		mockMetadata := mocks.NewMockMetadataStore(t)
+		mockDownloader := localMocks.NewMockBlockDownloader(t)
+		mockMetadata := localMocks.NewMockMetadataStore(t)
 
 		// Attempt to create a new BlockStore - should return an error
 		_, err := store.NewBlockStore(ctx, mockDownloader, mockMetadata)
@@ -455,8 +479,8 @@ func TestNewBlockStore_ProtocolNotFound(t *testing.T) {
 func TestBlockStore_VirtualReadEnabled(t *testing.T) {
 	coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 		// Arrange
-		mockDownloader := mocks.NewMockBlockDownloader(t)
-		mockMetadata := mocks.NewMockMetadataStore(t)
+		mockDownloader := localMocks.NewMockBlockDownloader(t)
+		mockMetadata := localMocks.NewMockMetadataStore(t)
 
 		bs, err := store.NewBlockStore(ctx, mockDownloader, mockMetadata)
 		require.NoError(tb, err)
@@ -508,9 +532,10 @@ func TestBlockStore_VirtualReadEnabled(t *testing.T) {
 func TestBlockStore_VirtualReadDisabled(t *testing.T) {
 	coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 		// Arrange
-		mockDownloader := mocks.NewMockBlockDownloader(t)
-		mockMetadata := mocks.NewMockMetadataStore(t)
+		mockDownloader := localMocks.NewMockBlockDownloader(t)
+		mockMetadata := localMocks.NewMockMetadataStore(t)
 		mockStorage := core.GetService[*coreTesting.MockStorageService](ctx, core.STORAGE_SERVICE)
+		mockUpload := core.GetService[*portalMocks.MockUploadService](ctx, core.UPLOAD_SERVICE)
 
 		bs, err := store.NewBlockStore(ctx, mockDownloader, mockMetadata)
 		require.NoError(tb, err)
@@ -544,7 +569,9 @@ func TestBlockStore_VirtualReadDisabled(t *testing.T) {
 		assert.Equal(tb, len(testData), size)
 
 		// Test Put
-		mockStorage.EXPECT().UploadObject(mock.Anything, mock.Anything).Return(nil, nil).Once()
+		mockUpload.EXPECT().GetUpload(mock.Anything, mock.Anything).Return(nil, core.ErrUploadNotFound).Once()
+		uploadRecord := testUploadRecord(testCid)
+		mockStorage.EXPECT().UploadObject(mock.Anything, mock.Anything).Return(uploadRecord, nil).Once()
 		mockMetadata.EXPECT().Pin(mock.Anything, mock.Anything).Return(nil).Once()
 		err = bs.Put(normalCtx, testBlock)
 		require.NoError(tb, err)
@@ -568,8 +595,8 @@ func TestBlockStore_VirtualReadDisabled(t *testing.T) {
 func TestBlockStore_AllKeysChan_ContextDone(t *testing.T) {
 	coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 		// Arrange
-		mockDownloader := mocks.NewMockBlockDownloader(t)
-		mockMetadata := mocks.NewMockMetadataStore(t)
+		mockDownloader := localMocks.NewMockBlockDownloader(t)
+		mockMetadata := localMocks.NewMockMetadataStore(t)
 		bs, err := store.NewBlockStore(ctx, mockDownloader, mockMetadata)
 		require.NoError(tb, err)
 
@@ -595,4 +622,15 @@ func TestBlockStore_AllKeysChan_ContextDone(t *testing.T) {
 		// Verify only the expected calls were made
 		mockMetadata.AssertExpectations(tb)
 	}, ipfsTestConfig)
+}
+
+// testUploadRecord creates a mock upload record for testing
+func testUploadRecord(c cid.Cid) *models.Upload {
+	data := []byte("test data")
+	return &models.Upload{
+		Hash:     c.Hash(),
+		UserID:   123,
+		Size:     uint64(len(data)),
+		Protocol: "ipfs",
+	}
 }


### PR DESCRIPTION
- Add UserID context helpers (UserOption, GetUserID) to store.go for passing user information through context

- Add upload service dependency to BlockStore struct and NewBlockStore constructor

- Rewrite Put method to:
  - Check existing uploads before creating duplicates using upload service GetUpload()
  - Use quota.ValidateUploadQuota() helper for authenticated users (skip if upload exists)
  - Use upload record returned from storage.UploadObject() instead of manual construction
  - Emit proper quota events (EmitUploadCompleted, EmitStorageObjectPinned)
  - Track both new and existing uploads correctly with appropriate user IDs

- Update tests to mock upload service (GetUpload, UploadObject) in all relevant test cases

- Add testUploadRecord() helper for creating mock upload records in tests

This ensures proper quota tracking without duplicate records and uses the official quota helpers for consistency across the codebase.

- `develop` <!-- branch-stack -->
  - **fix(blockstore): add proper quota tracking for upload and storage operations** :point\_left:

***

<!-- kody-pr-summary:start -->

**Pull Request Description:**

This PR fixes quota tracking for upload and storage operations in the IPFS blockstore. Previously, the blockstore was not properly recording upload and storage usage against user quotas when storing IPFS blocks.

**Key Changes:**

- **Upload Quota Validation**: Added validation to check user upload quotas before processing new block uploads, preventing storage of blocks when quotas are exceeded.

- **Storage Quota Tracking**: Implemented proper recording of storage usage when blocks are pinned, ensuring storage quotas accurately reflect pinned IPFS content.

- **Duplicate Upload Handling**: Added logic to check for existing uploads before recording quota usage, preventing double-counting when the same content is uploaded multiple times.

- **User Context Integration**: Enhanced context handling to extract user identity and client IP information required for quota tracking and audit purposes.

- **Service Dependencies**: Updated blockstore initialization to require the upload service for checking existing uploads and managing upload records.

The changes ensure that IPFS storage operations properly participate in the portal's quota management system, allowing accurate enforcement of upload limits and storage capacity restrictions for authenticated users.

<!-- kody-pr-summary:end -->
