### PR TITLE
refactor(store): remove redundant quota tracking from blockstore #424

### DIFF
--- a/internal/protocol/store/blockstore.go
+++ b/internal/protocol/store/blockstore.go
@@ -11,7 +11,7 @@ import (
 	format "github.com/ipfs/go-ipld-format"
 	"github.com/multiformats/go-multicodec"
 	"github.com/multiformats/go-multihash"
-	"go.lumeweb.com/portal/db/models"
+
 	pluginCore "go.lumeweb.com/portal-plugin-ipfs/core"
 	"go.lumeweb.com/portal-plugin-ipfs/internal"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/protocol/encoding"
@@ -32,7 +32,7 @@ type (
 		metadata   pluginCore.MetadataStore
 		downloader pluginCore.BlockDownloader
 		storage    core.StorageService
-		upload     core.UploadService
+
 		proto      core.StorageProtocol
 	}
 )
@@ -177,39 +177,9 @@ func (bs *BlockStore) Put(ctx context.Context, b blocks.Block) error {
 	start := time.Now()
 
 	size := uint64(len(b.RawData()))
-	userID := GetUserID(ctx)
-	clientIP := GetClientIP(ctx)
 
-	// Check if upload already exists: if so, skip quota checks and upload record creation
-	existingUpload, err := bs.upload.GetUpload(ctx, internal.NewIPFSHash(b.Cid()))
-	if err != nil {
-		log.Warn("Failed to check existing upload", zap.Error(err))
-		// Continue even if check fails - we'll get upload record from storage
-	}
-
-	// Validate upload quota for authenticated users if no existing upload
-	if IsValidUserID(userID) && existingUpload == nil && !IsQuotaCheckSkipped(ctx) {
-		if err := quota.ValidateUploadQuota(ctx, bs.ctx, userID, size); err != nil {
-			bs.log.Warn("Upload quota validation failed",
-				zap.Uint("user_id", userID),
-				zap.Uint64("size", size),
-				zap.Error(err))
-			return fmt.Errorf("upload quota validation failed: %w", err)
-		}
-	}
-
-	if existingUpload != nil {
-		log.Debug("Upload already exists, skipping upload record creation",
-			zap.Stringer("cid", b.Cid()),
-			zap.Uint("existing_user_id", existingUpload.UserID))
-	} else if IsValidUserID(userID) {
-		log.Debug("No existing upload, will create new record via storage upload",
-			zap.Stringer("cid", b.Cid()),
-			zap.Uint("user_id", userID))
-	}
-
-	// Upload to storage - this will return an upload record
-	storageUpload, err := bs.storage.UploadObject(ctx, service.NewStorageUploadRequest(
+	// Upload to storage
+	_, err := bs.storage.UploadObject(ctx, service.NewStorageUploadRequest(
 		core.StorageUploadWithProtocol(bs.proto),
 		core.StorageUploadWithData(bytes.NewReader(b.RawData())),
 		core.StorageUploadWithSize(size),
@@ -221,12 +191,6 @@ func (bs *BlockStore) Put(ctx context.Context, b blocks.Block) error {
 	}
 
 	log.Debug("object uploaded", zap.Duration("elapsed", time.Since(start)))
-
-	// Emit upload completion event if we have an authenticated user and this is a new upload
-	if IsValidUserID(userID) && existingUpload == nil && storageUpload != nil {
-		LogIfClientIPMissing(ctx, bs.log, b.Cid())
-		quota.EmitUploadCompleted(ctx, bs.ctx, &userID, storageUpload.ID, size, clientIP)
-	}
 
 	node, err := encoding.DecodeBlock(ctx, b)
 	if err != nil {
@@ -248,27 +212,7 @@ func (bs *BlockStore) Put(ctx context.Context, b blocks.Block) error {
 		return fmt.Errorf("failed to pin block %q: %w", b.Cid(), err)
 	}
 
-	// Use the upload record from storage or existing upload for quota tracking
-	storageUserID := userID
-	var storageUploadID uint
-	if storageUpload != nil {
-		storageUploadID = storageUpload.ID
-		storageUserID = storageUpload.UserID
-	} else if existingUpload != nil {
-		storageUploadID = existingUpload.ID
-		storageUserID = existingUpload.UserID
-	}
-
-	if IsValidUserID(storageUserID) {
-		LogIfClientIPMissing(ctx, bs.log, b.Cid())
-		metaPin := &models.Pin{
-			UserID:   storageUserID,
-			UploadID: storageUploadID,
-		}
-		quota.EmitStorageObjectPinned(ctx, bs.ctx, metaPin, clientIP)
-	}
-
-	log.Debug("put block", zap.Duration("duration", time.Since(start)), zap.Error(err))
+	log.Debug("put block", zap.Duration("duration", time.Since(start)))
 	return nil
 }
 
@@ -356,18 +300,12 @@ func NewBlockStore(ctx core.Context, downloader pluginCore.BlockDownloader, meta
 		return nil, fmt.Errorf("storage service not initialized")
 	}
 
-	uploadSvc := core.GetService[core.UploadService](ctx, core.UPLOAD_SERVICE)
-	if uploadSvc == nil {
-		return nil, fmt.Errorf("upload service not initialized")
-	}
-
 	return &BlockStore{
 		ctx:        ctx,
 		log:        ctx.Logger(),
 		metadata:   metadata,
 		downloader: downloader,
 		storage:    storageSvc,
-		upload:     uploadSvc,
 		proto:      proto,
 	}, nil
 }

--- a/internal/protocol/store/store.go
+++ b/internal/protocol/store/store.go
@@ -2,12 +2,10 @@ package store
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/ipfs/go-cid"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/protocol/encoding"
 	"go.lumeweb.com/portal/core"
-	"go.uber.org/zap"
 )
 
 type (
@@ -21,7 +19,6 @@ const (
 	DisableMetaCheck ContextKey = "disableMetaCheck"
 	ClientIPKey      ContextKey = "clientIP"
 	SkipQuotaCheck   ContextKey = "skipQuotaCheck"
-	UserIDKey        ContextKey = "userID"
 )
 
 // VirtualReadOption sets the virtual read option in the context
@@ -97,36 +94,4 @@ func IsQuotaCheckSkipped(ctx context.Context) bool {
 
 func cidKey(c cid.Cid) string {
 	return encoding.ToV1(c).String()
-}
-
-// UserOption sets user ID in the context
-func UserOption(ctx context.Context, userID uint) context.Context {
-	ctx, span := core.TraceMethod(ctx, "UserOption")
-	defer span.End()
-
-	return context.WithValue(ctx, UserIDKey, userID)
-}
-
-// GetUserID retrieves the user ID from the context
-func GetUserID(ctx context.Context) uint {
-	ctx, span := core.TraceMethod(ctx, "GetUserID")
-	defer span.End()
-
-	value, ok := ctx.Value(UserIDKey).(uint)
-	if !ok {
-		return 0
-	}
-	return value
-}
-
-// IsValidUserID checks if the user ID is valid (greater than 0)
-func IsValidUserID(userID uint) bool {
-	return userID > 0
-}
-
-// LogIfClientIPMissing logs a debug warning if client IP is not set in context
-func LogIfClientIPMissing(ctx context.Context, log *core.Logger, cid fmt.Stringer) {
-	if GetClientIP(ctx) == "" {
-		log.Debug("Client IP not set in context for quota tracking", zap.Stringer("cid", cid))
-	}
 }

--- a/internal/protocol/store/tests/blockstore_test.go
+++ b/internal/protocol/store/tests/blockstore_test.go
@@ -13,8 +13,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.lumeweb.com/portal/core"
 	coreTesting "go.lumeweb.com/portal/core/testing"
-	portalMocks "go.lumeweb.com/portal/core/testing/mocks"
-	"go.lumeweb.com/portal/db/models"
 	"go.lumeweb.com/portal-plugin-ipfs/internal"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/protocol/store"
 	localMocks "go.lumeweb.com/portal-plugin-ipfs/internal/testing/mocks"
@@ -175,7 +173,6 @@ func TestBlockStore_Put(t *testing.T) {
 		mockDownloader := localMocks.NewMockBlockDownloader(t)
 		mockMetadata := localMocks.NewMockMetadataStore(t)
 		mockStorage := core.GetService[*coreTesting.MockStorageService](ctx, core.STORAGE_SERVICE)
-		mockUpload := core.GetService[*portalMocks.MockUploadService](ctx, core.UPLOAD_SERVICE)
 
 		bs, err := store.NewBlockStore(ctx, mockDownloader, mockMetadata)
 		require.NoError(tb, err)
@@ -185,12 +182,8 @@ func TestBlockStore_Put(t *testing.T) {
 		testBlock, err := blocks.NewBlockWithCid([]byte(testData), testCid)
 		require.NoError(t, err)
 
-		// Mock the upload service GetUpload method (no existing upload)
-		mockUpload.EXPECT().GetUpload(mock.Anything, mock.Anything).Return(nil, core.ErrUploadNotFound).Once()
-
-		// Mock the storage's UploadObject method to return an upload record
-		uploadRecord := testUploadRecord(testCid)
-		mockStorage.EXPECT().UploadObject(mock.Anything, mock.Anything).Return(uploadRecord, nil).Once()
+		// Mock the storage's UploadObject method
+		mockStorage.EXPECT().UploadObject(mock.Anything, mock.Anything).Return(nil, nil).Once()
 
 		// Mock the metadata's Pin method
 		mockMetadata.EXPECT().Pin(mock.Anything, mock.Anything).Return(nil).Once()
@@ -209,7 +202,6 @@ func TestBlockStore_Put_UploadError(t *testing.T) {
 		mockDownloader := localMocks.NewMockBlockDownloader(t)
 		mockMetadata := localMocks.NewMockMetadataStore(t)
 		mockStorage := core.GetService[*coreTesting.MockStorageService](ctx, core.STORAGE_SERVICE)
-		mockUpload := core.GetService[*portalMocks.MockUploadService](ctx, core.UPLOAD_SERVICE)
 
 		bs, err := store.NewBlockStore(ctx, mockDownloader, mockMetadata)
 		require.NoError(tb, err)
@@ -219,9 +211,6 @@ func TestBlockStore_Put_UploadError(t *testing.T) {
 		testBlock, err := blocks.NewBlockWithCid([]byte(testData), testCid)
 		require.NoError(t, err)
 		expectedError := errors.New("upload failed")
-
-		// Mock the upload service GetUpload method (no existing upload)
-		mockUpload.EXPECT().GetUpload(mock.Anything, mock.Anything).Return(nil, core.ErrUploadNotFound).Once()
 
 		// Mock the storage's UploadObject method to return an error
 		mockStorage.EXPECT().UploadObject(mock.Anything, mock.Anything).Return(nil, expectedError).Once()
@@ -241,7 +230,6 @@ func TestBlockStore_Put_PinError(t *testing.T) {
 		mockDownloader := localMocks.NewMockBlockDownloader(t)
 		mockMetadata := localMocks.NewMockMetadataStore(t)
 		mockStorage := core.GetService[*coreTesting.MockStorageService](ctx, core.STORAGE_SERVICE)
-		mockUpload := core.GetService[*portalMocks.MockUploadService](ctx, core.UPLOAD_SERVICE)
 
 		bs, err := store.NewBlockStore(ctx, mockDownloader, mockMetadata)
 		require.NoError(tb, err)
@@ -252,12 +240,8 @@ func TestBlockStore_Put_PinError(t *testing.T) {
 		require.NoError(t, err)
 		expectedError := errors.New("pin failed")
 
-		// Mock the upload service GetUpload method (no existing upload)
-		mockUpload.EXPECT().GetUpload(mock.Anything, mock.Anything).Return(nil, core.ErrUploadNotFound).Once()
-
 		// Mock the storage's UploadObject method
-		uploadRecord := testUploadRecord(testCid)
-		mockStorage.EXPECT().UploadObject(mock.Anything, mock.Anything).Return(uploadRecord, nil).Once()
+		mockStorage.EXPECT().UploadObject(mock.Anything, mock.Anything).Return(nil, nil).Once()
 
 		// Mock the metadata's Pin method to return an error
 		mockMetadata.EXPECT().Pin(mock.Anything, mock.Anything).Return(expectedError).Once()
@@ -329,7 +313,6 @@ func TestBlockStore_PutMany(t *testing.T) {
 		mockDownloader := localMocks.NewMockBlockDownloader(t)
 		mockMetadata := localMocks.NewMockMetadataStore(t)
 		mockStorage := core.GetService[*coreTesting.MockStorageService](ctx, core.STORAGE_SERVICE)
-		mockUpload := core.GetService[*portalMocks.MockUploadService](ctx, core.UPLOAD_SERVICE)
 
 		bs, err := store.NewBlockStore(ctx, mockDownloader, mockMetadata)
 		require.NoError(tb, err)
@@ -345,9 +328,6 @@ func TestBlockStore_PutMany(t *testing.T) {
 		require.NoError(t, err)
 
 		_blocks := []blocks.Block{testBlock1, testBlock2}
-
-		// Mock the upload service GetUpload method for each block (no existing uploads)
-		mockUpload.EXPECT().GetUpload(mock.Anything, mock.Anything).Return(nil, core.ErrUploadNotFound).Times(2)
 
 		// Mock the storage's UploadObject method for each block
 		mockStorage.EXPECT().UploadObject(mock.Anything, mock.Anything).Return(nil, nil).Times(2)
@@ -366,10 +346,9 @@ func TestBlockStore_PutMany(t *testing.T) {
 func TestBlockStore_PutMany_PutError(t *testing.T) {
 	coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 		// Arrange
-		mockDownloader := localMocks.NewMockBlockDownloader(t)
+	mockDownloader := localMocks.NewMockBlockDownloader(t)
 		mockMetadata := localMocks.NewMockMetadataStore(t)
 		mockStorage := core.GetService[*coreTesting.MockStorageService](ctx, core.STORAGE_SERVICE)
-		mockUpload := core.GetService[*portalMocks.MockUploadService](ctx, core.UPLOAD_SERVICE)
 
 		bs, err := store.NewBlockStore(ctx, mockDownloader, mockMetadata)
 		require.NoError(tb, err)
@@ -386,9 +365,6 @@ func TestBlockStore_PutMany_PutError(t *testing.T) {
 
 		_blocks := []blocks.Block{testBlock1, testBlock2}
 		expectedError := errors.New("upload failed")
-
-		// Mock the upload service GetUpload method for the first block (no existing upload)
-		mockUpload.EXPECT().GetUpload(mock.Anything, mock.Anything).Return(nil, core.ErrUploadNotFound).Once()
 
 		// Mock the storage's UploadObject method to return an error for the first block
 		mockStorage.EXPECT().UploadObject(mock.Anything, mock.Anything).Return(nil, expectedError).Once()
@@ -535,7 +511,6 @@ func TestBlockStore_VirtualReadDisabled(t *testing.T) {
 		mockDownloader := localMocks.NewMockBlockDownloader(t)
 		mockMetadata := localMocks.NewMockMetadataStore(t)
 		mockStorage := core.GetService[*coreTesting.MockStorageService](ctx, core.STORAGE_SERVICE)
-		mockUpload := core.GetService[*portalMocks.MockUploadService](ctx, core.UPLOAD_SERVICE)
 
 		bs, err := store.NewBlockStore(ctx, mockDownloader, mockMetadata)
 		require.NoError(tb, err)
@@ -569,9 +544,7 @@ func TestBlockStore_VirtualReadDisabled(t *testing.T) {
 		assert.Equal(tb, len(testData), size)
 
 		// Test Put
-		mockUpload.EXPECT().GetUpload(mock.Anything, mock.Anything).Return(nil, core.ErrUploadNotFound).Once()
-		uploadRecord := testUploadRecord(testCid)
-		mockStorage.EXPECT().UploadObject(mock.Anything, mock.Anything).Return(uploadRecord, nil).Once()
+		mockStorage.EXPECT().UploadObject(mock.Anything, mock.Anything).Return(nil, nil).Once()
 		mockMetadata.EXPECT().Pin(mock.Anything, mock.Anything).Return(nil).Once()
 		err = bs.Put(normalCtx, testBlock)
 		require.NoError(tb, err)
@@ -624,13 +597,3 @@ func TestBlockStore_AllKeysChan_ContextDone(t *testing.T) {
 	}, ipfsTestConfig)
 }
 
-// testUploadRecord creates a mock upload record for testing
-func testUploadRecord(c cid.Cid) *models.Upload {
-	data := []byte("test data")
-	return &models.Upload{
-		Hash:     c.Hash(),
-		UserID:   123,
-		Size:     uint64(len(data)),
-		Protocol: "ipfs",
-	}
-}


### PR DESCRIPTION
Revert quota tracking logic that was added to the blockstore layer in PR #424. Quota tracking should only occur at the service layer (upload/pin services) to prevent double-counting in case of workflow task failures.

Changes:

- Remove upload service dependency from blockstore
- Remove quota validation logic from BlockStore.Put()
- Remove EmitUploadCompleted() and EmitStorageObjectPinned() calls from blockstore
- Remove unused context helpers (UserID, GetClientIP, LogIfClientIPMissing)
- Remove unused imports (models package)

Quota tracking remains properly wired in:

- UploadService.ProcessUpload() - Validates upload quota and emits events
- PinService.DeletePin() - Emits unpin events when pins are removed
- API layer - Handles download quota validation for authenticated requests

* `develop` <!-- branch-stack -->
  - **refactor(store): remove redundant quota tracking from blockstore #424** :point\_left:


---

<!-- kody-pr-summary:start -->
This pull request refactors the IPFS blockstore to remove redundant quota tracking and user context management that is now handled by the underlying storage service layer.

**Key Changes:**

- **Removed upload service dependency**: Eliminated direct dependency on `core.UploadService` and related upload existence checks from the blockstore
- **Simplified `Put` operations**: Removed quota validation, user ID extraction from context, and duplicate upload record lookups that were previously performed before storing blocks
- **Removed event emissions**: Eliminated direct emission of quota tracking events (`EmitUploadCompleted`, `EmitStorageObjectPinned`) from the blockstore layer
- **Cleaned up context utilities**: Removed user ID context helpers (`UserOption`, `GetUserID`, `IsValidUserID`) and client IP logging utilities from the store package
- **Updated tests**: Removed mock expectations for upload service calls and upload record creation in test cases

**Functional Impact:**

The blockstore now focuses solely on block storage and metadata pinning, delegating quota enforcement, user attribution, and upload tracking entirely to the storage service layer. This eliminates duplicate quota tracking logic and simplifies the blockstore's responsibility to core storage operations.
<!-- kody-pr-summary:end -->