### PR TITLE
fix(quota): use core.FireAsync instead of ctx.FireAsync

### DIFF
--- a/internal/quota/quota.go
+++ b/internal/quota/quota.go
@@ -68,22 +68,22 @@ func CheckStorageQuota(cctx context.Context, ctx core.Context, userID uint, requ
 
 // EmitUploadCompleted emits an upload completed event for quota tracking
 func EmitUploadCompleted(cctx context.Context, ctx core.Context, userID *uint, uploadID uint, bytes uint64, ip string) {
-	ctx.FireAsync(event.EVENT_UPLOAD_COMPLETED, event.NewUploadCompletedEvent(cctx, uploadID, bytes, ip, userID))
+	core.FireAsync(ctx, event.EVENT_UPLOAD_COMPLETED, event.NewUploadCompletedEvent(cctx, uploadID, bytes, ip, userID))
 }
 
 // EmitDownloadCompleted emits a download completed event for quota tracking
 func EmitDownloadCompleted(cctx context.Context, ctx core.Context, uploadID uint, bytes uint64, ip string, userID *uint) {
-	ctx.FireAsync(event.EVENT_DOWNLOAD_COMPLETED, event.NewDownloadCompletedEvent(cctx, uploadID, bytes, ip, userID))
+	core.FireAsync(ctx, event.EVENT_DOWNLOAD_COMPLETED, event.NewDownloadCompletedEvent(cctx, uploadID, bytes, ip, userID))
 }
 
 // EmitStorageObjectPinned emits a storage object pinned event for quota tracking
 func EmitStorageObjectPinned(cctx context.Context, ctx core.Context, pin *models.Pin, ip string) {
-	ctx.FireAsync(event.EVENT_STORAGE_OBJECT_PINNED, event.NewStorageObjectPinnedEvent(cctx, pin, ip))
+	core.FireAsync(ctx, event.EVENT_STORAGE_OBJECT_PINNED, event.NewStorageObjectPinnedEvent(cctx, pin, ip))
 }
 
 // EmitStorageObjectUnpinned emits a storage object unpinned event for quota tracking
 func EmitStorageObjectUnpinned(cctx context.Context, ctx core.Context, pin *models.Pin, ip string) {
-	ctx.FireAsync(event.EVENT_STORAGE_OBJECT_UNPINNED, event.NewStorageObjectUnpinnedEvent(cctx, pin, ip))
+	core.FireAsync(ctx, event.EVENT_STORAGE_OBJECT_UNPINNED, event.NewStorageObjectUnpinnedEvent(cctx, pin, ip))
 }
 
 // ValidateUploadQuota checks upload quota and returns an error if exceeded


### PR DESCRIPTION
Update all quota helper Emit functions to use the core package's FireAsync function directly, rather than the context method. This ensures proper event dispatching for quota tracking.

- EmitUploadCompleted
- EmitDownloadCompleted
- EmitStorageObjectPinned
- EmitStorageObjectUnpinned

* `develop` <!-- branch-stack -->
  - **fix(quota): use core.FireAsync instead of ctx.FireAsync** :point\_left:


---

<!-- kody-pr-summary:start -->
 Fixes the quota helper functions to use `core.FireAsync` instead of `ctx.FireAsync` for emitting asynchronous events. This change updates the event emission calls for upload completion, download completion, storage object pinning, and storage object unpinning to align with the core package API.
<!-- kody-pr-summary:end -->