### PR TITLE
fix(quota): use DetachContext to prevent canceled context contamination

### DIFF
--- a/internal/api/api_ipfs.go
+++ b/internal/api/api_ipfs.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ipfs/go-cid"
 	"github.com/labstack/echo/v4"
 	"go.lumeweb.com/httputil"
+	"go.lumeweb.com/portal/core"
 	"go.lumeweb.com/portal-plugin-ipfs/internal"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/api/dto"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/protocol/store"
@@ -111,7 +112,8 @@ func (a API) handleRawBlockRequest(ctx httputil.RequestContext, _cid cid.Cid, w 
 	}
 
 	// Emit download completion event only after successful write
-	quota.EmitDownloadCompleted(reqCtx, a.Context(), upload.ID, uint64(n), ip, &userID)
+	// Use DetachContext to prevent canceled request context from reaching event handlers
+	quota.EmitDownloadCompleted(core.DetachContext(reqCtx), a.Context(), upload.ID, uint64(n), ip, &userID)
 	return nil
 }
 

--- a/internal/protocol/store/blockstore.go
+++ b/internal/protocol/store/blockstore.go
@@ -125,7 +125,9 @@ func (bs *BlockStore) Get(ctx context.Context, c cid.Cid) (blocks.Block, error) 
 	}
 
 	// Emit download completion event - anonymous (nil userID)
-	quota.EmitDownloadCompleted(core.DetachContext(ctx), bs.ctx, 0, uint64(len(block.RawData())), clientIP, nil)
+	if !IsQuotaCheckSkipped(ctx) {
+		quota.EmitDownloadCompleted(core.DetachContext(ctx), bs.ctx, 0, uint64(len(block.RawData())), clientIP, nil)
+	}
 
 	return block, nil
 }

--- a/internal/protocol/store/blockstore.go
+++ b/internal/protocol/store/blockstore.go
@@ -125,7 +125,7 @@ func (bs *BlockStore) Get(ctx context.Context, c cid.Cid) (blocks.Block, error) 
 	}
 
 	// Emit download completion event - anonymous (nil userID)
-	quota.EmitDownloadCompleted(ctx, bs.ctx, 0, uint64(len(block.RawData())), clientIP, nil)
+	quota.EmitDownloadCompleted(core.DetachContext(ctx), bs.ctx, 0, uint64(len(block.RawData())), clientIP, nil)
 
 	return block, nil
 }


### PR DESCRIPTION
When HTTP clients disconnect or request contexts are canceled, the canceled context was being passed to quota event handlers, causing download recording to fail before completion.

This fix uses core.DetachContext() which:

- Preserves OpenTelemetry tracing from the original context
- Prevents context cancellation from propagating to event handlers
- Ensures download events are always recorded even if client disconnects

Affected path:

- internal/api/api\_ipfs.go: handleRawBlockRequest now detaches context before emitting download completed event

* `develop` <!-- branch-stack -->
  - **fix(quota): use DetachContext to prevent canceled context contamination** :point\_left:

***

<!-- kody-pr-summary:start -->

Fixes context contamination in quota event emission by detaching the request context before passing it to `quota.EmitDownloadCompleted`. This prevents canceled HTTP request contexts from interfering with asynchronous quota tracking operations when serving IPFS raw block downloads, ensuring reliable download completion accounting regardless of the original request's cancellation state.

<!-- kody-pr-summary:end -->
