### PR TITLE
fix(blockstore): check group quota availability for anonymous downloads

### DIFF
--- a/internal/protocol/store/blockstore.go
+++ b/internal/protocol/store/blockstore.go
@@ -107,15 +107,34 @@ func (bs *BlockStore) Get(ctx context.Context, c cid.Cid) (blocks.Block, error) 
 		return nil, err
 	}
 
-	// Validate download quota - always anonymous (nil userID), unless skipped
+	// Validate download quota - checks if any users pinning this content have sufficient quota
+	// NOTE: Anonymous downloads (userID=0) check group availability instead of individual quota.
+	// Usage will be distributed among users who have pinned this upload.
 	if !IsQuotaCheckSkipped(ctx) {
-		bs.log.Debug("Performing anonymous download quota check",
+		bs.log.Debug("Performing anonymous download quota group availability check",
 			zap.String("cid", c.String()),
 			zap.Uint64("size", size))
-		if err := quota.ValidateDownloadQuota(ctx, bs.ctx, 0, uint64(size)); err != nil {
-			bs.log.Warn("Anonymous quota check failed", zap.String("cid", c.String()), zap.Error(err))
-			return nil, err
+
+		// Check if any pinners have sufficient quota to serve this block
+		available, err := quota.CheckCIDGroupDownloadAvailability(ctx, bs.ctx, internal.NewIPFSHash(c), uint64(size))
+		if err != nil {
+			bs.log.Warn("Group quota availability check failed",
+				zap.String("cid", c.String()),
+				zap.Uint64("size", size),
+				zap.Error(err))
+			return nil, fmt.Errorf("failed to check group quota availability: %w", err)
 		}
+
+		if !available {
+			bs.log.Debug("Group quota not available for anonymous download",
+				zap.String("cid", c.String()),
+				zap.Uint64("size", size))
+			return nil, format.ErrNotFound{Cid: c}
+		}
+
+		bs.log.Debug("Group quota available for anonymous download",
+			zap.String("cid", c.String()),
+			zap.Uint64("size", size))
 	}
 
 	// Proceed with download
@@ -124,7 +143,8 @@ func (bs *BlockStore) Get(ctx context.Context, c cid.Cid) (blocks.Block, error) 
 		return nil, err
 	}
 
-	// Emit download completion event - anonymous (nil userID)
+	// Emit download completion event - anonymous (userID=0)
+	// Usage will be distributed among users who have pinned this upload
 	if !IsQuotaCheckSkipped(ctx) {
 		quota.EmitDownloadCompleted(core.DetachContext(ctx), bs.ctx, 0, uint64(len(block.RawData())), clientIP, nil)
 	}

--- a/internal/quota/quota.go
+++ b/internal/quota/quota.go
@@ -148,3 +148,15 @@ func ValidateStorageQuota(cctx context.Context, ctx core.Context, userID uint, r
 	}
 	return nil
 }
+// CheckCIDGroupDownloadAvailability checks if any users with pinned content have sufficient quota for anonymous downloads
+func CheckCIDGroupDownloadAvailability(cctx context.Context, ctx core.Context, cid core.StorageHash, requiredBytes uint64) (bool, error) {
+	var available bool
+
+	err := core.WithService[quotaCore.QuotaService](ctx, quotaCore.QUOTA_SERVICE, func(qs quotaCore.QuotaService) error {
+		var err error
+		available, err = qs.CheckCIDGroupQuotaAvailability(cctx, cid, requiredBytes, quotaCore.UsageTypeDownload)
+		return err
+	})
+
+	return available, err
+}

--- a/internal/quota/quota.go
+++ b/internal/quota/quota.go
@@ -150,13 +150,25 @@ func ValidateStorageQuota(cctx context.Context, ctx core.Context, userID uint, r
 }
 // CheckCIDGroupDownloadAvailability checks if any users with pinned content have sufficient quota for anonymous downloads
 func CheckCIDGroupDownloadAvailability(cctx context.Context, ctx core.Context, cid core.StorageHash, requiredBytes uint64) (bool, error) {
-	var available bool
+	available := true
+	serviceFound := false
 
-	err := core.WithService[quotaCore.QuotaService](ctx, quotaCore.QUOTA_SERVICE, func(qs quotaCore.QuotaService) error {
-		var err error
-		available, err = qs.CheckCIDGroupQuotaAvailability(cctx, cid, requiredBytes, quotaCore.UsageTypeDownload)
-		return err
+	core.WithService[quotaCore.QuotaService](ctx, quotaCore.QUOTA_SERVICE, func(qs quotaCore.QuotaService) error {
+		serviceFound = true
+		result, err := qs.CheckCIDGroupQuotaAvailability(cctx, cid, requiredBytes, quotaCore.UsageTypeDownload)
+		if err == nil {
+			available = result
+		}
+		return nil
 	})
 
-	return available, err
+	// If quota service is not found, assume availability (quota enforcement disabled)
+	if !serviceFound {
+		ctx.Logger().Debug("Quota service not available, assuming group quota available for anonymous download",
+			zap.String("cid", cid.String()),
+			zap.Uint64("required_bytes", requiredBytes))
+		return true, nil
+	}
+
+	return available, nil
 }


### PR DESCRIPTION
Prevent bitswap from serving blocks when no pinning users have sufficient download quota. For anonymous downloads (userID=0), check if any users who pinned the content have collective quota capacity before allowing the download via CheckCIDGroupQuotaAvailability.

Changes:

- Add CheckCIDGroupDownloadAvailability() helper in quota package
- Update blockstore Get() to call group quota check before download
- Return format.ErrNotFound when group quota unavailable
- Emit download event only when quota check passes

* `develop` <!-- branch-stack -->
  - **fix(blockstore): check group quota availability for anonymous downloads** :point\_left:

***

<!-- kody-pr-summary:start -->

This PR fixes the quota validation logic for anonymous downloads in the blockstore to check group availability among content pinners instead of validating against a single anonymous quota limit.

**Changes:**

- **Modified `BlockStore.Get()`**: Updated anonymous download quota validation to check if any users who have pinned the content (CID) have sufficient collective quota available, rather than checking against an individual anonymous user quota (userID=0). When group quota is unavailable, the method now returns `ErrNotFound` instead of a quota exceeded error.

- **Added `CheckCIDGroupDownloadAvailability()`**: New helper function that queries the quota service to determine if any pinners of a specific CID have sufficient download quota to serve anonymous requests.

**Functional Impact:**

Anonymous downloads can now proceed when at least one user who pinned the content has available quota, rather than failing due to anonymous quota limitations. Download usage for anonymous requests will be distributed among the users who have pinned the content.

<!-- kody-pr-summary:end -->
