### PR TITLE
fix(protocol): attribute downloads to upload records for proper quota tracking

### DIFF
--- a/internal/api/api_ipfs.go
+++ b/internal/api/api_ipfs.go
@@ -9,9 +9,9 @@ import (
 	"github.com/labstack/echo/v4"
 	"go.lumeweb.com/httputil"
 	"go.lumeweb.com/portal/core"
+	pc "go.lumeweb.com/portal-plugin-ipfs/internal/protocol/context"
 	"go.lumeweb.com/portal-plugin-ipfs/internal"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/api/dto"
-	"go.lumeweb.com/portal-plugin-ipfs/internal/protocol/store"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/quota"
 	"go.uber.org/zap"
 )
@@ -45,9 +45,9 @@ func (a *API) handleIPFSGet(c echo.Context) error {
 func (a API) handleRawBlockRequest(ctx httputil.RequestContext, _cid cid.Cid, w http.ResponseWriter, r *http.Request, c echo.Context) error {
 	// Create context with client IP for quota tracking
 	reqCtx := ctx.Request().Context()
-	reqCtx = store.ClientIPOption(reqCtx, c.RealIP())
+	reqCtx = pc.ClientIPOption(reqCtx, c.RealIP())
 	// Skip quota check in store since API already validates it
-	reqCtx = store.SkipQuotaCheckOption(reqCtx, true)
+	reqCtx = pc.SkipQuotaCheckOption(reqCtx, true)
 
 	// Check if the block exists before trying to fetch it
 	exists, err := a.ipfs.GetNode().HasBlock(reqCtx, _cid)

--- a/internal/api/api_pins.go
+++ b/internal/api/api_pins.go
@@ -14,8 +14,8 @@ import (
 	"go.lumeweb.com/portal-plugin-ipfs/internal"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/api/dto"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/protocol"
-	"go.lumeweb.com/portal-plugin-ipfs/internal/protocol/store"
 	"go.lumeweb.com/portal/core"
+	pc "go.lumeweb.com/portal-plugin-ipfs/internal/protocol/context"
 	"go.lumeweb.com/portal/db/types"
 	"go.lumeweb.com/queryutil"
 	queryUtilHttp "go.lumeweb.com/queryutil/http"
@@ -209,7 +209,7 @@ func (a *API) replacePin(c echo.Context) error {
 func (a *API) deletePin(c echo.Context) error {
 	ctx := httputil.Context(c)
 	reqCtx := ctx.Context.Request().Context()
-	reqCtx = store.ClientIPOption(reqCtx, c.RealIP())
+	reqCtx = pc.ClientIPOption(reqCtx, c.RealIP())
 	user, err := mcontext.GetUserID(c)
 	if err != nil {
 		return err

--- a/internal/protocol/context/context.go
+++ b/internal/protocol/context/context.go
@@ -1,0 +1,91 @@
+package context
+
+import (
+	"context"
+
+	"go.lumeweb.com/portal/core"
+)
+
+type (
+	// ContextKey is a type for context keys
+	ContextKey string
+)
+
+const (
+	// VirtualReadKey is the context key for the virtual read option
+	VirtualReadKey   ContextKey = "virtualRead"
+	DisableMetaCheck ContextKey = "disableMetaCheck"
+	ClientIPKey      ContextKey = "clientIP"
+	SkipQuotaCheck   ContextKey = "skipQuotaCheck"
+)
+
+// VirtualReadOption sets the virtual read option in the context
+func VirtualReadOption(ctx context.Context, enabled bool) context.Context {
+	ctx, span := core.TraceMethod(ctx, "VirtualReadOption")
+	defer span.End()
+
+	return context.WithValue(ctx, VirtualReadKey, enabled)
+}
+
+// IsVirtualReadEnabled checks if virtual read is enabled in the context
+func IsVirtualReadEnabled(ctx context.Context) bool {
+	ctx, span := core.TraceMethod(ctx, "IsVirtualReadEnabled")
+	defer span.End()
+
+	value, ok := ctx.Value(VirtualReadKey).(bool)
+	return ok && value
+}
+
+// DisableMetaCheckOption sets the disable metadata check option in the context
+func DisableMetaCheckOption(ctx context.Context, enabled bool) context.Context {
+	ctx, span := core.TraceMethod(ctx, "DisableMetaCheckOption")
+	defer span.End()
+
+	return context.WithValue(ctx, DisableMetaCheck, enabled)
+}
+
+// IsMetaCheckDisabled checks if metadata check is disabled in the context
+func IsMetaCheckDisabled(ctx context.Context) bool {
+	ctx, span := core.TraceMethod(ctx, "IsMetaCheckDisabled")
+	defer span.End()
+
+	value, ok := ctx.Value(DisableMetaCheck).(bool)
+	return ok && value
+}
+
+// ClientIPOption sets client IP in the context
+func ClientIPOption(ctx context.Context, clientIP string) context.Context {
+	ctx, span := core.TraceMethod(ctx, "ClientIPOption")
+	defer span.End()
+
+	return context.WithValue(ctx, ClientIPKey, clientIP)
+}
+
+// GetClientIP retrieves the client IP from the context
+func GetClientIP(ctx context.Context) string {
+	ctx, span := core.TraceMethod(ctx, "GetClientIP")
+	defer span.End()
+
+	value, ok := ctx.Value(ClientIPKey).(string)
+	if !ok {
+		return ""
+	}
+	return value
+}
+
+// SkipQuotaCheckOption sets the skip quota check option in the context
+func SkipQuotaCheckOption(ctx context.Context, enabled bool) context.Context {
+	ctx, span := core.TraceMethod(ctx, "SkipQuotaCheckOption")
+	defer span.End()
+
+	return context.WithValue(ctx, SkipQuotaCheck, enabled)
+}
+
+// IsQuotaCheckSkipped checks if quota check is skipped in the context
+func IsQuotaCheckSkipped(ctx context.Context) bool {
+	ctx, span := core.TraceMethod(ctx, "IsQuotaCheckSkipped")
+	defer span.End()
+
+	value, ok := ctx.Value(SkipQuotaCheck).(bool)
+	return ok && value
+}

--- a/internal/protocol/ipfs/node.go
+++ b/internal/protocol/ipfs/node.go
@@ -394,6 +394,11 @@ func NewNode(ctx core.Context, cfg *config.ProtocolConfig, rs pluginCore.Reprovi
 	// This allows downstream handlers to access the remote peer's IP for quota tracking
 	_bitswapWithPeerIP := NewPeerIPBitswap(_bitswap, node)
 
+	// Stop the network to deregister the inner bitswap instance as the receiver,
+	// then start it again with our wrapper so our ReceiveMessage override gets called
+	bitswapNet.Stop()
+	bitswapNet.Start(_bitswapWithPeerIP)
+
 	// Wrap the bitswap exchange with NopExchange to disable automatic block announcements
 	nopExchange := &NopExchange{_bitswapWithPeerIP}
 

--- a/internal/protocol/ipfs/node.go
+++ b/internal/protocol/ipfs/node.go
@@ -390,8 +390,12 @@ func NewNode(ctx core.Context, cfg *config.ProtocolConfig, rs pluginCore.Reprovi
 	bitswapNet := bsnet.NewFromIpfsHost(node)
 	_bitswap := bitswap.New(ctx, bitswapNet, routingImpl, bs, bitswapOpts...)
 
+	// Wrap bitswap with PeerIPBitswap to inject peer IP into context during message handling
+	// This allows downstream handlers to access the remote peer's IP for quota tracking
+	_bitswapWithPeerIP := NewPeerIPBitswap(_bitswap, node)
+
 	// Wrap the bitswap exchange with NopExchange to disable automatic block announcements
-	nopExchange := &NopExchange{_bitswap}
+	nopExchange := &NopExchange{_bitswapWithPeerIP}
 
 	blockServ := blockservice.New(bs, nopExchange)
 	dagService := merkledag.NewDAGService(blockServ)

--- a/internal/protocol/ipfs/peer_ip_bitswap.go
+++ b/internal/protocol/ipfs/peer_ip_bitswap.go
@@ -1,0 +1,53 @@
+package ipfs
+
+import (
+	"context"
+
+	"github.com/ipfs/boxo/bitswap"
+	bsmsg "github.com/ipfs/boxo/bitswap/message"
+	pc "go.lumeweb.com/portal-plugin-ipfs/internal/protocol/context"
+	"github.com/libp2p/go-libp2p/core/host"
+	"github.com/libp2p/go-libp2p/core/peer"
+)
+
+// PeerIPBitswap extends bitswap.Bitswap to inject peer IP addresses into context during message handling.
+// It extracts the remote peer's IP address from network connections and adds it to the context,
+// allowing downstream handlers to access the peer's IP for tracking and quota purposes.
+type PeerIPBitswap struct {
+	*bitswap.Bitswap
+	host host.Host
+}
+
+// NewPeerIPBitswap creates a new PeerIPBitswap that embeds a bitswap.Bitswap instance
+// and stores a reference to the libp2p host for extracting peer connection information.
+func NewPeerIPBitswap(bitswapInstance *bitswap.Bitswap, h host.Host) *PeerIPBitswap {
+	return &PeerIPBitswap{
+		Bitswap: bitswapInstance,
+		host:    h,
+	}
+}
+
+// ReceiveMessage intercepts incoming bitswap messages to extract the peer's IP address
+// and injects it into the context before delegating to the embedded Bitswap handler.
+//
+// The IP extraction process:
+// 1. Uses the host's network to find connections to the sender peer
+// 2. Extracts the remote address from the first connection
+// 3. Adds the IP string to the context with pc.ClientIPKey
+// 4. Delegates to the embedded Bitswap.ReceiveMessage with the modified context
+//
+// This allows downstream code (e.g., BlockStore.Get) to access the peer's IP for
+// quota tracking and download attribution.
+func (ps *PeerIPBitswap) ReceiveMessage(ctx context.Context, p peer.ID, incoming bsmsg.BitSwapMessage) {
+	// Get connections to this peer
+	conns := ps.host.Network().ConnsToPeer(p)
+	
+	// Extract IP address from connection and add to context using pc.ClientIPOption
+	if len(conns) > 0 {
+		remoteAddr := conns[0].RemoteMultiaddr().String()
+		ctx = pc.ClientIPOption(ctx, remoteAddr)
+	}
+	
+	// Delegate to embedded Bitswap with modified context
+	ps.Bitswap.ReceiveMessage(ctx, p, incoming)
+}

--- a/internal/protocol/op_confirm.go
+++ b/internal/protocol/op_confirm.go
@@ -9,7 +9,7 @@ import (
 	pluginCore "go.lumeweb.com/portal-plugin-ipfs/core"
 	"go.lumeweb.com/portal-plugin-ipfs/internal"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/db"
-	"go.lumeweb.com/portal-plugin-ipfs/internal/protocol/store"
+	pc "go.lumeweb.com/portal-plugin-ipfs/internal/protocol/context"
 	"go.lumeweb.com/portal/core"
 	"go.lumeweb.com/portal/db/models"
 	"go.lumeweb.com/portal/db/types"
@@ -50,7 +50,7 @@ func (h *ConfirmOperationHandler) Execute(ctx context.Context, req *models.Reque
 	metadataStore := proto.GetMetadataStore()
 
 	// Set client IP in context for quota tracking before any operations
-	ctx = store.ClientIPOption(ctx, req.SourceIP)
+	ctx = pc.ClientIPOption(ctx, req.SourceIP)
 
 	var cidList []cid.Cid
 

--- a/internal/protocol/op_post_upload.go
+++ b/internal/protocol/op_post_upload.go
@@ -12,7 +12,7 @@ import (
 	pluginCore "go.lumeweb.com/portal-plugin-ipfs/core"
 	"go.lumeweb.com/portal-plugin-ipfs/internal"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/db"
-	"go.lumeweb.com/portal-plugin-ipfs/internal/protocol/store"
+	pc "go.lumeweb.com/portal-plugin-ipfs/internal/protocol/context"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/upload"
 	"go.lumeweb.com/portal/core"
 	"go.lumeweb.com/portal/db/models"
@@ -266,7 +266,7 @@ func (h *PostUploadOperationHandler) processCIDs(ctx context.Context, allCids []
 		return fmt.Errorf("upload service not available")
 	}
 
-	ctx = store.ClientIPOption(ctx, sourceIP)
+	ctx = pc.ClientIPOption(ctx, sourceIP)
 	err := uploadSvc.ProcessUpload(ctx, allCids, userID)
 	if err != nil {
 		return fmt.Errorf("failed to process upload: %w", err)

--- a/internal/protocol/op_retrieve.go
+++ b/internal/protocol/op_retrieve.go
@@ -15,6 +15,7 @@ import (
 	pluginConfig "go.lumeweb.com/portal-plugin-ipfs/internal/config"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/protocol/encoding"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/protocol/store"
+	pc "go.lumeweb.com/portal-plugin-ipfs/internal/protocol/context"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/quota"
 	"go.lumeweb.com/portal/core"
 	"go.lumeweb.com/portal/db/models"
@@ -166,7 +167,7 @@ func (h *RetrieveOperationHandler) Execute(ctx context.Context, req *models.Requ
 			}
 
 			// Set client IP in context for quota tracking
-			ctx = store.ClientIPOption(ctx, req.SourceIP)
+			ctx = pc.ClientIPOption(ctx, req.SourceIP)
 
 			err = uploadSvc.ProcessUpload(ctx, validChildCids, *req.UserID)
 			if err != nil {
@@ -204,7 +205,7 @@ func isRecoverableNodeError(err error) bool {
 
 func collectDAGCids(ctx core.Context, ipfs *Protocol, c cid.Cid) ([]cid.Cid, error) {
 
-	getCtx := store.VirtualReadOption(ctx, true)
+	getCtx := pc.VirtualReadOption(ctx, true)
 	getCtx, cancel := context.WithTimeout(getCtx, ctx.Config().GetProtocol(internal.ProtocolName).(*pluginConfig.ProtocolConfig).BlockStore.Timeout)
 
 	sess := merkledag.NewSession(getCtx, ipfs.GetNode().DagService())

--- a/internal/protocol/protocol.go
+++ b/internal/protocol/protocol.go
@@ -21,6 +21,7 @@ import (
 	pluginDb "go.lumeweb.com/portal-plugin-ipfs/internal/db"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/protocol/ipfs"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/protocol/store"
+	pc "go.lumeweb.com/portal-plugin-ipfs/internal/protocol/context"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/protocol/store/downloader"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/upload"
 	"go.lumeweb.com/portal/config"
@@ -269,7 +270,7 @@ func NewProtocolOperations(p core.Protocol) []core.Operation {
 			}
 
 			// Set client IP in context for quota tracking
-			ctx = store.ClientIPOption(ctx, request.SourceIP)
+			ctx = pc.ClientIPOption(ctx, request.SourceIP)
 
 			err = uploadSvc.ProcessUpload(ctx, allCids, *request.UserID)
 			if err != nil {

--- a/internal/protocol/store/blockstore.go
+++ b/internal/protocol/store/blockstore.go
@@ -19,6 +19,7 @@ import (
 	"go.lumeweb.com/portal/core"
 	"go.lumeweb.com/portal/service"
 	"go.uber.org/zap"
+	pc "go.lumeweb.com/portal-plugin-ipfs/internal/protocol/context"
 )
 
 type (
@@ -29,11 +30,12 @@ type (
 
 		bucket string
 
-		metadata   pluginCore.MetadataStore
-		downloader pluginCore.BlockDownloader
-		storage    core.StorageService
+		metadata    pluginCore.MetadataStore
+		downloader  pluginCore.BlockDownloader
+		storage     core.StorageService
+		upload      core.UploadService
 
-		proto      core.StorageProtocol
+		proto       core.StorageProtocol
 	}
 )
 
@@ -45,7 +47,7 @@ func (bs *BlockStore) DeleteBlock(ctx context.Context, c cid.Cid) error {
 	key := cidKey(c)
 	log := bs.log.Named("DeleteBlock").With(zap.Stack("stack"), zap.Stringer("cid", c), zap.String("key", key))
 
-	if isVirtualReadEnabled(ctx) {
+	if pc.IsVirtualReadEnabled(ctx) {
 		log.Debug("virtual read enabled, skipping delete")
 		return nil
 	}
@@ -70,7 +72,7 @@ func (bs *BlockStore) Has(ctx context.Context, c cid.Cid) (bool, error) {
 
 	log := bs.log.Named("Has").With(zap.Stringer("cid", c))
 
-	if isVirtualReadEnabled(ctx) {
+	if pc.IsVirtualReadEnabled(ctx) {
 		log.Debug("virtual read enabled, assuming block does not exist")
 		return false, nil
 	}
@@ -93,13 +95,13 @@ func (bs *BlockStore) Get(ctx context.Context, c cid.Cid) (blocks.Block, error) 
 	ctx, span := core.TraceMethod(ctx, "BlockStore.Get")
 	defer span.End()
 
-	if isVirtualReadEnabled(ctx) {
+	if pc.IsVirtualReadEnabled(ctx) {
 		bs.log.Debug("virtual read enabled, fetching block without storing")
 		return bs.downloader.Get(ctx, c)
 	}
 
 	// Get client IP for tracking (may be empty)
-	clientIP := GetClientIP(ctx)
+	clientIP := pc.GetClientIP(ctx)
 
 	// Get block size for quota validation
 	size, err := bs.metadata.Size(ctx, c)
@@ -143,10 +145,20 @@ func (bs *BlockStore) Get(ctx context.Context, c cid.Cid) (blocks.Block, error) 
 		return nil, err
 	}
 
-	// Emit download completion event - anonymous (userID=0)
-	// Usage will be distributed among users who have pinned this upload
+	// Emit download completion event with upload tracking
+	// Only emit if we can successfully retrieve upload information
 	if !IsQuotaCheckSkipped(ctx) {
-		quota.EmitDownloadCompleted(core.DetachContext(ctx), bs.ctx, 0, uint64(len(block.RawData())), clientIP, nil)
+		upload, err := bs.upload.GetUpload(ctx, internal.NewIPFSHash(c))
+		if err != nil {
+			bs.log.Debug("Failed to get upload for download tracking, skipping event emission",
+				zap.Stringer("cid", c),
+				zap.Error(err))
+		} else if upload != nil {
+			quota.EmitDownloadCompleted(core.DetachContext(ctx), bs.ctx, upload.ID, uint64(len(block.RawData())), clientIP, &upload.UserID)
+		} else {
+			bs.log.Debug("Upload not found for CID, skipping download event emission",
+				zap.Stringer("cid", c))
+		}
 	}
 
 	return block, nil
@@ -160,7 +172,7 @@ func (bs *BlockStore) GetSize(ctx context.Context, c cid.Cid) (int, error) {
 	key := cidKey(c)
 	log := bs.log.Named("GetSize").With(zap.Stringer("cid", c), zap.String("key", key))
 
-	if isVirtualReadEnabled(ctx) {
+	if pc.IsVirtualReadEnabled(ctx) {
 		log.Debug("virtual read enabled, fetching block size without storing")
 		block, err := bs.Get(ctx, c)
 		if err != nil {
@@ -191,7 +203,7 @@ func (bs *BlockStore) Put(ctx context.Context, b blocks.Block) error {
 	key := cidKey(b.Cid())
 	log := bs.log.Named("Put").With(zap.Stringer("cid", b.Cid()), zap.String("key", key), zap.Int("size", len(b.RawData())))
 
-	if isVirtualReadEnabled(ctx) {
+	if pc.IsVirtualReadEnabled(ctx) {
 		log.Debug("virtual read enabled, skipping actual storage")
 		return nil
 	}
@@ -265,7 +277,7 @@ func (bs *BlockStore) AllKeysChan(ctx context.Context) (<-chan cid.Cid, error) {
 
 	log := bs.log.Named("AllKeysChan")
 
-	if isVirtualReadEnabled(ctx) {
+	if pc.IsVirtualReadEnabled(ctx) {
 		log.Debug("virtual read enabled, returning empty channel")
 		ch := make(chan cid.Cid)
 		close(ch)
@@ -322,12 +334,18 @@ func NewBlockStore(ctx core.Context, downloader pluginCore.BlockDownloader, meta
 		return nil, fmt.Errorf("storage service not initialized")
 	}
 
+	uploadSvc := core.GetService[core.UploadService](ctx, core.UPLOAD_SERVICE)
+	if uploadSvc == nil {
+		return nil, fmt.Errorf("upload service not initialized")
+	}
+
 	return &BlockStore{
 		ctx:        ctx,
 		log:        ctx.Logger(),
 		metadata:   metadata,
 		downloader: downloader,
 		storage:    storageSvc,
+		upload:     uploadSvc,
 		proto:      proto,
 	}, nil
 }

--- a/internal/protocol/store/downloader/downloader.go
+++ b/internal/protocol/store/downloader/downloader.go
@@ -16,7 +16,6 @@ import (
 	pluginCore "go.lumeweb.com/portal-plugin-ipfs/core"
 	"go.lumeweb.com/portal-plugin-ipfs/internal"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/protocol/store"
-	"go.lumeweb.com/portal-plugin-ipfs/internal/quota"
 	"go.lumeweb.com/portal/core"
 
 	blocks "github.com/ipfs/go-block-format"
@@ -180,10 +179,8 @@ func (bd *BlockDownloaderDefault) downloadBlockData(ctx context.Context, c cid.C
 		return nil, fmt.Errorf("block hash mismatch: expected %s, actual %s", c.Hash().HexString(), h.HexString())
 	}
 
-	// Emit download completion event for block retrieval
-	// uploadID=0 indicates this download is not associated with a specific upload record
-	// The clientIP is still tracked for quota purposes when available
-	quota.EmitDownloadCompleted(ctx, bd.ctx, 0, uint64(blockBuf.Len()), clientIP, nil)
+	// Note: Download emission is handled by BlockStore.Get which has access to
+	// upload information and can properly attribute downloads to uploads
 
 	return blockBuf.Bytes(), nil
 }

--- a/internal/protocol/store/tests/blockstore_test.go
+++ b/internal/protocol/store/tests/blockstore_test.go
@@ -15,6 +15,7 @@ import (
 	coreTesting "go.lumeweb.com/portal/core/testing"
 	"go.lumeweb.com/portal-plugin-ipfs/internal"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/protocol/store"
+	pc "go.lumeweb.com/portal-plugin-ipfs/internal/protocol/context"
 	localMocks "go.lumeweb.com/portal-plugin-ipfs/internal/testing/mocks"
 )
 

--- a/internal/protocol/store/tests/blockstore_test.go
+++ b/internal/protocol/store/tests/blockstore_test.go
@@ -468,7 +468,7 @@ func TestBlockStore_VirtualReadEnabled(t *testing.T) {
 		require.NoError(t, err)
 
 		// Enable virtual read
-		readCtx := store.VirtualReadOption(context.Background(), true)
+		readCtx := pc.VirtualReadOption(context.Background(), true)
 
 		// Test Get
 		mockDownloader.EXPECT().Get(mock.Anything, testCid).Return(testBlock, nil).Once()

--- a/internal/protocol/store/tests/blockstore_test.go
+++ b/internal/protocol/store/tests/blockstore_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.lumeweb.com/portal/core"
 	coreTesting "go.lumeweb.com/portal/core/testing"
+	"go.lumeweb.com/portal/core/testing/mocks"
 	"go.lumeweb.com/portal-plugin-ipfs/internal"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/protocol/store"
 	pc "go.lumeweb.com/portal-plugin-ipfs/internal/protocol/context"
@@ -36,6 +37,12 @@ func TestBlockStore_Get(t *testing.T) {
 
 		// Mock the downloader's Get method
 		mockDownloader.EXPECT().Get(mock.Anything, testCid).Return(expectedBlock, nil).Once()
+
+		// Mock the upload service's GetUpload method for download attribution
+		mockUploadService := core.GetService[*mocks.MockUploadService](ctx, core.UPLOAD_SERVICE)
+		if mockUploadService != nil {
+			mockUploadService.EXPECT().GetUpload(mock.Anything, mock.Anything).Return(nil, nil).Maybe()
+		}
 
 		// Act
 		block, err := bs.Get(context.Background(), testCid)
@@ -473,6 +480,13 @@ func TestBlockStore_VirtualReadEnabled(t *testing.T) {
 
 		// Test Get
 		mockDownloader.EXPECT().Get(mock.Anything, testCid).Return(testBlock, nil).Once()
+		
+		// Mock the upload service's GetUpload method for download attribution
+		mockUploadService := core.GetService[*mocks.MockUploadService](ctx, core.UPLOAD_SERVICE)
+		if mockUploadService != nil {
+			mockUploadService.EXPECT().GetUpload(mock.Anything, mock.Anything).Return(nil, nil).Maybe()
+		}
+		
 		block, err := bs.Get(readCtx, testCid)
 		require.NoError(tb, err)
 		assert.Equal(tb, testBlock, block)
@@ -527,6 +541,13 @@ func TestBlockStore_VirtualReadDisabled(t *testing.T) {
 		// Test Get
 		mockMetadata.EXPECT().Size(mock.Anything, testCid).Return(uint64(len(testData)), nil).Once()
 		mockDownloader.EXPECT().Get(mock.Anything, testCid).Return(testBlock, nil).Once()
+		
+		// Mock the upload service's GetUpload method for download attribution
+		mockUploadService := core.GetService[*mocks.MockUploadService](ctx, core.UPLOAD_SERVICE)
+		if mockUploadService != nil {
+			mockUploadService.EXPECT().GetUpload(mock.Anything, mock.Anything).Return(nil, nil).Maybe()
+		}
+		
 		block, err := bs.Get(normalCtx, testCid)
 		require.NoError(tb, err)
 		assert.Equal(tb, testBlock, block)

--- a/internal/protocol/store/tests/virtual_test.go
+++ b/internal/protocol/store/tests/virtual_test.go
@@ -54,7 +54,7 @@ func TestVirtualBlockStoreGetVirtualReadEnabled(t *testing.T) {
 		// Use Any() to match any context type
 		mockDirectBS.EXPECT().Get(mock.Anything, cid1).Return(block1, nil).Once()
 
-		readCtx := store.VirtualReadOption(ctx, true)
+		readCtx := pc.VirtualReadOption(ctx, true)
 		block, err := virtualBS.Get(readCtx, cid1)
 
 		assert.NoError(tb, err)
@@ -81,7 +81,7 @@ func TestVirtualBlockStoreHasVirtualReadEnabled(t *testing.T) {
 
 		mockDirectBS.EXPECT().Has(mock.Anything, cid1).Return(true, nil).Once()
 
-		readCtx := store.VirtualReadOption(ctx, true)
+		readCtx := pc.VirtualReadOption(ctx, true)
 		has, err := virtualBS.Has(readCtx, cid1)
 
 		assert.NoError(tb, err)
@@ -108,7 +108,7 @@ func TestVirtualBlockStorePutVirtualReadEnabled(t *testing.T) {
 
 		mockDirectBS.EXPECT().Put(mock.Anything, block1).Return(nil).Once()
 
-		readCtx := store.VirtualReadOption(ctx, true)
+		readCtx := pc.VirtualReadOption(ctx, true)
 		err := virtualBS.Put(readCtx, block1)
 
 		assert.NoError(tb, err)
@@ -133,7 +133,7 @@ func TestVirtualBlockStoreDeleteBlockVirtualReadEnabled(t *testing.T) {
 
 		mockDirectBS.EXPECT().DeleteBlock(mock.Anything, cid1).Return(nil).Once()
 
-		readCtx := store.VirtualReadOption(ctx, true)
+		readCtx := pc.VirtualReadOption(ctx, true)
 		err := virtualBS.DeleteBlock(readCtx, cid1)
 
 		assert.NoError(tb, err)
@@ -158,7 +158,7 @@ func TestVirtualBlockStoreGetSizeVirtualReadEnabled(t *testing.T) {
 
 		mockDirectBS.EXPECT().GetSize(mock.Anything, cid1).Return(100, nil).Once()
 
-		readCtx := store.VirtualReadOption(ctx, true)
+		readCtx := pc.VirtualReadOption(ctx, true)
 		size, err := virtualBS.GetSize(readCtx, cid1)
 
 		assert.NoError(tb, err)
@@ -186,7 +186,7 @@ func TestVirtualBlockStorePutManyVirtualReadEnabled(t *testing.T) {
 		_blocks := []blocks.Block{block1}
 		mockDirectBS.EXPECT().PutMany(mock.Anything, _blocks).Return(nil).Once()
 
-		readCtx := store.VirtualReadOption(ctx, true)
+		readCtx := pc.VirtualReadOption(ctx, true)
 		err := virtualBS.PutMany(readCtx, _blocks)
 
 		assert.NoError(tb, err)
@@ -210,7 +210,7 @@ func TestVirtualBlockStoreAllKeysChanVirtualReadEnabled(t *testing.T) {
 	coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 		virtualBS, _ := setupVirtualTest(tb, ctx, cid1, 2)
 
-		readCtx := store.VirtualReadOption(ctx, true)
+		readCtx := pc.VirtualReadOption(ctx, true)
 		ch, err := virtualBS.AllKeysChan(readCtx)
 
 		assert.NoError(tb, err)
@@ -236,7 +236,7 @@ func TestVirtualBlockStoreErrorFromDirectBlockstore(t *testing.T) {
 		expectedErr := errors.New("direct blockstore error")
 		mockDirectBS.EXPECT().Get(mock.Anything, cid1).Return(nil, expectedErr).Once()
 
-		readCtx := store.VirtualReadOption(ctx, true)
+		readCtx := pc.VirtualReadOption(ctx, true)
 		_, err := virtualBS.Get(readCtx, cid1)
 
 		assert.Error(tb, err)

--- a/internal/protocol/store/tests/virtual_test.go
+++ b/internal/protocol/store/tests/virtual_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/protocol/store"
+	pc "go.lumeweb.com/portal-plugin-ipfs/internal/protocol/context"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/testing/mocks"
 	coreTesting "go.lumeweb.com/portal/core/testing"
 )

--- a/internal/protocol/store/virtual.go
+++ b/internal/protocol/store/virtual.go
@@ -7,6 +7,7 @@ import (
 	blocks "github.com/ipfs/go-block-format"
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-datastore"
+	pc "go.lumeweb.com/portal-plugin-ipfs/internal/protocol/context"
 	"go.lumeweb.com/portal/core"
 )
 
@@ -41,7 +42,7 @@ func (v *VirtualBlockStore) DeleteBlock(ctx context.Context, c cid.Cid) error {
 	ctx, span := core.TraceMethod(ctx, "VirtualBlockStore.DeleteBlock")
 	defer span.End()
 
-	if isVirtualReadEnabled(ctx) {
+	if pc.IsVirtualReadEnabled(ctx) {
 		return v.directBS.DeleteBlock(ctx, c)
 	}
 	return v.cachedBS.DeleteBlock(ctx, c)
@@ -52,7 +53,7 @@ func (v *VirtualBlockStore) Has(ctx context.Context, c cid.Cid) (bool, error) {
 	ctx, span := core.TraceMethod(ctx, "VirtualBlockStore.Has")
 	defer span.End()
 
-	if isVirtualReadEnabled(ctx) {
+	if pc.IsVirtualReadEnabled(ctx) {
 		return v.directBS.Has(ctx, c)
 	}
 	return v.cachedBS.Has(ctx, c)
@@ -63,7 +64,7 @@ func (v *VirtualBlockStore) Get(ctx context.Context, c cid.Cid) (blocks.Block, e
 	ctx, span := core.TraceMethod(ctx, "VirtualBlockStore.Get")
 	defer span.End()
 
-	if isVirtualReadEnabled(ctx) {
+	if pc.IsVirtualReadEnabled(ctx) {
 		return v.directBS.Get(ctx, c)
 	}
 	return v.cachedBS.Get(ctx, c)
@@ -74,7 +75,7 @@ func (v *VirtualBlockStore) GetSize(ctx context.Context, c cid.Cid) (int, error)
 	ctx, span := core.TraceMethod(ctx, "VirtualBlockStore.GetSize")
 	defer span.End()
 
-	if isVirtualReadEnabled(ctx) {
+	if pc.IsVirtualReadEnabled(ctx) {
 		return v.directBS.GetSize(ctx, c)
 	}
 	return v.cachedBS.GetSize(ctx, c)
@@ -85,7 +86,7 @@ func (v *VirtualBlockStore) Put(ctx context.Context, b blocks.Block) error {
 	ctx, span := core.TraceMethod(ctx, "VirtualBlockStore.Put")
 	defer span.End()
 
-	if isVirtualReadEnabled(ctx) {
+	if pc.IsVirtualReadEnabled(ctx) {
 		return v.directBS.Put(ctx, b)
 	}
 	return v.cachedBS.Put(ctx, b)
@@ -96,7 +97,7 @@ func (v *VirtualBlockStore) PutMany(ctx context.Context, bs []blocks.Block) erro
 	ctx, span := core.TraceMethod(ctx, "VirtualBlockStore.PutMany")
 	defer span.End()
 
-	if isVirtualReadEnabled(ctx) {
+	if pc.IsVirtualReadEnabled(ctx) {
 		return v.directBS.PutMany(ctx, bs)
 	}
 	return v.cachedBS.PutMany(ctx, bs)
@@ -107,7 +108,7 @@ func (v *VirtualBlockStore) AllKeysChan(ctx context.Context) (<-chan cid.Cid, er
 	ctx, span := core.TraceMethod(ctx, "VirtualBlockStore.AllKeysChan")
 	defer span.End()
 
-	if isVirtualReadEnabled(ctx) {
+	if pc.IsVirtualReadEnabled(ctx) {
 		return v.directBS.AllKeysChan(ctx)
 	}
 	return v.cachedBS.AllKeysChan(ctx)

--- a/internal/protocol/streaming_blockstore.go
+++ b/internal/protocol/streaming_blockstore.go
@@ -14,7 +14,7 @@ import (
 	"github.com/ipfs/go-block-format"
 	"github.com/ipfs/go-cid"
 	ds "github.com/ipfs/go-datastore"
-	"go.lumeweb.com/portal-plugin-ipfs/internal/protocol/store"
+	pc "go.lumeweb.com/portal-plugin-ipfs/internal/protocol/context"
 	"go.lumeweb.com/portal/core"
 	"go.uber.org/zap"
 )
@@ -350,7 +350,7 @@ func (s *DefaultStreamingBlockstore) Get(ctx context.Context, c cid.Cid) (blocks
 						zap.String("cid", c.String()))
 				}
 				// Add SkipQuotaCheckOption for passthrough operations
-				passthroughCtx := store.SkipQuotaCheckOption(ctx, store.IsQuotaCheckSkipped(ctx))
+				passthroughCtx := pc.SkipQuotaCheckOption(ctx, pc.IsQuotaCheckSkipped(ctx))
 				return s.passthrough.Get(passthroughCtx, c)
 			}
 		}
@@ -413,7 +413,7 @@ func (s *DefaultStreamingBlockstore) Has(ctx context.Context, c cid.Cid) (bool, 
 	// Check passthrough
 	if s.passthrough != nil {
 		// Add SkipQuotaCheckOption for passthrough operations
-		passthroughCtx := store.SkipQuotaCheckOption(ctx, store.IsQuotaCheckSkipped(ctx))
+		passthroughCtx := pc.SkipQuotaCheckOption(ctx, pc.IsQuotaCheckSkipped(ctx))
 		return s.passthrough.Has(passthroughCtx, c)
 	}
 
@@ -443,7 +443,7 @@ func (s *DefaultStreamingBlockstore) GetSize(ctx context.Context, c cid.Cid) (in
 	// Check passthrough
 	if s.passthrough != nil {
 		// Add SkipQuotaCheckOption for passthrough operations
-		passthroughCtx := store.SkipQuotaCheckOption(ctx, store.IsQuotaCheckSkipped(ctx))
+		passthroughCtx := pc.SkipQuotaCheckOption(ctx, pc.IsQuotaCheckSkipped(ctx))
 		return s.passthrough.GetSize(passthroughCtx, c)
 	}
 
@@ -499,7 +499,7 @@ func (s *DefaultStreamingBlockstore) AllKeysChan(ctx context.Context) (<-chan ci
 		// Add results from passthrough if available
 		if s.passthrough != nil {
 			// Add SkipQuotaCheckOption for passthrough operations
-			passthroughCtx := store.SkipQuotaCheckOption(ctx, store.IsQuotaCheckSkipped(ctx))
+			passthroughCtx := pc.SkipQuotaCheckOption(ctx, pc.IsQuotaCheckSkipped(ctx))
 			passthroughChan, err := s.passthrough.AllKeysChan(passthroughCtx)
 			if err == nil {
 				for cid := range passthroughChan {


### PR DESCRIPTION
Previously, bitswap downloads were tracked as anonymous (upload ID=0, user ID=nil), preventing accurate quota accounting for downloads consumed from the network. Additionally, download events were emitted from both the downloader and blockstore, causing duplicate quota events for the same download.

This change adds PeerIPBitswap wrapper that extracts peer IP addresses from incoming
bitswap message connections and injects them into the request context. BlockStore.Get
then retrieves the upload record by CID and passes the peer IP to the download event for
auditing, allowing downloads to be properly attributed.

Key changes:

- Create internal/protocol/context/context.go for shared context utilities
- Add PeerIPBitswap wrapper embedding bitswap.Bitswap
- Override ReceiveMessage to extract peer IP via ConnsToPeer
- Integrate wrapper into node.go initialization
- Update BlockStore.Get to pass peer IP to EmitDownloadCompleted
- Remove duplicate download emission from downloader

Quota events now include actual upload ID and user ID instead of zero values, enabling accurate download accounting and billing.

- `develop` <!-- branch-stack -->
  - **fix(protocol): attribute downloads to upload records for proper quota tracking** :point\_left:

***

<!-- kody-pr-summary:start -->

This pull request implements proper attribution of downloads to upload records and adds peer IP tracking for Bitswap protocol operations to enable accurate quota management.

**Key Changes:**

1. **Download Attribution for Quota Tracking**: Modified the BlockStore to retrieve upload record information when emitting download completion events. Downloads are now attributed to specific upload records with the correct user ID, rather than being recorded as anonymous (userID=0). This ensures bandwidth usage is properly associated with the content owner for quota enforcement.

2. **Bitswap Peer IP Tracking**: Introduced a `PeerIPBitswap` wrapper that intercepts incoming Bitswap messages to extract the remote peer's IP address from libp2p network connections. This IP information is injected into the request context, allowing the system to track which peers are requesting blocks via the P2P protocol for quota accounting purposes.

3. **Context Utilities Refactoring**: Moved context option helpers (`ClientIPOption`, `VirtualReadOption`, `SkipQuotaCheckOption`, etc.) from the `store` package to a dedicated `protocol/context` package to improve code organization and reduce circular dependencies across the protocol implementation.

4. **Simplified Event Emission**: Removed redundant download event emission from the block downloader, centralizing this responsibility in the BlockStore where upload record lookup is available.

These changes ensure that both HTTP API downloads and P2P Bitswap exchanges are properly tracked against upload records and user quotas.

<!-- kody-pr-summary:end -->
