### PR TITLE
fix: always emit download events when quotas enabled, even without IP address

### DIFF
--- a/internal/protocol/store/blockstore.go
+++ b/internal/protocol/store/blockstore.go
@@ -170,12 +170,13 @@ func (bs *BlockStore) Get(ctx context.Context, c cid.Cid) (blocks.Block, error) 
 				}
 			}
 			
-			if attributionIP != "" {
-				quota.EmitDownloadCompleted(core.DetachContext(ctx), bs.ctx, upload.ID, uint64(len(block.RawData())), attributionIP, &upload.UserID)
-			} else {
-				bs.log.Debug("No attribution IP available, skipping download event emission",
+				// Emit download event regardless of attribution IP availability
+			// as long as quotas are not disabled
+			if attributionIP == "" {
+				bs.log.Debug("No attribution IP available, emitting download event without IP",
 					zap.Stringer("cid", c))
 			}
+			quota.EmitDownloadCompleted(core.DetachContext(ctx), bs.ctx, upload.ID, uint64(len(block.RawData())), attributionIP, &upload.UserID)
 		} else {
 			bs.log.Debug("Upload not found for CID, skipping download event emission",
 				zap.Stringer("cid", c))


### PR DESCRIPTION
Previously, download events were only emitted when an attribution IP was available. This meant that internal/bitswap requests without a client IP would not emit quota tracking events, even though quotas were enabled.

This change ensures download completion events are always emitted when quota checks are not disabled, regardless of whether an IP address was successfully retrieved. The attribution IP can be empty and the event handler already handles this case.

Changes:

- Removed conditional IP check before calling EmitDownloadCompleted
- Added debug logging for scenarios where attribution IP is unavailable
- Aligns behavior with API handler which already emits events unconditionally

Fixes: Missing download tracking for internal requests with quota enabled

- `develop` <!-- branch-stack -->
  - **fix: always emit download events when quotas enabled, even without IP address** :point\_left:


---

<!-- kody-pr-summary:start -->
 This pull request fixes an issue where download events were not being emitted when the attribution IP address was unavailable.

**Changes:**
- Modified the block store's `Get` method to emit download completion events regardless of whether an attribution IP address is present
- Previously, the system would skip event emission entirely if `attributionIP` was empty, causing downloads to go untracked in quota calculations
- Now, download events are always emitted when quotas are enabled, with the IP field being empty when attribution cannot be determined

**Impact:**
- Ensures accurate quota tracking and usage statistics for all downloads, even when the client's IP address cannot be identified
- Maintains debug logging to indicate when downloads occur without IP attribution for troubleshooting purposes
<!-- kody-pr-summary:end -->