### PR TITLE
fix: prevent nil pointer dereference in quota validation success logging

### DIFF
--- a/internal/quota/quota.go
+++ b/internal/quota/quota.go
@@ -104,10 +104,12 @@ func ValidateUploadQuota(cctx context.Context, ctx core.Context, userID uint, re
 			zap.Any("limit", result.Details.Limit))
 		return core.ErrUploadQuotaExceeded
 	}
-	ctx.Logger().Debug("Upload quota validated successfully",
-		zap.Uint("user_id", userID),
-		zap.Uint64("requested_bytes", requestedBytes),
-		zap.Uint64("current_usage", result.Details.CurrentUsage))
+	if result != nil {
+		ctx.Logger().Debug("Upload quota validated successfully",
+			zap.Uint("user_id", userID),
+			zap.Uint64("requested_bytes", requestedBytes),
+			zap.Uint64("current_usage", result.Details.CurrentUsage))
+	}
 	return nil
 }
 
@@ -129,10 +131,12 @@ func ValidateDownloadQuota(cctx context.Context, ctx core.Context, userID uint, 
 			zap.Any("limit", result.Details.Limit))
 		return core.ErrDownloadQuotaExceeded
 	}
-	ctx.Logger().Debug("Download quota validated successfully",
-		zap.Uint("user_id", userID),
-		zap.Uint64("requested_bytes", requestedBytes),
-		zap.Uint64("current_usage", result.Details.CurrentUsage))
+	if result != nil {
+		ctx.Logger().Debug("Download quota validated successfully",
+			zap.Uint("user_id", userID),
+			zap.Uint64("requested_bytes", requestedBytes),
+			zap.Uint64("current_usage", result.Details.CurrentUsage))
+	}
 	return nil
 }
 
@@ -154,10 +158,12 @@ func ValidateStorageQuota(cctx context.Context, ctx core.Context, userID uint, r
 			zap.Any("limit", result.Details.Limit))
 		return core.ErrStorageQuotaExceeded
 	}
-	ctx.Logger().Debug("Storage quota validated successfully",
-		zap.Uint("user_id", userID),
-		zap.Uint64("requested_bytes", requestedBytes),
-		zap.Uint64("current_usage", result.Details.CurrentUsage))
+	if result != nil {
+		ctx.Logger().Debug("Storage quota validated successfully",
+			zap.Uint("user_id", userID),
+			zap.Uint64("requested_bytes", requestedBytes),
+			zap.Uint64("current_usage", result.Details.CurrentUsage))
+	}
 	return nil
 }
 // CheckCIDGroupDownloadAvailability checks if any users with pinned content have sufficient quota for anonymous downloads


### PR DESCRIPTION
- `develop` <!-- branch-stack -->
  - **fix: prevent nil pointer dereference in quota validation success logging** :point\_left:


---

<!-- kody-pr-summary:start -->
 This pull request fixes a potential nil pointer dereference issue in quota validation logging.

**Changes Made:**
- Added nil checks for the `result` variable before logging debug messages in three quota validation functions: `ValidateUploadQuota`, `ValidateDownloadQuota`, and `ValidateStorageQuota`
- The success logging statements that access `result.Details.CurrentUsage` are now conditionally executed only when `result` is not nil

**Functional Impact:**
Prevents application panics that would occur if quota validation succeeds but returns a nil result object when attempting to log successful quota validation details (user ID, requested bytes, and current usage).
<!-- kody-pr-summary:end -->