### PR TITLE
feat(upload): implement quota reservations for upload operations

### DIFF
--- a/core/upload.go
+++ b/core/upload.go
@@ -5,6 +5,7 @@ import (
 	"io"
 
 	"github.com/ipfs/go-cid"
+	quotaCore "go.lumeweb.com/portal-plugin-quota/core"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/db"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/upload"
 	"go.lumeweb.com/portal/core"
@@ -27,7 +28,8 @@ type UploadService interface {
 	// ProcessUpload processes a list of CIDs and creates upload and core pin records for a user.
 	// It creates upload records and core pin records for ALL provided CIDs (both roots and children),
 	// but does NOT create any IPFS pin records.
-	ProcessUpload(ctx context.Context, cids []cid.Cid, userId uint) error
+	// The reservations parameter maps CIDs to quota reservation objects for upload quota tracking.
+	ProcessUpload(ctx context.Context, cids []cid.Cid, userId uint, reservations map[cid.Cid]*quotaCore.QuotaCheckResult) error
 
 	// CreateRootPin creates an IPFS pin record for a single root CID.
 	// This method should only be called for actual root CIDs, not child blocks.

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strconv"
 
 	"github.com/ipld/go-car/v2"
 	"github.com/labstack/echo/v4"
@@ -79,10 +78,19 @@ func NewAPI() (core.API, []core.ContextBuilderOption, error) {
 							return nil, core.ErrUploadQuotaExceeded
 						}
 						requestedBytes := uint64(size)
+
+						// Check upload quota (sanity check without reservation)
 						if err := quota.ValidateUploadQuota(eventCtx, ctx, uploaderId, requestedBytes); err != nil {
 							api.Logger().Error("Failed to check upload quota", zap.Error(err))
 							return nil, err
 						}
+
+						// Check storage quota (sanity check without reservation)
+						if err := quota.ValidateStorageQuota(eventCtx, ctx, uploaderId, requestedBytes); err != nil {
+							api.Logger().Error("Failed to check storage quota", zap.Error(err))
+							return nil, err
+						}
+
 						return nil, nil
 					}, nil),
 					UploadProgressHandler:   service.TUSDefaultUploadProgressHandler(ctx),
@@ -99,36 +107,11 @@ func NewAPI() (core.API, []core.ContextBuilderOption, error) {
 							return
 						}
 
-						var userID *uint
-						if hook.Upload.MetaData != nil {
-							if uploaderID, exists := hook.Upload.MetaData["uploader_id"]; exists {
-								if uid, err := strconv.ParseUint(uploaderID, 10, 64); err == nil {
-									userIDVal := uint(uid)
-									userID = &userIDVal
-								} else {
-									api.Logger().Warn("Failed to parse uploader_id from metadata", zap.String("uploader_id", uploaderID), zap.Error(err))
-								}
-							}
-						}
-
-						uploadID, err := strconv.ParseUint(hook.Upload.ID, 10, 64)
-						if err != nil {
-							api.Logger().Warn("Failed to parse upload ID", zap.String("upload_id", hook.Upload.ID), zap.Error(err))
-							return
-						}
-
-						echoCtx, ok := service.TusGetEchoContext(hook.Context)
-						var ip string
-						if ok && echoCtx != nil {
-							ip = echoCtx.RealIP()
-						}
-
 						size := hook.Upload.Size
 						if size < 0 {
 							api.Logger().Warn("Unexpected negative upload size in TUS completed hook", zap.Int64("size", size))
 							return
 						}
-						quota.EmitUploadCompleted(eventCtx, ctx, userID, uint(uploadID), uint64(size), ip, nil, true)
 					}, protocol.TUS_UPLOAD_WORKFLOW,
 						func(handlr core.TusHandler, hook handler.HookEvent, reader io.Reader) (core.StorageHash, error) {
 							return getCARUploadHash(reader, api.tus, ctx, sproto, hook.Upload.ID, api.Logger())

--- a/internal/api/errors.go
+++ b/internal/api/errors.go
@@ -31,6 +31,8 @@ const (
 	ErrKeyBlockNotFound         core.ErrorType = "BLOCK_NOT_FOUND"
 	ErrKeyUploadNotFound        core.ErrorType = "UPLOAD_NOT_FOUND"
 	ErrKeyUnauthorized          core.ErrorType = "UNAUTHORIZED"
+	ErrKeyUploadQuotaExceeded   core.ErrorType = "UPLOAD_QUOTA_EXCEEDED"
+	ErrKeyStorageQuotaExceeded  core.ErrorType = "STORAGE_QUOTA_EXCEEDED"
 	ErrKeyDownloadQuotaExceeded core.ErrorType = "DOWNLOAD_QUOTA_EXCEEDED"
 	ErrKeyInvalidRequest        core.ErrorType = "INVALID_REQUEST"
 	ErrKeyInvalidIdentifier    core.ErrorType = "INVALID_IDENTIFIER"
@@ -123,6 +125,8 @@ func init() {
 		ErrKeyBlockNotFound:         {Key: ErrKeyBlockNotFound, Message: "Block not found."},
 		ErrKeyUploadNotFound:        {Key: ErrKeyUploadNotFound, Message: "Upload not found."},
 		ErrKeyUnauthorized:          {Key: ErrKeyUnauthorized, Message: "Access denied. Please check your credentials and try again."},
+		ErrKeyUploadQuotaExceeded:   {Key: ErrKeyUploadQuotaExceeded, Message: "Upload quota exceeded. Please try again later."},
+		ErrKeyStorageQuotaExceeded:  {Key: ErrKeyStorageQuotaExceeded, Message: "Storage quota exceeded. Please try again later."},
 		ErrKeyDownloadQuotaExceeded: {Key: ErrKeyDownloadQuotaExceeded, Message: "Download quota exceeded. Please try again later."},
 		ErrKeyInvalidRequest:        {Key: ErrKeyInvalidRequest, Message: "Invalid request parameter: %s"},
 		ErrKeyInvalidIdentifier:     {Key: ErrKeyInvalidIdentifier, Message: "Invalid identifier format"},
@@ -153,6 +157,8 @@ func init() {
 		ErrKeyBlockNotFound:         http.StatusNotFound,
 		ErrKeyUploadNotFound:        http.StatusNotFound,
 		ErrKeyUnauthorized:          http.StatusUnauthorized,
+		ErrKeyUploadQuotaExceeded:   http.StatusTooManyRequests,
+		ErrKeyStorageQuotaExceeded:  http.StatusTooManyRequests,
 		ErrKeyDownloadQuotaExceeded: http.StatusTooManyRequests,
 		ErrKeyInvalidDomainFormat:   http.StatusBadRequest,
 		ErrKeyRecordNotFound:        http.StatusNotFound,

--- a/internal/protocol/ipfs/node.go
+++ b/internal/protocol/ipfs/node.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io"
+	"sync"
 	"time"
 
 	"github.com/ipfs/go-cid"
@@ -50,7 +51,10 @@ const (
 	libp2pProtocolPrefix = "/p2p/"
 )
 
-var cachedAnnouncementAddresses []multiaddr.Multiaddr
+var (
+	cachedAnnouncementAddresses []multiaddr.Multiaddr
+	cacheMutex                  sync.RWMutex
+)
 
 // DHTRouting combines the interfaces needed from a DHT routing implementation
 type DHTRouting interface {
@@ -452,6 +456,17 @@ func (n *Node) TriggerReprovider() {
 }
 
 func AnnouncementAddresses() ([]multiaddr.Multiaddr, error) {
+	cacheMutex.RLock()
+	if len(cachedAnnouncementAddresses) > 0 {
+		cached := cachedAnnouncementAddresses
+		cacheMutex.RUnlock()
+		return cached, nil
+	}
+	cacheMutex.RUnlock()
+
+	cacheMutex.Lock()
+	defer cacheMutex.Unlock()
+
 	if len(cachedAnnouncementAddresses) > 0 {
 		return cachedAnnouncementAddresses, nil
 	}

--- a/internal/protocol/op_confirm.go
+++ b/internal/protocol/op_confirm.go
@@ -82,7 +82,7 @@ func (h *ConfirmOperationHandler) Execute(ctx context.Context, req *models.Reque
 			return fmt.Errorf("upload service not available")
 		}
 
-		err := uploadSvc.ProcessUpload(ctx, cidList, lo.FromPtrOr(req.UserID, 0))
+		err := uploadSvc.ProcessUpload(ctx, cidList, lo.FromPtrOr(req.UserID, 0), nil)
 		if err != nil {
 			return fmt.Errorf("failed to process upload: %w", err)
 		}

--- a/internal/protocol/op_post_upload.go
+++ b/internal/protocol/op_post_upload.go
@@ -13,7 +13,9 @@ import (
 	"go.lumeweb.com/portal-plugin-ipfs/internal"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/db"
 	pc "go.lumeweb.com/portal-plugin-ipfs/internal/protocol/context"
+	"go.lumeweb.com/portal-plugin-ipfs/internal/quota"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/upload"
+	quotaCore "go.lumeweb.com/portal-plugin-quota/core"
 	"go.lumeweb.com/portal/core"
 	"go.lumeweb.com/portal/db/models"
 	"go.uber.org/zap"
@@ -40,6 +42,9 @@ func (h *PostUploadOperationHandler) Execute(ctx context.Context, req *models.Re
 	ctx, span := core.TraceMethod(ctx, "PostUploadOperationHandler.Execute")
 	defer span.End()
 
+	// Store quota check results for reservation management
+	checkResults := &quota.QuotaCheckResults{}
+
 	// Initialize progress tracker with manual mode for simple milestones
 	tracker, err := InitializeManualProgressTracker(h, req.ID, core.OpTypeUpload, 10)
 	if err != nil {
@@ -56,9 +61,25 @@ func (h *PostUploadOperationHandler) Execute(ctx context.Context, req *models.Re
 		h.Logger().Warn("Failed to update progress", zap.Error(err))
 	}
 
-	uploadFile, err := h.getUpload(ctx, workflow.UploadID)
+	// Get upload file to read size for quota sanity check
+	sizeCheckFile, err := h.getUpload(ctx, workflow.UploadID)
 	if err != nil {
 		return err
+	}
+
+	// Read entire file to determine size
+	fileData, err := io.ReadAll(sizeCheckFile)
+	sizeCheckFile.Close()
+	if err != nil {
+		return fmt.Errorf("failed to read upload file for size calculation: %w", err)
+	}
+
+	uploadFileSize := int64(len(fileData))
+
+	// Get fresh upload file handle for actual processing
+	uploadFile, err := h.getUpload(ctx, workflow.UploadID)
+	if err != nil {
+		return fmt.Errorf("failed to get fresh upload file handle: %w", err)
 	}
 	defer func(upload io.ReadCloser) {
 		err := upload.Close()
@@ -67,8 +88,34 @@ func (h *PostUploadOperationHandler) Execute(ctx context.Context, req *models.Re
 		}
 	}(uploadFile)
 
+	// Sanity check quota (no reservation) before processing
+	userID := lo.FromPtrOr(req.UserID, 0)
+	if userID == 0 {
+		return fmt.Errorf("user ID is required")
+	}
+
+	if uploadFileSize > 0 {
+		requestedBytes := uint64(uploadFileSize)
+
+		// Check upload quota with reservation
+		checkResult, err := quota.CheckWithReservation(ctx, h.Context(), "upload", userID, requestedBytes, quota.CheckUploadQuota)
+		if err != nil {
+			return err
+		}
+		checkResults.Upload = checkResult
+
+		// Check storage quota with reservation
+		checkResult, err = quota.CheckWithReservation(ctx, h.Context(), "storage", userID, requestedBytes, quota.CheckStorageQuota)
+		if err != nil {
+			checkResults.ReleaseAll()
+			return err
+		}
+		checkResults.Storage = checkResult
+	}
+
 	uploadedFormat, err := upload.DetectFormat(uploadFile)
 	if err != nil {
+		checkResults.ReleaseAll()
 		return err
 	}
 
@@ -79,6 +126,7 @@ func (h *PostUploadOperationHandler) Execute(ctx context.Context, req *models.Re
 
 	processor, err := h.createProcessor(uploadFile, uploadedFormat)
 	if err != nil {
+		checkResults.ReleaseAll()
 		return err
 	}
 	defer processor.Release()
@@ -90,17 +138,23 @@ func (h *PostUploadOperationHandler) Execute(ctx context.Context, req *models.Re
 
 	allCids, rootCids, err := ProcessBlocks(h.Context(), processor)
 	if err != nil {
+		checkResults.ReleaseAll()
 		return fmt.Errorf("failed to process CIDs from upload: %w", err)
 	}
 
 	// Check if any root CIDs were returned
 	if len(rootCids) == 0 {
+		checkResults.ReleaseAll()
 		return fmt.Errorf("no root CIDs found during block processing")
 	}
 
-	userID := lo.FromPtrOr(req.UserID, 0)
-	err = h.processCIDs(ctx, allCids, userID, req.SourceIP)
+	// Create reservations map
+	reservations := CreateReservationMap(allCids, checkResults.Upload)
+
+	err = h.processCIDs(ctx, allCids, userID, req.SourceIP, reservations)
 	if err != nil {
+		// Release reservations on error
+		quota.ReleaseReservations(checkResults.Upload, checkResults.Storage)
 		return err
 	}
 
@@ -256,7 +310,7 @@ func (h *PostUploadOperationHandler) createFileProcessor(uploadFile io.ReadClose
 }
 
 // processCIDs processes all CIDs and creates upload records
-func (h *PostUploadOperationHandler) processCIDs(ctx context.Context, allCids []cid.Cid, userID uint, sourceIP string) error {
+func (h *PostUploadOperationHandler) processCIDs(ctx context.Context, allCids []cid.Cid, userID uint, sourceIP string, reservations map[cid.Cid]*quotaCore.QuotaCheckResult) error {
 	ctx, span := core.TraceMethod(ctx, "PostUploadOperationHandler.processCIDs")
 	defer span.End()
 
@@ -267,7 +321,7 @@ func (h *PostUploadOperationHandler) processCIDs(ctx context.Context, allCids []
 	}
 
 	ctx = pc.ClientIPOption(ctx, sourceIP)
-	err := uploadSvc.ProcessUpload(ctx, allCids, userID)
+	err := uploadSvc.ProcessUpload(ctx, allCids, userID, reservations)
 	if err != nil {
 		return fmt.Errorf("failed to process upload: %w", err)
 	}

--- a/internal/protocol/op_post_upload.go
+++ b/internal/protocol/op_post_upload.go
@@ -66,15 +66,27 @@ func (h *PostUploadOperationHandler) Execute(ctx context.Context, req *models.Re
 	if err != nil {
 		return err
 	}
+	defer sizeCheckFile.Close()
 
-	// Read entire file to determine size
-	fileData, err := io.ReadAll(sizeCheckFile)
-	sizeCheckFile.Close()
-	if err != nil {
-		return fmt.Errorf("failed to read upload file for size calculation: %w", err)
+	// Determine file size efficiently
+	var uploadFileSize int64
+	if seeker, ok := sizeCheckFile.(io.Seeker); ok {
+		uploadFileSize, err = seeker.Seek(0, io.SeekEnd)
+		if err != nil {
+			return fmt.Errorf("failed to seek to end of upload file: %w", err)
+		}
+		_, err = seeker.Seek(0, io.SeekStart)
+		if err != nil {
+			return fmt.Errorf("failed to seek to start of upload file: %w", err)
+		}
+	} else {
+		// Fallback to reading all data only if seek not supported
+		fileData, err := io.ReadAll(sizeCheckFile)
+		if err != nil {
+			return fmt.Errorf("failed to read upload file for size calculation: %w", err)
+		}
+		uploadFileSize = int64(len(fileData))
 	}
-
-	uploadFileSize := int64(len(fileData))
 
 	// Get fresh upload file handle for actual processing
 	uploadFile, err := h.getUpload(ctx, workflow.UploadID)
@@ -172,6 +184,7 @@ func (h *PostUploadOperationHandler) Execute(ctx context.Context, req *models.Re
 
 	ipfsPin, err := h.createRootPin(ctx, rootCids[0], userID)
 	if err != nil {
+		quota.ReleaseReservations(checkResults.Upload, checkResults.Storage)
 		return err
 	}
 
@@ -194,6 +207,7 @@ func (h *PostUploadOperationHandler) Execute(ctx context.Context, req *models.Re
 
 	err = h.updateWorkflow(ctx, req.ID, rootCids, ipfsPin)
 	if err != nil {
+		quota.ReleaseReservations(checkResults.Upload, checkResults.Storage)
 		return err
 	}
 

--- a/internal/protocol/op_retrieve.go
+++ b/internal/protocol/op_retrieve.go
@@ -74,14 +74,17 @@ func (h *RetrieveOperationHandler) Execute(ctx context.Context, req *models.Requ
 
 	blockSize = uint64(len(block.RawData()))
 
+	// Store quota check results for reservation management
+	checkResults := &quota.QuotaCheckResults{}
+
 	// Check download quota if user ID is available
 	if req.UserID != nil && *req.UserID > 0 {
-		// Validate download quota using the already fetched block
-		err = quota.ValidateDownloadQuota(ctx, h.Context(), *req.UserID, blockSize)
+		// Check download quota with reservation
+		checkResult, err := quota.CheckWithReservation(ctx, h.Context(), "download", *req.UserID, blockSize, quota.CheckDownloadQuota)
 		if err != nil {
-			h.Logger().Warn("Download quota exceeded", zap.Uint("user_id", *req.UserID), zap.Uint64("block_size", blockSize), zap.Error(err))
 			return err
 		}
+		checkResults.Download = checkResult
 	}
 
 	cids, err := collectDAGCids(h.Context(), proto, c)
@@ -168,15 +171,38 @@ func (h *RetrieveOperationHandler) Execute(ctx context.Context, req *models.Requ
 		if len(validChildCids) > 0 {
 			// Validate user ID before processing
 			if req.UserID == nil || *req.UserID == 0 {
+				// Release download reservation on error
+				quota.ReleaseReservations(checkResults.Download)
 				return fmt.Errorf("user ID is required")
 			}
+
+			// Calculate total size of child blocks for quota check
+			totalSize, _ := CalculateTotalCIDSize(h.Context(), proto, validChildCids, h.Logger())
+
+			// Check upload quota with reservation for child blocks
+			if totalSize > 0 {
+				checkResult, err := quota.CheckWithReservation(ctx, h.Context(), "upload", *req.UserID, totalSize, quota.CheckUploadQuota)
+				if err != nil {
+					// Release download reservation on error
+					quota.ReleaseReservations(checkResults.Download)
+					return err
+				}
+				checkResults.Upload = checkResult
+			}
+
+			// Create reservations map for child CIDs
+			reservations := CreateReservationMap(validChildCids, checkResults.Upload)
 
 			// Set client IP in context for quota tracking
 			ctx = pc.ClientIPOption(ctx, req.SourceIP)
 
-			err = uploadSvc.ProcessUpload(ctx, validChildCids, *req.UserID)
+			err = uploadSvc.ProcessUpload(ctx, validChildCids, *req.UserID, reservations)
 			if err != nil {
 				h.Logger().Error("Failed to batch process child blocks", zap.Error(err))
+
+				// Release reservations on error
+				quota.ReleaseReservations(checkResults.Download, checkResults.Upload)
+				return err
 			}
 		}
 	}

--- a/internal/protocol/protocol.go
+++ b/internal/protocol/protocol.go
@@ -19,10 +19,11 @@ import (
 	"go.lumeweb.com/portal-plugin-ipfs/internal"
 	pluginConfig "go.lumeweb.com/portal-plugin-ipfs/internal/config"
 	pluginDb "go.lumeweb.com/portal-plugin-ipfs/internal/db"
+	pc "go.lumeweb.com/portal-plugin-ipfs/internal/protocol/context"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/protocol/ipfs"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/protocol/store"
-	pc "go.lumeweb.com/portal-plugin-ipfs/internal/protocol/context"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/protocol/store/downloader"
+	"go.lumeweb.com/portal-plugin-ipfs/internal/quota"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/upload"
 	"go.lumeweb.com/portal/config"
 	"go.lumeweb.com/portal/core"
@@ -204,14 +205,56 @@ func NewProtocolOperations(p core.Protocol) []core.Operation {
 		NewPostUploadOperation(p.Context()),
 		NewFilePathOperation(p.Context()),
 		service.NewTUSOperationHandler(p.Context(), p, func(ctx context.Context, helper core.OperationHelper, request *models.Request, tsReq *models.TUSRequest) error {
-			ctx, span := core.TraceMethod(ctx, "anonymous")
+			ctx, span := core.TraceMethod(ctx, "IPFS.NewTUSOperationHandler")
 			defer span.End()
 
-			tusHandler := core.GetAPI(internal.ProtocolName).(core.APITusHandler).GetTusHandler()
+			// Validate user ID
+			if request.UserID == nil || *request.UserID == 0 {
+				return fmt.Errorf("user ID is required")
+			}
+
+			// Get TUS handler to retrieve upload size
+			apiName := p.Name()
+			api := core.GetAPI(apiName)
+			if _, ok := api.(core.APITusHandler); !ok {
+				return fmt.Errorf("API %T does not implement core.APITusHandler", api)
+			}
+			tusProto := api.(core.APITusHandler)
+			tusHandler := tusProto.GetTusHandler()
 
 			proto := p.(core.StorageProtocol)
+
+			// Get upload size for quota check
+			uploadSize, err := tusHandler.UploadSize(ctx, proto, tsReq.TUSUploadID)
+			if err != nil {
+				return fmt.Errorf("failed to get upload size: %w", err)
+			}
+
+			// Store quota check results for reservation management
+			checkResults := &quota.QuotaCheckResults{}
+
+			// Check upload and storage quota with reservation before processing
+			if uploadSize > 0 {
+				// Check upload quota with reservation
+				checkResult, err := quota.CheckWithReservation(ctx, helper.Context(), "upload", *request.UserID, uploadSize, quota.CheckUploadQuota)
+				if err != nil {
+					return err
+				}
+				checkResults.Upload = checkResult
+
+				// Check storage quota with reservation
+				checkResult, err = quota.CheckWithReservation(ctx, helper.Context(), "storage", *request.UserID, uploadSize, quota.CheckStorageQuota)
+				if err != nil {
+					checkResults.ReleaseAll()
+					return err
+				}
+				checkResults.Storage = checkResult
+			}
+
+			// Get upload reader for processing
 			reader, err := tusHandler.UploadReader(ctx, tsReq.TUSUploadID, proto, 0)
 			if err != nil {
+				checkResults.ReleaseAll()
 				return fmt.Errorf("failed to get upload reader: %w", err)
 			}
 
@@ -230,6 +273,7 @@ func NewProtocolOperations(p core.Protocol) []core.Operation {
 			// Detect format using IPFS plugin logic
 			uploadedFormat, err := upload.DetectFormat(reader)
 			if err != nil {
+				checkResults.ReleaseAll()
 				return fmt.Errorf("failed to detect upload format: %w", err)
 			}
 
@@ -239,13 +283,15 @@ func NewProtocolOperations(p core.Protocol) []core.Operation {
 				// CAR format
 				processor, err = NewCARBlockProcessor(reader)
 				if err != nil {
+					checkResults.ReleaseAll()
 					return fmt.Errorf("failed to create CAR processor: %w", err)
 				}
 			} else {
 				// Single file format (archives treated as files, not extracted)
-				proto := p.(ProtoNode)
-				processor, err = createFileProcessorForTUS(reader, proto, helper.Logger())
+				protoNode := p.(ProtoNode)
+				processor, err = createFileProcessorForTUS(reader, protoNode, helper.Logger())
 				if err != nil {
+					checkResults.ReleaseAll()
 					return fmt.Errorf("failed to create file processor: %w", err)
 				}
 			}
@@ -254,26 +300,30 @@ func NewProtocolOperations(p core.Protocol) []core.Operation {
 			// Process the upload
 			allCids, rootCids, err := ProcessBlocks(helper.Context(), processor)
 			if err != nil {
+				checkResults.ReleaseAll()
 				return fmt.Errorf("failed to process upload: %w", err)
 			}
+
+			// Create reservations map for upload service
+			reservations := CreateReservationMap(allCids, checkResults.Upload)
 
 			// Process all CIDs to create upload and core pin records
 			uploadSvc := core.GetService[pluginCore.UploadService](helper.Context(), pluginCore.UPLOAD_SERVICE)
 			if uploadSvc == nil {
 				helper.Logger().Error("Upload service not available")
-				return fmt.Errorf("upload service not available")
-			}
 
-			// Validate user ID before processing
-			if request.UserID == nil || *request.UserID == 0 {
-				return fmt.Errorf("user ID is required")
+				// Release reservations on error
+				quota.ReleaseReservations(checkResults.Upload, checkResults.Storage)
+				return fmt.Errorf("upload service not available")
 			}
 
 			// Set client IP in context for quota tracking
 			ctx = pc.ClientIPOption(ctx, request.SourceIP)
 
-			err = uploadSvc.ProcessUpload(ctx, allCids, *request.UserID)
+			err = uploadSvc.ProcessUpload(ctx, allCids, *request.UserID, reservations)
 			if err != nil {
+				// Release reservations on error
+				checkResults.ReleaseAll()
 				return fmt.Errorf("failed to process upload: %w", err)
 			}
 
@@ -385,10 +435,10 @@ func NewProtocol() (core.Protocol, []core.ContextBuilderOption, error) {
 			if err != nil {
 				return fmt.Errorf("failed to create block downloader: %w", err)
 			}
-			
+
 			// Create peer request tracker for probabilistic attribution
 			peerTracker := ipfs.NewBlockRequestTracker()
-			
+
 			directBS, err := store.NewBlockStore(ctx, bd, ms, peerTracker)
 			if err != nil {
 				return fmt.Errorf("failed to create blockstore: %w", err)

--- a/internal/protocol/protocol.go
+++ b/internal/protocol/protocol.go
@@ -254,7 +254,9 @@ func NewProtocolOperations(p core.Protocol) []core.Operation {
 			// Get upload reader for processing
 			reader, err := tusHandler.UploadReader(ctx, tsReq.TUSUploadID, proto, 0)
 			if err != nil {
-				checkResults.ReleaseAll()
+				if uploadSize > 0 {
+					checkResults.ReleaseAll()
+				}
 				return fmt.Errorf("failed to get upload reader: %w", err)
 			}
 
@@ -273,7 +275,9 @@ func NewProtocolOperations(p core.Protocol) []core.Operation {
 			// Detect format using IPFS plugin logic
 			uploadedFormat, err := upload.DetectFormat(reader)
 			if err != nil {
-				checkResults.ReleaseAll()
+				if uploadSize > 0 {
+					checkResults.ReleaseAll()
+				}
 				return fmt.Errorf("failed to detect upload format: %w", err)
 			}
 
@@ -283,7 +287,9 @@ func NewProtocolOperations(p core.Protocol) []core.Operation {
 				// CAR format
 				processor, err = NewCARBlockProcessor(reader)
 				if err != nil {
-					checkResults.ReleaseAll()
+					if uploadSize > 0 {
+						checkResults.ReleaseAll()
+					}
 					return fmt.Errorf("failed to create CAR processor: %w", err)
 				}
 			} else {
@@ -291,7 +297,9 @@ func NewProtocolOperations(p core.Protocol) []core.Operation {
 				protoNode := p.(ProtoNode)
 				processor, err = createFileProcessorForTUS(reader, protoNode, helper.Logger())
 				if err != nil {
-					checkResults.ReleaseAll()
+					if uploadSize > 0 {
+						checkResults.ReleaseAll()
+					}
 					return fmt.Errorf("failed to create file processor: %w", err)
 				}
 			}
@@ -300,7 +308,9 @@ func NewProtocolOperations(p core.Protocol) []core.Operation {
 			// Process the upload
 			allCids, rootCids, err := ProcessBlocks(helper.Context(), processor)
 			if err != nil {
-				checkResults.ReleaseAll()
+				if uploadSize > 0 {
+					checkResults.ReleaseAll()
+				}
 				return fmt.Errorf("failed to process upload: %w", err)
 			}
 
@@ -313,7 +323,9 @@ func NewProtocolOperations(p core.Protocol) []core.Operation {
 				helper.Logger().Error("Upload service not available")
 
 				// Release reservations on error
-				quota.ReleaseReservations(checkResults.Upload, checkResults.Storage)
+				if uploadSize > 0 {
+					checkResults.ReleaseAll()
+				}
 				return fmt.Errorf("upload service not available")
 			}
 
@@ -323,7 +335,9 @@ func NewProtocolOperations(p core.Protocol) []core.Operation {
 			err = uploadSvc.ProcessUpload(ctx, allCids, *request.UserID, reservations)
 			if err != nil {
 				// Release reservations on error
-				checkResults.ReleaseAll()
+				if uploadSize > 0 {
+					checkResults.ReleaseAll()
+				}
 				return fmt.Errorf("failed to process upload: %w", err)
 			}
 

--- a/internal/protocol/quota_helpers.go
+++ b/internal/protocol/quota_helpers.go
@@ -1,0 +1,43 @@
+package protocol
+
+import (
+	"context"
+
+	"github.com/ipfs/go-cid"
+	"go.lumeweb.com/portal/core"
+	"go.uber.org/zap"
+	quotaCore "go.lumeweb.com/portal-plugin-quota/core"
+)
+
+// CalculateTotalCIDSize calculates the total size of a list of CIDs
+// Returns the total size and a map of individual CID sizes
+func CalculateTotalCIDSize(ctx context.Context, proto ProtoNode, cids []cid.Cid, logger *core.Logger) (uint64, map[cid.Cid]uint64) {
+	totalSize := uint64(0)
+	cidSizes := make(map[cid.Cid]uint64, len(cids))
+
+	for _, c := range cids {
+		size, err := proto.GetMetadataStore().Size(ctx, c)
+		if err != nil {
+			logger.Warn("Failed to get size for quota check", zap.Stringer("cid", c), zap.Error(err))
+			continue
+		}
+		cidSizes[c] = size
+		totalSize += size
+	}
+
+	return totalSize, cidSizes
+}
+
+// CreateReservationMap creates a map of CIDs to a single reservation object
+// This is used when a single quota check covers multiple CIDs
+func CreateReservationMap(cids []cid.Cid, result *quotaCore.QuotaCheckResult) map[cid.Cid]*quotaCore.QuotaCheckResult {
+	if result == nil || len(cids) == 0 {
+		return nil
+	}
+
+	reservations := make(map[cid.Cid]*quotaCore.QuotaCheckResult, len(cids))
+	for _, c := range cids {
+		reservations[c] = result
+	}
+	return reservations
+}

--- a/internal/quota/quota.go
+++ b/internal/quota/quota.go
@@ -190,3 +190,45 @@ func CheckCIDGroupDownloadAvailability(cctx context.Context, ctx core.Context, c
 
 	return available, nil
 }
+
+// CheckWithReservation performs a quota check with reservation and provides unified error handling
+// This encapsulates the common pattern of checking quota with reservation and returning appropriate errors
+func CheckWithReservation(cctx context.Context, ctx core.Context, checkType string, userID uint, requestedBytes uint64, checkFunc func(context.Context, core.Context, uint, uint64, ...quotaCore.CheckOption) (*quotaCore.QuotaCheckResult, error)) (*quotaCore.QuotaCheckResult, error) {
+	checkResult, err := checkFunc(cctx, ctx, userID, requestedBytes, quotaCore.WithCreateReservation())
+	if err != nil {
+		ctx.Logger().Warn("Failed to check quota", zap.String("check_type", checkType), zap.Uint("user_id", userID), zap.Uint64("requested_bytes", requestedBytes), zap.Error(err))
+		return nil, fmt.Errorf("%s quota check failed: %w", checkType, err)
+	}
+	if checkResult != nil && !checkResult.Allowed {
+		currentUsage := checkResult.Details.CurrentUsage
+		quotaLimit := uint64(0)
+		if checkResult.Details.Limit != nil {
+			quotaLimit = *checkResult.Details.Limit
+		}
+		ctx.Logger().Warn("Quota exceeded", zap.String("check_type", checkType), zap.Uint("user_id", userID), zap.Uint64("requested_bytes", requestedBytes), zap.Uint64("current_usage", currentUsage), zap.Uint64("quota_limit", quotaLimit))
+		return checkResult, fmt.Errorf("%s quota exceeded: current usage %d bytes + requested %d bytes would exceed quota limit of %d bytes", checkType, currentUsage, requestedBytes, quotaLimit)
+	}
+	return checkResult, nil
+}
+
+// ReleaseReservations releases multiple quota reservations safely
+// This handles nil checks and releases all provided reservations
+func ReleaseReservations(reservations ...*quotaCore.QuotaCheckResult) {
+	for _, result := range reservations {
+		if result != nil {
+			result.ReleaseReservation()
+		}
+	}
+}
+
+// QuotaCheckResults holds the results of quota checks with reservations
+type QuotaCheckResults struct {
+	Upload  *quotaCore.QuotaCheckResult
+	Storage *quotaCore.QuotaCheckResult
+	Download *quotaCore.QuotaCheckResult
+}
+
+// ReleaseAll releases all reservations held in the QuotaCheckResults struct
+func (q *QuotaCheckResults) ReleaseAll() {
+	ReleaseReservations(q.Upload, q.Storage, q.Download)
+}

--- a/internal/quota/quota.go
+++ b/internal/quota/quota.go
@@ -206,7 +206,8 @@ func CheckWithReservation(cctx context.Context, ctx core.Context, checkType stri
 			quotaLimit = *checkResult.Details.Limit
 		}
 		ctx.Logger().Warn("Quota exceeded", zap.String("check_type", checkType), zap.Uint("user_id", userID), zap.Uint64("requested_bytes", requestedBytes), zap.Uint64("current_usage", currentUsage), zap.Uint64("quota_limit", quotaLimit))
-		return checkResult, fmt.Errorf("%s quota exceeded: current usage %d bytes + requested %d bytes would exceed quota limit of %d bytes", checkType, currentUsage, requestedBytes, quotaLimit)
+		checkResult.ReleaseReservation()
+		return nil, fmt.Errorf("%s quota exceeded: current usage %d bytes + requested %d bytes would exceed quota limit of %d bytes", checkType, currentUsage, requestedBytes, quotaLimit)
 	}
 	return checkResult, nil
 }

--- a/internal/service/upload/upload.go
+++ b/internal/service/upload/upload.go
@@ -14,6 +14,7 @@ import (
 	"go.lumeweb.com/portal-plugin-ipfs/internal/protocol"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/quota"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/upload"
+	quotaCore "go.lumeweb.com/portal-plugin-quota/core"
 	"go.lumeweb.com/portal/core"
 	"go.lumeweb.com/portal/db/models"
 	"go.uber.org/zap"
@@ -121,7 +122,7 @@ func (s *UploadServiceDefault) HandleUploadWithMode(ctx context.Context, reader 
 	return result.CID, result.UploadID, err
 }
 
-func (s *UploadServiceDefault) ProcessUpload(ctx context.Context, cids []cid.Cid, userId uint) error {
+func (s *UploadServiceDefault) ProcessUpload(ctx context.Context, cids []cid.Cid, userId uint, reservations map[cid.Cid]*quotaCore.QuotaCheckResult) error {
 	ctx, span := core.TraceMethod(ctx, "UploadServiceDefault.ProcessUpload")
 	defer span.End()
 
@@ -133,8 +134,7 @@ func (s *UploadServiceDefault) ProcessUpload(ctx context.Context, cids []cid.Cid
 				return fmt.Errorf("no CIDs provided")
 			}
 
-			// Calculate total size for quota check and cache CID sizes
-			var totalSize uint64
+			// Cache CID sizes
 			cidSizes := make(map[string]uint64, len(cids))
 			for _, c := range cids {
 				size, err := s.ipfs.GetMetadataStore().Size(ctx, c)
@@ -143,25 +143,6 @@ func (s *UploadServiceDefault) ProcessUpload(ctx context.Context, cids []cid.Cid
 					continue
 				}
 				cidSizes[c.String()] = size
-				totalSize += size
-			}
-
-			// Validate upload quota
-			if totalSize > 0 {
-				result, err := quota.CheckUploadQuota(ctx, s.Context(), userId, totalSize)
-				if err != nil {
-					s.Context().Logger().Warn("Failed to check upload quota", zap.Uint("user_id", userId), zap.Uint64("total_size", totalSize), zap.Error(err))
-					return fmt.Errorf("failed to check upload quota: %w", err)
-				}
-				if result != nil && !result.Allowed {
-					currentUsage := result.Details.CurrentUsage
-					quotaLimit := uint64(0)
-					if result.Details.Limit != nil {
-						quotaLimit = *result.Details.Limit
-					}
-					s.Context().Logger().Warn("Upload quota exceeded", zap.Uint("user_id", userId), zap.Uint64("total_size", totalSize), zap.Uint64("current_usage", currentUsage), zap.Uint64("quota_limit", quotaLimit))
-					return fmt.Errorf("upload quota exceeded: current usage %d bytes + requested %d bytes would exceed quota limit of %d bytes", currentUsage, totalSize, quotaLimit)
-				}
 			}
 
 			// Create upload records and core pin records for ALL CIDs (both roots and children)
@@ -202,8 +183,17 @@ func (s *UploadServiceDefault) ProcessUpload(ctx context.Context, cids []cid.Cid
 				}
 				quota.EmitStorageObjectPinned(core.DetachContext(ctx), s.Context(), createdPin, clientIP)
 
+				// Get reservation ID for this CID
+				var uploadResID *string
+				if reservations != nil {
+					if checkResult, exists := reservations[c]; exists && checkResult != nil && checkResult.Reservation != nil {
+						uuid := checkResult.Reservation.UUID()
+						uploadResID = &uuid
+					}
+				}
+
 				// Emit upload completion event for quota tracking
-				quota.EmitUploadCompleted(core.DetachContext(ctx), s.Context(), &userId, uploadMeta.ID, size, clientIP, nil, true)
+				quota.EmitUploadCompleted(core.DetachContext(ctx), s.Context(), &userId, uploadMeta.ID, size, clientIP, uploadResID, true)
 			}
 
 			return nil

--- a/internal/testing/mocks/MockUploadService.go
+++ b/internal/testing/mocks/MockUploadService.go
@@ -12,6 +12,7 @@ import (
 	mock "github.com/stretchr/testify/mock"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/db"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/upload"
+	core0 "go.lumeweb.com/portal-plugin-quota/core"
 	"go.lumeweb.com/portal/config"
 	"go.lumeweb.com/portal/core"
 	"gorm.io/gorm"
@@ -509,16 +510,16 @@ func (_c *MockUploadService_Logger_Call) RunAndReturn(run func() *core.Logger) *
 }
 
 // ProcessUpload provides a mock function for the type MockUploadService
-func (_mock *MockUploadService) ProcessUpload(ctx context.Context, cids []cid.Cid, userId uint) error {
-	ret := _mock.Called(ctx, cids, userId)
+func (_mock *MockUploadService) ProcessUpload(ctx context.Context, cids []cid.Cid, userId uint, reservations map[cid.Cid]*core0.QuotaCheckResult) error {
+	ret := _mock.Called(ctx, cids, userId, reservations)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ProcessUpload")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, []cid.Cid, uint) error); ok {
-		r0 = returnFunc(ctx, cids, userId)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []cid.Cid, uint, map[cid.Cid]*core0.QuotaCheckResult) error); ok {
+		r0 = returnFunc(ctx, cids, userId, reservations)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -534,11 +535,12 @@ type MockUploadService_ProcessUpload_Call struct {
 //   - ctx context.Context
 //   - cids []cid.Cid
 //   - userId uint
-func (_e *MockUploadService_Expecter) ProcessUpload(ctx interface{}, cids interface{}, userId interface{}) *MockUploadService_ProcessUpload_Call {
-	return &MockUploadService_ProcessUpload_Call{Call: _e.mock.On("ProcessUpload", ctx, cids, userId)}
+//   - reservations map[cid.Cid]*core0.QuotaCheckResult
+func (_e *MockUploadService_Expecter) ProcessUpload(ctx interface{}, cids interface{}, userId interface{}, reservations interface{}) *MockUploadService_ProcessUpload_Call {
+	return &MockUploadService_ProcessUpload_Call{Call: _e.mock.On("ProcessUpload", ctx, cids, userId, reservations)}
 }
 
-func (_c *MockUploadService_ProcessUpload_Call) Run(run func(ctx context.Context, cids []cid.Cid, userId uint)) *MockUploadService_ProcessUpload_Call {
+func (_c *MockUploadService_ProcessUpload_Call) Run(run func(ctx context.Context, cids []cid.Cid, userId uint, reservations map[cid.Cid]*core0.QuotaCheckResult)) *MockUploadService_ProcessUpload_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -552,10 +554,15 @@ func (_c *MockUploadService_ProcessUpload_Call) Run(run func(ctx context.Context
 		if args[2] != nil {
 			arg2 = args[2].(uint)
 		}
+		var arg3 map[cid.Cid]*core0.QuotaCheckResult
+		if args[3] != nil {
+			arg3 = args[3].(map[cid.Cid]*core0.QuotaCheckResult)
+		}
 		run(
 			arg0,
 			arg1,
 			arg2,
+			arg3,
 		)
 	})
 	return _c
@@ -566,7 +573,7 @@ func (_c *MockUploadService_ProcessUpload_Call) Return(err error) *MockUploadSer
 	return _c
 }
 
-func (_c *MockUploadService_ProcessUpload_Call) RunAndReturn(run func(ctx context.Context, cids []cid.Cid, userId uint) error) *MockUploadService_ProcessUpload_Call {
+func (_c *MockUploadService_ProcessUpload_Call) RunAndReturn(run func(ctx context.Context, cids []cid.Cid, userId uint, reservations map[cid.Cid]*core0.QuotaCheckResult) error) *MockUploadService_ProcessUpload_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
- Reserve upload and storage quota before processing uploads
- Pass reservation IDs through to upload completion events
- Add reservation support in TUS upload, post-upload, and retrieve operations
- Clean up reservations on errors to prevent quota leaks
- Add quota helpers for CID size calculation and reservation mapping
- Add thread-safe caching for IPFS announcement addresses
- Add new quota exceeded error types (upload/storage) with proper HTTP status

* `develop` <!-- branch-stack -->
  - **feat(upload): implement quota reservations for upload operations** :point\_left:

***

<!-- kody-pr-summary:start -->

Based on the code changes, this pull request implements a **quota reservation system** for upload operations to prevent race conditions and ensure accurate quota enforcement when multiple concurrent operations occur.

## Summary of Changes

**Core Functionality:**

- Introduced reservation-based quota checking that reserves quota capacity before processing uploads, then releases reservations if errors occur or applies them upon successful completion
- Extended quota validation to cover upload, storage, and download quotas with unified reservation management
- Modified upload processing to accept and track quota reservations per CID (Content Identifier)

**Operational Impact:**

- Upload operations now validate both upload and storage quotas with reservations before processing content
- Retrieval operations now check download quotas with reservations and validate upload quotas when processing child blocks
- TUS (resumable upload) operations integrate quota reservations during the upload completion workflow

**Error Handling:**

- Added specific error types for upload quota exceeded (`UPLOAD_QUOTA_EXCEEDED`) and storage quota exceeded (`STORAGE_QUOTA_EXCEEDED`) with HTTP 429 status codes
- Ensures quota reservations are properly released when operations fail or encounter errors during processing

**Additional Fix:**

- Resolved a race condition in IPFS node announcement address caching by adding mutex protection for the cached addresses map

The changes ensure that quota limits are strictly enforced even under concurrent load by reserving capacity upfront rather than checking quotas after processing, preventing scenarios where multiple simultaneous uploads could collectively exceed quota limits.

<!-- kody-pr-summary:end -->
