### PR TITLE
feat: add quota validation to upload processors and error handling

### DIFF
--- a/internal/api/api_upload.go
+++ b/internal/api/api_upload.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/labstack/echo/v4"
@@ -13,6 +14,30 @@ import (
 	uploadpkg "go.lumeweb.com/portal-plugin-ipfs/internal/upload"
 	"go.lumeweb.com/portal/core"
 )
+
+// mapUploadError maps various error types to appropriate IPFS API errors
+// This handles core quota errors, upload-specific errors, and provides fallbacks
+func mapUploadError(err error) *IPFSError {
+	if err == nil {
+		return nil
+	}
+
+	// Check for core quota errors first using errors.Is for proper unwrapping
+	if errors.Is(err, core.ErrUploadQuotaExceeded) {
+		return NewError(ErrKeyUploadQuotaExceeded, err)
+	}
+	if errors.Is(err, core.ErrStorageQuotaExceeded) {
+		return NewError(ErrKeyStorageQuotaExceeded, err)
+	}
+
+	// Check for upload package errors
+	if uploadErr, ok := uploadpkg.AsUploadError(err); ok {
+		return NewError(pluginErrors.MapUploadErrorType(uploadErr.Type), uploadErr)
+	}
+
+	// Fallback to generic error for unexpected error types
+	return NewError(ErrKeyFileUploadFailed, err)
+}
 
 func (a *API) GetTusHandler() core.TusHandler {
 	return a.tus
@@ -47,16 +72,7 @@ func (a *API) handleUpload(c echo.Context) error {
 	_cid, uploadId, err := a.uploadService.HandleUploadWithMode(ctx.Request().Context(), upl.File, user, archiveMode)
 	if err != nil {
 		// Handle specific error types with appropriate HTTP status codes
-		var apiErr *IPFSError
-
-		// Check if it's an UploadError and extract the error type using the helper function
-		if uploadErr, ok := uploadpkg.AsUploadError(err); ok {
-			// Map upload error type to API error type using the helper function
-			apiErr = NewError(pluginErrors.MapUploadErrorType(uploadErr.Type), uploadErr)
-		} else {
-			// Fallback to generic error for unexpected error types
-			apiErr = NewError(ErrKeyFileUploadFailed, err)
-		}
+		apiErr := mapUploadError(err)
 
 		_ = ctx.Error(apiErr, apiErr.HttpStatus())
 		return nil

--- a/internal/api/api_upload_test.go
+++ b/internal/api/api_upload_test.go
@@ -3,14 +3,20 @@ package api
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/ipfs/go-cid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	pluginCore "go.lumeweb.com/portal-plugin-ipfs/core"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/api/dto"
+	"go.lumeweb.com/portal-plugin-ipfs/internal/testing/mocks"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/testing/util"
+	"go.lumeweb.com/portal/core"
 	coreTesting "go.lumeweb.com/portal/core/testing"
 )
 
@@ -40,6 +46,118 @@ func TestAPI_handleUpload(t *testing.T) {
 		err := json.Unmarshal(rec.Body.Bytes(), &resp)
 		assert.NoError(t, err)
 		assert.Equal(t, expectedCID.String(), resp.CID)
+	}, TestOptions)
+}
+
+func TestAPI_handleUpload_UploadQuotaExceeded(t *testing.T) {
+	coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		helper := newMockHelper(t, ctx)
+		token, _ := helper.SetupAuthenticatedTestWithCID(util.GenerateTestCID(t, "test data"))
+
+		// Get the upload service mock and setup quota error expectation
+		mockUploadService := core.GetService[*mocks.MockUploadService](helper.ctx, pluginCore.UPLOAD_SERVICE)
+
+		mockUploadService.EXPECT().HandleUploadWithMode(mock.Anything, mock.Anything, mock.AnythingOfType("uint"), mock.AnythingOfType("upload.ArchiveMode")).
+			Return(cid.Undef, "", core.ErrUploadQuotaExceeded)
+
+		carData, _ := createTestCAR(t)
+		body := &bytes.Buffer{}
+		writer := multipart.NewWriter(body)
+		part, _ := writer.CreateFormFile("file", "test.car")
+		part.Write(carData)
+		writer.Close()
+
+		req := ctx.NewAPIRequest(http.MethodPost, "/api/upload", body.Bytes())
+		setAuthHeader(req, token)
+		req.Header.Set("Content-Type", writer.FormDataContentType())
+		rec := httptest.NewRecorder()
+		ctx.Router().ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusTooManyRequests, rec.Code)
+
+		var errResp map[string]interface{}
+		err := json.Unmarshal(rec.Body.Bytes(), &errResp)
+		assert.NoError(t, err)
+
+		// Check that error structure contains quota exceeded information
+		if errData, ok := errResp["error"].(map[string]interface{}); ok {
+			assert.Contains(t, errData["reason"], "UploadQuotaExceeded")
+		}
+	}, TestOptions)
+}
+
+func TestAPI_handleUpload_StorageQuotaExceeded(t *testing.T) {
+	coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		helper := newMockHelper(t, ctx)
+		token, _ := helper.SetupAuthenticatedTestWithCID(util.GenerateTestCID(t, "test data"))
+
+		// Get the upload service mock and setup quota error expectation
+		mockUploadService := core.GetService[*mocks.MockUploadService](helper.ctx, pluginCore.UPLOAD_SERVICE)
+
+		mockUploadService.EXPECT().HandleUploadWithMode(mock.Anything, mock.Anything, mock.AnythingOfType("uint"), mock.AnythingOfType("upload.ArchiveMode")).
+			Return(cid.Undef, "", core.ErrStorageQuotaExceeded)
+
+		carData, _ := createTestCAR(t)
+		body := &bytes.Buffer{}
+		writer := multipart.NewWriter(body)
+		part, _ := writer.CreateFormFile("file", "test.car")
+		part.Write(carData)
+		writer.Close()
+
+		req := ctx.NewAPIRequest(http.MethodPost, "/api/upload", body.Bytes())
+		setAuthHeader(req, token)
+		req.Header.Set("Content-Type", writer.FormDataContentType())
+		rec := httptest.NewRecorder()
+		ctx.Router().ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusTooManyRequests, rec.Code)
+
+		var errResp map[string]interface{}
+		err := json.Unmarshal(rec.Body.Bytes(), &errResp)
+		assert.NoError(t, err)
+
+		// Check that error structure contains storage quota exceeded information
+		if errData, ok := errResp["error"].(map[string]interface{}); ok {
+			assert.Contains(t, errData["reason"], "StorageQuotaExceeded")
+		}
+	}, TestOptions)
+}
+
+func TestAPI_handleUpload_WrappedQuotaError(t *testing.T) {
+	coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		helper := newMockHelper(t, ctx)
+		token, _ := helper.SetupAuthenticatedTestWithCID(util.GenerateTestCID(t, "test data"))
+
+		// Get the upload service mock and setup wrapped quota error expectation
+		wrappedError := fmt.Errorf("processing failed: %w", core.ErrUploadQuotaExceeded)
+		mockUploadService := core.GetService[*mocks.MockUploadService](helper.ctx, pluginCore.UPLOAD_SERVICE)
+
+		mockUploadService.EXPECT().HandleUploadWithMode(mock.Anything, mock.Anything, mock.AnythingOfType("uint"), mock.AnythingOfType("upload.ArchiveMode")).
+			Return(cid.Undef, "", wrappedError)
+
+		carData, _ := createTestCAR(t)
+		body := &bytes.Buffer{}
+		writer := multipart.NewWriter(body)
+		part, _ := writer.CreateFormFile("file", "test.car")
+		part.Write(carData)
+		writer.Close()
+
+		req := ctx.NewAPIRequest(http.MethodPost, "/api/upload", body.Bytes())
+		setAuthHeader(req, token)
+		req.Header.Set("Content-Type", writer.FormDataContentType())
+		rec := httptest.NewRecorder()
+		ctx.Router().ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusTooManyRequests, rec.Code)
+
+		var errResp map[string]interface{}
+		err := json.Unmarshal(rec.Body.Bytes(), &errResp)
+		assert.NoError(t, err)
+
+		// Check that error structure contains quota exceeded information
+		if errData, ok := errResp["error"].(map[string]interface{}); ok {
+			assert.Contains(t, errData["reason"], "UploadQuotaExceeded")
+		}
 	}, TestOptions)
 }
 

--- a/internal/api/errors.go
+++ b/internal/api/errors.go
@@ -12,7 +12,7 @@ import (
 
 // Error keys
 const (
-	Namespace = "ipfs-plugin-api"
+	Namespace = "ipfs"
 
 	// Re-export error type constants from internal/errors
 	ErrKeyUnsupportedFormat = errors.ErrKeyUnsupportedFormat
@@ -35,22 +35,22 @@ const (
 	ErrKeyStorageQuotaExceeded  core.ErrorType = "STORAGE_QUOTA_EXCEEDED"
 	ErrKeyDownloadQuotaExceeded core.ErrorType = "DOWNLOAD_QUOTA_EXCEEDED"
 	ErrKeyInvalidRequest        core.ErrorType = "INVALID_REQUEST"
-	ErrKeyInvalidIdentifier    core.ErrorType = "INVALID_IDENTIFIER"
+	ErrKeyInvalidIdentifier     core.ErrorType = "INVALID_IDENTIFIER"
 	ErrKeyPermissionDenied      core.ErrorType = "PERMISSION_DENIED"
 	ErrKeyDeleteFailed          core.ErrorType = "DELETE_FAILED"
 	ErrKeyUpdateFailed          core.ErrorType = "UPDATE_FAILED"
 
 	// DNS error types
-	ErrKeyInvalidRecordType      core.ErrorType = "INVALID_RECORD_TYPE"
-	ErrKeyRecordNotFound         core.ErrorType = "RECORD_NOT_FOUND"
-	ErrKeyZoneNotFound           core.ErrorType = "ZONE_NOT_FOUND"
-	ErrKeyInvalidDomainFormat    core.ErrorType = "INVALID_DOMAIN_FORMAT"
-	ErrKeyDuplicateRecord        core.ErrorType = "DUPLICATE_RECORD"
-	ErrKeyValidationFailed       core.ErrorType = "VALIDATION_FAILED"
+	ErrKeyInvalidRecordType   core.ErrorType = "INVALID_RECORD_TYPE"
+	ErrKeyRecordNotFound      core.ErrorType = "RECORD_NOT_FOUND"
+	ErrKeyZoneNotFound        core.ErrorType = "ZONE_NOT_FOUND"
+	ErrKeyInvalidDomainFormat core.ErrorType = "INVALID_DOMAIN_FORMAT"
+	ErrKeyDuplicateRecord     core.ErrorType = "DUPLICATE_RECORD"
+	ErrKeyValidationFailed    core.ErrorType = "VALIDATION_FAILED"
 
 	// Website validation error types
-	ErrKeyInvalidCID            core.ErrorType = "INVALID_CID"
-	ErrKeyInvalidTarget         core.ErrorType = "INVALID_TARGET"
+	ErrKeyInvalidCID    core.ErrorType = "INVALID_CID"
+	ErrKeyInvalidTarget core.ErrorType = "INVALID_TARGET"
 )
 
 var _ router.ResponseError = (*IPFSError)(nil)

--- a/internal/service/upload/upload.go
+++ b/internal/service/upload/upload.go
@@ -101,7 +101,7 @@ func (s *UploadServiceDefault) HandleUploadWithMode(ctx context.Context, reader 
 				return UploadResult{}, fmt.Errorf("failed to reset reader for processing: %w", err)
 			}
 
-			processor, err := s.processorFactory.CreateProcessor(format, mode)
+			processor, err := s.processorFactory.CreateProcessor(format, mode, s.Context(), userId)
 			if err != nil {
 				return UploadResult{}, upload.NewProcessorError(format.String(), mode.String(), err)
 			}

--- a/internal/upload/upload.go
+++ b/internal/upload/upload.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ipfs/go-cid"
 	"github.com/ipld/go-car/v2"
 	"github.com/mholt/archives"
+	"go.lumeweb.com/portal/core"
 )
 
 var cidUndefSlice = []cid.Cid{cid.Undef}
@@ -91,7 +92,7 @@ type UploadProcessor interface {
 // UploadProcessorFactory creates processors based on format and mode
 type UploadProcessorFactory interface {
 	// CreateProcessor returns a processor suitable for the specified format
-	CreateProcessor(format Format, mode ArchiveMode) (UploadProcessor, error)
+	CreateProcessor(format Format, mode ArchiveMode, portalCtx core.Context, userID uint) (UploadProcessor, error)
 }
 
 // UniversalReader wraps an io.Reader to make it seekable by buffering its content

--- a/internal/upload/upload_processor.go
+++ b/internal/upload/upload_processor.go
@@ -11,6 +11,17 @@ import (
 	"go.lumeweb.com/portal/core"
 )
 
+// validateQuotas validates both upload and storage quotas for a file size
+func validateQuotas(ctx context.Context, portalCtx core.Context, userID uint, size uint64) error {
+	if err := quota.ValidateUploadQuota(ctx, portalCtx, userID, size); err != nil {
+		return fmt.Errorf("upload quota validation failed: %w", err)
+	}
+	if err := quota.ValidateStorageQuota(ctx, portalCtx, userID, size); err != nil {
+		return fmt.Errorf("storage quota validation failed: %w", err)
+	}
+	return nil
+}
+
 // FileProcessor implements UploadProcessor for individual files, wrapping them in CAR format
 type FileProcessor struct {
 	storage       core.StorageService
@@ -46,14 +57,8 @@ func (p *FileProcessor) Process(ctx context.Context, reader io.ReadSeekCloser) (
 	// Validate quotas using the CAR file size
 	carSize := uint64(car.Len())
 
-	// Check upload quota
-	if err := quota.ValidateUploadQuota(ctx, p.portalCtx, p.userID, carSize); err != nil {
-		return cid.Cid{}, "", fmt.Errorf("upload quota validation failed: %w", err)
-	}
-
-	// Check storage quota
-	if err := quota.ValidateStorageQuota(ctx, p.portalCtx, p.userID, carSize); err != nil {
-		return cid.Cid{}, "", fmt.Errorf("storage quota validation failed: %w", err)
+	if err := validateQuotas(ctx, p.portalCtx, p.userID, carSize); err != nil {
+		return cid.Cid{}, "", err
 	}
 
 	uploadID, err := p.storageHelper.StoreFile(ctx, NewUniversalReader(car), int64(car.Len()))
@@ -94,14 +99,8 @@ func (p *CARProcessor) Process(ctx context.Context, reader io.ReadSeekCloser) (c
 		return cid.Undef, "", err
 	}
 
-	// Check upload quota
-	if err := quota.ValidateUploadQuota(ctx, p.portalCtx, p.userID, uint64(size)); err != nil {
-		return cid.Undef, "", fmt.Errorf("upload quota validation failed: %w", err)
-	}
-
-	// Check storage quota
-	if err := quota.ValidateStorageQuota(ctx, p.portalCtx, p.userID, uint64(size)); err != nil {
-		return cid.Undef, "", fmt.Errorf("storage quota validation failed: %w", err)
+	if err := validateQuotas(ctx, p.portalCtx, p.userID, uint64(size)); err != nil {
+		return cid.Undef, "", err
 	}
 
 	roots, err := GetCarRoots(reader, false)
@@ -188,14 +187,8 @@ func (p *ArchiveProcessor) Process(ctx context.Context, reader io.ReadSeekCloser
 	// Validate quotas using the CAR file size
 	carSize := uint64(car.Len())
 
-	// Check upload quota
-	if err := quota.ValidateUploadQuota(ctx, p.portalCtx, p.userID, carSize); err != nil {
-		return cid.Cid{}, "", fmt.Errorf("upload quota validation failed: %w", err)
-	}
-
-	// Check storage quota
-	if err := quota.ValidateStorageQuota(ctx, p.portalCtx, p.userID, carSize); err != nil {
-		return cid.Cid{}, "", fmt.Errorf("storage quota validation failed: %w", err)
+	if err := validateQuotas(ctx, p.portalCtx, p.userID, carSize); err != nil {
+		return cid.Cid{}, "", err
 	}
 
 	uploadID, err := p.storageHelper.StoreFile(ctx, NewUniversalReader(car), int64(car.Len()))

--- a/internal/upload/upload_processor.go
+++ b/internal/upload/upload_processor.go
@@ -6,6 +6,7 @@ import (
 	"io"
 
 	"github.com/ipfs/go-cid"
+	"go.lumeweb.com/portal-plugin-ipfs/internal/quota"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/upload/common"
 	"go.lumeweb.com/portal/core"
 )
@@ -16,15 +17,19 @@ type FileProcessor struct {
 	ipfs          core.Protocol
 	carGenerator  CARGenerator
 	storageHelper *common.StorageHelper
+	portalCtx     core.Context
+	userID        uint
 }
 
 // NewFileProcessor creates a new file processor
-func NewFileProcessor(storage core.StorageService, ipfs core.Protocol, carGenerator CARGenerator) *FileProcessor {
+func NewFileProcessor(storage core.StorageService, ipfs core.Protocol, carGenerator CARGenerator, portalCtx core.Context, userID uint) *FileProcessor {
 	return &FileProcessor{
 		storage:       storage,
 		ipfs:          ipfs,
 		carGenerator:  carGenerator,
 		storageHelper: common.NewStorageHelper(storage, ipfs),
+		portalCtx:     portalCtx,
+		userID:        userID,
 	}
 }
 
@@ -36,6 +41,19 @@ func (p *FileProcessor) Process(ctx context.Context, reader io.ReadSeekCloser) (
 	car, c, err := p.carGenerator.FileToCAR(ctx, reader)
 	if err != nil {
 		return cid.Cid{}, "", err
+	}
+
+	// Validate quotas using the CAR file size
+	carSize := uint64(car.Len())
+
+	// Check upload quota
+	if err := quota.ValidateUploadQuota(ctx, p.portalCtx, p.userID, carSize); err != nil {
+		return cid.Cid{}, "", fmt.Errorf("upload quota validation failed: %w", err)
+	}
+
+	// Check storage quota
+	if err := quota.ValidateStorageQuota(ctx, p.portalCtx, p.userID, carSize); err != nil {
+		return cid.Cid{}, "", fmt.Errorf("storage quota validation failed: %w", err)
 	}
 
 	uploadID, err := p.storageHelper.StoreFile(ctx, NewUniversalReader(car), int64(car.Len()))
@@ -51,14 +69,18 @@ type CARProcessor struct {
 	storage       core.StorageService
 	ipfs          core.Protocol
 	storageHelper *common.StorageHelper
+	portalCtx     core.Context
+	userID        uint
 }
 
 // NewCARProcessor creates a new CAR processor
-func NewCARProcessor(storage core.StorageService, ipfs core.Protocol) *CARProcessor {
+func NewCARProcessor(storage core.StorageService, ipfs core.Protocol, portalCtx core.Context, userID uint) *CARProcessor {
 	return &CARProcessor{
 		storage:       storage,
 		ipfs:          ipfs,
 		storageHelper: common.NewStorageHelper(storage, ipfs),
+		portalCtx:     portalCtx,
+		userID:        userID,
 	}
 }
 
@@ -70,6 +92,16 @@ func (p *CARProcessor) Process(ctx context.Context, reader io.ReadSeekCloser) (c
 	size, err := common.PrepareReader(reader)
 	if err != nil {
 		return cid.Undef, "", err
+	}
+
+	// Check upload quota
+	if err := quota.ValidateUploadQuota(ctx, p.portalCtx, p.userID, uint64(size)); err != nil {
+		return cid.Undef, "", fmt.Errorf("upload quota validation failed: %w", err)
+	}
+
+	// Check storage quota
+	if err := quota.ValidateStorageQuota(ctx, p.portalCtx, p.userID, uint64(size)); err != nil {
+		return cid.Undef, "", fmt.Errorf("storage quota validation failed: %w", err)
 	}
 
 	roots, err := GetCarRoots(reader, false)
@@ -117,10 +149,12 @@ type ArchiveProcessor struct {
 	carGenerator  CARGenerator
 	storageHelper *common.StorageHelper
 	logger        *core.Logger
+	portalCtx     core.Context
+	userID        uint
 }
 
 // NewArchiveProcessor creates a new archive processor
-func NewArchiveProcessor(format Format, storage core.StorageService, ipfs core.Protocol, carGenerator CARGenerator, logger *core.Logger) *ArchiveProcessor {
+func NewArchiveProcessor(format Format, storage core.StorageService, ipfs core.Protocol, carGenerator CARGenerator, logger *core.Logger, portalCtx core.Context, userID uint) *ArchiveProcessor {
 	return &ArchiveProcessor{
 		format:        format,
 		storage:       storage,
@@ -128,6 +162,8 @@ func NewArchiveProcessor(format Format, storage core.StorageService, ipfs core.P
 		carGenerator:  carGenerator,
 		storageHelper: common.NewStorageHelper(storage, ipfs),
 		logger:        logger,
+		portalCtx:     portalCtx,
+		userID:        userID,
 	}
 }
 
@@ -147,6 +183,19 @@ func (p *ArchiveProcessor) Process(ctx context.Context, reader io.ReadSeekCloser
 	car, c, err := p.carGenerator.ArchiveToCAR(ctx, extractor)
 	if err != nil {
 		return cid.Cid{}, "", err
+	}
+
+	// Validate quotas using the CAR file size
+	carSize := uint64(car.Len())
+
+	// Check upload quota
+	if err := quota.ValidateUploadQuota(ctx, p.portalCtx, p.userID, carSize); err != nil {
+		return cid.Cid{}, "", fmt.Errorf("upload quota validation failed: %w", err)
+	}
+
+	// Check storage quota
+	if err := quota.ValidateStorageQuota(ctx, p.portalCtx, p.userID, carSize); err != nil {
+		return cid.Cid{}, "", fmt.Errorf("storage quota validation failed: %w", err)
 	}
 
 	uploadID, err := p.storageHelper.StoreFile(ctx, NewUniversalReader(car), int64(car.Len()))
@@ -174,17 +223,17 @@ func NewUploadProcessorFactory(logger *core.Logger, storage core.StorageService,
 }
 
 // CreateProcessor returns the appropriate processor based on file format
-func (f *DefaultUploadProcessorFactory) CreateProcessor(format Format, mode ArchiveMode) (UploadProcessor, error) {
+func (f *DefaultUploadProcessorFactory) CreateProcessor(format Format, mode ArchiveMode, portalCtx core.Context, userID uint) (UploadProcessor, error) {
 	switch format {
 	case FormatCAR:
-		return NewCARProcessor(f.storage, f.ipfs), nil
+		return NewCARProcessor(f.storage, f.ipfs, portalCtx, userID), nil
 	default:
 		gen := NewCARGeneratorWithDefaults(f.logger)
 
 		if format.IsArchiveFormat() && mode == ArchiveConvert {
-			return NewArchiveProcessor(format, f.storage, f.ipfs, gen, f.logger), nil
+			return NewArchiveProcessor(format, f.storage, f.ipfs, gen, f.logger, portalCtx, userID), nil
 		}
 		// For non-archive formats, or ArchivePreserve, use FileProcessor which wraps files in CAR
-		return NewFileProcessor(f.storage, f.ipfs, gen), nil
+		return NewFileProcessor(f.storage, f.ipfs, gen, portalCtx, userID), nil
 	}
 }


### PR DESCRIPTION
- Add mapUploadError to properly detect and map core quota errors
- Upload quota exceeded returns HTTP 429 (StatusTooManyRequests)
- Storage quota exceeded returns HTTP 429 (StatusTooManyRequests)
- Pass portal context and user ID to upload processors
- Validate upload and storage quotas before processing files
- Add comprehensive tests for quota error scenarios

* `develop` <!-- branch-stack -->
  - **feat: add quota validation to upload processors and error handling** :point\_left:

***

<!-- kody-pr-summary:start -->

This pull request implements quota validation enforcement within the IPFS upload processing pipeline and enhances error handling to properly detect and respond to quota limit violations.

**Key Changes:**

1. **Quota Validation in Upload Processors**: Added upload and storage quota validation to all upload processors (`FileProcessor`, `CARProcessor`, and `ArchiveProcessor`). The processors now validate user quotas against the CAR file size before completing the upload process, preventing users from exceeding their allocated limits.

2. **Enhanced Error Handling**: Introduced centralized error mapping that properly detects quota exceeded errors (`ErrUploadQuotaExceeded` and `ErrStorageQuotaExceeded`) using proper error unwrapping. This ensures wrapped errors are correctly identified and mapped to appropriate API error responses.

3. **API Error Response Improvements**: Quota violations now return HTTP 429 (Too Many Requests) status codes with descriptive error reasons, allowing clients to distinguish quota-related failures from other upload errors.

4. **Comprehensive Test Coverage**: Added test cases covering direct quota errors, storage quota errors, and wrapped/nested quota errors to ensure the error detection logic works correctly regardless of how errors are propagated through the call stack.

5. **Interface Updates**: Extended the `UploadProcessorFactory` interface and processor constructors to accept portal context and user ID parameters, enabling access to quota validation services during file processing.

<!-- kody-pr-summary:end -->
