### PR TITLE
fix(quota): create per-block quota reservations for download tracking

### DIFF
--- a/internal/protocol/op_post_upload.go
+++ b/internal/protocol/op_post_upload.go
@@ -42,9 +42,6 @@ func (h *PostUploadOperationHandler) Execute(ctx context.Context, req *models.Re
 	ctx, span := core.TraceMethod(ctx, "PostUploadOperationHandler.Execute")
 	defer span.End()
 
-	// Store quota check results for reservation management
-	checkResults := &quota.QuotaCheckResults{}
-
 	// Initialize progress tracker with manual mode for simple milestones
 	tracker, err := InitializeManualProgressTracker(h, req.ID, core.OpTypeUpload, 10)
 	if err != nil {
@@ -109,25 +106,21 @@ func (h *PostUploadOperationHandler) Execute(ctx context.Context, req *models.Re
 	if uploadFileSize > 0 {
 		requestedBytes := uint64(uploadFileSize)
 
-		// Check upload quota with reservation
-		checkResult, err := quota.CheckWithReservation(ctx, h.Context(), "upload", userID, requestedBytes, quota.CheckUploadQuota)
+		// Validate upload quota without reservation (sanity check only)
+		err = quota.ValidateUploadQuota(ctx, h.Context(), userID, requestedBytes)
 		if err != nil {
 			return err
 		}
-		checkResults.Upload = checkResult
 
-		// Check storage quota with reservation
-		checkResult, err = quota.CheckWithReservation(ctx, h.Context(), "storage", userID, requestedBytes, quota.CheckStorageQuota)
+		// Validate storage quota without reservation (sanity check only)
+		err = quota.ValidateStorageQuota(ctx, h.Context(), userID, requestedBytes)
 		if err != nil {
-			checkResults.ReleaseAll()
 			return err
 		}
-		checkResults.Storage = checkResult
 	}
 
 	uploadedFormat, err := upload.DetectFormat(uploadFile)
 	if err != nil {
-		checkResults.ReleaseAll()
 		return err
 	}
 
@@ -138,7 +131,6 @@ func (h *PostUploadOperationHandler) Execute(ctx context.Context, req *models.Re
 
 	processor, err := h.createProcessor(uploadFile, uploadedFormat)
 	if err != nil {
-		checkResults.ReleaseAll()
 		return err
 	}
 	defer processor.Release()
@@ -150,23 +142,25 @@ func (h *PostUploadOperationHandler) Execute(ctx context.Context, req *models.Re
 
 	allCids, rootCids, err := ProcessBlocks(h.Context(), processor)
 	if err != nil {
-		checkResults.ReleaseAll()
 		return fmt.Errorf("failed to process CIDs from upload: %w", err)
 	}
 
 	// Check if any root CIDs were returned
 	if len(rootCids) == 0 {
-		checkResults.ReleaseAll()
 		return fmt.Errorf("no root CIDs found during block processing")
 	}
 
-	// Create reservations map
-	reservations := CreateReservationMap(allCids, checkResults.Upload)
+	// Create per-block reservations for each block
+	proto := h.Protocol().(ProtoNode)
+	reservations, perBlockReservations, err := CreatePerBlockReservations(ctx, h.Context(), proto, allCids, userID)
+	if err != nil {
+		return err
+	}
 
 	err = h.processCIDs(ctx, allCids, userID, req.SourceIP, reservations)
 	if err != nil {
-		// Release reservations on error
-		quota.ReleaseReservations(checkResults.Upload, checkResults.Storage)
+		// Release all per-block reservations on error
+		ReleasePerBlockReservations(perBlockReservations)
 		return err
 	}
 
@@ -184,7 +178,8 @@ func (h *PostUploadOperationHandler) Execute(ctx context.Context, req *models.Re
 
 	ipfsPin, err := h.createRootPin(ctx, rootCids[0], userID)
 	if err != nil {
-		quota.ReleaseReservations(checkResults.Upload, checkResults.Storage)
+		// Release all per-block reservations on error
+		ReleasePerBlockReservations(perBlockReservations)
 		return err
 	}
 
@@ -207,7 +202,8 @@ func (h *PostUploadOperationHandler) Execute(ctx context.Context, req *models.Re
 
 	err = h.updateWorkflow(ctx, req.ID, rootCids, ipfsPin)
 	if err != nil {
-		quota.ReleaseReservations(checkResults.Upload, checkResults.Storage)
+		// Release all per-block reservations on error
+		ReleasePerBlockReservations(perBlockReservations)
 		return err
 	}
 

--- a/internal/protocol/protocol.go
+++ b/internal/protocol/protocol.go
@@ -230,33 +230,24 @@ func NewProtocolOperations(p core.Protocol) []core.Operation {
 				return fmt.Errorf("failed to get upload size: %w", err)
 			}
 
-			// Store quota check results for reservation management
-			checkResults := &quota.QuotaCheckResults{}
-
-			// Check upload and storage quota with reservation before processing
+			// Sanity check quota without reservation before processing
 			if uploadSize > 0 {
-				// Check upload quota with reservation
-				checkResult, err := quota.CheckWithReservation(ctx, helper.Context(), "upload", *request.UserID, uploadSize, quota.CheckUploadQuota)
+				// Validate upload quota without reservation (sanity check only)
+				err = quota.ValidateUploadQuota(ctx, helper.Context(), *request.UserID, uploadSize)
 				if err != nil {
 					return err
 				}
-				checkResults.Upload = checkResult
 
-				// Check storage quota with reservation
-				checkResult, err = quota.CheckWithReservation(ctx, helper.Context(), "storage", *request.UserID, uploadSize, quota.CheckStorageQuota)
+				// Validate storage quota without reservation (sanity check only)
+				err = quota.ValidateStorageQuota(ctx, helper.Context(), *request.UserID, uploadSize)
 				if err != nil {
-					checkResults.ReleaseAll()
 					return err
 				}
-				checkResults.Storage = checkResult
 			}
 
 			// Get upload reader for processing
 			reader, err := tusHandler.UploadReader(ctx, tsReq.TUSUploadID, proto, 0)
 			if err != nil {
-				if uploadSize > 0 {
-					checkResults.ReleaseAll()
-				}
 				return fmt.Errorf("failed to get upload reader: %w", err)
 			}
 
@@ -275,21 +266,15 @@ func NewProtocolOperations(p core.Protocol) []core.Operation {
 			// Detect format using IPFS plugin logic
 			uploadedFormat, err := upload.DetectFormat(reader)
 			if err != nil {
-				if uploadSize > 0 {
-					checkResults.ReleaseAll()
-				}
 				return fmt.Errorf("failed to detect upload format: %w", err)
 			}
 
-			// Create appropriate processor based on format
+		// Create appropriate processor based on format
 			var processor BlockProcessor
 			if uploadedFormat.IsUploadFormat() {
 				// CAR format
 				processor, err = NewCARBlockProcessor(reader)
 				if err != nil {
-					if uploadSize > 0 {
-						checkResults.ReleaseAll()
-					}
 					return fmt.Errorf("failed to create CAR processor: %w", err)
 				}
 			} else {
@@ -297,9 +282,6 @@ func NewProtocolOperations(p core.Protocol) []core.Operation {
 				protoNode := p.(ProtoNode)
 				processor, err = createFileProcessorForTUS(reader, protoNode, helper.Logger())
 				if err != nil {
-					if uploadSize > 0 {
-						checkResults.ReleaseAll()
-					}
 					return fmt.Errorf("failed to create file processor: %w", err)
 				}
 			}
@@ -308,24 +290,23 @@ func NewProtocolOperations(p core.Protocol) []core.Operation {
 			// Process the upload
 			allCids, rootCids, err := ProcessBlocks(helper.Context(), processor)
 			if err != nil {
-				if uploadSize > 0 {
-					checkResults.ReleaseAll()
-				}
 				return fmt.Errorf("failed to process upload: %w", err)
 			}
 
-			// Create reservations map for upload service
-			reservations := CreateReservationMap(allCids, checkResults.Upload)
+			// Create per-block reservations for each block
+			protoNode := p.(ProtoNode)
+			reservations, perBlockReservations, err := CreatePerBlockReservations(ctx, helper.Context(), protoNode, allCids, *request.UserID)
+			if err != nil {
+				return err
+			}
 
 			// Process all CIDs to create upload and core pin records
 			uploadSvc := core.GetService[pluginCore.UploadService](helper.Context(), pluginCore.UPLOAD_SERVICE)
 			if uploadSvc == nil {
 				helper.Logger().Error("Upload service not available")
 
-				// Release reservations on error
-				if uploadSize > 0 {
-					checkResults.ReleaseAll()
-				}
+				// Release all per-block reservations on error
+				ReleasePerBlockReservations(perBlockReservations)
 				return fmt.Errorf("upload service not available")
 			}
 
@@ -334,10 +315,8 @@ func NewProtocolOperations(p core.Protocol) []core.Operation {
 
 			err = uploadSvc.ProcessUpload(ctx, allCids, *request.UserID, reservations)
 			if err != nil {
-				// Release reservations on error
-				if uploadSize > 0 {
-					checkResults.ReleaseAll()
-				}
+				// Release all per-block reservations on error
+				ReleasePerBlockReservations(perBlockReservations)
 				return fmt.Errorf("failed to process upload: %w", err)
 			}
 

--- a/internal/protocol/quota_helpers.go
+++ b/internal/protocol/quota_helpers.go
@@ -2,9 +2,11 @@ package protocol
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/ipfs/go-cid"
 	"go.lumeweb.com/portal/core"
+	"go.lumeweb.com/portal-plugin-ipfs/internal/quota"
 	"go.uber.org/zap"
 	quotaCore "go.lumeweb.com/portal-plugin-quota/core"
 )
@@ -40,4 +42,66 @@ func CreateReservationMap(cids []cid.Cid, result *quotaCore.QuotaCheckResult) ma
 		reservations[c] = result
 	}
 	return reservations
+}
+
+// ReleasePerBlockReservations releases multiple quota reservations safely
+// This is used for cleanup when per-block reservations are created
+func ReleasePerBlockReservations(reservations []*quotaCore.QuotaCheckResult) {
+	for _, result := range reservations {
+		if result != nil {
+			result.ReleaseReservation()
+		}
+	}
+}
+
+// CreatePerBlockReservations creates individual quota reservations for each block
+// This ensures each CID maps to its own reservation for accurate download tracking.
+// Returns the reservations map (CID -> upload reservation) and the slice of all reservations for cleanup.
+func CreatePerBlockReservations(ctx context.Context, coreCtx core.Context, proto ProtoNode, cids []cid.Cid, userID uint) (map[cid.Cid]*quotaCore.QuotaCheckResult, []*quotaCore.QuotaCheckResult, error) {
+	blockstore := proto.GetNode().GetBlockstore()
+
+	// Track per-block reservations for cleanup on error
+	var perBlockReservations []*quotaCore.QuotaCheckResult
+
+	// Create per-block reservations
+	reservations := make(map[cid.Cid]*quotaCore.QuotaCheckResult)
+	for _, c := range cids {
+		// Get block size
+		size, err := blockstore.GetSize(ctx, c)
+		if err != nil {
+			coreCtx.Logger().Warn("Failed to get block size for reservation, skipping",
+				zap.String("cid", c.String()),
+				zap.Error(err))
+			continue
+		}
+
+		if size <= 0 {
+			continue
+		}
+
+		blockSize := uint64(size)
+
+		// Create upload quota reservation for this specific block
+		uploadReservation, err := quota.CheckWithReservation(ctx, coreCtx, "upload", userID, blockSize, quota.CheckUploadQuota)
+		if err != nil {
+			// Release all previously created reservations
+			ReleasePerBlockReservations(perBlockReservations)
+			return nil, nil, fmt.Errorf("failed to create upload reservation for block %s: %w", c.String(), err)
+		}
+		perBlockReservations = append(perBlockReservations, uploadReservation)
+
+		// Create storage quota reservation for this specific block
+		storageReservation, err := quota.CheckWithReservation(ctx, coreCtx, "storage", userID, blockSize, quota.CheckStorageQuota)
+		if err != nil {
+			// Release all previously created reservations (including upload)
+			ReleasePerBlockReservations(perBlockReservations)
+			return nil, nil, fmt.Errorf("failed to create storage reservation for block %s: %w", c.String(), err)
+		}
+		perBlockReservations = append(perBlockReservations, storageReservation)
+
+		// Map this CID to its upload reservation for download tracking
+		reservations[c] = uploadReservation
+	}
+
+	return reservations, perBlockReservations, nil
 }


### PR DESCRIPTION
- Replace single shared quota reservation with per-block reservations
- Add initial quota validation without reservation before block processing (sanity check)
- Create individual upload/storage reservations for each block after processing
- Extract shared reservation logic to CreatePerBlockReservations() helper
- Add ReleasePerBlockReservations() for cleanup on error paths
- Each CID now maps to its own upload reservation for accurate download attribution

Fixes bug where download emits were ignored due to all IPFS blocks using the same reservation ID instead of per-block reservations.

- `develop` <!-- branch-stack -->
  - **fix(quota): create per-block quota reservations for download tracking** :point\_left:


---

<!-- kody-pr-summary:start -->
 This PR fixes quota reservation logic to implement per-block quota reservations rather than file-level reservations, enabling accurate download tracking.

**Changes:**
- Replaces upfront file-size-based quota reservations with post-processing per-block reservations created after block processing
- Converts initial quota checks to validation-only sanity checks (without reservations) before upload processing
- Creates individual upload and storage quota reservations for each block/CID based on actual block sizes retrieved from the blockstore
- Maps each CID to its specific upload reservation to support granular download tracking
- Implements `ReleasePerBlockReservations` for proper cleanup of individual block reservations on errors

**Impact:**
Quota reservations now accurately reflect actual storage consumption at the block level rather than estimated file sizes, with each CID maintaining its own reservation for precise download tracking and quota management.
<!-- kody-pr-summary:end -->