### PR TITLE
refactor(quota): implement per-block upload and storage reservations

### DIFF
--- a/core/upload.go
+++ b/core/upload.go
@@ -5,8 +5,8 @@ import (
 	"io"
 
 	"github.com/ipfs/go-cid"
-	quotaCore "go.lumeweb.com/portal-plugin-quota/core"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/db"
+	"go.lumeweb.com/portal-plugin-ipfs/internal/quota"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/upload"
 	"go.lumeweb.com/portal/core"
 )
@@ -28,8 +28,8 @@ type UploadService interface {
 	// ProcessUpload processes a list of CIDs and creates upload and core pin records for a user.
 	// It creates upload records and core pin records for ALL provided CIDs (both roots and children),
 	// but does NOT create any IPFS pin records.
-	// The reservations parameter maps CIDs to quota reservation objects for upload quota tracking.
-	ProcessUpload(ctx context.Context, cids []cid.Cid, userId uint, reservations map[cid.Cid]*quotaCore.QuotaCheckResult) error
+	// The reservations parameter maps CIDs to BlockReservations containing both upload and storage quota reservations.
+	ProcessUpload(ctx context.Context, cids []cid.Cid, userId uint, reservations map[cid.Cid]*quota.BlockReservations) error
 
 	// CreateRootPin creates an IPFS pin record for a single root CID.
 	// This method should only be called for actual root CIDs, not child blocks.

--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	go.lumeweb.com/portal-middleware v0.3.7
 	go.lumeweb.com/portal-plugin-core v0.0.0-20260109024150-b4ac33cb7c47
 	go.lumeweb.com/portal-plugin-dashboard v0.2.7-0.20260312042836-d9dfa043a80d
-	go.lumeweb.com/portal-plugin-quota v0.0.0-20260405055034-2e92441f8890
+	go.lumeweb.com/portal-plugin-quota v0.0.0-20260406132551-2b829d0f2377
 	go.lumeweb.com/portal-router v0.6.13
 	go.lumeweb.com/queryutil v0.3.16
 	go.lumeweb.com/web/go/portal-plugin-ipfs v0.0.0-20260123053442-479cd558a2fc

--- a/go.sum
+++ b/go.sum
@@ -1571,6 +1571,8 @@ go.lumeweb.com/portal-plugin-quota v0.0.0-20260402230122-0dce0a23b87c h1:fko+T6w
 go.lumeweb.com/portal-plugin-quota v0.0.0-20260402230122-0dce0a23b87c/go.mod h1:E57OLoVg6WvI88my4qetJPtyPWKw8bZ3Zes2K2N/uc8=
 go.lumeweb.com/portal-plugin-quota v0.0.0-20260405055034-2e92441f8890 h1:/x8qboJnfRuVJPDFZ/25vwHLnrRBwlp8fdirS8gSe04=
 go.lumeweb.com/portal-plugin-quota v0.0.0-20260405055034-2e92441f8890/go.mod h1:E57OLoVg6WvI88my4qetJPtyPWKw8bZ3Zes2K2N/uc8=
+go.lumeweb.com/portal-plugin-quota v0.0.0-20260406132551-2b829d0f2377 h1:5iENnHOQASL7d9YaGAhzXfY2jfaftD4tzAeVKvl07is=
+go.lumeweb.com/portal-plugin-quota v0.0.0-20260406132551-2b829d0f2377/go.mod h1:xLdwzzGFihkElXf+q962g7CxYnjMY6ONwJSQTXk+kYA=
 go.lumeweb.com/portal-router v0.6.11 h1:0PTej57mtNcRpKZNukD0j0ZYp5ntbR7fl5g6DO+0mvk=
 go.lumeweb.com/portal-router v0.6.11/go.mod h1:4tb+XYa0GYiFVraMoossGgMBTN9z4U54v8SL+EOBvbs=
 go.lumeweb.com/portal-router v0.6.13 h1:WqBNN4naPuERAwLqjCwxpAhpvzBxom8w8KqdP+EoTvw=

--- a/internal/protocol/op_post_upload.go
+++ b/internal/protocol/op_post_upload.go
@@ -15,7 +15,6 @@ import (
 	pc "go.lumeweb.com/portal-plugin-ipfs/internal/protocol/context"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/quota"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/upload"
-	quotaCore "go.lumeweb.com/portal-plugin-quota/core"
 	"go.lumeweb.com/portal/core"
 	"go.lumeweb.com/portal/db/models"
 	"go.uber.org/zap"
@@ -152,7 +151,7 @@ func (h *PostUploadOperationHandler) Execute(ctx context.Context, req *models.Re
 
 	// Create per-block reservations for each block
 	proto := h.Protocol().(ProtoNode)
-	reservations, perBlockReservations, err := CreatePerBlockReservations(ctx, h.Context(), proto, allCids, userID)
+	reservations, err := CreatePerBlockReservations(ctx, h.Context(), proto, allCids, userID)
 	if err != nil {
 		return err
 	}
@@ -160,7 +159,7 @@ func (h *PostUploadOperationHandler) Execute(ctx context.Context, req *models.Re
 	err = h.processCIDs(ctx, allCids, userID, req.SourceIP, reservations)
 	if err != nil {
 		// Release all per-block reservations on error
-		ReleasePerBlockReservations(perBlockReservations)
+		quota.ReleaseBlockReservationsMap(reservations)
 		return err
 	}
 
@@ -179,7 +178,7 @@ func (h *PostUploadOperationHandler) Execute(ctx context.Context, req *models.Re
 	ipfsPin, err := h.createRootPin(ctx, rootCids[0], userID)
 	if err != nil {
 		// Release all per-block reservations on error
-		ReleasePerBlockReservations(perBlockReservations)
+		quota.ReleaseBlockReservationsMap(reservations)
 		return err
 	}
 
@@ -203,7 +202,7 @@ func (h *PostUploadOperationHandler) Execute(ctx context.Context, req *models.Re
 	err = h.updateWorkflow(ctx, req.ID, rootCids, ipfsPin)
 	if err != nil {
 		// Release all per-block reservations on error
-		ReleasePerBlockReservations(perBlockReservations)
+		quota.ReleaseBlockReservationsMap(reservations)
 		return err
 	}
 
@@ -320,7 +319,7 @@ func (h *PostUploadOperationHandler) createFileProcessor(uploadFile io.ReadClose
 }
 
 // processCIDs processes all CIDs and creates upload records
-func (h *PostUploadOperationHandler) processCIDs(ctx context.Context, allCids []cid.Cid, userID uint, sourceIP string, reservations map[cid.Cid]*quotaCore.QuotaCheckResult) error {
+func (h *PostUploadOperationHandler) processCIDs(ctx context.Context, allCids []cid.Cid, userID uint, sourceIP string, reservations map[cid.Cid]*quota.BlockReservations) error {
 	ctx, span := core.TraceMethod(ctx, "PostUploadOperationHandler.processCIDs")
 	defer span.End()
 

--- a/internal/protocol/op_retrieve.go
+++ b/internal/protocol/op_retrieve.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/ipfs/boxo/ipld/merkledag"
-	blocks "github.com/ipfs/go-block-format"
 	"github.com/ipfs/go-cid"
 	"github.com/labstack/gommon/log"
 	"github.com/samber/lo"
@@ -19,6 +18,7 @@ import (
 	"go.lumeweb.com/portal-plugin-ipfs/internal/quota"
 	"go.lumeweb.com/portal/core"
 	"go.lumeweb.com/portal/db/models"
+	quotaCore "go.lumeweb.com/portal-plugin-quota/core"
 	"go.uber.org/zap"
 )
 
@@ -55,56 +55,30 @@ func (h *RetrieveOperationHandler) Execute(ctx context.Context, req *models.Requ
 		return fmt.Errorf("failed to create CID: %w", err)
 	}
 
-	// Get block for quota validation and reuse for downstream processing
-	var block blocks.Block
-	var blockSize uint64
-
 	protoCfg := h.Context().Config().GetProtocol(internal.ProtocolName).(*pluginConfig.ProtocolConfig)
-	getCtx, cancel := context.WithTimeout(ctx, protoCfg.BlockStore.Timeout)
-	defer cancel()
-
-	// Skip quota check for internal retrieve operations
-	getCtx = pc.SkipQuotaCheckOption(getCtx, true)
-
 	proto := h.Protocol().(*Protocol)
-	block, err = proto.GetNode().GetBlock(getCtx, c)
-	if err != nil {
-		return fmt.Errorf("failed to get block: %w", err)
-	}
-
-	blockSize = uint64(len(block.RawData()))
 
 	// Store quota check results for reservation management
 	checkResults := &quota.QuotaCheckResults{}
 
-	// Check download quota if user ID is available
-	if req.UserID != nil && *req.UserID > 0 {
-		// Check download quota with reservation
-		checkResult, err := quota.CheckWithReservation(ctx, h.Context(), "download", *req.UserID, blockSize, quota.CheckDownloadQuota)
-		if err != nil {
-			return err
-		}
-		checkResults.Download = checkResult
-	}
-
-	cids, err := collectDAGCids(h.Context(), proto, c)
+	// Collect DAG CIDs and sizes BEFORE any non-virtual fetching
+	// This ensures we have all metadata before downloading content
+	dagResult, err := collectDAGCids(h.Context(), proto, c)
 	if err != nil {
-		return fmt.Errorf("failed to collect cids: %w", err)
+		return fmt.Errorf("failed to collect DAG CIDs: %w", err)
 	}
 
-	// Set progress - collecting DAG CIDs
-	if err := tracker.SetProgress(30); err != nil {
-		h.Logger().Warn("Failed to update progress", zap.Error(err))
-	}
+	h.setProgressOrWarn(tracker, 30)
 
-	childCids := lo.Filter(cids, func(item cid.Cid, _ int) bool {
+	// Filter out the root CID to get only child CIDs
+	childCids := lo.Filter(dagResult.Cids, func(item cid.Cid, _ int) bool {
 		return !item.Equals(c)
 	})
 
 	// Fix any UnixFS metadata gaps before proceeding with child block processing
-	_store := proto.GetMetadataStore()
-	if _store != nil {
-		err = _store.ProcessMissingUnixFSNames(ctx, cids)
+	metadataStore := proto.GetMetadataStore()
+	if metadataStore != nil {
+		err = metadataStore.ProcessMissingUnixFSNames(ctx, dagResult.Cids)
 		if err != nil {
 			h.Logger().Warn("Failed to process missing UnixFS names", zap.Error(err))
 		}
@@ -121,96 +95,94 @@ func (h *RetrieveOperationHandler) Execute(ctx context.Context, req *models.Requ
 		return err
 	}
 
-	// Set progress - updating workflow data
-	if err := tracker.SetProgress(50); err != nil {
-		h.Logger().Warn("Failed to update progress", zap.Error(err))
+	h.setProgressOrWarn(tracker, 50)
+
+	// Check download quota for the root block size
+	// Now we can make a non-virtual fetch for the root block
+	if req.UserID != nil && *req.UserID > 0 {
+		checkResult, err := quota.CheckWithReservation(ctx, h.Context(), "download", *req.UserID, dagResult.CIDSizes[c], quota.CheckDownloadQuota)
+		if err != nil {
+			return err
+		}
+		checkResults.Download = checkResult
 	}
 
 	if len(childCids) > 0 {
-		// Set progress - processing child blocks
-		if err := tracker.SetProgress(70); err != nil {
-			h.Logger().Warn("Failed to update progress", zap.Error(err))
+		h.setProgressOrWarn(tracker, 70)
+
+		// Validate user ID before processing
+		if err := h.validateUserID(req.UserID, checkResults.Download); err != nil {
+			return err
+		}
+
+		// Calculate total child size using DAG result (faster than loop)
+		childTotalSize := dagResult.TotalSize - dagResult.CIDSizes[c]
+
+		// Quick non-reservation quota check for the cumulative size
+		// This provides an early failure if the user doesn't have enough quota
+		if childTotalSize > 0 {
+			err = quota.ValidateUploadQuota(ctx, h.Context(), *req.UserID, childTotalSize)
+			if err != nil {
+				cleanupDownloadReservation(checkResults.Download)
+				return err
+			}
+		}
+
+		// Create per-block reservations for upload and storage quota using cached sizes
+		// This ensures each block has its own reservation for accurate tracking
+		// Build efficient lookup set and filter sizes in O(n+m) time
+		childCidSet := lo.SliceToMap(childCids, func(c cid.Cid) (cid.Cid, struct{}) {
+			return c, struct{}{}
+		})
+		childSizes := lo.PickBy(dagResult.CIDSizes, func(c cid.Cid, size uint64) bool {
+			return size > 0 && lo.HasKey(childCidSet, c)
+		})
+
+		reservations, err := CreatePerBlockReservationsWithSizes(ctx, h.Context(), *req.UserID, childSizes)
+		if err != nil {
+			return err
 		}
 
 		uploadSvc := core.GetService[pluginCore.UploadService](h.Context(), pluginCore.UPLOAD_SERVICE)
 		if uploadSvc == nil {
 			h.Logger().Error("Upload service not available")
+			quota.ReleaseBlockReservationsMap(reservations)
+			cleanupReservations(checkResults.Download)
 			return fmt.Errorf("upload service not available")
 		}
 
-		// Prepare all child blocks and metadata first
+		// Set client IP in context for quota tracking
+		ctx = pc.ClientIPOption(ctx, req.SourceIP)
+
+		// Fetch and prepare all child blocks and metadata before processing
 		var validChildCids []cid.Cid
+		getCtx, cancel := context.WithTimeout(ctx, protoCfg.BlockStore.Timeout)
+
+		// Skip quota check for internal retrieve operations
+		getCtx = pc.SkipQuotaCheckOption(getCtx, true)
+
 		for _, childCid := range childCids {
-			// Skip quota check for internal retrieve operations
-			childGetCtx := pc.SkipQuotaCheckOption(getCtx, true)
-			block, err := proto.GetNode().GetBlock(childGetCtx, childCid)
-			if err != nil {
-				h.Logger().Error("Failed to fetch child block", zap.Stringer("cid", childCid), zap.Error(err))
+			if _, ok := reservations[childCid]; !ok {
+				// Skip CIDs without reservations
 				continue
 			}
 
-			// Update UnixFS metadata
-			if _store != nil {
-				pinnedBlock := pluginCore.PinnedBlock{
-					Cid:  childCid,
-					Node: block,
-					Size: uint64(len(block.RawData())),
-				}
-				unixFSNode, err := store.ExtractNodeMetadata(h.Logger(), pinnedBlock)
-				if err == nil {
-					if err := _store.UpdateUnixFSMetadata(childCid, unixFSNode); err != nil {
-						h.Logger().Warn("Failed to update UnixFS metadata", zap.Stringer("cid", childCid), zap.Error(err))
-					}
-				}
+			if h.fetchAndPrepareChildBlock(getCtx, proto, metadataStore, childCid) {
+				validChildCids = append(validChildCids, childCid)
 			}
-
-			validChildCids = append(validChildCids, childCid)
 		}
+		cancel()
 
-		// Batch process all valid child CIDs
-		if len(validChildCids) > 0 {
-			// Validate user ID before processing
-			if req.UserID == nil || *req.UserID == 0 {
-				// Release download reservation on error
-				quota.ReleaseReservations(checkResults.Download)
-				return fmt.Errorf("user ID is required")
-			}
-
-			// Calculate total size of child blocks for quota check
-			totalSize, _ := CalculateTotalCIDSize(h.Context(), proto, validChildCids, h.Logger())
-
-			// Check upload quota with reservation for child blocks
-			if totalSize > 0 {
-				checkResult, err := quota.CheckWithReservation(ctx, h.Context(), "upload", *req.UserID, totalSize, quota.CheckUploadQuota)
-				if err != nil {
-					// Release download reservation on error
-					quota.ReleaseReservations(checkResults.Download)
-					return err
-				}
-				checkResults.Upload = checkResult
-			}
-
-			// Create reservations map for child CIDs
-			reservations := CreateReservationMap(validChildCids, checkResults.Upload)
-
-			// Set client IP in context for quota tracking
-			ctx = pc.ClientIPOption(ctx, req.SourceIP)
-
-			err = uploadSvc.ProcessUpload(ctx, validChildCids, *req.UserID, reservations)
-			if err != nil {
-				h.Logger().Error("Failed to batch process child blocks", zap.Error(err))
-
-				// Release reservations on error
-				quota.ReleaseReservations(checkResults.Download, checkResults.Upload)
-				return err
-			}
+		err = uploadSvc.ProcessUpload(ctx, validChildCids, *req.UserID, reservations)
+		if err != nil {
+			h.Logger().Error("Failed to batch process child blocks", zap.Error(err))
+			quota.ReleaseBlockReservationsMap(reservations)
+			cleanupReservations(checkResults.Download)
+			return err
 		}
 	}
 
-	// Complete
-	if err := tracker.SetProgress(100); err != nil {
-		h.Logger().Warn("Failed to update progress", zap.Error(err))
-	}
+	h.setProgressOrWarn(tracker, 100)
 
 	return nil
 }
@@ -230,12 +202,81 @@ func NewRetrieveOperation(ctx core.Context) core.Operation {
 	})
 }
 
+// setProgressOrWarn is a helper to set progress and log warnings
+func (h *RetrieveOperationHandler) setProgressOrWarn(tracker *core.ProgressTracker, progress float64) {
+	if err := tracker.SetProgress(progress); err != nil {
+		h.Logger().Warn("Failed to update progress", zap.Error(err))
+	}
+}
+
+// cleanupDownloadReservation releases download reservation if it exists
+func cleanupDownloadReservation(downloadReservation *quotaCore.QuotaCheckResult) {
+	if downloadReservation != nil {
+		downloadReservation.ReleaseReservation()
+	}
+}
+
+// cleanupReservations releases the download reservation
+func cleanupReservations(downloadReservation *quotaCore.QuotaCheckResult) {
+	cleanupDownloadReservation(downloadReservation)
+}
+
+// fetchAndPrepareChildBlock fetches a child block and updates UnixFS metadata
+// Returns true if successful, false if the block should be skipped
+func (h *RetrieveOperationHandler) fetchAndPrepareChildBlock(
+	ctx context.Context,
+	proto ProtoNode,
+	metadataStore pluginCore.MetadataStore,
+	childCid cid.Cid,
+) bool {
+	block, err := proto.GetNode().GetBlock(ctx, childCid)
+	if err != nil {
+		h.Logger().Error("Failed to fetch child block", zap.Stringer("cid", childCid), zap.Error(err))
+		return false
+	}
+
+	// Update UnixFS metadata
+	if metadataStore != nil {
+		pinnedBlock := pluginCore.PinnedBlock{
+			Cid:  childCid,
+			Node: block,
+			Size: uint64(len(block.RawData())),
+		}
+		unixFSNode, err := store.ExtractNodeMetadata(h.Logger(), pinnedBlock)
+		if err == nil {
+			if err := metadataStore.UpdateUnixFSMetadata(childCid, unixFSNode); err != nil {
+				h.Logger().Warn("Failed to update UnixFS metadata", zap.Stringer("cid", childCid), zap.Error(err))
+			}
+		}
+	}
+
+	return true
+}
+
+// validateUserID validates that a user ID is provided and releases download reservation on failure
+func (h *RetrieveOperationHandler) validateUserID(userID *uint, downloadReservation *quotaCore.QuotaCheckResult) error {
+	if userID == nil || *userID == 0 {
+		cleanupDownloadReservation(downloadReservation)
+		return fmt.Errorf("user ID is required")
+	}
+	return nil
+}
+
 func isRecoverableNodeError(err error) bool {
 	return !strings.Contains(err.Error(), "protobuf:")
 }
 
-func collectDAGCids(ctx core.Context, ipfs *Protocol, c cid.Cid) ([]cid.Cid, error) {
+// DAGCollectResult holds the results of a DAG collection operation
+type DAGCollectResult struct {
+	Cids          []cid.Cid           // All CIDs in the DAG (normalized)
+	TotalSize     uint64              // Total size of all blocks in bytes
+	CIDSizes      map[cid.Cid]uint64  // Size of each individual block
+}
 
+// collectDAGCids walks the DAG virtually to collect all CIDs and their sizes
+// This function performs a virtual read (no quota checking) to gather information
+// about all blocks in the DAG without downloading content
+func collectDAGCids(ctx core.Context, ipfs *Protocol, c cid.Cid) (*DAGCollectResult, error) {
 	getCtx := pc.VirtualReadOption(ctx, true)
 	// Skip quota check for internal retrieve operations
 	getCtx = pc.SkipQuotaCheckOption(getCtx, true)
@@ -244,17 +285,26 @@ func collectDAGCids(ctx core.Context, ipfs *Protocol, c cid.Cid) ([]cid.Cid, err
 	sess := merkledag.NewSession(getCtx, ipfs.GetNode().DagService())
 	seen := make(map[string]bool)
 	var cids []cid.Cid
+	cidSizes := make(map[cid.Cid]uint64)
+	var totalSize uint64
+
 	err := merkledag.Walk(getCtx, merkledag.GetLinksWithDAG(sess), c, func(c cid.Cid) bool {
 		c = encoding.NormalizeCid(c)
 		key := c.String()
 		if seen[key] {
 			return false
 		}
-		_, err := sess.Get(getCtx, c)
+		node, err := sess.Get(getCtx, c)
 		if err != nil {
 			log.Error("failed to get node", zap.Error(err))
 			return false
 		}
+		
+		// Get block size from the node
+		blockSize := uint64(len(node.RawData()))
+		cidSizes[c] = blockSize
+		totalSize += blockSize
+		
 		if !seen[key] {
 			cids = append(cids, c)
 		}
@@ -264,5 +314,9 @@ func collectDAGCids(ctx core.Context, ipfs *Protocol, c cid.Cid) ([]cid.Cid, err
 
 	cancel()
 
-	return cids, err
+	return &DAGCollectResult{
+		Cids:      cids,
+		TotalSize: totalSize,
+		CIDSizes:  cidSizes,
+	}, err
 }

--- a/internal/protocol/protocol.go
+++ b/internal/protocol/protocol.go
@@ -295,7 +295,7 @@ func NewProtocolOperations(p core.Protocol) []core.Operation {
 
 			// Create per-block reservations for each block
 			protoNode := p.(ProtoNode)
-			reservations, perBlockReservations, err := CreatePerBlockReservations(ctx, helper.Context(), protoNode, allCids, *request.UserID)
+			reservations, err := CreatePerBlockReservations(ctx, helper.Context(), protoNode, allCids, *request.UserID)
 			if err != nil {
 				return err
 			}
@@ -306,7 +306,7 @@ func NewProtocolOperations(p core.Protocol) []core.Operation {
 				helper.Logger().Error("Upload service not available")
 
 				// Release all per-block reservations on error
-				ReleasePerBlockReservations(perBlockReservations)
+				quota.ReleaseBlockReservationsMap(reservations)
 				return fmt.Errorf("upload service not available")
 			}
 
@@ -316,7 +316,7 @@ func NewProtocolOperations(p core.Protocol) []core.Operation {
 			err = uploadSvc.ProcessUpload(ctx, allCids, *request.UserID, reservations)
 			if err != nil {
 				// Release all per-block reservations on error
-				ReleasePerBlockReservations(perBlockReservations)
+				quota.ReleaseBlockReservationsMap(reservations)
 				return fmt.Errorf("failed to process upload: %w", err)
 			}
 

--- a/internal/protocol/quota_helpers.go
+++ b/internal/protocol/quota_helpers.go
@@ -56,17 +56,14 @@ func ReleasePerBlockReservations(reservations []*quotaCore.QuotaCheckResult) {
 
 // CreatePerBlockReservations creates individual quota reservations for each block
 // This ensures each CID maps to its own reservation for accurate download tracking.
-// Returns the reservations map (CID -> upload reservation) and the slice of all reservations for cleanup.
-func CreatePerBlockReservations(ctx context.Context, coreCtx core.Context, proto ProtoNode, cids []cid.Cid, userID uint) (map[cid.Cid]*quotaCore.QuotaCheckResult, []*quotaCore.QuotaCheckResult, error) {
+// Returns a map of BlockReservations containing both upload and storage reservations for each CID.
+// This version queries the blockstore for CID sizes.
+func CreatePerBlockReservations(ctx context.Context, coreCtx core.Context, proto ProtoNode, cids []cid.Cid, userID uint) (map[cid.Cid]*quota.BlockReservations, error) {
 	blockstore := proto.GetNode().GetBlockstore()
 
-	// Track per-block reservations for cleanup on error
-	var perBlockReservations []*quotaCore.QuotaCheckResult
-
-	// Create per-block reservations
-	reservations := make(map[cid.Cid]*quotaCore.QuotaCheckResult)
+	// Build size map from blockstore
+	sizes := make(map[cid.Cid]uint64, len(cids))
 	for _, c := range cids {
-		// Get block size
 		size, err := blockstore.GetSize(ctx, c)
 		if err != nil {
 			coreCtx.Logger().Warn("Failed to get block size for reservation, skipping",
@@ -74,34 +71,50 @@ func CreatePerBlockReservations(ctx context.Context, coreCtx core.Context, proto
 				zap.Error(err))
 			continue
 		}
+		if size > 0 {
+			sizes[c] = uint64(size)
+		}
+	}
 
-		if size <= 0 {
+	return CreatePerBlockReservationsWithSizes(ctx, coreCtx, userID, sizes)
+}
+
+// CreatePerBlockReservationsWithSizes creates individual quota reservations for each block
+// This ensures each CID maps to its own reservation for accurate download tracking.
+// Returns a map of BlockReservations containing both upload and storage reservations for each CID.
+// Use this version when CID sizes are already known to avoid unnecessary blockstore queries.
+func CreatePerBlockReservationsWithSizes(ctx context.Context, coreCtx core.Context, userID uint, sizes map[cid.Cid]uint64) (map[cid.Cid]*quota.BlockReservations, error) {
+	// Create per-block reservations
+	reservations := make(map[cid.Cid]*quota.BlockReservations, len(sizes))
+	for c, blockSize := range sizes {
+		if blockSize == 0 {
 			continue
 		}
-
-		blockSize := uint64(size)
 
 		// Create upload quota reservation for this specific block
 		uploadReservation, err := quota.CheckWithReservation(ctx, coreCtx, "upload", userID, blockSize, quota.CheckUploadQuota)
 		if err != nil {
 			// Release all previously created reservations
-			ReleasePerBlockReservations(perBlockReservations)
-			return nil, nil, fmt.Errorf("failed to create upload reservation for block %s: %w", c.String(), err)
+			quota.ReleaseBlockReservationsMap(reservations)
+			return nil, fmt.Errorf("failed to create upload reservation for block %s: %w", c.String(), err)
 		}
-		perBlockReservations = append(perBlockReservations, uploadReservation)
 
 		// Create storage quota reservation for this specific block
 		storageReservation, err := quota.CheckWithReservation(ctx, coreCtx, "storage", userID, blockSize, quota.CheckStorageQuota)
 		if err != nil {
-			// Release all previously created reservations (including upload)
-			ReleasePerBlockReservations(perBlockReservations)
-			return nil, nil, fmt.Errorf("failed to create storage reservation for block %s: %w", c.String(), err)
+			// Release upload reservation before returning error
+			uploadReservation.ReleaseReservation()
+			// Release all previously created reservations
+			quota.ReleaseBlockReservationsMap(reservations)
+			return nil, fmt.Errorf("failed to create storage reservation for block %s: %w", c.String(), err)
 		}
-		perBlockReservations = append(perBlockReservations, storageReservation)
 
-		// Map this CID to its upload reservation for download tracking
-		reservations[c] = uploadReservation
+		// Map this CID to both upload and storage reservations
+		reservations[c] = &quota.BlockReservations{
+			UploadReservation:  uploadReservation,
+			StorageReservation: storageReservation,
+		}
 	}
 
-	return reservations, perBlockReservations, nil
+	return reservations, nil
 }

--- a/internal/quota/quota.go
+++ b/internal/quota/quota.go
@@ -4,12 +4,38 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/ipfs/go-cid"
 	quotaCore "go.lumeweb.com/portal-plugin-quota/core"
 	"go.lumeweb.com/portal/core"
 	"go.lumeweb.com/portal/db/models"
 	"go.lumeweb.com/portal/event"
 	"go.uber.org/zap"
 )
+
+// BlockReservations holds both upload and storage reservations for a block
+type BlockReservations struct {
+	UploadReservation  *quotaCore.QuotaCheckResult
+	StorageReservation *quotaCore.QuotaCheckResult
+}
+
+// ReleaseAll releases both upload and storage reservations
+func (br *BlockReservations) ReleaseAll() {
+	if br.UploadReservation != nil {
+		br.UploadReservation.ReleaseReservation()
+	}
+	if br.StorageReservation != nil {
+		br.StorageReservation.ReleaseReservation()
+	}
+}
+
+// ReleaseBlockReservationsMap releases all reservations in a BlockReservations map
+func ReleaseBlockReservationsMap(reservations map[cid.Cid]*BlockReservations) {
+	for _, blockRes := range reservations {
+		if blockRes != nil {
+			blockRes.ReleaseAll()
+		}
+	}
+}
 
 // WithQuotaService executes a function with quota service if available
 func WithQuotaService(cctx context.Context, ctx core.Context, fn func(quotaCore.QuotaService, context.Context) error) error {
@@ -77,8 +103,8 @@ func EmitDownloadCompleted(cctx context.Context, ctx core.Context, userID *uint,
 }
 
 // EmitStorageObjectPinned emits a storage object pinned event for quota tracking
-func EmitStorageObjectPinned(cctx context.Context, ctx core.Context, pin *models.Pin, ip string) {
-	core.Fire(ctx, event.EVENT_STORAGE_OBJECT_PINNED, event.NewStorageObjectPinnedEvent(cctx, pin, ip))
+func EmitStorageObjectPinned(cctx context.Context, ctx core.Context, pin *models.Pin, ip string, reservationID *string) {
+	core.Fire(ctx, event.EVENT_STORAGE_OBJECT_PINNED, event.NewStorageObjectPinnedEvent(cctx, pin, ip, reservationID))
 }
 
 // EmitStorageObjectUnpinned emits a storage object unpinned event for quota tracking

--- a/internal/service/upload/upload.go
+++ b/internal/service/upload/upload.go
@@ -14,7 +14,6 @@ import (
 	"go.lumeweb.com/portal-plugin-ipfs/internal/protocol"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/quota"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/upload"
-	quotaCore "go.lumeweb.com/portal-plugin-quota/core"
 	"go.lumeweb.com/portal/core"
 	"go.lumeweb.com/portal/db/models"
 	"go.uber.org/zap"
@@ -122,7 +121,7 @@ func (s *UploadServiceDefault) HandleUploadWithMode(ctx context.Context, reader 
 	return result.CID, result.UploadID, err
 }
 
-func (s *UploadServiceDefault) ProcessUpload(ctx context.Context, cids []cid.Cid, userId uint, reservations map[cid.Cid]*quotaCore.QuotaCheckResult) error {
+func (s *UploadServiceDefault) ProcessUpload(ctx context.Context, cids []cid.Cid, userId uint, reservations map[cid.Cid]*quota.BlockReservations) error {
 	ctx, span := core.TraceMethod(ctx, "UploadServiceDefault.ProcessUpload")
 	defer span.End()
 
@@ -177,20 +176,29 @@ func (s *UploadServiceDefault) ProcessUpload(ctx context.Context, cids []cid.Cid
 					return fmt.Errorf("failed to create pin record for CID %s: %w", c.String(), err)
 				}
 
+				// Get reservation IDs for this CID
+				var uploadResID *string
+				var storageResID *string
+				if reservations != nil {
+					if blockRes, exists := reservations[c]; exists && blockRes != nil {
+						// Extract upload reservation ID
+						if blockRes.UploadReservation != nil && blockRes.UploadReservation.Reservation != nil {
+							uploadUUID := blockRes.UploadReservation.Reservation.UUID()
+							uploadResID = &uploadUUID
+						}
+						// Extract storage reservation ID
+						if blockRes.StorageReservation != nil && blockRes.StorageReservation.Reservation != nil {
+							storageUUID := blockRes.StorageReservation.Reservation.UUID()
+							storageResID = &storageUUID
+						}
+					}
+				}
+
 				// Emit storage object pinned event for quota tracking
 				if clientIP == "" {
 					s.Context().Logger().Warn("Client IP not set in context for quota tracking", zap.String("cid", c.String()))
 				}
-				quota.EmitStorageObjectPinned(core.DetachContext(ctx), s.Context(), createdPin, clientIP)
-
-				// Get reservation ID for this CID
-				var uploadResID *string
-				if reservations != nil {
-					if checkResult, exists := reservations[c]; exists && checkResult != nil && checkResult.Reservation != nil {
-						uuid := checkResult.Reservation.UUID()
-						uploadResID = &uuid
-					}
-				}
+				quota.EmitStorageObjectPinned(core.DetachContext(ctx), s.Context(), createdPin, clientIP, storageResID)
 
 				// Emit upload completion event for quota tracking
 				quota.EmitUploadCompleted(core.DetachContext(ctx), s.Context(), &userId, uploadMeta.ID, size, clientIP, uploadResID, true)

--- a/internal/testing/mocks/MockUploadService.go
+++ b/internal/testing/mocks/MockUploadService.go
@@ -11,8 +11,8 @@ import (
 	"github.com/ipfs/go-cid"
 	mock "github.com/stretchr/testify/mock"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/db"
+	"go.lumeweb.com/portal-plugin-ipfs/internal/quota"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/upload"
-	core0 "go.lumeweb.com/portal-plugin-quota/core"
 	"go.lumeweb.com/portal/config"
 	"go.lumeweb.com/portal/core"
 	"gorm.io/gorm"
@@ -510,7 +510,7 @@ func (_c *MockUploadService_Logger_Call) RunAndReturn(run func() *core.Logger) *
 }
 
 // ProcessUpload provides a mock function for the type MockUploadService
-func (_mock *MockUploadService) ProcessUpload(ctx context.Context, cids []cid.Cid, userId uint, reservations map[cid.Cid]*core0.QuotaCheckResult) error {
+func (_mock *MockUploadService) ProcessUpload(ctx context.Context, cids []cid.Cid, userId uint, reservations map[cid.Cid]*quota.BlockReservations) error {
 	ret := _mock.Called(ctx, cids, userId, reservations)
 
 	if len(ret) == 0 {
@@ -518,7 +518,7 @@ func (_mock *MockUploadService) ProcessUpload(ctx context.Context, cids []cid.Ci
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, []cid.Cid, uint, map[cid.Cid]*core0.QuotaCheckResult) error); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []cid.Cid, uint, map[cid.Cid]*quota.BlockReservations) error); ok {
 		r0 = returnFunc(ctx, cids, userId, reservations)
 	} else {
 		r0 = ret.Error(0)
@@ -535,12 +535,12 @@ type MockUploadService_ProcessUpload_Call struct {
 //   - ctx context.Context
 //   - cids []cid.Cid
 //   - userId uint
-//   - reservations map[cid.Cid]*core0.QuotaCheckResult
+//   - reservations map[cid.Cid]*quota.BlockReservations
 func (_e *MockUploadService_Expecter) ProcessUpload(ctx interface{}, cids interface{}, userId interface{}, reservations interface{}) *MockUploadService_ProcessUpload_Call {
 	return &MockUploadService_ProcessUpload_Call{Call: _e.mock.On("ProcessUpload", ctx, cids, userId, reservations)}
 }
 
-func (_c *MockUploadService_ProcessUpload_Call) Run(run func(ctx context.Context, cids []cid.Cid, userId uint, reservations map[cid.Cid]*core0.QuotaCheckResult)) *MockUploadService_ProcessUpload_Call {
+func (_c *MockUploadService_ProcessUpload_Call) Run(run func(ctx context.Context, cids []cid.Cid, userId uint, reservations map[cid.Cid]*quota.BlockReservations)) *MockUploadService_ProcessUpload_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -554,9 +554,9 @@ func (_c *MockUploadService_ProcessUpload_Call) Run(run func(ctx context.Context
 		if args[2] != nil {
 			arg2 = args[2].(uint)
 		}
-		var arg3 map[cid.Cid]*core0.QuotaCheckResult
+		var arg3 map[cid.Cid]*quota.BlockReservations
 		if args[3] != nil {
-			arg3 = args[3].(map[cid.Cid]*core0.QuotaCheckResult)
+			arg3 = args[3].(map[cid.Cid]*quota.BlockReservations)
 		}
 		run(
 			arg0,
@@ -573,7 +573,7 @@ func (_c *MockUploadService_ProcessUpload_Call) Return(err error) *MockUploadSer
 	return _c
 }
 
-func (_c *MockUploadService_ProcessUpload_Call) RunAndReturn(run func(ctx context.Context, cids []cid.Cid, userId uint, reservations map[cid.Cid]*core0.QuotaCheckResult) error) *MockUploadService_ProcessUpload_Call {
+func (_c *MockUploadService_ProcessUpload_Call) RunAndReturn(run func(ctx context.Context, cids []cid.Cid, userId uint, reservations map[cid.Cid]*quota.BlockReservations) error) *MockUploadService_ProcessUpload_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
- Add BlockReservations type to track both upload and storage quotas per block
- Update CreatePerBlockReservations to return BlockReservations
- Optimize retrieve operation by collecting DAG metadata virtually first
- Use cached sizes to eliminate redundant blockstore queries
- Improve error handling with proper reservation cleanup
- Update quota helpers to support new reservation structure
- Emit storage events with storage reservation IDs

* `develop` <!-- branch-stack -->
  - **refactor(quota): implement per-block upload and storage reservations** :point\_left:

***

<!-- kody-pr-summary:start -->

This PR refactors the quota reservation system to implement per-block tracking for both **upload and storage quotas**. Previously, the system only maintained upload quota reservations per block; now each block maintains separate reservations for both quota types through a new `BlockReservations` structure.

**Key Changes:**

- **Dual Reservation Tracking**: Introduced `BlockReservations` struct to encapsulate both upload and storage quota reservations for individual IPFS blocks, ensuring accurate accounting for both data transfer and storage consumption.

- **Enhanced Retrieval Workflow**: Refactored the retrieval operation to collect DAG metadata (CIDs and block sizes) via virtual reads before performing actual block fetches. This enables upfront quota validation and per-block reservation creation using cached sizes.

- **Improved Resource Management**: Replaced separate reservation slices with a unified map-based approach and added `ReleaseBlockReservationsMap` for consistent cleanup of both reservation types on errors.

- **Storage Quota Integration**: Updated storage object pinning events to include storage reservation IDs, enabling the quota system to properly track and reconcile storage allocations per block.

- **API Updates**: Modified `ProcessUpload` and reservation helper functions to work with the new `BlockReservations` type, supporting both upload and storage quota checks throughout the upload and pin creation workflows.

<!-- kody-pr-summary:end -->
