### PR TITLE
fix: properly wrap quota errors with core error types in CheckWithReservation

### DIFF
--- a/internal/protocol/op_retrieve.go
+++ b/internal/protocol/op_retrieve.go
@@ -100,7 +100,7 @@ func (h *RetrieveOperationHandler) Execute(ctx context.Context, req *models.Requ
 	// Check download quota for the root block size
 	// Now we can make a non-virtual fetch for the root block
 	if req.UserID != nil && *req.UserID > 0 {
-		checkResult, err := quota.CheckWithReservation(ctx, h.Context(), "download", *req.UserID, dagResult.CIDSizes[c], quota.CheckDownloadQuota)
+		checkResult, err := quota.CheckWithReservation(ctx, h.Context(), quota.CheckTypeDownload, *req.UserID, dagResult.CIDSizes[c], quota.CheckDownloadQuota)
 		if err != nil {
 			return err
 		}

--- a/internal/protocol/quota_helpers.go
+++ b/internal/protocol/quota_helpers.go
@@ -92,7 +92,7 @@ func CreatePerBlockReservationsWithSizes(ctx context.Context, coreCtx core.Conte
 		}
 
 		// Create upload quota reservation for this specific block
-		uploadReservation, err := quota.CheckWithReservation(ctx, coreCtx, "upload", userID, blockSize, quota.CheckUploadQuota)
+		uploadReservation, err := quota.CheckWithReservation(ctx, coreCtx, quota.CheckTypeUpload, userID, blockSize, quota.CheckUploadQuota)
 		if err != nil {
 			// Release all previously created reservations
 			quota.ReleaseBlockReservationsMap(reservations)
@@ -100,7 +100,7 @@ func CreatePerBlockReservationsWithSizes(ctx context.Context, coreCtx core.Conte
 		}
 
 		// Create storage quota reservation for this specific block
-		storageReservation, err := quota.CheckWithReservation(ctx, coreCtx, "storage", userID, blockSize, quota.CheckStorageQuota)
+		storageReservation, err := quota.CheckWithReservation(ctx, coreCtx, quota.CheckTypeStorage, userID, blockSize, quota.CheckStorageQuota)
 		if err != nil {
 			// Release upload reservation before returning error
 			uploadReservation.ReleaseReservation()

--- a/internal/quota/quota.go
+++ b/internal/quota/quota.go
@@ -12,6 +12,20 @@ import (
 	"go.uber.org/zap"
 )
 
+const (
+	CheckTypeUpload   = "upload"
+	CheckTypeStorage  = "storage"
+	CheckTypeDownload = "download"
+)
+
+const (
+	checkFailedTemplate         = "%s usage check failed: %w"
+	uploadUsageErrTemplate      = "%w (current: %d bytes, requested: %d bytes, maximum: %d bytes)"
+	storageUsageErrTemplate     = "%w (current: %d bytes, requested: %d bytes, maximum: %d bytes)"
+	downloadUsageErrTemplate    = "%w (current: %d bytes, requested: %d bytes, maximum: %d bytes)"
+	defaultUsageErrTemplate     = "%s usage over capacity: current %d bytes + requested %d bytes would exceed threshold of %d bytes"
+)
+
 // BlockReservations holds both upload and storage reservations for a block
 type BlockReservations struct {
 	UploadReservation  *quotaCore.QuotaCheckResult
@@ -223,30 +237,30 @@ func CheckWithReservation(cctx context.Context, ctx core.Context, checkType stri
 	checkResult, err := checkFunc(cctx, ctx, userID, requestedBytes, quotaCore.WithCreateReservation())
 	if err != nil {
 		ctx.Logger().Warn("Failed to check quota", zap.String("check_type", checkType), zap.Uint("user_id", userID), zap.Uint64("requested_bytes", requestedBytes), zap.Error(err))
-		return nil, fmt.Errorf("%s quota check failed: %w", checkType, err)
+		return nil, fmt.Errorf(checkFailedTemplate, checkType, err)
 	}
 	if checkResult != nil && !checkResult.Allowed {
 		currentUsage := checkResult.Details.CurrentUsage
-		quotaLimit := uint64(0)
+		usageLimit := uint64(0)
 		if checkResult.Details.Limit != nil {
-			quotaLimit = *checkResult.Details.Limit
+			usageLimit = *checkResult.Details.Limit
 		}
 		
-		var quotaErr error
+		var usageErr error
 		switch checkType {
-		case "upload":
-			quotaErr = fmt.Errorf("%w (current: %d bytes, requested: %d bytes, limit: %d bytes)", core.ErrUploadQuotaExceeded, currentUsage, requestedBytes, quotaLimit)
-		case "storage":
-			quotaErr = fmt.Errorf("%w (current: %d bytes, requested: %d bytes, limit: %d bytes)", core.ErrStorageQuotaExceeded, currentUsage, requestedBytes, quotaLimit)
-		case "download":
-			quotaErr = fmt.Errorf("%w (current: %d bytes, requested: %d bytes, limit: %d bytes)", core.ErrDownloadQuotaExceeded, currentUsage, requestedBytes, quotaLimit)
+		case CheckTypeUpload:
+			usageErr = fmt.Errorf(uploadUsageErrTemplate, core.ErrUploadQuotaExceeded, currentUsage, requestedBytes, usageLimit)
+		case CheckTypeStorage:
+			usageErr = fmt.Errorf(storageUsageErrTemplate, core.ErrStorageQuotaExceeded, currentUsage, requestedBytes, usageLimit)
+		case CheckTypeDownload:
+			usageErr = fmt.Errorf(downloadUsageErrTemplate, core.ErrDownloadQuotaExceeded, currentUsage, requestedBytes, usageLimit)
 		default:
-			quotaErr = fmt.Errorf("%s quota exceeded: current usage %d bytes + requested %d bytes would exceed quota limit of %d bytes", checkType, currentUsage, requestedBytes, quotaLimit)
+			usageErr = fmt.Errorf(defaultUsageErrTemplate, checkType, currentUsage, requestedBytes, usageLimit)
 		}
 		
-		ctx.Logger().Warn("Quota exceeded", zap.String("check_type", checkType), zap.Uint("user_id", userID), zap.Uint64("requested_bytes", requestedBytes), zap.Uint64("current_usage", currentUsage), zap.Uint64("quota_limit", quotaLimit))
+		ctx.Logger().Warn("Quota exceeded", zap.String("check_type", checkType), zap.Uint("user_id", userID), zap.Uint64("requested_bytes", requestedBytes), zap.Uint64("current_usage", currentUsage), zap.Uint64("usage_limit", usageLimit))
 		checkResult.ReleaseReservation()
-		return nil, quotaErr
+		return nil, usageErr
 	}
 	return checkResult, nil
 }

--- a/internal/quota/quota.go
+++ b/internal/quota/quota.go
@@ -231,9 +231,22 @@ func CheckWithReservation(cctx context.Context, ctx core.Context, checkType stri
 		if checkResult.Details.Limit != nil {
 			quotaLimit = *checkResult.Details.Limit
 		}
+		
+		var quotaErr error
+		switch checkType {
+		case "upload":
+			quotaErr = fmt.Errorf("%w (current: %d bytes, requested: %d bytes, limit: %d bytes)", core.ErrUploadQuotaExceeded, currentUsage, requestedBytes, quotaLimit)
+		case "storage":
+			quotaErr = fmt.Errorf("%w (current: %d bytes, requested: %d bytes, limit: %d bytes)", core.ErrStorageQuotaExceeded, currentUsage, requestedBytes, quotaLimit)
+		case "download":
+			quotaErr = fmt.Errorf("%w (current: %d bytes, requested: %d bytes, limit: %d bytes)", core.ErrDownloadQuotaExceeded, currentUsage, requestedBytes, quotaLimit)
+		default:
+			quotaErr = fmt.Errorf("%s quota exceeded: current usage %d bytes + requested %d bytes would exceed quota limit of %d bytes", checkType, currentUsage, requestedBytes, quotaLimit)
+		}
+		
 		ctx.Logger().Warn("Quota exceeded", zap.String("check_type", checkType), zap.Uint("user_id", userID), zap.Uint64("requested_bytes", requestedBytes), zap.Uint64("current_usage", currentUsage), zap.Uint64("quota_limit", quotaLimit))
 		checkResult.ReleaseReservation()
-		return nil, fmt.Errorf("%s quota exceeded: current usage %d bytes + requested %d bytes would exceed quota limit of %d bytes", checkType, currentUsage, requestedBytes, quotaLimit)
+		return nil, quotaErr
 	}
 	return checkResult, nil
 }


### PR DESCRIPTION
- Wrap quota exceeded errors with appropriate core error types (ErrUploadQuotaExceeded, ErrStorageQuotaExceeded, ErrDownloadQuotaExceeded)
- Ensures errors.Is() checks work correctly for quota error detection
- Preserves error context with usage details in error messages

* `develop` <!-- branch-stack -->
  - **fix: properly wrap quota errors with core error types in CheckWithReservation** :point\_left:

***

<!-- kody-pr-summary:start -->

This pull request fixes error handling in the quota checking functionality to properly wrap quota exceeded errors with standardized core error types.

**Changes:**

- Modified the `CheckWithReservation` function to wrap quota exceeded errors using specific core error constants (`core.ErrUploadQuotaExceeded`, `core.ErrStorageQuotaExceeded`, `core.ErrDownloadQuotaExceeded`) based on the check type
- Enhanced error messages to include detailed context (current usage, requested bytes, and quota limit) for better debugging and user feedback
- Maintained fallback error formatting for non-standard check types

**Impact:**

- Enables upstream error handling code to properly identify and distinguish between upload, storage, and download quota violations using standard error type checking
- Improves error traceability and programmatic handling of quota enforcement failures throughout the application
- Provides clearer diagnostic information when quota limits are exceeded

<!-- kody-pr-summary:end -->
