### PR TITLE
feat(api): add UnixFSType enum and separate block/unixfs sizes in BlockMetaResponse

### DIFF
--- a/core/unixfs.go
+++ b/core/unixfs.go
@@ -1,0 +1,14 @@
+package core
+
+import "go.lumeweb.com/portal-plugin-ipfs/internal/api/dto"
+
+// Re-export UnixFSType from dto package for use in internal packages
+type UnixFSType = dto.UnixFSType
+
+// Re-export UnixFSType constants from dto package
+const (
+	UnixFSTypeDirectory = dto.UnixFSTypeDirectory
+	UnixFSTypeFile      = dto.UnixFSTypeFile
+	UnixFSTypeSymlink   = dto.UnixFSTypeSymlink
+	UnixFSTypeHAMTShard = dto.UnixFSTypeHAMTShard
+)

--- a/internal/api/api_blocks_test.go
+++ b/internal/api/api_blocks_test.go
@@ -39,8 +39,9 @@ func TestAPI_handleGetBlockMeta(t *testing.T) {
 
 		assert.NotNil(t, response)
 		assert.IsType(t, "", response.Name)
-		assert.IsType(t, uint8(0), response.Type)
-		assert.IsType(t, int64(0), response.BlockSize)
+		assert.IsType(t, dto.UnixFSType(0), response.Type)
+		assert.IsType(t, uint64(0), response.BlockSize)
+		assert.IsType(t, int64(0), response.UnixFSSize)
 		assert.IsType(t, []string{}, response.ChildCID)
 		assert.True(t, len(response.ChildCID) > 0, "ChildCID should not be empty")
 	}, TestOptions)
@@ -64,8 +65,9 @@ func TestAPI_handleGetBlockMetaBatch(t *testing.T) {
 			assert.NotEmpty(t, cidKey)
 			assert.NotNil(t, meta)
 			assert.IsType(t, "", meta.Name)
-			assert.IsType(t, uint8(0), meta.Type)
-			assert.IsType(t, int64(0), meta.BlockSize)
+			assert.IsType(t, dto.UnixFSType(0), meta.Type)
+			assert.IsType(t, uint64(0), meta.BlockSize)
+			assert.IsType(t, int64(0), meta.UnixFSSize)
 			assert.IsType(t, []string{}, meta.ChildCID)
 			assert.True(t, len(meta.ChildCID) > 0, "ChildCID should not be empty")
 		}

--- a/internal/api/dto/block_meta.go
+++ b/internal/api/dto/block_meta.go
@@ -10,6 +10,121 @@ import (
 	"go.lumeweb.com/portal-plugin-ipfs/internal/protocol/encoding"
 )
 
+// UnixFSType represents the type of a UnixFS node (content type within an IPLD block).
+//
+// UnixFS is a data model used by IPFS to represent files and directories on top of IPLD.
+// This enum describes the semantic type of content stored in a UnixFS node, which is
+// independent from the block's encoding format (e.g., dag-pb, cbor, raw).
+//
+// Type Mappings:
+//   - UnixFSTypeDirectory (1): Container nodes that hold links to child nodes
+//   - UnixFSTypeFile (2): Regular file nodes (may have data or links to chunk blocks)
+//   - UnixFSTypeSymlink (4): Symbolic link nodes containing a target path string
+//   - UnixFSTypeHAMTShard (5): HAMT (Hash Array Mapped Trie) shard nodes for large directories
+//
+// Note: Values 3, 6+ are reserved or unused in the UnixFS specification.
+//
+// Related Types:
+//   - NodeInfoType (internal/node.go): The encoding/codec type of the IPLD block
+//   - UnixFSType should not be confused with block encoding types (raw, dag-pb, cbor)
+type UnixFSType uint8
+
+const (
+	// UnixFSTypeDirectory represents a UnixFS directory node.
+	//
+	// Directory nodes contain only links to child nodes (subdirectories and files).
+	// They do not contain inline data. The directory's "size" is typically 0 or reflects
+	// only the size of the node structure itself, not the cumulative size of children.
+	//
+	// Value: 1
+	UnixFSTypeDirectory UnixFSType = 1
+
+	// UnixFSTypeFile represents a UnixFS regular file node.
+	//
+	// File nodes can either:
+	//   - Contain inline data (small files that fit in one block)
+	//   - Contain links to data chunk blocks (large files split across multiple blocks)
+	//
+	// For large files with children, the UnixFSTypeFile node contains block size information
+	// in its BlockSize field that represents the cumulative size of all chunks.
+	//
+	// Value: 2
+	UnixFSTypeFile UnixFSType = 2
+
+	// UnixFSTypeSymlink represents a UnixFS symbolic link node.
+	//
+	// Symlink nodes contain a target path as inline data. The "data" field stores
+	// the path that the symlink points to. Symlinks are resolved during file system
+	// operations, not during IPFS retrieval.
+	//
+	// Value: 4
+	UnixFSTypeSymlink UnixFSType = 4
+
+	// UnixFSTypeHAMTShard represents a HAMT (Hash Array Mapped Trie) shard node.
+	//
+	// HAMT shards are used for extremely large directories that would exceed the block
+	// size limit if stored as a single directory node. HAMT uses a trie structure to
+	// efficiently distribute child entries across multiple blocks with O(log n) lookup.
+	//
+	// HAMT is implemented using UnixFS shard nodes and is typically transparent to users -
+	// the directory appears as a normal directory to traversals.
+	//
+	// Value: 5
+	UnixFSTypeHAMTShard UnixFSType = 5
+)
+
+// String returns a human-readable representation of the UnixFS type.
+func (t UnixFSType) String() string {
+	switch t {
+	case UnixFSTypeDirectory:
+		return "directory"
+	case UnixFSTypeFile:
+		return "file"
+	case UnixFSTypeSymlink:
+		return "symlink"
+	case UnixFSTypeHAMTShard:
+		return "hamt-shard"
+	default:
+		return "unknown"
+	}
+}
+
+// IsDirectory returns true if the node is a directory or HAMT shard (both are directory-like).
+func (t UnixFSType) IsDirectory() bool {
+	return t == UnixFSTypeDirectory || t == UnixFSTypeHAMTShard
+}
+
+// IsFile returns true if the node is a regular file.
+func (t UnixFSType) IsFile() bool {
+	return t == UnixFSTypeFile
+}
+
+// IsSymlink returns true if the node is a symbolic link.
+func (t UnixFSType) IsSymlink() bool {
+	return t == UnixFSTypeSymlink
+}
+
+// IsValid returns true if the unixfs type is a known valid type.
+func (t UnixFSType) IsValid() bool {
+	switch t {
+	case UnixFSTypeDirectory, UnixFSTypeFile, UnixFSTypeSymlink, UnixFSTypeHAMTShard:
+		return true
+	default:
+		return false
+	}
+}
+
+// ToUint8 returns the type as a uint8, suitable for database storage.
+func (t UnixFSType) ToUint8() uint8 {
+	return uint8(t)
+}
+
+// FromUint8 converts a uint8 from the database to a UnixFSType.
+// Returns UnixFSType(value) even for invalid values - caller should check IsValid().
+func FromUint8(value uint8) UnixFSType {
+	return UnixFSType(value)
+}
+
 // GetBlockMetaBatchRequest and GetBlockMetaBatchResponse
 var _ httputil.DTOValidator = (*GetBlockMetaBatchRequest)(nil)
 var _ httputil.DTOValidator = (*GetBlockMetaRequest)(nil)
@@ -87,16 +202,18 @@ func (g *GetBlockMetaBatchRequest) ToModel() (*GetBlockMetaBatchParsedRequest, e
 }
 
 type BlockMetaResponse struct {
-	Name      string   `json:"name"`
-	Type      uint8    `json:"type"`
-	BlockSize int64    `json:"block_size"`
-	ChildCID  []string `json:"child_cid"`
+	Name       string   `json:"name"`
+	Type       UnixFSType `json:"type"`
+	BlockSize  uint64   `json:"block_size"` // Actual size of this block (from IPFSBlock.Size)
+	UnixFSSize int64    `json:"unixfs_size"` // Cumulative size including children (from UnixFSNode.BlockSize)
+	ChildCID   []string `json:"child_cid"`
 }
 
 func (b *BlockMetaResponse) FromModel(model *pluginDb.UnixFSNode) error {
 	b.Name = model.Name
-	b.Type = model.Type
-	b.BlockSize = model.BlockSize
+	b.Type = UnixFSType(model.Type) // Convert uint8 to UnixFSType enum
+	b.BlockSize = model.Block.Size  // Actual block size from IPFSBlock table
+	b.UnixFSSize = model.BlockSize  // Cumulative UnixFS size including children
 	b.ChildCID = lo.Map(model.ChildCID, func(c cid.Cid, _ int) string {
 		return encoding.ToV1(c).String()
 	})
@@ -110,9 +227,10 @@ func (g *GetBlockMetaBatchResponse) FromModel(model map[string]*pluginDb.UnixFSN
 	*g = make(GetBlockMetaBatchResponse)
 	for _cid, node := range model {
 		(*g)[_cid] = &BlockMetaResponse{
-			Name:      node.Name,
-			Type:      node.Type,
-			BlockSize: node.BlockSize,
+			Name:       node.Name,
+			Type:       UnixFSType(node.Type), // Convert uint8 to UnixFSType enum
+			BlockSize:  node.Block.Size,      // Actual block size from IPFSBlock table
+			UnixFSSize: node.BlockSize,        // Cumulative UnixFS size including children
 			ChildCID: lo.Map(node.ChildCID, func(c cid.Cid, _ int) string {
 				return encoding.ToV1(c).String()
 			}),

--- a/internal/protocol/op_file_path.go
+++ b/internal/protocol/op_file_path.go
@@ -313,7 +313,7 @@ func (h *FilePathOperationHandler) createOrphanEntry(ctx context.Context, fileMa
 	if unixfsMeta != nil {
 		filePath.Size = unixfsMeta.BlockSize
 		filePath.Type = unixfsMeta.Type
-		filePath.IsDirectory = unixfsMeta.Type == 1 // Type 1 = directory
+		filePath.IsDirectory = unixfsMeta.Type == pluginCore.UnixFSTypeDirectory.ToUint8()
 		// Use name from metadata if available
 		if unixfsMeta.Name != "" {
 			filePath.Name = unixfsMeta.Name
@@ -428,7 +428,7 @@ func (h *FilePathOperationHandler) ComputePathsRecursive(ctx context.Context, fi
 		Name:        nodeName,
 		Type:        currentNodeMeta.Type,
 		Size:        int64(currentNodeMeta.BlockSize), // Start with just this block's size
-		IsDirectory: currentNodeMeta.Type == 1,        // Type 1 = directory
+		IsDirectory: currentNodeMeta.Type == pluginCore.UnixFSTypeDirectory.ToUint8(),
 		IsOrphan:    isOrphan,
 		ParentPath:  effectiveParentPath,
 		Depth:       depth,
@@ -460,7 +460,7 @@ func (h *FilePathOperationHandler) ComputePathsRecursive(ctx context.Context, fi
 		zap.Uint64("size", uint64(currentNodeMeta.BlockSize)))
 
 	// If this is a directory and has children, process them recursively
-	if currentNodeMeta.Type == 1 && len(currentNodeMeta.ChildCID) > 0 {
+	if currentNodeMeta.Type == pluginCore.UnixFSTypeDirectory.ToUint8() && len(currentNodeMeta.ChildCID) > 0 {
 		blockSvc := core.GetService[pluginCore.BlockService](h.Context(), pluginCore.BLOCK_SERVICE)
 
 		for _, childCID := range currentNodeMeta.ChildCID {

--- a/internal/protocol/op_file_path.go
+++ b/internal/protocol/op_file_path.go
@@ -313,7 +313,7 @@ func (h *FilePathOperationHandler) createOrphanEntry(ctx context.Context, fileMa
 	if unixfsMeta != nil {
 		filePath.Size = unixfsMeta.BlockSize
 		filePath.Type = unixfsMeta.Type
-		filePath.IsDirectory = unixfsMeta.Type == pluginCore.UnixFSTypeDirectory.ToUint8()
+		filePath.IsDirectory = pluginCore.UnixFSType(unixfsMeta.Type).IsDirectory()
 		// Use name from metadata if available
 		if unixfsMeta.Name != "" {
 			filePath.Name = unixfsMeta.Name
@@ -428,7 +428,7 @@ func (h *FilePathOperationHandler) ComputePathsRecursive(ctx context.Context, fi
 		Name:        nodeName,
 		Type:        currentNodeMeta.Type,
 		Size:        int64(currentNodeMeta.BlockSize), // Start with just this block's size
-		IsDirectory: currentNodeMeta.Type == pluginCore.UnixFSTypeDirectory.ToUint8(),
+		IsDirectory: pluginCore.UnixFSType(currentNodeMeta.Type).IsDirectory(),
 		IsOrphan:    isOrphan,
 		ParentPath:  effectiveParentPath,
 		Depth:       depth,
@@ -460,7 +460,7 @@ func (h *FilePathOperationHandler) ComputePathsRecursive(ctx context.Context, fi
 		zap.Uint64("size", uint64(currentNodeMeta.BlockSize)))
 
 	// If this is a directory and has children, process them recursively
-	if currentNodeMeta.Type == pluginCore.UnixFSTypeDirectory.ToUint8() && len(currentNodeMeta.ChildCID) > 0 {
+	if pluginCore.UnixFSType(currentNodeMeta.Type).IsDirectory() && len(currentNodeMeta.ChildCID) > 0 {
 		blockSvc := core.GetService[pluginCore.BlockService](h.Context(), pluginCore.BLOCK_SERVICE)
 
 		for _, childCID := range currentNodeMeta.ChildCID {

--- a/internal/protocol/store/metadata.go
+++ b/internal/protocol/store/metadata.go
@@ -731,16 +731,16 @@ func ExtractNodeMetadata(clogger *core.Logger, block pluginCore.PinnedBlock) (*p
 
 	switch analyzedNode.UnixFSType {
 	case unixfs.TFile:
-		metadata.Type = 2
+		metadata.Type = pluginCore.UnixFSTypeFile.ToUint8()
 		logger.Debug("Processing UnixFS file", zap.Stringer("cid", block.Cid))
 	case unixfs.TDirectory:
-		metadata.Type = 1
+		metadata.Type = pluginCore.UnixFSTypeDirectory.ToUint8()
 		logger.Debug("Processing UnixFS directory", zap.Stringer("cid", block.Cid))
 	case unixfs.TSymlink:
-		metadata.Type = 4
+		metadata.Type = pluginCore.UnixFSTypeSymlink.ToUint8()
 		logger.Debug("Processing UnixFS symlink", zap.Stringer("cid", block.Cid))
 	case unixfs.THAMTShard:
-		metadata.Type = 5
+		metadata.Type = pluginCore.UnixFSTypeHAMTShard.ToUint8()
 		logger.Debug("Processing UnixFS HAMT shard", zap.Stringer("cid", block.Cid))
 	default:
 		logger.Debug("Unsupported UnixFS type", zap.Stringer("cid", block.Cid), zap.String("type", analyzedNode.UnixFSType.String()))


### PR DESCRIPTION
- Add UnixFSType enum with constants (Directory=1, File=2, Symlink=4, HAMTShard=5)
- Add helper methods: String(), IsDirectory(), IsFile(), IsSymlink(), IsValid(), ToUint8()
- Create core/unixfs.go to re-export enum for internal packages
- Replace hardcoded type constants with enum constants in metadata and routing
- Update BlockMetaResponse: Type field to UnixFSType, BlockSize to uint64, add UnixFSSize field
- Update FromModel() methods to populate both size fields from Block and UnixFSNode tables
- Update test assertions to use typed enum

* `develop` <!-- branch-stack -->
  - **feat(api): add UnixFSType enum and separate block/unixfs sizes in BlockMetaResponse** :point\_left:

***

<!-- kody-pr-summary:start -->

This pull request introduces a type-safe enumeration for UnixFS node types and clarifies size semantics in block metadata responses.

**Key Changes:**

1. **Added `UnixFSType` Enum**: Introduced a strongly-typed `UnixFSType` enum (backed by uint8) to replace raw integer values when representing UnixFS node types (Directory=1, File=2, Symlink=4, HAMTShard=5). The enum includes helper methods (`IsDirectory()`, `IsFile()`, `IsSymlink()`, `IsValid()`, `String()`) for type checking and serialization.

2. **Separated Size Fields in BlockMetaResponse**: Split the ambiguous size field into two distinct measurements:
   - `BlockSize` (uint64): The actual physical size of the IPLD block
   - `UnixFSSize` (int64): The cumulative logical size including all child nodes (for directories and chunked files)

3. **Eliminated Magic Numbers**: Replaced hardcoded integer literals (1, 2, 4, 5) throughout the codebase with the new enum constants, improving code clarity and maintainability when checking node types in file path operations and metadata extraction.

4. **Updated API Response Types**: Modified `BlockMetaResponse.Type` from `uint8` to `UnixFSType`, ensuring consumers receive semantically meaningful type information rather than opaque integers.

The changes improve type safety and API clarity while maintaining backward compatibility with existing data storage formats (the enum serializes to the same uint8 values).

<!-- kody-pr-summary:end -->
