### PR TITLE
fix: store logical UnixFS file size in UnixFSNode.BlockSize

### DIFF
--- a/internal/api/dto/block_meta.go
+++ b/internal/api/dto/block_meta.go
@@ -204,16 +204,16 @@ func (g *GetBlockMetaBatchRequest) ToModel() (*GetBlockMetaBatchParsedRequest, e
 type BlockMetaResponse struct {
 	Name       string   `json:"name"`
 	Type       UnixFSType `json:"type"`
-	BlockSize  uint64   `json:"block_size"` // Actual size of this block (from IPFSBlock.Size)
-	UnixFSSize int64    `json:"unixfs_size"` // Cumulative size including children (from UnixFSNode.BlockSize)
+	BlockSize  uint64   `json:"block_size"` // Raw encoded block size (includes protobuf framing overhead)
+	UnixFSSize int64    `json:"unixfs_size"` // Logical UnixFS file size (local size, original file size before chunking)
 	ChildCID   []string `json:"child_cid"`
 }
 
 func (b *BlockMetaResponse) FromModel(model *pluginDb.UnixFSNode) error {
 	b.Name = model.Name
 	b.Type = UnixFSType(model.Type) // Convert uint8 to UnixFSType enum
-	b.BlockSize = model.Block.Size  // Actual block size from IPFSBlock table
-	b.UnixFSSize = model.BlockSize  // Cumulative UnixFS size including children
+	b.BlockSize = model.Block.Size  // Raw encoded block size
+	b.UnixFSSize = model.BlockSize  // Logical UnixFS file size
 	b.ChildCID = lo.Map(model.ChildCID, func(c cid.Cid, _ int) string {
 		return encoding.ToV1(c).String()
 	})
@@ -229,8 +229,8 @@ func (g *GetBlockMetaBatchResponse) FromModel(model map[string]*pluginDb.UnixFSN
 		(*g)[_cid] = &BlockMetaResponse{
 			Name:       node.Name,
 			Type:       UnixFSType(node.Type), // Convert uint8 to UnixFSType enum
-			BlockSize:  node.Block.Size,      // Actual block size from IPFSBlock table
-			UnixFSSize: node.BlockSize,        // Cumulative UnixFS size including children
+			BlockSize:  node.Block.Size,      // Raw encoded block size
+			UnixFSSize: node.BlockSize,        // Logical UnixFS file size
 			ChildCID: lo.Map(node.ChildCID, func(c cid.Cid, _ int) string {
 				return encoding.ToV1(c).String()
 			}),

--- a/internal/protocol/store/metadata.go
+++ b/internal/protocol/store/metadata.go
@@ -748,18 +748,10 @@ func ExtractNodeMetadata(clogger *core.Logger, block pluginCore.PinnedBlock) (*p
 	}
 
 	if analyzedNode.UnixFSType == unixfs.TFile {
-		if analyzedNode.ChunkSizes != nil && len(analyzedNode.ChunkSizes) > 0 {
-			logger.Debug("Processing file block sizes", zap.Stringer("cid", block.Cid), zap.Int("block_count", len(analyzedNode.ChunkSizes)))
-			var totalSize int64
-			for _, size := range analyzedNode.ChunkSizes {
-				totalSize += int64(size)
-			}
-			metadata.BlockSize = totalSize
-			logger.Debug("File block size calculated", zap.Stringer("cid", block.Cid), zap.Int64("total_size", totalSize))
-		} else {
-			metadata.BlockSize = int64(analyzedNode.BlockSize)
-			logger.Debug("File block size set from raw data", zap.Stringer("cid", block.Cid), zap.Int64("block_size", metadata.BlockSize))
-		}
+		// Use FileSize as the logical UnixFS file size (local size)
+		// This is the original file size before chunking, not the encoded block size
+		metadata.BlockSize = int64(analyzedNode.FileSize)
+		logger.Debug("File block size set from UnixFS FileSize", zap.Stringer("cid", block.Cid), zap.Int64("file_size", metadata.BlockSize))
 	}
 
 	logger.Debug("Processing child CIDs", zap.Stringer("cid", block.Cid), zap.Int("child_count", len(block.Links)))


### PR DESCRIPTION
ExtractNodeMetadata now uses analyzedNode.FileSize instead of manually summing ChunkSizes.

BlockMetaResponse fields now represent:

- block\_size: Raw encoded block size
- unixfs\_size: Logical UnixFS file size

* `develop` <!-- branch-stack -->
  - **fix: store logical UnixFS file size in UnixFSNode.BlockSize** :point\_left:


---

<!-- kody-pr-summary:start -->
 This pull request fixes the UnixFS metadata extraction logic to correctly store the **logical file size** (original file size before chunking) rather than the encoded block size or cumulative chunk sizes.

**Changes Made:**

1. **Metadata Extraction (`internal/protocol/store/metadata.go`)**: 
   - Modified `ExtractNodeMetadata` to use `analyzedNode.FileSize` directly for file nodes (`TFile`) instead of calculating size from chunk arrays or using raw block data
   - This ensures the stored value represents the actual logical content size rather than the protobuf-encoded block size with framing overhead

2. **API Documentation (`internal/api/dto/block_meta
<!-- kody-pr-summary:end -->