### PR TITLE
fix: remove strict Times(2) mock expectation in TestReprovider_Run

### DIFF
--- a/internal/protocol/ipfs/provide_test.go
+++ b/internal/protocol/ipfs/provide_test.go
@@ -50,18 +50,13 @@ func TestReprovider_Run(t *testing.T) {
 	// Mock provider ready
 	mockProvider.EXPECT().Ready().Return(true)
 
-	// Mock store returning CIDs - expect multiple calls since reprovider runs in a loop
 	testCIDs := []core.PinnedCID{
 		{CID: cid.Cid{}, LastAnnouncement: time.Now().Add(-2 * interval)},
 		{CID: cid.Cid{}, LastAnnouncement: time.Now().Add(-2 * interval)},
 	}
-	mockStore.EXPECT().ProvideCIDs(mock.Anything, batchSize).Return(testCIDs, nil).Times(2).Maybe()
-
-	// Mock provider ProvideMany - expect multiple calls
-	mockProvider.EXPECT().ProvideMany(mock.Anything, mock.Anything).Return(nil).Times(2).Maybe()
-
-	// Mock store SetLastAnnouncement - expect multiple calls
-	mockStore.EXPECT().SetLastAnnouncement(mock.Anything, mock.Anything, mock.Anything).Return(nil).Times(2).Maybe()
+	mockStore.EXPECT().ProvideCIDs(mock.Anything, batchSize).Return(testCIDs, nil).Maybe()
+	mockProvider.EXPECT().ProvideMany(mock.Anything, mock.Anything).Return(nil).Maybe()
+	mockStore.EXPECT().SetLastAnnouncement(mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
 
 	runReproviderAndWait(ctx, cancel, reprovider, interval, timeout, batchSize, 2*interval)
 }


### PR DESCRIPTION
The reprovider loop could iterate more than twice before context cancellation propagated, causing the mock to reject unexpected calls. Remove the Times(2) constraint and rely on Maybe() alone since this test only verifies the loop runs without error, not an exact count.

- `develop` <!-- branch-stack -->
  - **fix: remove strict Times(2) mock expectation in TestReprovider\_Run** :point\_left:

---

<!-- kody-pr-summary:start -->
## Description

This PR fixes a flaky test in `TestReprovider_Run` by removing strict `Times(2)` mock expectations on `ProvideCIDs`, `ProvideMany`, and `SetLastAnnouncement` calls. The strict expectation of exactly two calls could cause intermittent test failures due to timing variability in the reprovider's loop execution. The mocks now use only `Maybe()`, allowing the calls to occur any number of times (including zero), which makes the test resilient to timing-based flakiness while still verifying the correct mock interactions occur when they do happen.
<!-- kody-pr-summary:end -->