### PR TITLE
chore: remove push trigger from build CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,6 @@
 name: Build
 
 on:
-  push:
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Remove the `push` trigger from the Build CI workflow, so it only runs on pull requests and manual workflow dispatches.
<!-- kody-pr-summary:end -->