### PR TITLE
fix: remove unprocessed %s from ErrKeyFileUploadFailed message

### DIFF
--- a/internal/api/errors.go
+++ b/internal/api/errors.go
@@ -134,7 +134,7 @@ func init() {
 		ErrKeyCorruptedFile:         {Key: ErrKeyCorruptedFile, Message: "Corrupted or invalid file format"},
 		ErrKeyEmptyZIP:              {Key: ErrKeyEmptyZIP, Message: "Empty ZIP file cannot be converted"},
 		ErrKeyPasswordProtected:     {Key: ErrKeyPasswordProtected, Message: "Password-protected ZIP files are not supported"},
-		ErrKeyFileUploadFailed:      {Key: ErrKeyFileUploadFailed, Message: "Failed to process upload: %s"},
+		ErrKeyFileUploadFailed:      {Key: ErrKeyFileUploadFailed, Message: "Failed to process upload."},
 		ErrKeyInvalidRecordType:     {Key: ErrKeyInvalidRecordType, Message: "Invalid DNS record type"},
 		ErrKeyRecordNotFound:        {Key: ErrKeyRecordNotFound, Message: "DNS record not found"},
 		ErrKeyZoneNotFound:          {Key: ErrKeyZoneNotFound, Message: "DNS zone not found"},


### PR DESCRIPTION
The error definition template used %s but the callers never pass format args — the UploadError is passed as the wrapped err, not as an arg to Sprintf. This resulted in the literal %s appearing in the response. The wrapped error already carries the full details, so the message just needs to describe the error type.

---

<!-- kody-pr-summary:start -->
Fix: Remove unprocessed `%s` placeholder from `ErrKeyFileUploadFailed` error message

The `%s` format verb in the `ErrKeyFileUploadFailed` error message was not being populated, resulting in the literal `%s` appearing in the error output. The message has been updated to a static string: "Failed to process upload."
<!-- kody-pr-summary:end -->