### PR TITLE
feat: migrate avast/retry-go from v4 to v5 API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.26.0
 
 require (
 	github.com/Oudwins/zog v0.22.2
-	github.com/avast/retry-go/v4 v4.7.0
 	github.com/avast/retry-go/v5 v5.0.0
 	github.com/bits-and-blooms/bloom/v3 v3.7.1
 	github.com/bwesterb/go-zonefile v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -112,8 +112,7 @@ github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hC
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
-github.com/avast/retry-go/v4 v4.7.0 h1:yjDs35SlGvKwRNSykujfjdMxMhMQQM0TnIjJaHB+Zio=
-github.com/avast/retry-go/v4 v4.7.0/go.mod h1:ZMPDa3sY2bKgpLtap9JRUgk2yTAba7cgiFhqxY2Sg6Q=
+github.com/avast/retry-go/v5 v5.0.0 h1:kf1Qc2UsTZ4qq8elDymqfbISvkyMuhgRxuJqX2NHP7k=
 github.com/avast/retry-go/v5 v5.0.0/go.mod h1://d+usmKWio1agtZfS1H/ltTqwtIfBnRq9zEwjc3eH8=
 github.com/aws/aws-sdk-go-v2 v1.41.7 h1:DWpAJt66FmnnaRIOT/8ASTucrvuDPZASqhhLey6tLY8=
 github.com/aws/aws-sdk-go-v2 v1.41.7/go.mod h1:4LAfZOPHNVNQEckOACQx60Y8pSRjIkNZQz1w92xpMJc=

--- a/internal/protocol/block_queue.go
+++ b/internal/protocol/block_queue.go
@@ -9,7 +9,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/avast/retry-go/v4"
+	"github.com/avast/retry-go/v5"
 	"github.com/gammazero/workerpool"
 	blocks "github.com/ipfs/go-block-format"
 	"github.com/ipfs/go-cid"
@@ -131,10 +131,7 @@ func (bp *BlockQueue) processBlock(ctx context.Context, job *blockJob) error {
 	ctx, span := core.TraceMethod(ctx, "BlockQueue.processBlock")
 	defer span.End()
 
-	return retry.Do(
-		func() error {
-			return bp.processBlockInternal(ctx, job)
-		},
+	return retry.New(
 		retry.Context(ctx),
 		retry.Attempts(maxRetries),
 		retry.Delay(time.Second),
@@ -148,7 +145,9 @@ func (bp *BlockQueue) processBlock(ctx context.Context, job *blockJob) error {
 				zap.Uint("attempt", n+1),
 				zap.String("CID", job.Block.Cid().String()))
 		}),
-	)
+	).Do(func() error {
+		return bp.processBlockInternal(ctx, job)
+	})
 }
 
 func (bp *BlockQueue) processBlockInternal(ctx context.Context, job *blockJob) error {


### PR DESCRIPTION
- `develop` <!-- branch-stack -->
  - **feat: migrate avast/retry-go from v4 to v5 API** :point\_left:

---

<!-- kody-pr-summary:start -->
This pull request migrates the `avast/retry-go` dependency from v4 to v5. 

The main code change updates the retry logic in `internal/protocol/block_queue.go` to align with the v5 API. Specifically, it replaces the `retry.Do` function call with the new `retry.New` constructor pattern, where retry options are passed to `retry.New()` and the action function is subsequently passed to the `.Do()` method.
<!-- kody-pr-summary:end -->