### PR TITLE
feat: expose gateway domain in website API responses and config endpoint

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -45,6 +45,7 @@ type API struct {
 	ipnsKeyService     pluginCore.IPNSKeyService
 	websiteService     pluginCore.WebsiteService
 	dnsService         pluginCore.DNSService
+	dnsConfig          *pluginConfig.DnsConfig
 	tus                core.TusHandler
 	ipfs               protocol.ProtoNode
 }
@@ -62,6 +63,13 @@ func NewAPI() (core.API, []core.ContextBuilderOption, error) {
 			api.ipnsKeyService = core.GetService[pluginCore.IPNSKeyService](ctx, pluginCore.IPNS_KEY_SERVICE)
 			api.websiteService = core.GetService[pluginCore.WebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
 			api.dnsService = core.GetService[pluginCore.DNSService](ctx, pluginCore.DNS_SERVICE)
+			if api.dnsService != nil {
+				if cfg, err := api.dnsService.GetConfig(); err == nil {
+					if dnsCfg, ok := cfg.(*pluginConfig.DnsConfig); ok {
+						api.dnsConfig = dnsCfg
+					}
+				}
+			}
 			proto := core.GetProtocol(internal.ProtocolName)
 			sproto := proto.(core.StorageProtocol)
 			event.OnBootStartupFuncsCompleted(ctx, func(ctx core.Context, eventCtx context.Context) error {
@@ -634,6 +642,25 @@ See also:.*`),
 
 	if err := router.RegisterRoutes(apiGroup, accessSvc, a.Subdomain(), websiteRoutes, router.WithMiddlewares(authMw), router.WithCors()); err != nil {
 		return fmt.Errorf("failed to register website routes: %w", err)
+	}
+
+	websiteConfigRoutes := router.DefineRoutes(
+		router.NewRoute(http.MethodGet, "/websites/config", a.getWebsiteConfig,
+			router.WithSwagger(
+				router.WithSummary("Get website hosting configuration"),
+				router.WithDescription(`Returns website hosting configuration including the gateway domain.
+
+Clients use this endpoint to discover the gateway domain they should point their custom domain's DNS records to when hosting a website. This is required when dns_hosting_enabled is false and the user manages their own DNS.
+
+See also:.*`),
+				router.WithTags("Websites"),
+				router.WithSuccessResponse(http.StatusOK, "Website configuration", router.WithJSONContent(dto.WebsiteConfigResponse{})),
+			),
+		),
+	)
+
+	if err := router.RegisterRoutes(apiGroup, accessSvc, a.Subdomain(), websiteConfigRoutes, router.WithCors()); err != nil {
+		return fmt.Errorf("failed to register website config routes: %w", err)
 	}
 
 	// DNS routes for zone and record management

--- a/internal/api/api_websites.go
+++ b/internal/api/api_websites.go
@@ -26,6 +26,21 @@ import (
 // Applications should use this constant to ensure consistency across the codebase
 const DefaultWebsiteEnabled = true
 
+func (a *API) gatewayDomain() string {
+	if a.dnsConfig != nil {
+		return a.dnsConfig.GatewayDomain
+	}
+	return ""
+}
+
+func (a *API) getWebsiteConfig(c echo.Context) error {
+	ctx := httputil.Context(c)
+	cfg := &dto.WebsiteConfig{
+		GatewayDomain: a.gatewayDomain(),
+	}
+	return httputil.EncodeResponse(ctx, cfg, &dto.WebsiteConfigResponse{})
+}
+
 // handleWebsiteValidationError is a DRY helper for handling website validation errors with proper context
 func (a *API) handleWebsiteValidationError(err error, c echo.Context) (error, bool) {
 	if err == nil {
@@ -96,6 +111,7 @@ func (a *API) createWebsite(c echo.Context) error {
 		apiErr := NewError(ErrKeyFileProcessingFailed, err)
 		return ctx.Error(apiErr, apiErr.HttpStatus())
 	}
+	resp.GatewayDomain = a.gatewayDomain()
 
 	ctx.Response().Before(func() {
 		ctx.Response().Status = http.StatusCreated
@@ -149,6 +165,7 @@ func (a *API) listWebsites(c echo.Context) error {
 			apiErr := NewError(ErrKeyFileProcessingFailed, err)
 			return ctx.Error(apiErr, apiErr.HttpStatus())
 		}
+		responses[i].GatewayDomain = a.gatewayDomain()
 	}
 
 	// Convert to WebsiteItem for list response
@@ -188,6 +205,7 @@ func (a *API) getWebsite(c echo.Context) error {
 	if isBroken || website.DeletedAt.Valid {
 		var resp dto.WebsiteResponse
 		if err := resp.FromModel(website); err == nil {
+			resp.GatewayDomain = a.gatewayDomain()
 			ctx.Response().Before(func() {
 				ctx.Response().Status = http.StatusGone
 			})
@@ -195,7 +213,9 @@ func (a *API) getWebsite(c echo.Context) error {
 		}
 	}
 
-	return httputil.EncodeResponse(ctx, website, &dto.WebsiteResponse{})
+	resp := &dto.WebsiteResponse{}
+	resp.GatewayDomain = a.gatewayDomain()
+	return httputil.EncodeResponse(ctx, website, resp)
 }
 
 func (a *API) updateWebsite(c echo.Context) error {
@@ -242,6 +262,7 @@ func (a *API) updateWebsite(c echo.Context) error {
 		apiErr := NewError(ErrKeyFileProcessingFailed, err)
 		return ctx.Error(apiErr, apiErr.HttpStatus())
 	}
+	resp.GatewayDomain = a.gatewayDomain()
 
 	return httputil.EncodeResponse(ctx, website, &resp)
 }
@@ -339,7 +360,9 @@ func (a *API) getSSLStatus(c echo.Context) error {
 		return ctx.Error(apiErr, http.StatusNotFound)
 	}
 
-	return httputil.EncodeResponse(ctx, website, &dto.WebsiteResponse{})
+	resp := &dto.WebsiteResponse{}
+	resp.GatewayDomain = a.gatewayDomain()
+	return httputil.EncodeResponse(ctx, website, resp)
 }
 
 func (a *API) updateSSLStatus(c echo.Context) error {
@@ -378,5 +401,7 @@ func (a *API) updateSSLStatus(c echo.Context) error {
 		return ctx.Error(apiErr, apiErr.HttpStatus())
 	}
 
-	return httputil.EncodeResponse(ctx, website, &dto.WebsiteResponse{})
+	resp := &dto.WebsiteResponse{}
+	resp.GatewayDomain = a.gatewayDomain()
+	return httputil.EncodeResponse(ctx, website, resp)
 }

--- a/internal/api/dto/website.go
+++ b/internal/api/dto/website.go
@@ -267,6 +267,7 @@ type WebsiteResponse struct {
 	LastCheckedAt       *time.Time     `json:"last_checked_at,omitempty"`
 	DNSZoneID           *uint          `json:"dns_zone_id,omitempty"`
 	Enabled             bool           `json:"dns_hosting_enabled"`
+	GatewayDomain       string         `json:"gateway_domain,omitempty"`
 	Created             time.Time      `json:"created"`
 	Updated             time.Time      `json:"updated"`
 	Expired             bool            `json:"expired"` // Whether validation token has expired
@@ -359,6 +360,23 @@ func (f WebsiteFilter) Schema() *zog.StructSchema {
 
 func (f WebsiteFilter) ToModel() (WebsiteFilter, error) {
 	return f, nil
+}
+
+// WebsiteConfig holds website-related configuration
+type WebsiteConfig struct {
+	GatewayDomain string
+}
+
+// WebsiteConfigResponse returns website-related configuration for client use
+type WebsiteConfigResponse struct {
+	GatewayDomain string `json:"gateway_domain,omitempty"`
+}
+
+var _ httputil.DTOResponse[*WebsiteConfig] = (*WebsiteConfigResponse)(nil)
+
+func (r *WebsiteConfigResponse) FromModel(cfg *WebsiteConfig) error {
+	r.GatewayDomain = cfg.GatewayDomain
+	return nil
 }
 
 // SSLStatusUpdateRequest represents a request to update SSL certificate status from Caddy webhook


### PR DESCRIPTION
The gateway domain was configured but never exposed to clients. Users managing their own DNS (dns\_hosting\_enabled=false) had no way to know where to point their CNAME/ALIAS records, and the CLI could not guide them.

- Add gateway\_domain field to WebsiteResponse DTO
- Add GET /websites/config public endpoint returning the gateway domain
- Populate gateway\_domain from DNS config in all website response paths
- Store dnsConfig on API struct, loaded from dnsService.GetConfig()

* `develop` <!-- branch-stack -->
  - **feat: expose gateway domain in website API responses and config endpoint** :point\_left:

---

<!-- kody-pr-summary:start -->
Expose the gateway domain in all website API responses and add a dedicated `/websites/config` endpoint

This change adds the `gateway_domain` field to all website-related API responses (create, list, get, update, SSL status) and introduces a new `GET /websites/config` endpoint that returns website hosting configuration. Clients can use this endpoint to discover the gateway domain they should point their custom domain's DNS records to when hosting a website, which is particularly needed when DNS hosting is disabled and the user manages their own DNS. The gateway domain value is sourced from the DNS service configuration.
<!-- kody-pr-summary:end -->