### PR TITLE
fix: use core.GetServiceConfig instead of direct GetConfig for DNS config

### DIFF
--- a/internal/api/admin_extension_test.go
+++ b/internal/api/admin_extension_test.go
@@ -7,9 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	pluginCore "go.lumeweb.com/portal-plugin-ipfs/core"
 	pluginCoreCore "go.lumeweb.com/portal-plugin-ipfs/core"
-	pluginConfig "go.lumeweb.com/portal-plugin-ipfs/internal/config"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/testing/mocks"
 	"go.lumeweb.com/portal/core"
 	coreTesting "go.lumeweb.com/portal/core/testing"
@@ -17,9 +15,7 @@ import (
 
 // AdminTestOptions provides test configuration for admin extension tests
 var AdminTestOptions = coreTesting.CombineOptions(
-	coreTesting.WithMockServiceFactory(pluginCore.WEBSITE_SERVICE, mocks.NewMockWebsiteService, &pluginConfig.WebsiteConfig{}),
-	coreTesting.WithMockServiceFactory(pluginCoreCore.IPNS_KEY_SERVICE, mocks.NewMockIPNSKeyService),
-	coreTesting.WithMockServiceFactory(pluginCore.DNS_SERVICE, mocks.NewMockDNSService, &pluginConfig.DnsConfig{}),
+	testPluginOptions,
 	coreTesting.WithAPIExtension(NewAdminExtension()),
 	coreTesting.WithAPIID("admin"),
 )

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -63,13 +63,7 @@ func NewAPI() (core.API, []core.ContextBuilderOption, error) {
 			api.ipnsKeyService = core.GetService[pluginCore.IPNSKeyService](ctx, pluginCore.IPNS_KEY_SERVICE)
 			api.websiteService = core.GetService[pluginCore.WebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
 			api.dnsService = core.GetService[pluginCore.DNSService](ctx, pluginCore.DNS_SERVICE)
-			if api.dnsService != nil {
-				if cfg, err := api.dnsService.GetConfig(); err == nil {
-					if dnsCfg, ok := cfg.(*pluginConfig.DnsConfig); ok {
-						api.dnsConfig = dnsCfg
-					}
-				}
-			}
+			api.dnsConfig = core.GetServiceConfig[*pluginConfig.DnsConfig](ctx, pluginCore.DNS_SERVICE)
 			proto := core.GetProtocol(internal.ProtocolName)
 			sproto := proto.(core.StorageProtocol)
 			event.OnBootStartupFuncsCompleted(ctx, func(ctx core.Context, eventCtx context.Context) error {

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -3,38 +3,28 @@ package api
 import (
 	"testing"
 
-	pluginCore "go.lumeweb.com/portal-plugin-ipfs/core"
 	"go.lumeweb.com/portal-plugin-ipfs/internal"
 	pluginConfig "go.lumeweb.com/portal-plugin-ipfs/internal/config"
-	"go.lumeweb.com/portal-plugin-ipfs/internal/testing/mocks"
+	"go.lumeweb.com/portal-plugin-ipfs/internal/testing/testopts"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/testing/util"
 	coreTesting "go.lumeweb.com/portal/core/testing"
 )
 
 func TestMain(m *testing.M) {
 	coreTesting.WithOptions(m,
-		coreTesting.WithMockServiceFactory(pluginCore.FILE_MANAGER_SERVICE, mocks.NewMockFileManagerService),
-		coreTesting.WithMockServiceFactory(pluginCore.PIN_SERVICE, mocks.NewMockIPFSPinService),
-		coreTesting.WithMockServiceFactory(pluginCore.BLOCK_SERVICE, mocks.NewMockBlockService),
-		coreTesting.WithMockServiceFactory(pluginCore.UPLOAD_SERVICE, mocks.NewMockUploadService),
-		coreTesting.WithMockServiceFactory(pluginCore.WEBSITE_SERVICE, mocks.NewMockWebsiteService),
 		coreTesting.WithAPI(internal.ProtocolName, NewAPI),
 		coreTesting.WithAPIID(internal.ProtocolName),
-
 		util.GetProtocolMock(),
 		coreTesting.WithProtocolConfig(internal.ProtocolName, pluginConfig.ProtocolConfig{}),
 	)
 }
 
-// TestOptions provides test configuration for API tests
+var testPluginOptions = coreTesting.CombineOptions(
+	testopts.NewMockPluginBuilder().BuilderOption(),
+)
+
 var TestOptions = coreTesting.CombineOptions(
-	coreTesting.WithMockServiceFactory(pluginCore.FILE_MANAGER_SERVICE, mocks.NewMockFileManagerService),
-	coreTesting.WithMockServiceFactory(pluginCore.PIN_SERVICE, mocks.NewMockIPFSPinService),
-	coreTesting.WithMockServiceFactory(pluginCore.BLOCK_SERVICE, mocks.NewMockBlockService),
-	coreTesting.WithMockServiceFactory(pluginCore.UPLOAD_SERVICE, mocks.NewMockUploadService),
-	coreTesting.WithMockServiceFactory(pluginCore.IPNS_KEY_SERVICE, mocks.NewMockIPNSKeyService),
-	coreTesting.WithMockServiceFactory(pluginCore.WEBSITE_SERVICE, mocks.NewMockWebsiteService, &pluginConfig.WebsiteConfig{}),
-	coreTesting.WithMockServiceFactory(pluginCore.DNS_SERVICE, mocks.NewMockDNSService, &pluginConfig.DnsConfig{}),
+	testPluginOptions,
 	coreTesting.WithHTTPService(),
 	coreTesting.WithPlugins(),
 	coreTesting.WithAPIConfig(internal.ProtocolName, &pluginConfig.APIConfig{

--- a/internal/protocol/tests/test_utils.go
+++ b/internal/protocol/tests/test_utils.go
@@ -7,12 +7,18 @@ import (
 	"net/http"
 	"time"
 
-	"go.lumeweb.com/portal-plugin-ipfs/internal/testing/testopts"
+	"go.lumeweb.com/portal-plugin-ipfs/internal/plugin"
 	coreTesting "go.lumeweb.com/portal/core/testing"
+	serviceTesting "go.lumeweb.com/portal/service/testing"
 )
 
 func GetStandardTestOptions() []coreTesting.TestContextBuilderOption {
-	return testopts.GetStandardTestOptions()
+	return []coreTesting.TestContextBuilderOption{
+		serviceTesting.PresetE2E(),
+		coreTesting.WithConfig("core.mail.host", "localhost"),
+		coreTesting.WithConfig("core.mail.port", 25),
+		coreTesting.WithPlugins(plugin.GetPluginInfoWithTemplates(nil)),
+	}
 }
 
 // HTTPTestClient wraps an HTTP client with helper methods for testing

--- a/internal/service/dns/dns_service_test.go
+++ b/internal/service/dns/dns_service_test.go
@@ -12,12 +12,12 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/samber/lo"
 	pluginCore "go.lumeweb.com/portal-plugin-ipfs/core"
-	"go.lumeweb.com/portal-plugin-ipfs/internal"
 	apiDTO "go.lumeweb.com/portal-plugin-ipfs/internal/api/dto"
 	pluginConfig "go.lumeweb.com/portal-plugin-ipfs/internal/config"
 	pluginDb "go.lumeweb.com/portal-plugin-ipfs/internal/db"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/db/migrations"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/dns/powerdns"
+	"go.lumeweb.com/portal-plugin-ipfs/internal/testing/testopts"
 	"go.lumeweb.com/portal/core"
 	coreTesting "go.lumeweb.com/portal/core/testing"
 	"go.uber.org/zap"
@@ -116,7 +116,7 @@ func setupDefaultServerHandlers(mux *http.ServeMux) {
 
 // createTestOptionsWithPowerDNSClient creates test options with a custom PowerDNS client
 func createTestOptionsWithPowerDNSClient(client *PowerDNSClient) coreTesting.TestContextBuilderOption {
-	return coreTesting.NewMockPluginBuilder(internal.ProtocolName).WithService(pluginCore.DNS_SERVICE, func() (core.Service, []core.ContextBuilderOption, error) {
+	return testopts.NewBaseMockPluginBuilder().WithService(pluginCore.DNS_SERVICE, func() (core.Service, []core.ContextBuilderOption, error) {
 		return NewDNSServiceWithOptions(WithPowerDNSClient(client))
 	}).WithServiceConfig(pluginCore.DNS_SERVICE, getTestDnsConfig()).WithMigrations(map[core.DBType]fs.FS{
 		core.DB_TYPE_SQLITE: migrations.GetSQLite(),

--- a/internal/service/dns/nameserver_validator_job_test.go
+++ b/internal/service/dns/nameserver_validator_job_test.go
@@ -10,18 +10,18 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	pluginCore "go.lumeweb.com/portal-plugin-ipfs/core"
-	"go.lumeweb.com/portal-plugin-ipfs/internal"
 	pluginConfig "go.lumeweb.com/portal-plugin-ipfs/internal/config"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/db"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/db/migrations"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/testing/mocks"
+	"go.lumeweb.com/portal-plugin-ipfs/internal/testing/testopts"
 	"go.lumeweb.com/portal/core"
 	coreTesting "go.lumeweb.com/portal/core/testing"
 	"go.uber.org/zap"
 )
 
 var NameserverValidatorTestOptions = coreTesting.CombineOptions(
-	coreTesting.NewMockPluginBuilder(internal.ProtocolName).WithService(pluginCore.DNS_SERVICE, func() (core.Service, []core.ContextBuilderOption, error) {
+	testopts.NewBaseMockPluginBuilder().WithService(pluginCore.DNS_SERVICE, func() (core.Service, []core.ContextBuilderOption, error) {
 		logger := zap.NewNop()
 		coreLogger := &core.Logger{Logger: logger}
 		pdnsClient, err := NewPowerDNSClient("http://localhost:8081", "test-api-key", coreLogger)

--- a/internal/service/website/janitor_test.go
+++ b/internal/service/website/janitor_test.go
@@ -12,26 +12,19 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.lumeweb.com/ipfs-content/paths"
 	pluginCore "go.lumeweb.com/portal-plugin-ipfs/core"
-	"go.lumeweb.com/portal-plugin-ipfs/internal"
 	pluginConfig "go.lumeweb.com/portal-plugin-ipfs/internal/config"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/db/migrations"
-	"go.lumeweb.com/portal-plugin-ipfs/internal/testing/mocks"
+	"go.lumeweb.com/portal-plugin-ipfs/internal/testing/testopts"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/testing/util"
 	"go.lumeweb.com/portal/core"
 	coreTesting "go.lumeweb.com/portal/core/testing"
 )
 
 var JanitorTestOptions = coreTesting.CombineOptions(
-	coreTesting.NewMockPluginBuilder(internal.ProtocolName).
-		WithMockServiceFactory(pluginCore.WEBSITE_SERVICE, mocks.NewMockWebsiteService).
+	testopts.NewMockPluginBuilder().
 		WithServiceConfig(pluginCore.WEBSITE_SERVICE, &pluginConfig.WebsiteConfig{
 			NotificationsEnabled: false,
 		}).
-		WithMockServiceFactory(pluginCore.IPNS_KEY_SERVICE, mocks.NewMockIPNSKeyService).
-		WithMockServiceFactory(pluginCore.PIN_SERVICE, mocks.NewMockIPFSPinService).
-		WithMockServiceFactory(pluginCore.FILE_MANAGER_SERVICE, mocks.NewMockFileManagerService).
-		WithMockServiceFactory(pluginCore.DNS_SERVICE, mocks.NewMockDNSService).
-		WithServiceConfig(pluginCore.DNS_SERVICE, &pluginConfig.DnsConfig{}).
 		WithMigrations(map[core.DBType]fs.FS{
 			core.DB_TYPE_SQLITE: migrations.GetSQLite(),
 		}).BuilderOption(),

--- a/internal/service/website/website_test.go
+++ b/internal/service/website/website_test.go
@@ -18,6 +18,7 @@ import (
 	pluginDb "go.lumeweb.com/portal-plugin-ipfs/internal/db"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/db/migrations"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/testing/mocks"
+	"go.lumeweb.com/portal-plugin-ipfs/internal/testing/testopts"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/testing/util"
 	"go.lumeweb.com/portal/core"
 	coreTesting "go.lumeweb.com/portal/core/testing"
@@ -157,16 +158,13 @@ func createMockDNSZone(zoneID uint, domain string, userID uint) *pluginDb.DNSZon
 
 var TestOptions = coreTesting.CombineOptions(
 	coreTesting.WithProtocolConfig(internal.ProtocolName, &pluginConfig.ProtocolConfig{}),
-	coreTesting.NewMockPluginBuilder(internal.ProtocolName).
+	testopts.NewBaseMockPluginBuilder().
 		WithService(pluginCore.WEBSITE_SERVICE, NewWebsiteService).
 		WithServiceConfig(pluginCore.WEBSITE_SERVICE, &pluginConfig.WebsiteConfig{
 			NotificationsEnabled: false,
 			AdminEmail:           "",
 			ValidationTokenTTL:   24 * time.Hour,
 		}).
-		WithMockServiceFactory(pluginCore.IPNS_KEY_SERVICE, mocks.NewMockIPNSKeyService).
-		WithMockServiceFactory(pluginCore.PIN_SERVICE, mocks.NewMockIPFSPinService).
-		WithMockServiceFactory(pluginCore.FILE_MANAGER_SERVICE, mocks.NewMockFileManagerService).
 		WithMockServiceFactory(pluginCore.DNS_SERVICE, mocks.NewMockDNSService).
 		WithServiceConfig(pluginCore.DNS_SERVICE, &pluginConfig.DnsConfig{
 			Enabled:                      true,

--- a/internal/testing/testopts/options.go
+++ b/internal/testing/testopts/options.go
@@ -1,16 +1,26 @@
 package testopts
 
 import (
-	"go.lumeweb.com/portal-plugin-ipfs/internal/plugin"
+	pluginCore "go.lumeweb.com/portal-plugin-ipfs/core"
+	"go.lumeweb.com/portal-plugin-ipfs/internal"
+	"go.lumeweb.com/portal-plugin-ipfs/internal/config"
+	"go.lumeweb.com/portal-plugin-ipfs/internal/testing/mocks"
 	coreTesting "go.lumeweb.com/portal/core/testing"
-	serviceTesting "go.lumeweb.com/portal/service/testing"
 )
 
-func GetStandardTestOptions() []coreTesting.TestContextBuilderOption {
-	return []coreTesting.TestContextBuilderOption{
-		serviceTesting.PresetE2E(),
-		coreTesting.WithConfig("core.mail.host", "localhost"),
-		coreTesting.WithConfig("core.mail.port", 25),
-		coreTesting.WithPlugins(plugin.GetPluginInfoWithTemplates(nil)),
-	}
+func NewMockPluginBuilder() *coreTesting.MockPluginBuilder {
+	return NewBaseMockPluginBuilder().
+		WithMockServiceFactory(pluginCore.WEBSITE_SERVICE, mocks.NewMockWebsiteService).
+		WithMockServiceFactory(pluginCore.DNS_SERVICE, mocks.NewMockDNSService).
+		WithServiceConfig(pluginCore.WEBSITE_SERVICE, config.WebsiteConfig{}).
+		WithServiceConfig(pluginCore.DNS_SERVICE, config.DnsConfig{})
+}
+
+func NewBaseMockPluginBuilder() *coreTesting.MockPluginBuilder {
+	return coreTesting.NewMockPluginBuilder(internal.ProtocolName).
+		WithMockServiceFactory(pluginCore.FILE_MANAGER_SERVICE, mocks.NewMockFileManagerService).
+		WithMockServiceFactory(pluginCore.PIN_SERVICE, mocks.NewMockIPFSPinService).
+		WithMockServiceFactory(pluginCore.BLOCK_SERVICE, mocks.NewMockBlockService).
+		WithMockServiceFactory(pluginCore.UPLOAD_SERVICE, mocks.NewMockUploadService).
+		WithMockServiceFactory(pluginCore.IPNS_KEY_SERVICE, mocks.NewMockIPNSKeyService)
 }

--- a/internal/testing/testopts/options.go
+++ b/internal/testing/testopts/options.go
@@ -12,8 +12,8 @@ func NewMockPluginBuilder() *coreTesting.MockPluginBuilder {
 	return NewBaseMockPluginBuilder().
 		WithMockServiceFactory(pluginCore.WEBSITE_SERVICE, mocks.NewMockWebsiteService).
 		WithMockServiceFactory(pluginCore.DNS_SERVICE, mocks.NewMockDNSService).
-		WithServiceConfig(pluginCore.WEBSITE_SERVICE, config.WebsiteConfig{}).
-		WithServiceConfig(pluginCore.DNS_SERVICE, config.DnsConfig{})
+		WithServiceConfig(pluginCore.WEBSITE_SERVICE, &config.WebsiteConfig{}).
+		WithServiceConfig(pluginCore.DNS_SERVICE, &config.DnsConfig{})
 }
 
 func NewBaseMockPluginBuilder() *coreTesting.MockPluginBuilder {


### PR DESCRIPTION
- `develop` <!-- branch-stack -->
  - **fix: use core.GetServiceConfig instead of direct GetConfig for DNS config** :point\_left:

***

<!-- kody-pr-summary:start -->

Refactor DNS config retrieval to use `core.GetServiceConfig` instead of manually fetching the DNS service and calling `GetConfig` with a type assertion. This replaces the multi-step nil-check, config fetch, and type-assertion pattern with a single utility function call, simplifying the code and aligning with the core framework's intended API.

<!-- kody-pr-summary:end -->
