### PR TITLE
feat: inherit SSL state from soft-deleted website on recreate

### DIFF
--- a/internal/service/website/website.go
+++ b/internal/service/website/website.go
@@ -29,6 +29,8 @@ import (
 	"gorm.io/gorm/clause"
 )
 
+const sslCertValidity = 90 * 24 * time.Hour
+
 // Validation error types
 var (
 	ErrInvalidCID    = errors.New("invalid CID")
@@ -105,6 +107,23 @@ func (s *WebsiteServiceDefault) CreateWebsite(ctx context.Context, website *plug
 			}
 			if existing != nil {
 				return nil, fmt.Errorf("domain already exists: %s", website.Domain)
+			}
+
+			// Inherit SSL state from soft-deleted website if cert is still valid
+			var deletedWebsite pluginDb.Website
+			err = db.RetryableComponentTransaction(s, ctx, func(tx *gorm.DB) *gorm.DB {
+				return tx.Unscoped().
+					Where("domain = ? AND deleted_at IS NOT NULL", website.Domain).
+					Where("ssl_status = ?", string(pluginDb.SSLStatusReady)).
+					Order("deleted_at DESC").
+					First(&deletedWebsite)
+			})
+			if err == nil && deletedWebsite.SSLIssuedAt != nil {
+				if time.Since(*deletedWebsite.SSLIssuedAt) < sslCertValidity {
+					website.SSLStatus = string(pluginDb.SSLStatusReady)
+					website.SSLIssuedAt = deletedWebsite.SSLIssuedAt
+					website.SSLLastUpdatedAt = deletedWebsite.SSLLastUpdatedAt
+				}
 			}
 
 			// Generate validation token

--- a/internal/service/website/website_test.go
+++ b/internal/service/website/website_test.go
@@ -2024,3 +2024,106 @@ func TestWebsiteService_UpdateWebsite_DNSHostingTransitionWithExistingZone(t *te
 		mockDNS.AssertNotCalled(t, "CreateZone")
 	}, TestOptions)
 }
+
+func TestWebsiteService_CreateWebsite_InheritsSSLFromSoftDeletedWebsite(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		websiteService := core.GetService[pluginCore.WebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
+		require.NotNil(tb, websiteService)
+
+		testCID := util.GenerateTestCID(t, "test data")
+		domain := "ssl-inherit-test.com"
+
+		website := createTestIPFSWebsite(testUserID1, domain, testCID.String())
+		createdWebsite, err := websiteService.CreateWebsite(context.Background(), website)
+		require.NoError(tb, err)
+
+		now := time.Now()
+		_, err = websiteService.UpdateSSLStatus(context.Background(), domain, pluginDb.SSLStatusReady, "", &now)
+		require.NoError(tb, err)
+
+		err = websiteService.DeleteWebsite(context.Background(), testUserID1, createdWebsite.ID)
+		require.NoError(tb, err)
+
+		_, err = websiteService.GetWebsiteByDomain(context.Background(), domain)
+		require.NoError(tb, err)
+
+		newWebsite := createTestIPFSWebsite(testUserID1, domain, testCID.String())
+		recreatedWebsite, err := websiteService.CreateWebsite(context.Background(), newWebsite)
+		require.NoError(tb, err)
+
+		assert.Equal(tb, string(pluginDb.SSLStatusReady), recreatedWebsite.SSLStatus)
+		assert.NotNil(tb, recreatedWebsite.SSLIssuedAt)
+		assert.NotNil(tb, recreatedWebsite.SSLLastUpdatedAt)
+	}, TestOptions)
+}
+
+func TestWebsiteService_CreateWebsite_DoesNotInheritExpiredSSLCert(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		websiteService := core.GetService[pluginCore.WebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
+		require.NotNil(tb, websiteService)
+
+		testCID := util.GenerateTestCID(t, "test data")
+		domain := "ssl-expired-inherit-test.com"
+
+		website := createTestIPFSWebsite(testUserID1, domain, testCID.String())
+		createdWebsite, err := websiteService.CreateWebsite(context.Background(), website)
+		require.NoError(tb, err)
+
+		oldIssuedAt := time.Now().Add(-91 * 24 * time.Hour)
+		_, err = websiteService.UpdateSSLStatus(context.Background(), domain, pluginDb.SSLStatusReady, "", &oldIssuedAt)
+		require.NoError(tb, err)
+
+		err = websiteService.DeleteWebsite(context.Background(), testUserID1, createdWebsite.ID)
+		require.NoError(tb, err)
+
+		newWebsite := createTestIPFSWebsite(testUserID1, domain, testCID.String())
+		recreatedWebsite, err := websiteService.CreateWebsite(context.Background(), newWebsite)
+		require.NoError(tb, err)
+
+		assert.Equal(tb, string(pluginDb.SSLStatusPending), recreatedWebsite.SSLStatus)
+		assert.Nil(tb, recreatedWebsite.SSLIssuedAt)
+	}, TestOptions)
+}
+
+func TestWebsiteService_CreateWebsite_DoesNotInheritFailedSSL(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		websiteService := core.GetService[pluginCore.WebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
+		require.NotNil(tb, websiteService)
+
+		testCID := util.GenerateTestCID(t, "test data")
+		domain := "ssl-failed-inherit-test.com"
+
+		website := createTestIPFSWebsite(testUserID1, domain, testCID.String())
+		createdWebsite, err := websiteService.CreateWebsite(context.Background(), website)
+		require.NoError(tb, err)
+
+		_, err = websiteService.UpdateSSLStatus(context.Background(), domain, pluginDb.SSLStatusFailed, "cert failed", nil)
+		require.NoError(tb, err)
+
+		err = websiteService.DeleteWebsite(context.Background(), testUserID1, createdWebsite.ID)
+		require.NoError(tb, err)
+
+		newWebsite := createTestIPFSWebsite(testUserID1, domain, testCID.String())
+		recreatedWebsite, err := websiteService.CreateWebsite(context.Background(), newWebsite)
+		require.NoError(tb, err)
+
+		assert.Equal(tb, string(pluginDb.SSLStatusPending), recreatedWebsite.SSLStatus)
+	}, TestOptions)
+}
+
+func TestWebsiteService_CreateWebsite_NoInheritWithoutSoftDeletedWebsite(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		websiteService := core.GetService[pluginCore.WebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
+		require.NotNil(tb, websiteService)
+
+		testCID := util.GenerateTestCID(t, "test data")
+		domain := "ssl-no-inherit-test.com"
+
+		website := createTestIPFSWebsite(testUserID1, domain, testCID.String())
+		createdWebsite, err := websiteService.CreateWebsite(context.Background(), website)
+		require.NoError(tb, err)
+
+		assert.Equal(tb, string(pluginDb.SSLStatusPending), createdWebsite.SSLStatus)
+		assert.Nil(tb, createdWebsite.SSLIssuedAt)
+	}, TestOptions)
+}


### PR DESCRIPTION
When a website is deleted and recreated for the same domain, Caddy reuses its cached certificate and never fires a webhook, leaving the new website stuck at ssl\_status=pending. On CreateWebsite, query for a soft-deleted record with ssl\_status=ready and inherit its SSL fields if SSLIssuedAt is within the 90-day cert validity window.

- `develop` <!-- branch-stack -->
  - **feat: inherit SSL state from soft-deleted website on recreate** :point\_left:

---

<!-- kody-pr-summary:start -->
## Description

This PR implements SSL state inheritance from soft-deleted websites when a website is recreated with the same domain.

When creating a new website, the system now checks for any previously soft-deleted website with the same domain that had a valid SSL certificate (status "Ready"). If the certificate was issued within the last 90 days (the defined validity period), the new website inherits the SSL state — including `SSLStatus`, `SSLIssuedAt`, and `SSLLastUpdatedAt` — from the most recently deleted record. This avoids unnecessary SSL certificate re-issuance when a website is deleted and recreated.

The inheritance only applies when:
- A soft-deleted website with the same domain exists
- The deleted website's SSL status was "Ready"
- The SSL certificate is still within its 90-day validity window

If the certificate has expired or the previous SSL status was not "Ready" (e.g., "Failed"), the new website defaults to the "Pending" SSL status as usual.

Tests cover: successful inheritance from a valid soft-deleted website, no inheritance for expired certificates, no inheritance for failed SSL status, and default "Pending" status when no soft-deleted website exists.
<!-- kody-pr-summary:end -->