### PR TITLE
fix: support partial updates for website update endpoint

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -592,12 +592,12 @@ See also:.*`),
 				router.WithSummary("Update website"),
 				router.WithDescription(`Updates an existing website configuration.
 
-Modifies domain, target CID, or settings for a website. Changes take effect after validation and DNS propagation.
+Modifies domain, target CID, DNS hosting, or other settings for a website. Only fields included in the request body will be updated; omitted fields remain unchanged. Changes take effect after validation and DNS propagation.
 
 See also:.*`),
 				router.WithTags("Websites"),
 				router.WithPathParam("id", "Website ID", ""),
-				router.WithRequestBody(&dto.WebsiteRequest{}, "Website request", true),
+				router.WithRequestBody(&dto.WebsiteUpdateRequest{}, "Website update request", true),
 				router.WithSuccessResponse(http.StatusOK, "Website updated", router.WithJSONContent(dto.WebsiteResponse{})),
 			),
 		),

--- a/internal/api/api_websites.go
+++ b/internal/api/api_websites.go
@@ -232,19 +232,27 @@ func (a *API) updateWebsite(c echo.Context) error {
 		return ctx.Error(apiErr, apiErr.HttpStatus())
 	}
 
-	var req dto.WebsiteRequest
+	var req dto.WebsiteUpdateRequest
 	if _, ok := httputil.DecodeAndValidateRequest(ctx, &req); !ok {
 		return nil
 	}
 
-	// Build updates map
-	updates := map[string]interface{}{
-		"domain":      req.Domain,
-		"target_type": req.TargetType,
-		"target_hash": req.TargetHash,
+	if !req.HasUpdates() {
+		return ctx.Error(NewError(ErrKeyInvalidRequest, fmt.Errorf("at least one field must be provided")), http.StatusUnprocessableEntity)
 	}
 
-	// Add dns_enabled if specified in request
+	// Build updates map from non-nil fields
+	updates := map[string]interface{}{}
+
+	if req.Domain != nil {
+		updates["domain"] = *req.Domain
+	}
+	if req.TargetType != nil {
+		updates["target_type"] = string(*req.TargetType)
+	}
+	if req.TargetHash != nil {
+		updates["target_hash"] = *req.TargetHash
+	}
 	if req.DNSEnabled != nil {
 		updates["dns_enabled"] = *req.DNSEnabled
 	}

--- a/internal/api/api_websites.go
+++ b/internal/api/api_websites.go
@@ -247,10 +247,11 @@ func (a *API) updateWebsite(c echo.Context) error {
 	if req.Domain != nil {
 		updates["domain"] = *req.Domain
 	}
-	if req.TargetType != nil {
+	if req.TargetType != nil || req.TargetHash != nil {
+		if req.TargetType == nil || req.TargetHash == nil {
+			return ctx.Error(NewError(ErrKeyInvalidRequest, fmt.Errorf("target_type and target_hash must both be provided")), http.StatusUnprocessableEntity)
+		}
 		updates["target_type"] = string(*req.TargetType)
-	}
-	if req.TargetHash != nil {
 		updates["target_hash"] = *req.TargetHash
 	}
 	if req.DNSEnabled != nil {

--- a/internal/api/api_websites_test.go
+++ b/internal/api/api_websites_test.go
@@ -862,6 +862,41 @@ func TestAPI_UpdateWebsite(t *testing.T) {
 		}, TestOptions)
 	})
 
+	t.Run("success_dns_hosting_only", func(t *testing.T) {
+		coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+			helper := newMockHelper(t, ctx)
+			token, userID := helper.SetupAuthenticatedTestWithCID(cid.MustParse(TestCID))
+
+			mockWebsiteService := core.GetService[*mocks.MockWebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
+
+			mockWebsite := createMockIPFSWebsite(1, userID, "example.com", TestCID, db.WebsiteStatusActive, "")
+
+			mockWebsiteService.EXPECT().UpdateWebsite(mock.Anything, userID, uint(1), mock.AnythingOfType("map[string]interface {}")).Return(mockWebsite, nil)
+
+			reqBody := `{"dns_hosting_enabled":true}`
+			rec := helper.makeAuthenticatedRequest(http.MethodPut, "/api/websites/1", token, []byte(reqBody))
+
+			assert.Equal(t, http.StatusOK, rec.Code)
+
+			var response dto.WebsiteResponse
+			err := json.Unmarshal(rec.Body.Bytes(), &response)
+			require.NoError(t, err)
+			assert.Equal(t, uint(1), response.ID)
+		}, TestOptions)
+	})
+
+	t.Run("error_no_fields", func(t *testing.T) {
+		coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+			helper := newMockHelper(t, ctx)
+			token, _ := helper.SetupAuthenticatedTestWithCID(cid.MustParse(TestCID))
+
+			reqBody := `{}`
+			rec := helper.makeAuthenticatedRequest(http.MethodPut, "/api/websites/1", token, []byte(reqBody))
+
+			assert.Equal(t, http.StatusUnprocessableEntity, rec.Code)
+		}, TestOptions)
+	})
+
 	t.Run("error_invalid_id", func(t *testing.T) {
 		coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 			helper := newMockHelper(t, ctx)

--- a/internal/api/api_websites_test.go
+++ b/internal/api/api_websites_test.go
@@ -897,6 +897,30 @@ func TestAPI_UpdateWebsite(t *testing.T) {
 		}, TestOptions)
 	})
 
+	t.Run("error_target_type_without_target_hash", func(t *testing.T) {
+		coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+			helper := newMockHelper(t, ctx)
+			token, _ := helper.SetupAuthenticatedTestWithCID(cid.MustParse(TestCID))
+
+			reqBody := `{"target_type":"ipfs"}`
+			rec := helper.makeAuthenticatedRequest(http.MethodPut, "/api/websites/1", token, []byte(reqBody))
+
+			assert.Equal(t, http.StatusUnprocessableEntity, rec.Code)
+		}, TestOptions)
+	})
+
+	t.Run("error_target_hash_without_target_type", func(t *testing.T) {
+		coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+			helper := newMockHelper(t, ctx)
+			token, _ := helper.SetupAuthenticatedTestWithCID(cid.MustParse(TestCID))
+
+			reqBody := fmt.Sprintf(`{"target_hash":"%s"}`, TestCID)
+			rec := helper.makeAuthenticatedRequest(http.MethodPut, "/api/websites/1", token, []byte(reqBody))
+
+			assert.Equal(t, http.StatusUnprocessableEntity, rec.Code)
+		}, TestOptions)
+	})
+
 	t.Run("error_invalid_id", func(t *testing.T) {
 		coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 			helper := newMockHelper(t, ctx)

--- a/internal/api/dto/website.go
+++ b/internal/api/dto/website.go
@@ -167,7 +167,7 @@ func (r *IPNSRepublishResponse) FromModel(any) error {
 
 // Website DTOs
 
-// WebsiteRequest represents a request to create or update a website
+// WebsiteRequest represents a request to create a website
 type WebsiteRequest struct {
 	Domain          string              `json:"domain"`
 	TargetType      db.WebsiteTargetType `json:"target_type"` // db.WebsiteTargetTypeIPFS or db.WebsiteTargetTypeIPNS
@@ -242,6 +242,82 @@ func (r *WebsiteRequest) ToModel() (*db.Website, error) {
 		}
 		website.TargetMultihash = target.ToMultihash()
 		website.CIDVersion = nil // NULL for IPNS
+	}
+
+	return website, nil
+}
+
+// WebsiteUpdateRequest represents a request to update a website
+// All fields are optional — only provided fields will be updated
+type WebsiteUpdateRequest struct {
+	Domain     *string              `json:"domain,omitempty"`
+	TargetType *db.WebsiteTargetType `json:"target_type,omitempty"`
+	TargetHash *string              `json:"target_hash,omitempty"`
+	DNSEnabled *bool                `json:"dns_hosting_enabled,omitempty"`
+}
+
+// HasUpdates returns true if at least one field is set
+func (r *WebsiteUpdateRequest) HasUpdates() bool {
+	return r.Domain != nil || r.TargetType != nil || r.TargetHash != nil || r.DNSEnabled != nil
+}
+
+func (r WebsiteUpdateRequest) Schema() *zog.StructSchema {
+	return zog.Struct(zog.Shape{
+		"Domain": zog.Ptr(zog.String().Required().Min(1).Max(255)),
+		"TargetType": zog.Ptr(config.ZogStringLike[db.WebsiteTargetType]().OneOf([]db.WebsiteTargetType{
+			db.WebsiteTargetTypeIPFS,
+			db.WebsiteTargetTypeIPNS,
+		})),
+		"TargetHash": zog.Ptr(zog.String().Required().Min(1).Max(255)),
+		"DNSEnabled": zog.Ptr(zog.Bool()),
+	})
+}
+
+func (r *WebsiteUpdateRequest) ToModel() (*db.Website, error) {
+	website := &db.Website{}
+
+	if r.Domain != nil {
+		website.Domain = *r.Domain
+	}
+
+	if r.TargetType != nil {
+		website.TargetType = string(*r.TargetType)
+	}
+
+	if r.DNSEnabled != nil {
+		website.Enabled = *r.DNSEnabled
+	}
+
+	if r.TargetHash != nil && r.TargetType != nil {
+		if *r.TargetType == db.WebsiteTargetTypeIPFS {
+			c, err := cid.Parse(*r.TargetHash)
+			if err != nil {
+				return nil, &httputil.ValidationError{
+					FieldErrors: map[string]string{
+						"target_hash": fmt.Sprintf("invalid CID: %v", err),
+					},
+				}
+			}
+			normalizedCid := encoding.NormalizeCid(c)
+			website.TargetMultihash = normalizedCid.Hash()
+			version := uint8(normalizedCid.Version())
+			website.CIDVersion = &version
+			codec := uint8(normalizedCid.Type())
+			website.CIDType = &codec
+		}
+
+		if *r.TargetType == db.WebsiteTargetTypeIPNS {
+			target, err := db.NewIPNSTargetFromString(*r.TargetHash)
+			if err != nil {
+				return nil, &httputil.ValidationError{
+					FieldErrors: map[string]string{
+						"target_hash": fmt.Sprintf("invalid IPNS target: %v", err),
+					},
+				}
+			}
+			website.TargetMultihash = target.ToMultihash()
+			website.CIDVersion = nil
+		}
 	}
 
 	return website, nil
@@ -424,6 +500,8 @@ var _ httputil.DTOValidator = (*IPNSPublishRequest)(nil)
 var _ httputil.DTORequest[*IPNSPublishRequest] = (*IPNSPublishRequest)(nil)
 var _ httputil.DTOValidator = (*WebsiteRequest)(nil)
 var _ httputil.DTORequest[*db.Website] = (*WebsiteRequest)(nil)
+var _ httputil.DTOValidator = (*WebsiteUpdateRequest)(nil)
+var _ httputil.DTORequest[*db.Website] = (*WebsiteUpdateRequest)(nil)
 var _ httputil.DTOValidator = (*WebsiteFilter)(nil)
 var _ httputil.DTORequest[WebsiteFilter] = (*WebsiteFilter)(nil)
 var _ httputil.DTOValidator = (*SSLStatusUpdateRequest)(nil)


### PR DESCRIPTION
The PUT /websites/:id endpoint reused WebsiteRequest which required domain, target\_type, and target\_hash, making partial updates (like toggling --dns-hosting) impossible. Introduced WebsiteUpdateRequest with optional pointer fields so only provided fields are included in the updates map.

- `develop` <!-- branch-stack -->
  - **fix: support partial updates for website update endpoint** :point\_left:

***

<!-- kody-pr-summary:start -->

Support partial updates for the website update endpoint by introducing a dedicated `WebsiteUpdateRequest` DTO with optional (pointer) fields, replacing the previous `WebsiteRequest` which required all fields. Only fields included in the request body are applied; omitted fields remain unchanged. An empty request body now returns a 422 Unprocessable Entity error.

<!-- kody-pr-summary:end -->
