### PR TITLE
feat: include nameservers in website config when DNS hosting is enabled

### DIFF
--- a/internal/api/api_websites.go
+++ b/internal/api/api_websites.go
@@ -38,6 +38,9 @@ func (a *API) getWebsiteConfig(c echo.Context) error {
 	cfg := &dto.WebsiteConfig{
 		GatewayDomain: a.gatewayDomain(),
 	}
+	if a.dnsConfig != nil && a.dnsConfig.Enabled && len(a.dnsConfig.Nameservers) > 0 {
+		cfg.Nameservers = a.dnsConfig.Nameservers
+	}
 	return httputil.EncodeResponse(ctx, cfg, &dto.WebsiteConfigResponse{})
 }
 

--- a/internal/api/dto/website.go
+++ b/internal/api/dto/website.go
@@ -441,17 +441,20 @@ func (f WebsiteFilter) ToModel() (WebsiteFilter, error) {
 // WebsiteConfig holds website-related configuration
 type WebsiteConfig struct {
 	GatewayDomain string
+	Nameservers   []string
 }
 
 // WebsiteConfigResponse returns website-related configuration for client use
 type WebsiteConfigResponse struct {
-	GatewayDomain string `json:"gateway_domain,omitempty"`
+	GatewayDomain string   `json:"gateway_domain,omitempty"`
+	Nameservers   []string `json:"nameservers,omitempty"`
 }
 
 var _ httputil.DTOResponse[*WebsiteConfig] = (*WebsiteConfigResponse)(nil)
 
 func (r *WebsiteConfigResponse) FromModel(cfg *WebsiteConfig) error {
 	r.GatewayDomain = cfg.GatewayDomain
+	r.Nameservers = cfg.Nameservers
 	return nil
 }
 


### PR DESCRIPTION
- `develop` <!-- branch-stack -->
  - **feat: include nameservers in website config when DNS hosting is enabled** :point\_left:

---

<!-- kody-pr-summary:start -->
Include nameservers in the website configuration response when DNS hosting is enabled

This PR extends the website configuration API to return the configured nameservers when DNS hosting is enabled and nameservers are available. The `WebsiteConfig` and `WebsiteConfigResponse` DTOs now include a `Nameservers` field, and the `getWebsiteConfig` endpoint populates it from the DNS configuration only when DNS is enabled and nameservers are configured. This allows clients to discover which nameservers to use when pointing their domains to the portal's DNS hosting service.
<!-- kody-pr-summary:end -->