### PR TITLE
fix: make DNS zone creation idempotent and preserve zone ref on delete failure

### DIFF
--- a/internal/service/dns/dns_service_test.go
+++ b/internal/service/dns/dns_service_test.go
@@ -215,6 +215,23 @@ func TestDNSServiceCreateZoneDuplicate(t *testing.T) {
 	}, getTestOptions())
 }
 
+func TestDNSServiceCreateZoneDuplicateDifferentUser(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		svc := core.GetService[*DNSServiceDefault](ctx, pluginCore.DNS_SERVICE)
+		require.NotNil(tb, svc)
+
+		zone1, err := svc.CreateZone(ctx, "example.com.", 1)
+		require.NoError(tb, err)
+		require.NotNil(tb, zone1)
+
+		// Different user trying to create zone for same domain should fail
+		zone2, err := svc.CreateZone(ctx, "example.com.", 2)
+		require.Error(tb, err)
+		require.Nil(tb, zone2)
+		require.Contains(tb, err.Error(), "already owned by another user")
+	}, getTestOptions())
+}
+
 func TestDNSServiceCreateZoneIdempotentAfterPowerDNSConflict(t *testing.T) {
 	zoneCreated := false
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/service/dns/dns_service_test.go
+++ b/internal/service/dns/dns_service_test.go
@@ -203,16 +203,65 @@ func TestDNSServiceCreateZoneDuplicate(t *testing.T) {
 		svc := core.GetService[*DNSServiceDefault](ctx, pluginCore.DNS_SERVICE)
 		require.NotNil(tb, svc)
 
-		// Create first zone
 		zone1, err := svc.CreateZone(ctx, "example.com.", 1)
 		require.NoError(tb, err)
 		require.NotNil(tb, zone1)
 
-		// Try to create duplicate zone
+		// Duplicate should return existing zone instead of erroring
 		zone2, err := svc.CreateZone(ctx, "example.com.", 1)
-		require.Error(tb, err)
-		require.Nil(tb, zone2)
+		require.NoError(tb, err)
+		require.NotNil(tb, zone2)
+		require.Equal(tb, zone1.ID, zone2.ID)
 	}, getTestOptions())
+}
+
+func TestDNSServiceCreateZoneIdempotentAfterPowerDNSConflict(t *testing.T) {
+	zoneCreated := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && r.URL.Path == "/servers/localhost/zones" {
+			if zoneCreated {
+				w.WriteHeader(http.StatusConflict)
+				w.Write([]byte(`{"error": "Conflict"}`))
+				return
+			}
+			zoneCreated = true
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(powerdns.Zone{
+				Id:   new("conflict-test.com."),
+				Name: new("conflict-test.com."),
+				Kind: (*powerdns.ZoneKind)(new("Native")),
+			})
+			return
+		}
+		if r.Method == http.MethodGet && r.URL.Path == "/servers/localhost/zones/conflict-test.com." {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(powerdns.Zone{
+				Id:   new("conflict-test.com."),
+				Name: new("conflict-test.com."),
+				Kind: (*powerdns.ZoneKind)(new("Native")),
+			})
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		svc := core.GetService[*DNSServiceDefault](ctx, pluginCore.DNS_SERVICE)
+		require.NotNil(tb, svc)
+
+		// First call creates zone normally in PowerDNS + DB
+		zone1, err := svc.CreateZone(ctx, "conflict-test.com.", 1)
+		require.NoError(tb, err)
+		require.NotNil(tb, zone1)
+
+		// The DB zone was deleted externally (simulating toggle-off),
+		// but PowerDNS still has the zone (returns 409 on re-create).
+		// Service should handle this gracefully via GetZoneByDomain returning
+		// nil for the DB, then PowerDNS 409 → fetch existing → create DB row.
+	}, createTestOptionsWithServer(server))
 }
 
 func TestDNSServiceCreateZoneTableDriven(t *testing.T) {

--- a/internal/service/dns/dns_service_zone.go
+++ b/internal/service/dns/dns_service_zone.go
@@ -34,6 +34,9 @@ func (s *DNSServiceDefault) CreateZone(ctx context.Context, domain string, userI
 		return nil, fmt.Errorf("failed to check existing domain: %w", err)
 	}
 	if existing != nil {
+		if existing.UserID != userID {
+			return nil, fmt.Errorf("domain %q is already owned by another user", domain)
+		}
 		return existing, nil
 	}
 
@@ -74,6 +77,9 @@ func (s *DNSServiceDefault) CreateZone(ctx context.Context, domain string, userI
 			}
 			if existing == nil {
 				return nil, fmt.Errorf("concurrent zone creation detected but existing zone not found for domain %q", domain)
+			}
+			if existing.UserID != userID {
+				return nil, fmt.Errorf("domain %q is already owned by another user", domain)
 			}
 			return existing, nil
 		}

--- a/internal/service/dns/dns_service_zone.go
+++ b/internal/service/dns/dns_service_zone.go
@@ -64,6 +64,19 @@ func (s *DNSServiceDefault) CreateZone(ctx context.Context, domain string, userI
 		return tx.Create(dnsZone)
 	})
 	if err != nil {
+		if isDuplicateKeyError(err) {
+			s.Logger().Info("DNS zone already exists in database (concurrent create), fetching existing",
+				zap.String("domain", domain))
+
+			existing, getErr := s.GetZoneByDomain(ctx, domain)
+			if getErr != nil {
+				return nil, fmt.Errorf("concurrent zone creation detected but failed to fetch existing: %w", getErr)
+			}
+			if existing == nil {
+				return nil, fmt.Errorf("concurrent zone creation detected but existing zone not found for domain %q", domain)
+			}
+			return existing, nil
+		}
 		return nil, fmt.Errorf("failed to create zone in database: %w", err)
 	}
 
@@ -494,11 +507,8 @@ func (s *DNSServiceDefault) validateDomain(domain string) error {
 		return fmt.Errorf("domain too long (max 255 characters)")
 	}
 
-	// Strip trailing dot if present (FQDN format)
 	trimmedDomain := strings.TrimSuffix(domain, ".")
 
-	// Validate domain format according to RFC 1035
-	// Domain labels must be 1-63 characters, alphanumeric or hyphen, cannot start/end with hyphen
 	labels := strings.Split(trimmedDomain, ".")
 
 	for _, label := range labels {
@@ -516,4 +526,14 @@ func (s *DNSServiceDefault) validateDomain(domain string) error {
 	}
 
 	return nil
+}
+
+func isDuplicateKeyError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "UNIQUE constraint failed") ||
+		strings.Contains(msg, "Duplicate entry") ||
+		strings.Contains(msg, "duplicate key value")
 }

--- a/internal/service/dns/dns_service_zone.go
+++ b/internal/service/dns/dns_service_zone.go
@@ -28,21 +28,20 @@ func (s *DNSServiceDefault) CreateZone(ctx context.Context, domain string, userI
 		return nil, fmt.Errorf("invalid domain: %w", err)
 	}
 
-	// Check if domain already exists
+	// Check if domain already exists in database
 	existing, err := s.GetZoneByDomain(ctx, domain)
 	if err != nil {
 		return nil, fmt.Errorf("failed to check existing domain: %w", err)
 	}
 	if existing != nil {
-		return nil, fmt.Errorf("domain already exists: %s", domain)
+		return existing, nil
 	}
 
-	// Create zone in PowerDNS
+	// Create zone in PowerDNS (idempotent: returns existing zone on 409)
 	if s.pdnsClient == nil {
 		return nil, fmt.Errorf("DNS hosting not enabled")
 	}
 
-	// Get approved nameservers from config
 	nameservers := s.config.Nameservers
 	if len(nameservers) == 0 {
 		return nil, fmt.Errorf("no approved nameservers configured")

--- a/internal/service/dns/powerdns_client.go
+++ b/internal/service/dns/powerdns_client.go
@@ -58,12 +58,10 @@ func handleResponse[T any](resp *http.Response) (*T, error) {
 	return &result, nil
 }
 
-// CreateZone creates a new zone in PowerDNS
+// CreateZone creates a new zone in PowerDNS, or returns the existing zone if it already exists (409)
 func (c *PowerDNSClient) CreateZone(ctx context.Context, domain string, nameservers []string) (*powerdns.Zone, error) {
-	// PowerDNS requires canonical zone names with trailing dots
 	canonicalDomain := strings.TrimSuffix(domain, ".") + "."
 
-	// Normalize nameservers to canonical form (with trailing dots)
 	canonicalNameservers := make([]string, len(nameservers))
 	for i, ns := range nameservers {
 		canonicalNameservers[i] = strings.TrimSuffix(ns, ".") + "."
@@ -90,6 +88,20 @@ func (c *PowerDNSClient) CreateZone(ctx context.Context, domain string, nameserv
 
 	zone, err := handleResponse[powerdns.Zone](resp)
 	if err != nil {
+		if strings.Contains(err.Error(), "status 409") {
+			c.logger.Info("Zone already exists in PowerDNS, fetching existing zone",
+				zap.String("domain", domain))
+
+			existingZone, getErr := c.GetZone(ctx, canonicalDomain)
+			if getErr != nil {
+				return nil, fmt.Errorf("zone already exists but failed to fetch it: %w", getErr)
+			}
+			if existingZone.Id == nil {
+				return nil, fmt.Errorf("existing zone has no ID for domain %q", domain)
+			}
+
+			return existingZone, nil
+		}
 		return nil, err
 	}
 

--- a/internal/service/dns/powerdns_client_test.go
+++ b/internal/service/dns/powerdns_client_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -962,6 +963,29 @@ func TestCreateZoneConflictExistingZoneNoID(t *testing.T) {
 	}
 	if zone != nil {
 		t.Errorf("expected nil zone on error, got %v", zone)
+	}
+}
+
+func TestIsDuplicateKeyError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{"sqlite unique", fmt.Errorf("UNIQUE constraint failed: ipfs_dns_zones.domain"), true},
+		{"mysql duplicate", fmt.Errorf("Duplicate entry 'example.com' for key 'idx_dns_zones_domain'"), true},
+		{"postgres duplicate", fmt.Errorf("duplicate key value violates unique constraint"), true},
+		{"other error", fmt.Errorf("some other error"), false},
+		{"nil error", nil, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isDuplicateKeyError(tt.err)
+			if result != tt.expected {
+				t.Errorf("isDuplicateKeyError(%v) = %v, want %v", tt.err, result, tt.expected)
+			}
+		})
 	}
 }
 

--- a/internal/service/dns/powerdns_client_test.go
+++ b/internal/service/dns/powerdns_client_test.go
@@ -845,6 +845,126 @@ func TestCreateZoneErrorResponseBody(t *testing.T) {
 	}
 }
 
+func TestCreateZoneConflictFetchesExisting(t *testing.T) {
+	requestCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if r.Method == http.MethodPost && r.URL.Path == "/servers/localhost/zones" {
+			w.WriteHeader(http.StatusConflict)
+			w.Write([]byte(`{"error": "Conflict"}`))
+			return
+		}
+		if r.Method == http.MethodGet && r.URL.Path == "/servers/localhost/zones/example.com." {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(powerdns.Zone{
+				Id:   strPtr("example.com."),
+				Name: strPtr("example.com."),
+				Kind: (*powerdns.ZoneKind)(strPtr("Native")),
+			})
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	logger := zap.NewNop()
+	coreLogger := &core.Logger{Logger: logger}
+	client, err := NewPowerDNSClient(server.URL, "test-api-key", coreLogger)
+	if err != nil {
+		t.Fatalf("NewPowerDNSClient failed: %v", err)
+	}
+
+	ctx := context.Background()
+	zone, err := client.CreateZone(ctx, "example.com", []string{"ns1.example.com."})
+
+	if err != nil {
+		t.Fatalf("expected no error on 409 conflict, got: %v", err)
+	}
+	if zone == nil {
+		t.Fatal("expected zone, got nil")
+	}
+	if zone.Id == nil || *zone.Id != "example.com." {
+		t.Errorf("expected zone ID 'example.com.', got %v", zone.Id)
+	}
+	if requestCount != 2 {
+		t.Errorf("expected 2 requests (POST + GET), got %d", requestCount)
+	}
+}
+
+func TestCreateZoneConflictGetAlsoFails(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && r.URL.Path == "/servers/localhost/zones" {
+			w.WriteHeader(http.StatusConflict)
+			w.Write([]byte(`{"error": "Conflict"}`))
+			return
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	logger := zap.NewNop()
+	coreLogger := &core.Logger{Logger: logger}
+	client, err := NewPowerDNSClient(server.URL, "test-api-key", coreLogger)
+	if err != nil {
+		t.Fatalf("NewPowerDNSClient failed: %v", err)
+	}
+
+	ctx := context.Background()
+	zone, err := client.CreateZone(ctx, "example.com", []string{"ns1.example.com."})
+
+	if err == nil {
+		t.Error("expected error when GET also fails after 409")
+	}
+	if !strings.Contains(err.Error(), "zone already exists") {
+		t.Errorf("expected error to mention 'zone already exists', got: %v", err)
+	}
+	if zone != nil {
+		t.Errorf("expected nil zone on error, got %v", zone)
+	}
+}
+
+func TestCreateZoneConflictExistingZoneNoID(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && r.URL.Path == "/servers/localhost/zones" {
+			w.WriteHeader(http.StatusConflict)
+			w.Write([]byte(`{"error": "Conflict"}`))
+			return
+		}
+		if r.Method == http.MethodGet {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(powerdns.Zone{
+				Name: strPtr("example.com."),
+				Kind: (*powerdns.ZoneKind)(strPtr("Native")),
+			})
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	logger := zap.NewNop()
+	coreLogger := &core.Logger{Logger: logger}
+	client, err := NewPowerDNSClient(server.URL, "test-api-key", coreLogger)
+	if err != nil {
+		t.Fatalf("NewPowerDNSClient failed: %v", err)
+	}
+
+	ctx := context.Background()
+	zone, err := client.CreateZone(ctx, "example.com", []string{"ns1.example.com."})
+
+	if err == nil {
+		t.Error("expected error when existing zone has no ID")
+	}
+	if !strings.Contains(err.Error(), "existing zone has no ID") {
+		t.Errorf("expected error about missing ID, got: %v", err)
+	}
+	if zone != nil {
+		t.Errorf("expected nil zone on error, got %v", zone)
+	}
+}
+
 // Helper functions
 
 func intPtr(i int) *int {

--- a/internal/service/website/website.go
+++ b/internal/service/website/website.go
@@ -726,6 +726,8 @@ func (s *WebsiteServiceDefault) handleDNSDisabledTransition(ctx context.Context,
 		zap.Uint("website_id", website.ID),
 		zap.String("domain", website.Domain))
 
+	zoneDeleted := false
+
 	// Delete DNS zone if it exists
 	if website.DNSZoneID != nil && s.dnsSvc != nil {
 		err := s.dnsSvc.DeleteZone(ctx, *website.DNSZoneID)
@@ -734,20 +736,25 @@ func (s *WebsiteServiceDefault) handleDNSDisabledTransition(ctx context.Context,
 				zap.Error(err),
 				zap.Uint("website_id", website.ID),
 				zap.Uint("dns_zone_id", *website.DNSZoneID))
-			// Continue despite DNS zone deletion failure
 		} else {
+			zoneDeleted = true
 			s.Logger().Info("DNS zone deleted for website",
 				zap.Uint("website_id", website.ID),
 				zap.Uint("dns_zone_id", *website.DNSZoneID))
 		}
 	}
 
-	// Reset status to pending_validation and clear dns_zone_id so user can re-validate without DNS
+	// Reset status to pending_validation
+	// Only clear dns_zone_id if the zone was actually deleted from PowerDNS
+	updates := map[string]interface{}{
+		"status": string(pluginDb.WebsiteStatusPendingValidation),
+	}
+	if zoneDeleted {
+		updates["dns_zone_id"] = nil
+	}
+
 	err := db.RetryableComponentTransaction(s, ctx, func(tx *gorm.DB) *gorm.DB {
-		return tx.Model(website).Updates(map[string]interface{}{
-			"status":      string(pluginDb.WebsiteStatusPendingValidation),
-			"dns_zone_id": nil,
-		})
+		return tx.Model(website).Updates(updates)
 	})
 	if err != nil {
 		s.Logger().Error("Failed to update website",
@@ -756,9 +763,10 @@ func (s *WebsiteServiceDefault) handleDNSDisabledTransition(ctx context.Context,
 		return fmt.Errorf("failed to update website: %w", err)
 	}
 
-	s.Logger().Info("DNS zone deleted, website reset to pending_validation",
+	s.Logger().Info("DNS hosting disabled, website reset to pending_validation",
 		zap.Uint("website_id", website.ID),
-		zap.String("domain", website.Domain))
+		zap.String("domain", website.Domain),
+		zap.Bool("zone_deleted", zoneDeleted))
 
 	return nil
 }

--- a/internal/service/website/website_test.go
+++ b/internal/service/website/website_test.go
@@ -2,6 +2,7 @@ package website
 
 import (
 	"context"
+	"errors"
 	"io/fs"
 	"testing"
 	"time"
@@ -2022,6 +2023,90 @@ func TestWebsiteService_UpdateWebsite_DNSHostingTransitionWithExistingZone(t *te
 
 		// Verify CreateZone was NOT called (zone already existed)
 		mockDNS.AssertNotCalled(t, "CreateZone")
+	}, TestOptions)
+}
+
+func TestWebsiteService_UpdateWebsite_DNSEnableToggleOffOn(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		websiteService := core.GetService[pluginCore.WebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
+		mockDNS := core.GetService[*mocks.MockDNSService](ctx, pluginCore.DNS_SERVICE)
+		mockIPNSKey := core.GetService[*mocks.MockIPNSKeyService](ctx, pluginCore.IPNS_KEY_SERVICE)
+
+		testCID := util.GenerateTestCID(t, "test data")
+		domain := "dns-toggle-test.com"
+		testZoneID := uint(8001)
+
+		website := createTestIPFSWebsite(testUserID1, domain, testCID.String())
+		website.Enabled = true
+		website.Status = string(pluginDb.WebsiteStatusActive)
+
+		// Initial creation with DNS enabled
+		setupIPNSAutoCreationMocks(t, mockIPNSKey, testUserID1, domain, testCID)
+		setupDNSZoneCreationMocks(t, mockDNS, testZoneID, domain, testUserID1)
+
+		createdWebsite, err := websiteService.CreateWebsite(context.Background(), website)
+		require.NoError(tb, err)
+		require.NotNil(tb, createdWebsite)
+		assert.True(t, createdWebsite.Enabled)
+		assert.NotNil(t, createdWebsite.DNSZoneID)
+
+		// Toggle DNS off
+		mockDNS.EXPECT().DeleteZone(mock.Anything, *createdWebsite.DNSZoneID).Return(nil).Once()
+		updatedWebsite, err := websiteService.UpdateWebsite(context.Background(), testUserID1, createdWebsite.ID, map[string]interface{}{
+			"dns_enabled": false,
+		})
+		require.NoError(tb, err)
+		assert.False(t, updatedWebsite.Enabled)
+		assert.Nil(t, updatedWebsite.DNSZoneID, "dns_zone_id should be nil after successful delete")
+
+		// Toggle DNS back on - handleDNSEnabledTransition only creates zone + records (no IPNS)
+		newZoneID := uint(8002)
+		newMockZone := createMockDNSZone(newZoneID, domain, testUserID1)
+		mockDNS.EXPECT().CreateZone(mock.Anything, domain, testUserID1).Return(newMockZone, nil).Once()
+		mockDNS.EXPECT().CreateWebsiteDNSRecords(mock.Anything, newZoneID, mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
+
+		updatedWebsite2, err := websiteService.UpdateWebsite(context.Background(), testUserID1, createdWebsite.ID, map[string]interface{}{
+			"dns_enabled": true,
+		})
+		require.NoError(tb, err)
+		assert.True(t, updatedWebsite2.Enabled)
+		assert.NotNil(t, updatedWebsite2.DNSZoneID, "dns_zone_id should be set after re-enable")
+		assert.Equal(t, newZoneID, *updatedWebsite2.DNSZoneID)
+	}, TestOptions)
+}
+
+func TestWebsiteService_UpdateWebsite_DisableDNSHostingDeleteZoneFails(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		websiteService := core.GetService[pluginCore.WebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
+		mockDNS := core.GetService[*mocks.MockDNSService](ctx, pluginCore.DNS_SERVICE)
+		mockIPNSKey := core.GetService[*mocks.MockIPNSKeyService](ctx, pluginCore.IPNS_KEY_SERVICE)
+
+		testCID := util.GenerateTestCID(t, "test data")
+		domain := "dns-delete-fail-test.com"
+		testZoneID := uint(8003)
+
+		website := createTestIPFSWebsite(testUserID1, domain, testCID.String())
+		website.Enabled = true
+		website.Status = string(pluginDb.WebsiteStatusActive)
+
+		setupIPNSAutoCreationMocks(t, mockIPNSKey, testUserID1, domain, testCID)
+		setupDNSZoneCreationMocks(t, mockDNS, testZoneID, domain, testUserID1)
+
+		createdWebsite, err := websiteService.CreateWebsite(context.Background(), website)
+		require.NoError(tb, err)
+		require.NotNil(tb, createdWebsite)
+		assert.NotNil(t, createdWebsite.DNSZoneID)
+
+		// Toggle DNS off but DeleteZone fails
+		mockDNS.EXPECT().DeleteZone(mock.Anything, *createdWebsite.DNSZoneID).Return(errors.New("powerdns unavailable")).Once()
+
+		updatedWebsite, err := websiteService.UpdateWebsite(context.Background(), testUserID1, createdWebsite.ID, map[string]interface{}{
+			"dns_enabled": false,
+		})
+		require.NoError(tb, err)
+		assert.False(t, updatedWebsite.Enabled)
+		assert.NotNil(t, updatedWebsite.DNSZoneID, "dns_zone_id should be preserved when DeleteZone fails")
+		assert.Equal(t, *createdWebsite.DNSZoneID, *updatedWebsite.DNSZoneID)
 	}, TestOptions)
 }
 


### PR DESCRIPTION
PowerDNS CreateZone now handles 409 Conflict by fetching the existing zone instead of failing. DNS service CreateZone returns existing DB records on duplicate instead of erroring. Website disable handler only clears dns\_zone\_id if the PowerDNS zone was actually deleted, preventing orphaned zones on re-enable.

- `develop` <!-- branch-stack -->
  - **fix: make DNS zone creation idempotent and preserve zone ref on delete failure** :point\_left:

***

<!-- kody-pr-summary:start -->

Make DNS zone creation idempotent and preserve zone reference on delete failure

This PR fixes two related issues with DNS zone toggling:

1. **Idempotent zone creation**: When `CreateZone` is called for a domain that already exists in the database, it now returns the existing zone instead of returning an error. Similarly, when PowerDNS returns a 409 Conflict (zone already exists), the client fetches and returns the existing zone rather than failing. This allows DNS hosting to be toggled off and back on without errors, even when the zone still exists in PowerDNS.

2. **Preserve zone reference on delete failure**: When DNS hosting is disabled and the PowerDNS `DeleteZone` call fails, the `dns_zone_id` is now preserved in the database instead of being cleared. Previously, clearing the reference on failure created orphaned zones in PowerDNS that could no longer be managed or cleaned up. The reference is only cleared when the zone is successfully deleted.

<!-- kody-pr-summary:end -->
