### PR TITLE
fix: restore soft-deleted DNS zones on re-enable instead of failing on unique constraint

### DIFF
--- a/internal/service/dns/dns_service_test.go
+++ b/internal/service/dns/dns_service_test.go
@@ -1024,41 +1024,37 @@ func TestDNSServiceCreateZoneRestoresSoftDeletedZone(t *testing.T) {
 		svc := core.GetService[*DNSServiceDefault](ctx, pluginCore.DNS_SERVICE)
 		require.NotNil(tb, svc)
 
-		// Create a zone
 		zone1, err := svc.CreateZone(ctx, "example.com.", 1)
 		require.NoError(tb, err)
 		require.NotNil(tb, zone1)
 		originalID := zone1.ID
+		originalPDNSZoneID := zone1.PowerDNSZoneID
 
-		// Soft-delete the zone
 		err = svc.DeleteZone(ctx, zone1.ID)
 		require.NoError(tb, err)
 
-		// Verify GetZoneByDomain still finds the soft-deleted zone
 		deleted, err := svc.GetZoneByDomain(ctx, "example.com.")
 		require.NoError(tb, err)
 		require.NotNil(tb, deleted)
 		require.True(tb, deleted.DeletedAt.Valid, "zone should be soft-deleted")
 
-		// Verify normal GetZone no longer finds it
 		_, err = svc.GetZone(ctx, originalID)
 		require.Equal(tb, gorm.ErrRecordNotFound, err)
 
-		// Re-create the zone — should restore the soft-deleted row
 		zone2, err := svc.CreateZone(ctx, "example.com.", 1)
 		require.NoError(tb, err)
 		require.NotNil(tb, zone2)
 
-		// Should be the same row (restored, not new)
 		require.Equal(tb, originalID, zone2.ID, "restored zone should have same ID")
 		require.False(tb, zone2.DeletedAt.Valid, "restored zone should not be soft-deleted")
 		require.Equal(tb, string(pluginDb.DNSZoneStatusPendingNameserver), zone2.Status)
+		require.Equal(tb, originalPDNSZoneID, zone2.PowerDNSZoneID, "restored zone should have updated PowerDNSZoneID from recreation")
 
-		// Verify GetZone now finds it normally
 		freshZone, err := svc.GetZone(ctx, zone2.ID)
 		require.NoError(tb, err)
 		require.NotNil(tb, freshZone)
 		require.Equal(tb, "example.com.", freshZone.Domain)
+		require.Equal(tb, originalPDNSZoneID, freshZone.PowerDNSZoneID)
 	}, getTestOptions())
 }
 
@@ -1112,16 +1108,71 @@ func TestDNSServiceCreateZoneActiveZoneNotSoftDeletedReturnsExisting(t *testing.
 		svc := core.GetService[*DNSServiceDefault](ctx, pluginCore.DNS_SERVICE)
 		require.NotNil(tb, svc)
 
-		// Create a zone
 		zone1, err := svc.CreateZone(ctx, "example.com.", 1)
 		require.NoError(tb, err)
 		require.NotNil(tb, zone1)
 
-		// Creating again should return the existing zone (not soft-deleted)
 		zone2, err := svc.CreateZone(ctx, "example.com.", 1)
 		require.NoError(tb, err)
 		require.NotNil(tb, zone2)
 		require.Equal(tb, zone1.ID, zone2.ID)
 		require.False(tb, zone2.DeletedAt.Valid, "existing active zone should not be soft-deleted")
 	}, getTestOptions())
+}
+
+func TestDNSServiceCreateZoneRestoresSoftDeletedZoneWithNewPowerDNSZoneID(t *testing.T) {
+	createCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && r.URL.Path == "/servers/localhost/zones" {
+			createCount++
+			zoneID := fmt.Sprintf("pdns-zone-%d.", createCount)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(powerdns.Zone{
+				Id:   &zoneID,
+				Name: new("recreate-test.com."),
+				Kind: (*powerdns.ZoneKind)(new("Native")),
+			})
+			return
+		}
+		if r.Method == http.MethodGet && r.URL.Path == "/servers/localhost/zones/pdns-zone-1." {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(powerdns.Zone{
+				Id:     new("pdns-zone-1."),
+				Name:   new("recreate-test.com."),
+				Kind:   (*powerdns.ZoneKind)(new("Native")),
+				Rrsets: &[]powerdns.RRSet{},
+			})
+			return
+		}
+		if r.Method == http.MethodDelete {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		svc := core.GetService[*DNSServiceDefault](ctx, pluginCore.DNS_SERVICE)
+		require.NotNil(tb, svc)
+
+		zone1, err := svc.CreateZone(ctx, "recreate-test.com.", 1)
+		require.NoError(tb, err)
+		require.NotNil(tb, zone1)
+		require.Equal(tb, "pdns-zone-1.", zone1.PowerDNSZoneID)
+
+		err = svc.DeleteZone(ctx, zone1.ID)
+		require.NoError(tb, err)
+
+		zone2, err := svc.CreateZone(ctx, "recreate-test.com.", 1)
+		require.NoError(tb, err)
+		require.NotNil(tb, zone2)
+
+		require.Equal(tb, zone1.ID, zone2.ID, "restored zone should have same DB ID")
+		require.Equal(tb, "pdns-zone-2.", zone2.PowerDNSZoneID, "restored zone should have new PowerDNS zone ID from recreation")
+		require.False(tb, zone2.DeletedAt.Valid)
+		require.Equal(tb, string(pluginDb.DNSZoneStatusPendingNameserver), zone2.Status)
+	}, createTestOptionsWithServer(server))
 }

--- a/internal/service/dns/dns_service_test.go
+++ b/internal/service/dns/dns_service_test.go
@@ -1018,3 +1018,110 @@ func TestDNSServiceGetRRSet(t *testing.T) {
 		}, testOptions)
 	})
 }
+
+func TestDNSServiceCreateZoneRestoresSoftDeletedZone(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		svc := core.GetService[*DNSServiceDefault](ctx, pluginCore.DNS_SERVICE)
+		require.NotNil(tb, svc)
+
+		// Create a zone
+		zone1, err := svc.CreateZone(ctx, "example.com.", 1)
+		require.NoError(tb, err)
+		require.NotNil(tb, zone1)
+		originalID := zone1.ID
+
+		// Soft-delete the zone
+		err = svc.DeleteZone(ctx, zone1.ID)
+		require.NoError(tb, err)
+
+		// Verify GetZoneByDomain still finds the soft-deleted zone
+		deleted, err := svc.GetZoneByDomain(ctx, "example.com.")
+		require.NoError(tb, err)
+		require.NotNil(tb, deleted)
+		require.True(tb, deleted.DeletedAt.Valid, "zone should be soft-deleted")
+
+		// Verify normal GetZone no longer finds it
+		_, err = svc.GetZone(ctx, originalID)
+		require.Equal(tb, gorm.ErrRecordNotFound, err)
+
+		// Re-create the zone — should restore the soft-deleted row
+		zone2, err := svc.CreateZone(ctx, "example.com.", 1)
+		require.NoError(tb, err)
+		require.NotNil(tb, zone2)
+
+		// Should be the same row (restored, not new)
+		require.Equal(tb, originalID, zone2.ID, "restored zone should have same ID")
+		require.False(tb, zone2.DeletedAt.Valid, "restored zone should not be soft-deleted")
+		require.Equal(tb, string(pluginDb.DNSZoneStatusPendingNameserver), zone2.Status)
+
+		// Verify GetZone now finds it normally
+		freshZone, err := svc.GetZone(ctx, zone2.ID)
+		require.NoError(tb, err)
+		require.NotNil(tb, freshZone)
+		require.Equal(tb, "example.com.", freshZone.Domain)
+	}, getTestOptions())
+}
+
+func TestDNSServiceCreateZoneSoftDeletedDifferentUser(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		svc := core.GetService[*DNSServiceDefault](ctx, pluginCore.DNS_SERVICE)
+		require.NotNil(tb, svc)
+
+		// Create a zone for user 1
+		zone1, err := svc.CreateZone(ctx, "example.com.", 1)
+		require.NoError(tb, err)
+		require.NotNil(tb, zone1)
+
+		// Soft-delete the zone
+		err = svc.DeleteZone(ctx, zone1.ID)
+		require.NoError(tb, err)
+
+		// User 2 trying to create the same domain should fail
+		zone2, err := svc.CreateZone(ctx, "example.com.", 2)
+		require.Error(tb, err)
+		require.Nil(tb, zone2)
+		require.Contains(tb, err.Error(), "already owned by another user")
+	}, getTestOptions())
+}
+
+func TestDNSServiceGetZoneByDomainFindsSoftDeleted(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		svc := core.GetService[*DNSServiceDefault](ctx, pluginCore.DNS_SERVICE)
+		require.NotNil(tb, svc)
+
+		// Create a zone
+		zone, err := svc.CreateZone(ctx, "example.com.", 1)
+		require.NoError(tb, err)
+		require.NotNil(tb, zone)
+
+		// Soft-delete the zone
+		err = svc.DeleteZone(ctx, zone.ID)
+		require.NoError(tb, err)
+
+		// GetZoneByDomain should still find the soft-deleted zone
+		found, err := svc.GetZoneByDomain(ctx, "example.com.")
+		require.NoError(tb, err)
+		require.NotNil(tb, found)
+		require.Equal(tb, "example.com.", found.Domain)
+		require.True(tb, found.DeletedAt.Valid, "should find the soft-deleted zone")
+	}, getTestOptions())
+}
+
+func TestDNSServiceCreateZoneActiveZoneNotSoftDeletedReturnsExisting(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		svc := core.GetService[*DNSServiceDefault](ctx, pluginCore.DNS_SERVICE)
+		require.NotNil(tb, svc)
+
+		// Create a zone
+		zone1, err := svc.CreateZone(ctx, "example.com.", 1)
+		require.NoError(tb, err)
+		require.NotNil(tb, zone1)
+
+		// Creating again should return the existing zone (not soft-deleted)
+		zone2, err := svc.CreateZone(ctx, "example.com.", 1)
+		require.NoError(tb, err)
+		require.NotNil(tb, zone2)
+		require.Equal(tb, zone1.ID, zone2.ID)
+		require.False(tb, zone2.DeletedAt.Valid, "existing active zone should not be soft-deleted")
+	}, getTestOptions())
+}

--- a/internal/service/dns/dns_service_zone.go
+++ b/internal/service/dns/dns_service_zone.go
@@ -39,10 +39,24 @@ func (s *DNSServiceDefault) CreateZone(ctx context.Context, domain string, userI
 		}
 		// If soft-deleted, un-delete and reset
 		if existing.DeletedAt.Valid {
+			var newPowerDNSZoneID string
+			if s.pdnsClient != nil {
+				nameservers := s.config.Nameservers
+				if len(nameservers) == 0 {
+					return nil, fmt.Errorf("no approved nameservers configured")
+				}
+				pdnsZone, pdnsErr := s.pdnsClient.CreateZone(ctx, domain, nameservers)
+				if pdnsErr != nil {
+					return nil, fmt.Errorf("failed to recreate zone in PowerDNS: %w", pdnsErr)
+				}
+				newPowerDNSZoneID = *pdnsZone.Id
+			}
+
 			err = db.RetryableComponentTransaction(s, ctx, func(tx *gorm.DB) *gorm.DB {
 				return tx.Unscoped().Model(existing).Updates(map[string]interface{}{
-					"deleted_at": nil,
-					"status":     string(pluginDb.DNSZoneStatusPendingNameserver),
+					"deleted_at":       nil,
+					"status":           string(pluginDb.DNSZoneStatusPendingNameserver),
+					"powerdns_zone_id": newPowerDNSZoneID,
 				})
 			})
 			if err != nil {
@@ -50,6 +64,7 @@ func (s *DNSServiceDefault) CreateZone(ctx context.Context, domain string, userI
 			}
 			existing.DeletedAt = gorm.DeletedAt{}
 			existing.Status = string(pluginDb.DNSZoneStatusPendingNameserver)
+			existing.PowerDNSZoneID = newPowerDNSZoneID
 			s.Logger().Info("Restored soft-deleted DNS zone",
 				zap.Uint("id", existing.ID),
 				zap.String("domain", domain))
@@ -100,10 +115,24 @@ func (s *DNSServiceDefault) CreateZone(ctx context.Context, domain string, userI
 			}
 			// If soft-deleted, un-delete and reset
 			if existing.DeletedAt.Valid {
+				var newPowerDNSZoneID string
+				if s.pdnsClient != nil {
+					nameservers := s.config.Nameservers
+					if len(nameservers) == 0 {
+						return nil, fmt.Errorf("no approved nameservers configured")
+					}
+					pdnsZone, pdnsErr := s.pdnsClient.CreateZone(ctx, domain, nameservers)
+					if pdnsErr != nil {
+						return nil, fmt.Errorf("concurrent zone creation detected but failed to recreate zone in PowerDNS: %w", pdnsErr)
+					}
+					newPowerDNSZoneID = *pdnsZone.Id
+				}
+
 				unDeleteErr := db.RetryableComponentTransaction(s, ctx, func(tx *gorm.DB) *gorm.DB {
 					return tx.Unscoped().Model(existing).Updates(map[string]interface{}{
-						"deleted_at": nil,
-						"status":     string(pluginDb.DNSZoneStatusPendingNameserver),
+						"deleted_at":       nil,
+						"status":           string(pluginDb.DNSZoneStatusPendingNameserver),
+						"powerdns_zone_id": newPowerDNSZoneID,
 					})
 				})
 				if unDeleteErr != nil {
@@ -111,6 +140,7 @@ func (s *DNSServiceDefault) CreateZone(ctx context.Context, domain string, userI
 				}
 				existing.DeletedAt = gorm.DeletedAt{}
 				existing.Status = string(pluginDb.DNSZoneStatusPendingNameserver)
+				existing.PowerDNSZoneID = newPowerDNSZoneID
 			}
 			return existing, nil
 		}

--- a/internal/service/dns/dns_service_zone.go
+++ b/internal/service/dns/dns_service_zone.go
@@ -28,7 +28,7 @@ func (s *DNSServiceDefault) CreateZone(ctx context.Context, domain string, userI
 		return nil, fmt.Errorf("invalid domain: %w", err)
 	}
 
-	// Check if domain already exists in database
+	// Check if domain already exists in database (including soft-deleted)
 	existing, err := s.GetZoneByDomain(ctx, domain)
 	if err != nil {
 		return nil, fmt.Errorf("failed to check existing domain: %w", err)
@@ -36,6 +36,23 @@ func (s *DNSServiceDefault) CreateZone(ctx context.Context, domain string, userI
 	if existing != nil {
 		if existing.UserID != userID {
 			return nil, fmt.Errorf("domain %q is already owned by another user", domain)
+		}
+		// If soft-deleted, un-delete and reset
+		if existing.DeletedAt.Valid {
+			err = db.RetryableComponentTransaction(s, ctx, func(tx *gorm.DB) *gorm.DB {
+				return tx.Unscoped().Model(existing).Updates(map[string]interface{}{
+					"deleted_at": nil,
+					"status":     string(pluginDb.DNSZoneStatusPendingNameserver),
+				})
+			})
+			if err != nil {
+				return nil, fmt.Errorf("failed to restore soft-deleted zone: %w", err)
+			}
+			existing.DeletedAt = gorm.DeletedAt{}
+			existing.Status = string(pluginDb.DNSZoneStatusPendingNameserver)
+			s.Logger().Info("Restored soft-deleted DNS zone",
+				zap.Uint("id", existing.ID),
+				zap.String("domain", domain))
 		}
 		return existing, nil
 	}
@@ -81,6 +98,20 @@ func (s *DNSServiceDefault) CreateZone(ctx context.Context, domain string, userI
 			if existing.UserID != userID {
 				return nil, fmt.Errorf("domain %q is already owned by another user", domain)
 			}
+			// If soft-deleted, un-delete and reset
+			if existing.DeletedAt.Valid {
+				unDeleteErr := db.RetryableComponentTransaction(s, ctx, func(tx *gorm.DB) *gorm.DB {
+					return tx.Unscoped().Model(existing).Updates(map[string]interface{}{
+						"deleted_at": nil,
+						"status":     string(pluginDb.DNSZoneStatusPendingNameserver),
+					})
+				})
+				if unDeleteErr != nil {
+					return nil, fmt.Errorf("concurrent zone creation detected but failed to restore soft-deleted zone: %w", unDeleteErr)
+				}
+				existing.DeletedAt = gorm.DeletedAt{}
+				existing.Status = string(pluginDb.DNSZoneStatusPendingNameserver)
+			}
 			return existing, nil
 		}
 		return nil, fmt.Errorf("failed to create zone in database: %w", err)
@@ -120,7 +151,7 @@ func (s *DNSServiceDefault) GetZone(ctx context.Context, zoneID uint) (*pluginDb
 	return &zone, nil
 }
 
-// GetZoneByDomain retrieves a zone by domain name
+// GetZoneByDomain retrieves a zone by domain name, including soft-deleted zones
 func (s *DNSServiceDefault) GetZoneByDomain(ctx context.Context, domain string) (*pluginDb.DNSZone, error) {
 	ctx, span := core.TraceMethod(ctx, "DNSService.GetZoneByDomain")
 	defer span.End()
@@ -128,7 +159,7 @@ func (s *DNSServiceDefault) GetZoneByDomain(ctx context.Context, domain string) 
 	var zone pluginDb.DNSZone
 
 	err := db.RetryableComponentTransaction(s, ctx, func(tx *gorm.DB) *gorm.DB {
-		return tx.Where("domain = ?", domain).First(&zone)
+		return tx.Unscoped().Where("domain = ?", domain).First(&zone)
 	})
 
 	if err != nil {

--- a/internal/service/dns/dns_service_zone.go
+++ b/internal/service/dns/dns_service_zone.go
@@ -37,37 +37,10 @@ func (s *DNSServiceDefault) CreateZone(ctx context.Context, domain string, userI
 		if existing.UserID != userID {
 			return nil, fmt.Errorf("domain %q is already owned by another user", domain)
 		}
-		// If soft-deleted, un-delete and reset
 		if existing.DeletedAt.Valid {
-			var newPowerDNSZoneID string
-			if s.pdnsClient != nil {
-				nameservers := s.config.Nameservers
-				if len(nameservers) == 0 {
-					return nil, fmt.Errorf("no approved nameservers configured")
-				}
-				pdnsZone, pdnsErr := s.pdnsClient.CreateZone(ctx, domain, nameservers)
-				if pdnsErr != nil {
-					return nil, fmt.Errorf("failed to recreate zone in PowerDNS: %w", pdnsErr)
-				}
-				newPowerDNSZoneID = *pdnsZone.Id
+			if err := s.restoreSoftDeletedZone(ctx, existing, domain); err != nil {
+				return nil, err
 			}
-
-			err = db.RetryableComponentTransaction(s, ctx, func(tx *gorm.DB) *gorm.DB {
-				return tx.Unscoped().Model(existing).Updates(map[string]interface{}{
-					"deleted_at":       nil,
-					"status":           string(pluginDb.DNSZoneStatusPendingNameserver),
-					"powerdns_zone_id": newPowerDNSZoneID,
-				})
-			})
-			if err != nil {
-				return nil, fmt.Errorf("failed to restore soft-deleted zone: %w", err)
-			}
-			existing.DeletedAt = gorm.DeletedAt{}
-			existing.Status = string(pluginDb.DNSZoneStatusPendingNameserver)
-			existing.PowerDNSZoneID = newPowerDNSZoneID
-			s.Logger().Info("Restored soft-deleted DNS zone",
-				zap.Uint("id", existing.ID),
-				zap.String("domain", domain))
 		}
 		return existing, nil
 	}
@@ -113,34 +86,10 @@ func (s *DNSServiceDefault) CreateZone(ctx context.Context, domain string, userI
 			if existing.UserID != userID {
 				return nil, fmt.Errorf("domain %q is already owned by another user", domain)
 			}
-			// If soft-deleted, un-delete and reset
 			if existing.DeletedAt.Valid {
-				var newPowerDNSZoneID string
-				if s.pdnsClient != nil {
-					nameservers := s.config.Nameservers
-					if len(nameservers) == 0 {
-						return nil, fmt.Errorf("no approved nameservers configured")
-					}
-					pdnsZone, pdnsErr := s.pdnsClient.CreateZone(ctx, domain, nameservers)
-					if pdnsErr != nil {
-						return nil, fmt.Errorf("concurrent zone creation detected but failed to recreate zone in PowerDNS: %w", pdnsErr)
-					}
-					newPowerDNSZoneID = *pdnsZone.Id
+				if restoreErr := s.restoreSoftDeletedZone(ctx, existing, domain); restoreErr != nil {
+					return nil, fmt.Errorf("concurrent zone creation detected but failed to restore soft-deleted zone: %w", restoreErr)
 				}
-
-				unDeleteErr := db.RetryableComponentTransaction(s, ctx, func(tx *gorm.DB) *gorm.DB {
-					return tx.Unscoped().Model(existing).Updates(map[string]interface{}{
-						"deleted_at":       nil,
-						"status":           string(pluginDb.DNSZoneStatusPendingNameserver),
-						"powerdns_zone_id": newPowerDNSZoneID,
-					})
-				})
-				if unDeleteErr != nil {
-					return nil, fmt.Errorf("concurrent zone creation detected but failed to restore soft-deleted zone: %w", unDeleteErr)
-				}
-				existing.DeletedAt = gorm.DeletedAt{}
-				existing.Status = string(pluginDb.DNSZoneStatusPendingNameserver)
-				existing.PowerDNSZoneID = newPowerDNSZoneID
 			}
 			return existing, nil
 		}
@@ -592,6 +541,48 @@ func (s *DNSServiceDefault) validateDomain(domain string) error {
 		}
 	}
 
+	return nil
+}
+
+func (s *DNSServiceDefault) restoreSoftDeletedZone(ctx context.Context, zone *pluginDb.DNSZone, domain string) error {
+	updates := map[string]interface{}{
+		"deleted_at": nil,
+		"status":     string(pluginDb.DNSZoneStatusPendingNameserver),
+	}
+	var newPowerDNSZoneID string
+	if s.pdnsClient != nil {
+		nameservers := s.config.Nameservers
+		if len(nameservers) == 0 {
+			return fmt.Errorf("no approved nameservers configured")
+		}
+		pdnsZone, pdnsErr := s.pdnsClient.CreateZone(ctx, domain, nameservers)
+		if pdnsErr != nil {
+			return fmt.Errorf("failed to recreate zone in PowerDNS: %w", pdnsErr)
+		}
+		newPowerDNSZoneID = *pdnsZone.Id
+		updates["powerdns_zone_id"] = newPowerDNSZoneID
+	}
+
+	err := db.RetryableComponentTransaction(s, ctx, func(tx *gorm.DB) *gorm.DB {
+		return tx.Unscoped().Model(zone).Updates(updates)
+	})
+	if err != nil {
+		if s.pdnsClient != nil && newPowerDNSZoneID != "" {
+			if delErr := s.pdnsClient.DeleteZone(ctx, newPowerDNSZoneID); delErr != nil {
+				s.Logger().Warn("Failed to clean up orphaned PowerDNS zone after DB restore failure",
+					zap.Error(delErr), zap.String("powerdns_zone_id", newPowerDNSZoneID))
+			}
+		}
+		return fmt.Errorf("failed to restore soft-deleted zone: %w", err)
+	}
+	zone.DeletedAt = gorm.DeletedAt{}
+	zone.Status = string(pluginDb.DNSZoneStatusPendingNameserver)
+	if newPowerDNSZoneID != "" {
+		zone.PowerDNSZoneID = newPowerDNSZoneID
+	}
+	s.Logger().Info("Restored soft-deleted DNS zone",
+		zap.Uint("id", zone.ID),
+		zap.String("domain", domain))
 	return nil
 }
 


### PR DESCRIPTION
- `develop` <!-- branch-stack -->
  - **fix: restore soft-deleted DNS zones on re-enable instead of failing on unique constraint** :point\_left:

***

<!-- kody-pr-summary:start -->

Fix: Restore soft-deleted DNS zones on re-enable instead of failing on unique constraint

Previously, when a DNS zone was soft-deleted and a user attempted to re-create the same domain, the operation would fail due to a unique constraint violation on the domain column (since soft-deleted rows still exist in the database). This change makes `CreateZone` detect and restore soft-deleted zones by clearing the `deleted_at` timestamp and resetting the status to `PendingNameserver`, rather than failing. The `GetZoneByDomain` method now uses `Unscoped()` to include soft-deleted records in its lookup, enabling the restoration logic to find them. A different user attempting to claim a soft-deleted domain still receives an error.

<!-- kody-pr-summary:end -->
