### PR TITLE
fix: PowerDNS TXT quoting, ALIAS apex records, and soft-deleted zone restore

### DIFF
--- a/internal/service/dns/dns_helpers.go
+++ b/internal/service/dns/dns_helpers.go
@@ -194,13 +194,40 @@ func recordToDTOWithZoneID(rrset powerdns.RRSet, record powerdns.Record, zoneDom
 		ZoneID:   zoneID,
 		Name:     stripDomain(rrset.Name, zoneDomain),
 		Type:     rrset.Type,
-		Content:  record.Content,
+		Content:  stripTXTQuotes(rrset.Type, record.Content),
 		TTL:      uint(getTTL(rrset.Ttl)),
 		Disabled: getDisabled(record.Disabled),
 	}
 }
 
 
+
+// formatTXTContent wraps TXT record content in double quotes as required by PowerDNS API.
+// PowerDNS expects TXT record values to be quoted strings (e.g., "v=spf1 ~all").
+func formatTXTContent(content string) string {
+	if len(content) >= 2 && content[0] == '"' && content[len(content)-1] == '"' {
+		return content
+	}
+	return `"` + content + `"`
+}
+
+// formatRecordContent formats DNS record content for PowerDNS based on record type.
+// TXT records require double-quoted content; other types are passed through as-is.
+func formatRecordContent(recordType, content string) string {
+	if strings.EqualFold(recordType, "TXT") {
+		return formatTXTContent(content)
+	}
+	return content
+}
+
+// stripTXTQuotes removes surrounding double quotes from TXT record content
+// when reading back from PowerDNS, so the API returns unquoted values.
+func stripTXTQuotes(recordType, content string) string {
+	if strings.EqualFold(recordType, "TXT") && len(content) >= 2 && content[0] == '"' && content[len(content)-1] == '"' {
+		return content[1 : len(content)-1]
+	}
+	return content
+}
 
 // buildCreatedRecord creates a CreatedRecord response from zone file entry data
 func buildCreatedRecord(name, recordType, content string, ttl uint) apiDTO.CreatedRecord {

--- a/internal/service/dns/dns_service_record.go
+++ b/internal/service/dns/dns_service_record.go
@@ -93,7 +93,9 @@ func (s *DNSServiceDefault) CreateRecord(ctx context.Context, zoneID uint, name 
 
 	fullName := buildFullName(name, zone.Domain)
 
-	rrset := buildRRSet(fullName, recordType, powerdns.REPLACE, lo.ToPtr(int(ttl)), []powerdns.Record{{Content: content}})
+	pdnsContent := formatRecordContent(recordType, content)
+
+	rrset := buildRRSet(fullName, recordType, powerdns.REPLACE, lo.ToPtr(int(ttl)), []powerdns.Record{{Content: pdnsContent}})
 
 	err = s.pdnsClient.UpdateZoneRRSets(ctx, zone.PowerDNSZoneID, []powerdns.RRSet{rrset})
 	if err != nil {
@@ -143,7 +145,7 @@ func (s *DNSServiceDefault) UpdateRecord(ctx context.Context, zoneID uint, name 
 	fullName := buildFullName(name, zone.Domain)
 
 	pdnsRecords := lo.Map(records, func(r string, _ int) powerdns.Record {
-		return powerdns.Record{Content: r}
+		return powerdns.Record{Content: formatRecordContent(recordType, r)}
 	})
 
 	rrset := buildRRSet(fullName, recordType, powerdns.REPLACE, lo.ToPtr(int(ttl)), pdnsRecords)

--- a/internal/service/dns/dns_service_zone.go
+++ b/internal/service/dns/dns_service_zone.go
@@ -358,7 +358,6 @@ func (s *DNSServiceDefault) CreateWebsiteDNSRecords(ctx context.Context, zoneID 
 	targetPath := string(buildTargetPath(targetHash, targetType))
 
 	rrsets := []powerdns.RRSet{
-		// _dnslink.domain.com TXT record → DNSLink path
 		{
 			Name:       "_dnslink." + zone.Domain + ".",
 			Type:       "TXT",
@@ -366,12 +365,11 @@ func (s *DNSServiceDefault) CreateWebsiteDNSRecords(ctx context.Context, zoneID 
 			Ttl:        &ttl,
 			Records: []powerdns.Record{
 				{
-					Content:  targetPath,
+					Content:  formatTXTContent(targetPath),
 					Disabled: &disabled,
 				},
 			},
 		},
-		// domain.com TXT record → lumeweb-verify=TOKEN (for validation)
 		{
 			Name:       zone.Domain + ".",
 			Type:       "TXT",
@@ -379,24 +377,26 @@ func (s *DNSServiceDefault) CreateWebsiteDNSRecords(ctx context.Context, zoneID 
 			Ttl:        &ttl,
 			Records: []powerdns.Record{
 				{
-					Content:  "lumeweb-verify=" + validationToken,
+					Content:  formatTXTContent(validationToken),
 					Disabled: &disabled,
 				},
 			},
 		},
-		// www.domain.com CNAME → domain.com (flattening support)
-		{
-			Name:       "www." + zone.Domain + ".",
-			Type:       "CNAME",
+	}
+
+	if s.config.GatewayDomain != "" {
+		rrsets = append(rrsets, powerdns.RRSet{
+			Name:       zone.Domain + ".",
+			Type:       "ALIAS",
 			Changetype: "REPLACE",
 			Ttl:        &ttl,
 			Records: []powerdns.Record{
 				{
-					Content:  zone.Domain + ".",
+					Content:  s.config.GatewayDomain + ".",
 					Disabled: &disabled,
 				},
 			},
-		},
+		})
 	}
 
 	if err := s.pdnsClient.UpdateZoneRRSets(ctx, zone.PowerDNSZoneID, rrsets); err != nil {
@@ -434,7 +434,6 @@ func (s *DNSServiceDefault) UpdateWebsiteDNSRecords(ctx context.Context, zoneID 
 	targetPath := string(buildTargetPath(targetHash, targetType))
 
 	rrsets := []powerdns.RRSet{
-		// Update _dnslink.domain.com TXT record with new target
 		{
 			Name:       "_dnslink." + zone.Domain + ".",
 			Type:       "TXT",
@@ -442,7 +441,7 @@ func (s *DNSServiceDefault) UpdateWebsiteDNSRecords(ctx context.Context, zoneID 
 			Ttl:        &ttl,
 			Records: []powerdns.Record{
 				{
-					Content:  targetPath,
+					Content:  formatTXTContent(targetPath),
 					Disabled: &disabled,
 				},
 			},
@@ -478,26 +477,25 @@ func (s *DNSServiceDefault) DeleteWebsiteDNSRecords(ctx context.Context, zoneID 
 		return fmt.Errorf("DNS hosting not enabled")
 	}
 
-	// Delete all DNS records created by CreateWebsiteDNSRecords
 	rrsets := []powerdns.RRSet{
-		// Delete _dnslink.domain.com TXT record
 		{
 			Name:       "_dnslink." + zone.Domain + ".",
 			Type:       "TXT",
 			Changetype: "DELETE",
 		},
-		// Delete domain.com TXT record (validation token)
 		{
 			Name:       zone.Domain + ".",
 			Type:       "TXT",
 			Changetype: "DELETE",
 		},
-		// Delete www.domain.com CNAME record
-		{
-			Name:       "www." + zone.Domain + ".",
-			Type:       "CNAME",
+	}
+
+	if s.config.GatewayDomain != "" {
+		rrsets = append(rrsets, powerdns.RRSet{
+			Name:       zone.Domain + ".",
+			Type:       "ALIAS",
 			Changetype: "DELETE",
-		},
+		})
 	}
 
 	if err := s.pdnsClient.UpdateZoneRRSets(ctx, zone.PowerDNSZoneID, rrsets); err != nil {

--- a/internal/service/website/website.go
+++ b/internal/service/website/website.go
@@ -274,7 +274,7 @@ func (s *WebsiteServiceDefault) CreateWebsite(ctx context.Context, website *plug
 						zap.String("domain", website.Domain))
 
 					// Create DNS records for the website
-					if err := s.dnsSvc.CreateWebsiteDNSRecords(ctx, dnsZone.ID, website.TargetHash(), pluginDb.WebsiteTargetType(website.TargetType), website.ValidationToken); err != nil {
+					if err := s.dnsSvc.CreateWebsiteDNSRecords(ctx, dnsZone.ID, website.TargetHash(), pluginDb.WebsiteTargetType(website.TargetType), fmt.Sprintf("%s=%s", s.config.VerificationTokenKey, website.ValidationToken)); err != nil {
 						s.Logger().Error("Failed to create DNS records for website",
 							zap.Error(err),
 							zap.Uint("website_id", website.ID),
@@ -688,7 +688,7 @@ func (s *WebsiteServiceDefault) handleDNSEnabledTransition(ctx context.Context, 
 		}
 
 		// Create DNS records
-		err := s.dnsSvc.CreateWebsiteDNSRecords(ctx, *website.DNSZoneID, website.TargetHash(), pluginDb.WebsiteTargetType(website.TargetType), newToken)
+		err := s.dnsSvc.CreateWebsiteDNSRecords(ctx, *website.DNSZoneID, website.TargetHash(), pluginDb.WebsiteTargetType(website.TargetType), fmt.Sprintf("%s=%s", s.config.VerificationTokenKey, newToken))
 		if err != nil {
 			return fmt.Errorf("failed to create DNS records: %w", err)
 		}

--- a/internal/service/website/website_test.go
+++ b/internal/service/website/website_test.go
@@ -3,6 +3,7 @@ package website
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io/fs"
 	"testing"
 	"time"
@@ -162,9 +163,10 @@ var TestOptions = coreTesting.CombineOptions(
 	testopts.NewBaseMockPluginBuilder().
 		WithService(pluginCore.WEBSITE_SERVICE, NewWebsiteService).
 		WithServiceConfig(pluginCore.WEBSITE_SERVICE, &pluginConfig.WebsiteConfig{
-			NotificationsEnabled: false,
-			AdminEmail:           "",
-			ValidationTokenTTL:   24 * time.Hour,
+			NotificationsEnabled:  false,
+			AdminEmail:            "",
+			ValidationTokenTTL:    24 * time.Hour,
+			VerificationTokenKey:  "lumeweb-verify",
 		}).
 		WithMockServiceFactory(pluginCore.DNS_SERVICE, mocks.NewMockDNSService).
 		WithServiceConfig(pluginCore.DNS_SERVICE, &pluginConfig.DnsConfig{
@@ -1220,7 +1222,8 @@ func TestWebsiteService_CreateWebsite_DNSRecordsCreated(t *testing.T) {
 		assert.NotEmpty(tb, capturedTargetHash, "Target hash should be captured")
 		assert.Equal(tb, pluginDb.WebsiteTargetTypeIPNS, capturedTargetType, "Target type should be IPNS after auto-conversion")
 		assert.NotEmpty(tb, capturedToken, "Validation token should be non-empty")
-		assert.Equal(tb, createdWebsite.ValidationToken, capturedToken, "Validation token should match website token")
+		expectedFormattedToken := fmt.Sprintf("lumeweb-verify=%s", createdWebsite.ValidationToken)
+		assert.Equal(tb, expectedFormattedToken, capturedToken, "Validation token should be formatted with key prefix")
 
 	}, TestOptions)
 }


### PR DESCRIPTION
- Quote TXT record content for PowerDNS API (requires double-quoted strings)
- Strip quotes when reading TXT records back from PowerDNS
- Use ALIAS record at zone apex instead of CNAME at www subdomain
- Use configurable GatewayDomain for ALIAS target
- Pass formatted verification token from caller using VerificationTokenKey
- Fix soft-deleted zone restore: recreate PowerDNS zone, clean up on DB failure
- GetZoneByDomain uses Unscoped to find soft-deleted zones
- Extract restoreSoftDeletedZone helper to DRY restore logic

* `develop` <!-- branch-stack -->
  - **fix: PowerDNS TXT quoting, ALIAS apex records, and soft-deleted zone restore** :point\_left:

---

<!-- kody-pr-summary:start -->
## PR Description

This PR fixes three issues related to DNS record management with PowerDNS:

### 1. PowerDNS TXT Record Quoting
PowerDNS requires TXT record values to be wrapped in double quotes. Previously, TXT content was sent unquoted, causing issues with the PowerDNS API. The fix adds:
- **`formatTXTContent`** / **`formatRecordContent`**: Automatically wraps TXT record content in double quotes when sending to PowerDNS.
- **`stripTXTQuotes`**: Removes the surrounding quotes when reading TXT records back from PowerDNS, so the API returns clean unquoted values.

These helpers are now applied in `CreateRecord`, `UpdateRecord`, `recordToDTOWithZoneID`, and the website DNS record lifecycle methods.

### 2. ALIAS Apex Records Replacing www CNAME
Replaced the `www.<domain>` CNAME record with an ALIAS record at the zone apex (`<domain>`). ALIAS records provide CNAME-like behavior at the root domain level, which is not possible with standard CNAME records (since the apex must also have SOA/NS records). The ALIAS record points to a configurable `GatewayDomain` and is only created/deleted when a gateway domain is configured.

### 3. Configurable Verification Token Key
Moved the verification token key prefix (e.g., `lumeweb-verify=`) from hardcoded usage in the DNS service to the website service, where it is now constructed using the configurable `VerificationTokenKey` setting. This ensures the full formatted token string (key + value) is passed to the DNS service and properly quoted as a TXT record.
<!-- kody-pr-summary:end -->