### PR TITLE
fix: normalize trailing dots in DNS nameserver validation

### DIFF
--- a/internal/service/dns/dns_service_zone.go
+++ b/internal/service/dns/dns_service_zone.go
@@ -291,10 +291,14 @@ func (s *DNSServiceDefault) ValidateNameservers(ctx context.Context, zoneID uint
 	}
 
 	// Check if at least one approved nameserver is present in DNS response
+	// Normalize by stripping trailing dots — net.LookupNS returns FQDNs with
+	// trailing dots (e.g. "ns1.example.com.") but config values typically lack them.
 	valid := false
 	for _, approvedNS := range approvedNameservers {
+		normalizedApproved := strings.TrimSuffix(approvedNS, ".")
 		for _, dnsNS := range dnsNameservers {
-			if dnsNS.Host == approvedNS {
+			normalizedDNS := strings.TrimSuffix(dnsNS.Host, ".")
+			if normalizedDNS == normalizedApproved {
 				valid = true
 				break
 			}


### PR DESCRIPTION
net.LookupNS returns FQDNs with trailing dots (e.g. "ns1.example.com.") but config values typically lack them, causing the strict == comparison to never match. Strip trailing dots from both sides before comparing.

- `develop` <!-- branch-stack -->
  - **fix: normalize trailing dots in DNS nameserver validation** :point\_left:

---

<!-- kody-pr-summary:start -->
Fix DNS nameserver validation by normalizing trailing dots before comparison

The `net.LookupNS` function returns fully qualified domain names with trailing dots (e.g., `ns1.example.com.`), while configured approved nameservers typically lack them (e.g., `ns1.example.com`). This mismatch caused valid nameserver comparisons to fail. The fix strips trailing dots from both the DNS response and the approved nameserver values before comparing, ensuring consistent matching regardless of format.
<!-- kody-pr-summary:end -->