### PR TITLE
fix: update DNS records when switching website from IPNS to IPFS target type

### DIFF
--- a/internal/service/website/website.go
+++ b/internal/service/website/website.go
@@ -458,6 +458,7 @@ func (s *WebsiteServiceDefault) UpdateWebsite(ctx context.Context, userID uint, 
 				oldEnabled = website.Enabled
 				targetHashChanged := false
 				dnsEnabledChanged = false
+				var newTargetHashStr string
 
 				// Validate domain if being updated
 				if domain, ok := updates["domain"].(string); ok {
@@ -496,6 +497,7 @@ func (s *WebsiteServiceDefault) UpdateWebsite(ctx context.Context, userID uint, 
 					// Check if target hash changed
 					if targetHashStr != oldTargetHash {
 						targetHashChanged = true
+						newTargetHashStr = targetHashStr
 					}
 
 					// Convert string to multihash and CID version
@@ -553,37 +555,36 @@ func (s *WebsiteServiceDefault) UpdateWebsite(ctx context.Context, userID uint, 
 							zap.Uint("website_id", websiteID),
 							zap.Uint("ipns_key_id", *website.IPNSKeyID))
 					} else {
-						// Get the new target hash (from updates, since website was just updated)
-						newTargetHash := oldTargetHash
-						if targetHashStr, ok := updates["target_hash"].(string); ok {
-							newTargetHash = targetHashStr
+						publishHash := newTargetHashStr
+						if publishHash == "" {
+							publishHash = website.TargetHash()
 						}
 
 						// Publish the new CID to the IPNS key
 						ttl := 24 * time.Hour
-						err = s.ipnsKeySvc.PublishCID(ctx, ipnsKey.PeerID().String(), newTargetHash, ttl)
+						err = s.ipnsKeySvc.PublishCID(ctx, ipnsKey.PeerID().String(), publishHash, ttl)
 						if err != nil {
 							s.Logger().Warn("Failed to republish new CID to IPNS key",
 								zap.Error(err),
 								zap.String("domain", website.Domain),
 								zap.String("peer_id", ipnsKey.PeerID().String()),
-								zap.String("cid", newTargetHash))
+								zap.String("cid", publishHash))
 						} else {
 							s.Logger().Info("Republished new CID to IPNS key",
 								zap.String("domain", website.Domain),
 								zap.String("peer_id", ipnsKey.PeerID().String()),
-								zap.String("cid", newTargetHash))
+								zap.String("cid", publishHash))
 						}
 					}
 				}
 
-				// Update DNS records if target changed and DNS hosting is enabled
-				// Note: For IPNS targets, DNS records don't need updating since the peer ID stays the same
-				if targetHashChanged && website.Enabled && website.DNSZoneID != nil && s.dnsSvc != nil {
-					// Only update DNS if not using IPNS (IPNS peer ID doesn't change)
-					if website.IPNSKeyID == nil {
-						newTargetHash := website.TargetHash()
-						newTargetType := pluginDb.WebsiteTargetType(website.TargetType)
+			// Update DNS records if target changed and DNS hosting is enabled
+			// Note: For IPNS targets staying as IPNS, DNS records don't need updating since the peer ID stays the same
+			if targetHashChanged && website.Enabled && website.DNSZoneID != nil && s.dnsSvc != nil {
+				newTargetType := pluginDb.WebsiteTargetType(website.TargetType)
+				// Update DNS unless the new target type is still IPNS (peer ID doesn't change)
+				if newTargetType != pluginDb.WebsiteTargetTypeIPNS {
+					newTargetHash := website.TargetHash()
 						if err := s.dnsSvc.UpdateWebsiteDNSRecords(ctx, *website.DNSZoneID, newTargetHash, newTargetType); err != nil {
 							s.Logger().Warn("Failed to update DNS records for website",
 								zap.Error(err),

--- a/internal/service/website/website.go
+++ b/internal/service/website/website.go
@@ -455,6 +455,7 @@ func (s *WebsiteServiceDefault) UpdateWebsite(ctx context.Context, userID uint, 
 
 				// Store old values for DNS updates and state transitions
 				oldTargetHash := website.TargetHash()
+				oldTargetType := pluginDb.WebsiteTargetType(website.TargetType)
 				oldEnabled = website.Enabled
 				targetHashChanged := false
 				dnsEnabledChanged = false
@@ -579,19 +580,18 @@ func (s *WebsiteServiceDefault) UpdateWebsite(ctx context.Context, userID uint, 
 				}
 
 			// Update DNS records if target changed and DNS hosting is enabled
-			// Note: For IPNS targets staying as IPNS, DNS records don't need updating since the peer ID stays the same
+			// Note: Skip DNS only when staying as IPNS (peer ID doesn't change)
 			if targetHashChanged && website.Enabled && website.DNSZoneID != nil && s.dnsSvc != nil {
 				newTargetType := pluginDb.WebsiteTargetType(website.TargetType)
-				// Update DNS unless the new target type is still IPNS (peer ID doesn't change)
-				if newTargetType != pluginDb.WebsiteTargetTypeIPNS {
+				if !(oldTargetType == pluginDb.WebsiteTargetTypeIPNS && newTargetType == pluginDb.WebsiteTargetTypeIPNS) {
 					newTargetHash := website.TargetHash()
-						if err := s.dnsSvc.UpdateWebsiteDNSRecords(ctx, *website.DNSZoneID, newTargetHash, newTargetType); err != nil {
-							s.Logger().Warn("Failed to update DNS records for website",
-								zap.Error(err),
-								zap.Uint("website_id", websiteID),
-								zap.Uint("dns_zone_id", *website.DNSZoneID))
-						}
+					if err := s.dnsSvc.UpdateWebsiteDNSRecords(ctx, *website.DNSZoneID, newTargetHash, newTargetType); err != nil {
+						s.Logger().Warn("Failed to update DNS records for website",
+							zap.Error(err),
+							zap.Uint("website_id", websiteID),
+							zap.Uint("dns_zone_id", *website.DNSZoneID))
 					}
+				}
 				}
 
 				return tx

--- a/internal/service/website/website_test.go
+++ b/internal/service/website/website_test.go
@@ -2335,3 +2335,83 @@ func TestWebsiteService_UpdateWebsite_IPNSToIPNS_NoDNSUpdate(t *testing.T) {
 		mockDNS.AssertNotCalled(t, "UpdateWebsiteDNSRecords")
 	}, TestOptions)
 }
+
+// TestWebsiteService_UpdateWebsite_ConvertIPFSToIPNS_UpdatesDNSRecords verifies that
+// when a website with DNS hosting is updated from IPFS to IPNS target type,
+// the DNS _dnslink record is updated from /ipfs/<cid> to /ipns/<peerID>.
+func TestWebsiteService_UpdateWebsite_ConvertIPFSToIPNS_UpdatesDNSRecords(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		websiteService := core.GetService[pluginCore.WebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
+		mockDNS := core.GetService[*mocks.MockDNSService](ctx, pluginCore.DNS_SERVICE)
+		mockIPNSKey := core.GetService[*mocks.MockIPNSKeyService](ctx, pluginCore.IPNS_KEY_SERVICE)
+
+		testCID := util.GenerateTestCID(t, "test data")
+		domain := "ipfs-to-ipns-dns-test.com"
+		testZoneID := uint(9003)
+
+		// Create website with DNS hosting enabled (auto-creates IPNS key, starts as IPNS)
+		website := createTestIPFSWebsite(testUserID1, domain, testCID.String())
+		website.Enabled = true
+
+		testIPNSKey := setupIPNSAutoCreationMocks(t, mockIPNSKey, testUserID1, domain, testCID)
+
+		mockDNS.EXPECT().CreateZone(mock.Anything, domain, testUserID1).Return(createMockDNSZone(testZoneID, domain, testUserID1), nil).Once()
+		mockDNS.EXPECT().CreateWebsiteDNSRecords(
+			mock.Anything,
+			testZoneID,
+			mock.Anything,
+			pluginDb.WebsiteTargetTypeIPNS,
+			mock.Anything,
+		).Return(nil).Once()
+
+		createdWebsite, err := websiteService.CreateWebsite(context.Background(), website)
+		require.NoError(tb, err)
+		require.NotNil(tb, createdWebsite)
+		require.NotNil(tb, createdWebsite.DNSZoneID)
+
+		// First, switch back to IPFS to set up the IPFS→IPNS scenario
+		newCID := util.GenerateTestCID(t, "intermediate ipfs content")
+		ipfsUpdates := map[string]interface{}{
+			"target_hash": newCID.String(),
+			"target_type": string(pluginDb.WebsiteTargetTypeIPFS),
+		}
+
+		mockIPNSKey.EXPECT().GetKeyByID(mock.Anything, testUserID1, *createdWebsite.IPNSKeyID).Return(testIPNSKey, nil).Once()
+		mockIPNSKey.EXPECT().PublishCID(mock.Anything, mock.Anything, mock.Anything, mock.AnythingOfType("time.Duration")).Return(nil).Once()
+		mockDNS.EXPECT().UpdateWebsiteDNSRecords(
+			mock.Anything,
+			testZoneID,
+			newCID.String(),
+			pluginDb.WebsiteTargetTypeIPFS,
+		).Return(nil).Once()
+
+		ipfsWebsite, err := websiteService.UpdateWebsite(context.Background(), testUserID1, createdWebsite.ID, ipfsUpdates)
+		require.NoError(tb, err)
+		assert.Equal(tb, string(pluginDb.WebsiteTargetTypeIPFS), ipfsWebsite.TargetType)
+
+		// Act - Update from IPFS to IPNS
+		testPeerID := "12D3KooWCqvCZqaG6LmG4mtoWZZwrvYB911DK8qqwE9gc25s4Hft"
+		ipnsUpdates := map[string]interface{}{
+			"target_hash": testPeerID,
+		}
+
+		// IPNS republish (website still has IPNSKeyID)
+		mockIPNSKey.EXPECT().GetKeyByID(mock.Anything, testUserID1, *ipfsWebsite.IPNSKeyID).Return(testIPNSKey, nil).Once()
+		mockIPNSKey.EXPECT().PublishCID(mock.Anything, mock.Anything, mock.Anything, mock.AnythingOfType("time.Duration")).Return(nil).Once()
+
+		// DNS records must be updated when switching from IPFS to IPNS
+		mockDNS.EXPECT().UpdateWebsiteDNSRecords(
+			mock.Anything,
+			testZoneID,
+			testPeerID,
+			pluginDb.WebsiteTargetTypeIPNS,
+		).Return(nil).Once()
+
+		updatedWebsite, err := websiteService.UpdateWebsite(context.Background(), testUserID1, ipfsWebsite.ID, ipnsUpdates)
+
+		// Assert
+		require.NoError(tb, err)
+		require.NotNil(tb, updatedWebsite)
+		assert.Equal(tb, string(pluginDb.WebsiteTargetTypeIPNS), updatedWebsite.TargetType)
+	}, TestOptions)
+}

--- a/internal/service/website/website_test.go
+++ b/internal/service/website/website_test.go
@@ -2215,3 +2215,123 @@ func TestWebsiteService_CreateWebsite_NoInheritWithoutSoftDeletedWebsite(t *test
 		assert.Nil(tb, createdWebsite.SSLIssuedAt)
 	}, TestOptions)
 }
+
+// TestWebsiteService_UpdateWebsite_ConvertIPNSToIPFS_UpdatesDNSRecords verifies that
+// when a website with DNS hosting enabled is updated from IPNS to IPFS target type,
+// the DNS _dnslink record is updated from /ipns/<peerID> to /ipfs/<cid>.
+// This tests the fix for the bug where IPNSKeyID != nil caused DNS update to be skipped
+// even when the target type was changing away from IPNS.
+func TestWebsiteService_UpdateWebsite_ConvertIPNSToIPFS_UpdatesDNSRecords(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		websiteService := core.GetService[pluginCore.WebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
+		mockDNS := core.GetService[*mocks.MockDNSService](ctx, pluginCore.DNS_SERVICE)
+		mockIPNSKey := core.GetService[*mocks.MockIPNSKeyService](ctx, pluginCore.IPNS_KEY_SERVICE)
+
+		testCID := util.GenerateTestCID(t, "test data")
+		domain := "ipns-to-ipfs-dns-test.com"
+		testZoneID := uint(9001)
+
+		// Create website with DNS hosting enabled (auto-creates IPNS key)
+		website := createTestIPFSWebsite(testUserID1, domain, testCID.String())
+		website.Enabled = true
+
+		testIPNSKey := setupIPNSAutoCreationMocks(t, mockIPNSKey, testUserID1, domain, testCID)
+
+		mockDNS.EXPECT().CreateZone(mock.Anything, domain, testUserID1).Return(createMockDNSZone(testZoneID, domain, testUserID1), nil).Once()
+		mockDNS.EXPECT().CreateWebsiteDNSRecords(
+			mock.Anything,
+			testZoneID,
+			mock.Anything,
+			pluginDb.WebsiteTargetTypeIPNS,
+			mock.Anything,
+		).Return(nil).Once()
+
+		createdWebsite, err := websiteService.CreateWebsite(context.Background(), website)
+		require.NoError(tb, err)
+		require.NotNil(tb, createdWebsite)
+		assert.Equal(tb, string(pluginDb.WebsiteTargetTypeIPNS), createdWebsite.TargetType)
+		require.NotNil(tb, createdWebsite.IPNSKeyID)
+		require.NotNil(tb, createdWebsite.DNSZoneID)
+
+		// Act - Update from IPNS to IPFS
+		newCID := util.GenerateTestCID(t, "new ipfs content")
+		updates := map[string]interface{}{
+			"target_hash": newCID.String(),
+			"target_type": string(pluginDb.WebsiteTargetTypeIPFS),
+		}
+
+		// IPNS republish attempt (website still has IPNSKeyID from creation)
+		mockIPNSKey.EXPECT().GetKeyByID(mock.Anything, testUserID1, *createdWebsite.IPNSKeyID).Return(testIPNSKey, nil).Once()
+		mockIPNSKey.EXPECT().PublishCID(mock.Anything, mock.Anything, mock.Anything, mock.AnythingOfType("time.Duration")).Return(nil).Once()
+
+		// DNS records must be updated when switching from IPNS to IPFS
+		mockDNS.EXPECT().UpdateWebsiteDNSRecords(
+			mock.Anything,
+			testZoneID,
+			newCID.String(),
+			pluginDb.WebsiteTargetTypeIPFS,
+		).Return(nil).Once()
+
+		updatedWebsite, err := websiteService.UpdateWebsite(context.Background(), testUserID1, createdWebsite.ID, updates)
+
+		// Assert
+		require.NoError(tb, err)
+		require.NotNil(tb, updatedWebsite)
+		assert.Equal(tb, string(pluginDb.WebsiteTargetTypeIPFS), updatedWebsite.TargetType)
+		assert.Equal(tb, newCID.String(), updatedWebsite.TargetHash())
+	}, TestOptions)
+}
+
+// TestWebsiteService_UpdateWebsite_IPNSToIPNS_NoDNSUpdate verifies that
+// when a website with DNS hosting stays as IPNS (only the CID published
+// to the IPNS key changes), DNS records are NOT updated since the peer ID
+// in the _dnslink record stays the same.
+func TestWebsiteService_UpdateWebsite_IPNSToIPNS_NoDNSUpdate(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		websiteService := core.GetService[pluginCore.WebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
+		mockDNS := core.GetService[*mocks.MockDNSService](ctx, pluginCore.DNS_SERVICE)
+		mockIPNSKey := core.GetService[*mocks.MockIPNSKeyService](ctx, pluginCore.IPNS_KEY_SERVICE)
+
+		testCID := util.GenerateTestCID(t, "test data")
+		domain := "ipns-same-type-test.com"
+		testZoneID := uint(9002)
+
+		website := createTestIPFSWebsite(testUserID1, domain, testCID.String())
+		website.Enabled = true
+
+		testIPNSKey := setupIPNSAutoCreationMocks(t, mockIPNSKey, testUserID1, domain, testCID)
+
+		mockDNS.EXPECT().CreateZone(mock.Anything, domain, testUserID1).Return(createMockDNSZone(testZoneID, domain, testUserID1), nil).Once()
+		mockDNS.EXPECT().CreateWebsiteDNSRecords(
+			mock.Anything,
+			testZoneID,
+			mock.Anything,
+			pluginDb.WebsiteTargetTypeIPNS,
+			mock.Anything,
+		).Return(nil).Once()
+
+		createdWebsite, err := websiteService.CreateWebsite(context.Background(), website)
+		require.NoError(tb, err)
+		require.NotNil(tb, createdWebsite)
+
+		// Act - Update to a new IPNS peer ID (staying as IPNS)
+		testPeerID := "12D3KooWCqvCZqaG6LmG4mtoWZZwrvYB911DK8qqwE9gc25s4Hft"
+		updates := map[string]interface{}{
+			"target_hash": testPeerID,
+		}
+
+		// IPNS republish attempt (website still has IPNSKeyID)
+		mockIPNSKey.EXPECT().GetKeyByID(mock.Anything, testUserID1, *createdWebsite.IPNSKeyID).Return(testIPNSKey, nil).Once()
+		mockIPNSKey.EXPECT().PublishCID(mock.Anything, mock.Anything, mock.Anything, mock.AnythingOfType("time.Duration")).Return(nil).Once()
+
+		updatedWebsite, err := websiteService.UpdateWebsite(context.Background(), testUserID1, createdWebsite.ID, updates)
+
+		// Assert
+		require.NoError(tb, err)
+		require.NotNil(tb, updatedWebsite)
+		assert.Equal(tb, string(pluginDb.WebsiteTargetTypeIPNS), updatedWebsite.TargetType)
+
+		// DNS records should NOT be updated when staying as IPNS
+		mockDNS.AssertNotCalled(t, "UpdateWebsiteDNSRecords")
+	}, TestOptions)
+}


### PR DESCRIPTION
Two bugs in UpdateWebsite:

1. DNS records were skipped when IPNSKeyID != nil, even when switching away from IPNS. Changed condition from IPNSKeyID check to checking the new target type — only skip DNS update when staying as IPNS.
2. IPNS republish read updates\["target\_hash"] which was deleted from the map earlier. Now uses the preserved newTargetHashStr variable.

- `develop` <!-- branch-stack -->
  - **fix: update DNS records when switching website from IPNS to IPFS target type** :point\_left:

***

<!-- kody-pr-summary:start -->

Fix DNS record updates when switching a website from IPNS to IPFS target type

Previously, when a website with an IPNS key was updated to use an IPFS target type, DNS records were not updated because the code checked `IPNSKeyID == nil` to skip DNS updates. This incorrectly skipped DNS updates for any website that had ever been assigned an IPNS key, even after switching away from IPNS.

The fix changes the condition to check the **new** target type instead: DNS records are now updated whenever the new target type is not IPNS, and skipped only when the target type remains IPNS (where the peer ID in the `_dnslink` record doesn't change). This correctly handles the IPNS-to-IPFS conversion scenario by updating the DNS `_dnslink` record from `/ipns/<peerID>` to `/ipfs/<cid>`.

Also includes a minor refactoring to reuse the already-resolved target hash for IPNS republishing instead of re-reading it from the updates map.

<!-- kody-pr-summary:end -->
