### PR TITLE
fix: add dnslink= prefix to DNSLink TXT record values

### DIFF
--- a/internal/service/dns/dns_helpers_test.go
+++ b/internal/service/dns/dns_helpers_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	pluginDb "go.lumeweb.com/portal-plugin-ipfs/internal/db"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -500,6 +501,34 @@ func TestBuildFullName_RealWorldScenarios(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result := buildFullName(tt.name, tt.domain)
 			assert.Equal(t, tt.expected, result, "buildFullName(%q, %q)", tt.name, tt.domain)
+		})
+	}
+}
+
+func TestBuildTargetPath(t *testing.T) {
+	tests := []struct {
+		name       string
+		targetHash string
+		targetType pluginDb.WebsiteTargetType
+		expected   DNSLinkTarget
+	}{
+		{
+			name:       "ipfs target includes dnslink prefix",
+			targetHash: "QmHash123",
+			targetType: pluginDb.WebsiteTargetTypeIPFS,
+			expected:   DNSLinkTarget("dnslink=/ipfs/QmHash123"),
+		},
+		{
+			name:       "ipns target includes dnslink prefix",
+			targetHash: "12D3KooWExamplePeerID",
+			targetType: pluginDb.WebsiteTargetTypeIPNS,
+			expected:   DNSLinkTarget("dnslink=/ipns/12D3KooWExamplePeerID"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := buildTargetPath(tt.targetHash, tt.targetType)
+			assert.Equal(t, tt.expected, result)
 		})
 	}
 }

--- a/internal/service/dns/dns_service_zone.go
+++ b/internal/service/dns/dns_service_zone.go
@@ -335,9 +335,11 @@ func (s *DNSServiceDefault) ValidateNameservers(ctx context.Context, zoneID uint
 	return true, nil
 }
 
-// buildTargetPath constructs the DNSLink target path based on target type
+// buildTargetPath constructs the DNSLink target path based on target type.
+// Per the dnslink spec (https://dnslink.info/), TXT record values must be
+// prefixed with "dnslink=" (e.g., "dnslink=/ipns/<peerID>").
 func buildTargetPath(targetHash string, targetType pluginDb.WebsiteTargetType) DNSLinkTarget {
-	return DNSLinkTarget(targetType.ToDNSLinkPath(targetHash))
+	return DNSLinkTarget("dnslink=" + targetType.ToDNSLinkPath(targetHash))
 }
 
 // CreateWebsiteDNSRecords creates initial DNS records for a new website


### PR DESCRIPTION
Per the dnslink spec, TXT record values must be prefixed with "dnslink=" (e.g., "dnslink=/ipns/<peerID>"). The previous implementation was missing this prefix.

- `develop` <!-- branch-stack -->
  - **fix: add dnslink= prefix to DNSLink TXT record values** :point\_left:

---

<!-- kody-pr-summary:start -->
Add required `dnslink=` prefix to DNSLink TXT record values

Per the DNSLink specification (https://dnslink.info/), TXT record values must be prefixed with `dnslink=` (e.g., `dnslink=/ipfs/QmHash123`). The `buildTargetPath` function was previously constructing paths without this prefix, which would cause DNSLink resolution to fail. This fix prepends the required prefix to both IPFS and IPNS target paths, and includes corresponding tests to verify the correct format.
<!-- kody-pr-summary:end -->