### PR TITLE
fix: allow partial website updates and refactor IPNS key management

### DIFF
--- a/internal/api/api_websites.go
+++ b/internal/api/api_websites.go
@@ -251,11 +251,14 @@ func (a *API) updateWebsite(c echo.Context) error {
 		updates["domain"] = *req.Domain
 	}
 	if req.TargetType != nil || req.TargetHash != nil {
-		if req.TargetType == nil || req.TargetHash == nil {
-			return ctx.Error(NewError(ErrKeyInvalidRequest, fmt.Errorf("target_type and target_hash must both be provided")), http.StatusUnprocessableEntity)
+		if req.TargetType != nil && req.TargetHash == nil {
+			updates["target_type"] = string(*req.TargetType)
+		} else if req.TargetHash != nil && req.TargetType == nil {
+			return ctx.Error(NewError(ErrKeyInvalidRequest, fmt.Errorf("target_type is required when target_hash is provided")), http.StatusUnprocessableEntity)
+		} else {
+			updates["target_type"] = string(*req.TargetType)
+			updates["target_hash"] = *req.TargetHash
 		}
-		updates["target_type"] = string(*req.TargetType)
-		updates["target_hash"] = *req.TargetHash
 	}
 	if req.DNSEnabled != nil {
 		updates["dns_enabled"] = *req.DNSEnabled

--- a/internal/api/api_websites_test.go
+++ b/internal/api/api_websites_test.go
@@ -897,15 +897,21 @@ func TestAPI_UpdateWebsite(t *testing.T) {
 		}, TestOptions)
 	})
 
-	t.Run("error_target_type_without_target_hash", func(t *testing.T) {
+	t.Run("success_target_type_ipns_without_target_hash", func(t *testing.T) {
 		coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 			helper := newMockHelper(t, ctx)
-			token, _ := helper.SetupAuthenticatedTestWithCID(cid.MustParse(TestCID))
+			token, userID := helper.SetupAuthenticatedTestWithCID(cid.MustParse(TestCID))
 
-			reqBody := `{"target_type":"ipfs"}`
+			mockWebsiteService := core.GetService[*mocks.MockWebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
+
+			mockWebsite := createMockIPFSWebsite(1, userID, "example.com", TestCID, db.WebsiteStatusActive, "")
+
+			mockWebsiteService.EXPECT().UpdateWebsite(mock.Anything, userID, uint(1), mock.AnythingOfType("map[string]interface {}")).Return(mockWebsite, nil)
+
+			reqBody := `{"target_type":"ipns"}`
 			rec := helper.makeAuthenticatedRequest(http.MethodPut, "/api/websites/1", token, []byte(reqBody))
 
-			assert.Equal(t, http.StatusUnprocessableEntity, rec.Code)
+			assert.Equal(t, http.StatusOK, rec.Code)
 		}, TestOptions)
 	})
 

--- a/internal/service/website/website.go
+++ b/internal/service/website/website.go
@@ -153,72 +153,12 @@ func (s *WebsiteServiceDefault) CreateWebsite(ctx context.Context, website *plug
 			}
 
 			// Auto-create IPNS key for managed DNS when using IPFS target
-			var ipnsKey *pluginDb.IPFSIPNSKey
 			if website.Enabled && website.TargetType == string(pluginDb.WebsiteTargetTypeIPFS) {
-				// Generate IPNS key name based on domain
-				keyName := fmt.Sprintf("%s-auto", website.Domain)
-
-				// Check if IPNS key with this name already exists
-				keys, err := s.ipnsKeySvc.ListKeys(ctx, website.UserID)
+				ipnsKey, err := s.ensureIPNSKey(ctx, website.UserID, website.Domain, website.TargetHash())
 				if err != nil {
-					s.Logger().Error("Failed to list existing IPNS keys",
-						zap.Error(err),
-						zap.String("domain", website.Domain))
-					return nil, fmt.Errorf("failed to list existing IPNS keys: %w", err)
-				}
-				for _, k := range keys {
-					if k.Name == keyName {
-						ipnsKey = &k
-						break
-					}
+					return nil, err
 				}
 
-				// Create IPNS key if it doesn't exist
-				if ipnsKey == nil {
-					ipnsKey, err = s.ipnsKeySvc.CreateKey(ctx, website.UserID, keyName, 1)
-					if err != nil {
-						s.Logger().Error("Failed to create IPNS key for managed DNS",
-							zap.Error(err),
-							zap.String("domain", website.Domain))
-						return nil, fmt.Errorf("failed to create IPNS key: %w", err)
-					}
-					s.Logger().Info("Created new IPNS key for managed DNS",
-						zap.String("domain", website.Domain),
-						zap.String("key_name", keyName),
-						zap.Stringer("peer_id", ipnsKey.PeerID()))
-				} else {
-					s.Logger().Info("Reusing existing IPNS key for managed DNS",
-						zap.String("domain", website.Domain),
-						zap.String("key_name", keyName),
-						zap.Stringer("peer_id", ipnsKey.PeerID()))
-				}
-				if err != nil {
-					s.Logger().Error("Failed to create IPNS key for managed DNS",
-						zap.Error(err),
-						zap.String("domain", website.Domain))
-					return nil, fmt.Errorf("failed to create IPNS key: %w", err)
-				}
-
-				// Publish the IPFS CID to the IPNS key
-				if s.ipnsKeySvc != nil {
-					// Use default TTL (24 hours)
-					ttl := 24 * time.Hour
-					err = s.ipnsKeySvc.PublishCID(ctx, ipnsKey.PeerID().String(), website.TargetHash(), ttl)
-					if err != nil {
-						s.Logger().Warn("Failed to publish CID to IPNS key for managed DNS",
-							zap.Error(err),
-							zap.String("domain", website.Domain),
-							zap.String("peer_id", ipnsKey.PeerID().String()))
-						// Continue - DNS records will still be created
-					} else {
-						s.Logger().Info("Published CID to IPNS key for managed DNS",
-							zap.String("domain", website.Domain),
-							zap.String("peer_id", ipnsKey.PeerID().String()),
-							zap.String("cid", website.TargetHash()))
-					}
-				}
-
-				// Update website to use IPNS target instead of IPFS
 				website.TargetType = string(pluginDb.WebsiteTargetTypeIPNS)
 				website.TargetMultihash = ipnsKey.PeerIDMultihash
 				website.CIDVersion = nil
@@ -459,6 +399,7 @@ func (s *WebsiteServiceDefault) UpdateWebsite(ctx context.Context, userID uint, 
 				oldEnabled = website.Enabled
 				targetHashChanged := false
 				dnsEnabledChanged = false
+				ipnsAutoCreated := false
 				var newTargetHashStr string
 
 				// Validate domain if being updated
@@ -482,51 +423,103 @@ func (s *WebsiteServiceDefault) UpdateWebsite(ctx context.Context, userID uint, 
 						targetType = tt
 					}
 
-					// Auto-detect targetType if it's IPFS but target_hash is a peer ID
-					// This handles cases where user updates target_hash without updating target_type
-					if targetType == string(pluginDb.WebsiteTargetTypeIPFS) && isValidIPNSTarget(targetHashStr) {
-						targetType = string(pluginDb.WebsiteTargetTypeIPNS)
-						updates["target_type"] = targetType
-					}
+					// Auto-detect: target_type=ipns with a plain IPFS CID means
+					// "create/use IPNS key and publish this CID to it"
+					if targetType == string(pluginDb.WebsiteTargetTypeIPNS) && isIPFSCid(targetHashStr) && !isValidIPNSTarget(targetHashStr) {
+						publishCID := targetHashStr
+						var publishHash string
 
-					// Validate target hash
-					if err := s.validateTarget(targetType, targetHashStr); err != nil {
-						_ = tx.AddError(fmt.Errorf("invalid target: %w", err))
-						return tx
-					}
-
-					// Check if target hash changed
-					if targetHashStr != oldTargetHash {
-						targetHashChanged = true
-						newTargetHashStr = targetHashStr
-					}
-
-					// Convert string to multihash and CID version
-					if targetType == string(pluginDb.WebsiteTargetTypeIPFS) {
-						c, err := cid.Decode(targetHashStr)
+						ipnsKey, err := s.ensureIPNSKey(ctx, website.UserID, website.Domain, publishCID)
 						if err != nil {
-							_ = tx.AddError(fmt.Errorf("failed to decode CID: %w", err))
+							_ = tx.AddError(err)
 							return tx
 						}
-						normalizedCid := encoding.NormalizeCid(c)
-						updates["target_multihash"] = normalizedCid.Hash()
-						version := uint8(normalizedCid.Version())
-						updates["cid_version"] = &version
-						codec := uint8(normalizedCid.Type())
-						updates["cid_type"] = &codec
+						publishHash = ipnsKey.PeerID().String()
+						ipnsAutoCreated = true
+
+						setIPNSTargetUpdates(updates, ipnsKey)
+						updates["target_type"] = string(pluginDb.WebsiteTargetTypeIPNS)
+
+						if publishHash != oldTargetHash {
+							targetHashChanged = true
+							newTargetHashStr = publishHash
+						}
+						delete(updates, "target_hash")
 					} else {
-						target, err := pluginDb.NewIPNSTargetFromString(targetHashStr)
-						if err != nil {
-							_ = tx.AddError(fmt.Errorf("failed to parse IPNS target: %w", err))
+						// Auto-detect targetType if it's IPFS but target_hash is a peer ID
+						if targetType == string(pluginDb.WebsiteTargetTypeIPFS) && isValidIPNSTarget(targetHashStr) {
+							targetType = string(pluginDb.WebsiteTargetTypeIPNS)
+							updates["target_type"] = targetType
+						}
+
+						// Validate target hash
+						if err := s.validateTarget(targetType, targetHashStr); err != nil {
+							_ = tx.AddError(fmt.Errorf("invalid target: %w", err))
 							return tx
 						}
-						updates["target_multihash"] = target.ToMultihash()
-						updates["cid_version"] = nil
-						updates["cid_type"] = nil
-					}
 
-					// Remove old target_hash from updates
-					delete(updates, "target_hash")
+						// Check if target hash changed
+						if targetHashStr != oldTargetHash {
+							targetHashChanged = true
+							newTargetHashStr = targetHashStr
+						}
+
+						// Convert string to multihash and CID version
+						if targetType == string(pluginDb.WebsiteTargetTypeIPFS) {
+							c, err := cid.Decode(targetHashStr)
+							if err != nil {
+								_ = tx.AddError(fmt.Errorf("failed to decode CID: %w", err))
+								return tx
+							}
+							normalizedCid := encoding.NormalizeCid(c)
+							updates["target_multihash"] = normalizedCid.Hash()
+							version := uint8(normalizedCid.Version())
+							updates["cid_version"] = &version
+							codec := uint8(normalizedCid.Type())
+							updates["cid_type"] = &codec
+						} else {
+							target, err := pluginDb.NewIPNSTargetFromString(targetHashStr)
+							if err != nil {
+								_ = tx.AddError(fmt.Errorf("failed to parse IPNS target: %w", err))
+								return tx
+							}
+							updates["target_multihash"] = target.ToMultihash()
+							updates["cid_version"] = nil
+							updates["cid_type"] = nil
+						}
+
+						// Remove old target_hash from updates
+						delete(updates, "target_hash")
+					}
+				} else if newTargetType, ok := updates["target_type"].(string); ok {
+					// target_type provided without target_hash — conversion request
+					requestedType := pluginDb.WebsiteTargetType(newTargetType)
+
+					if requestedType == pluginDb.WebsiteTargetTypeIPNS && oldTargetType == pluginDb.WebsiteTargetTypeIPFS {
+						// IPFS → IPNS: auto-create key, publish current CID
+						publishCID := oldTargetHash
+
+						ipnsKey, err := s.ensureIPNSKey(ctx, website.UserID, website.Domain, publishCID)
+						if err != nil {
+							_ = tx.AddError(err)
+							return tx
+						}
+						ipnsAutoCreated = true
+
+						setIPNSTargetUpdates(updates, ipnsKey)
+
+						newPeerID := ipnsKey.PeerID().String()
+						if newPeerID != oldTargetHash {
+							targetHashChanged = true
+							newTargetHashStr = newPeerID
+						}
+					} else if requestedType == pluginDb.WebsiteTargetTypeIPFS && oldTargetType == pluginDb.WebsiteTargetTypeIPNS {
+						_ = tx.AddError(fmt.Errorf("cannot convert from IPNS to IPFS without specifying a target CID"))
+						return tx
+					} else if requestedType == oldTargetType {
+						// Same type — no-op, remove from updates
+						delete(updates, "target_type")
+					}
 				}
 
 				// Check if dns_enabled is being changed with validation
@@ -548,7 +541,8 @@ func (s *WebsiteServiceDefault) UpdateWebsite(ctx context.Context, userID uint, 
 				updatedWebsite = &website
 
 				// If target hash changed and website has auto-created IPNS key, republish to IPNS
-				if targetHashChanged && website.IPNSKeyID != nil {
+				// Skip if ensureIPNSKey already handled the publish
+				if targetHashChanged && website.IPNSKeyID != nil && !ipnsAutoCreated {
 					ipnsKey, err := s.ipnsKeySvc.GetKeyByID(ctx, website.UserID, *website.IPNSKeyID)
 					if err != nil {
 						s.Logger().Warn("Failed to get IPNS key for republishing",
@@ -583,7 +577,7 @@ func (s *WebsiteServiceDefault) UpdateWebsite(ctx context.Context, userID uint, 
 			// Note: Skip DNS only when staying as IPNS (peer ID doesn't change)
 			if targetHashChanged && website.Enabled && website.DNSZoneID != nil && s.dnsSvc != nil {
 				newTargetType := pluginDb.WebsiteTargetType(website.TargetType)
-				if !(oldTargetType == pluginDb.WebsiteTargetTypeIPNS && newTargetType == pluginDb.WebsiteTargetTypeIPNS) {
+				if oldTargetType != pluginDb.WebsiteTargetTypeIPNS || newTargetType != pluginDb.WebsiteTargetTypeIPNS {
 					newTargetHash := website.TargetHash()
 					if err := s.dnsSvc.UpdateWebsiteDNSRecords(ctx, *website.DNSZoneID, newTargetHash, newTargetType); err != nil {
 						s.Logger().Warn("Failed to update DNS records for website",
@@ -1186,6 +1180,75 @@ func isValidIPNSTarget(targetHash string) bool {
 		return true
 	}
 	return true
+}
+
+// ensureIPNSKey creates or reuses an IPNS key for a domain, and publishes the given CID to it.
+// Returns the IPNS key on success.
+func (s *WebsiteServiceDefault) ensureIPNSKey(ctx context.Context, userID uint, domain string, publishCID string) (*pluginDb.IPFSIPNSKey, error) {
+	keyName := fmt.Sprintf("%s-auto", domain)
+
+	keys, err := s.ipnsKeySvc.ListKeys(ctx, userID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list existing IPNS keys: %w", err)
+	}
+
+	var ipnsKey *pluginDb.IPFSIPNSKey
+	for i := range keys {
+		if keys[i].Name == keyName {
+			ipnsKey = &keys[i]
+			break
+		}
+	}
+
+	if ipnsKey == nil {
+		ipnsKey, err = s.ipnsKeySvc.CreateKey(ctx, userID, keyName, 1)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create IPNS key: %w", err)
+		}
+		s.Logger().Info("Created new IPNS key for managed DNS",
+			zap.String("domain", domain),
+			zap.String("key_name", keyName),
+			zap.Stringer("peer_id", ipnsKey.PeerID()))
+	} else {
+		s.Logger().Info("Reusing existing IPNS key for managed DNS",
+			zap.String("domain", domain),
+			zap.String("key_name", keyName),
+			zap.Stringer("peer_id", ipnsKey.PeerID()))
+	}
+
+	if s.ipnsKeySvc != nil && publishCID != "" {
+		ttl := 24 * time.Hour
+		err = s.ipnsKeySvc.PublishCID(ctx, ipnsKey.PeerID().String(), publishCID, ttl)
+		if err != nil {
+			s.Logger().Warn("Failed to publish CID to IPNS key",
+				zap.Error(err),
+				zap.String("domain", domain),
+				zap.String("peer_id", ipnsKey.PeerID().String()),
+				zap.String("cid", publishCID))
+		} else {
+			s.Logger().Info("Published CID to IPNS key",
+				zap.String("domain", domain),
+				zap.String("peer_id", ipnsKey.PeerID().String()),
+				zap.String("cid", publishCID))
+		}
+	}
+
+	return ipnsKey, nil
+}
+
+// setIPNSTargetUpdates populates the updates map with IPNS target fields
+// from an IPNS key, preparing them for a GORM Updates call.
+func setIPNSTargetUpdates(updates map[string]any, ipnsKey *pluginDb.IPFSIPNSKey) {
+	updates["target_multihash"] = ipnsKey.PeerIDMultihash
+	updates["cid_version"] = nil
+	updates["cid_type"] = nil
+	updates["ipns_key_id"] = ipnsKey.ID
+}
+
+// isIPFSCid checks if a string is a valid IPFS CID (not an IPNS peer ID).
+func isIPFSCid(hash string) bool {
+	_, err := cid.Decode(hash)
+	return err == nil
 }
 
 // validateTarget validates the target type and hash

--- a/internal/service/website/website_test.go
+++ b/internal/service/website/website_test.go
@@ -2415,3 +2415,147 @@ func TestWebsiteService_UpdateWebsite_ConvertIPFSToIPNS_UpdatesDNSRecords(t *tes
 		assert.Equal(tb, string(pluginDb.WebsiteTargetTypeIPNS), updatedWebsite.TargetType)
 	}, TestOptions)
 }
+
+func TestWebsiteService_UpdateWebsite_TargetTypeIPNSAlone(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		websiteService := core.GetService[pluginCore.WebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
+		mockIPNSKey := core.GetService[*mocks.MockIPNSKeyService](ctx, pluginCore.IPNS_KEY_SERVICE)
+
+		testCID := util.GenerateTestCID(t, "test data")
+		domain := "type-only-convert.com"
+
+		website := createTestIPFSWebsite(testUserID1, domain, testCID.String())
+		website.Enabled = false
+
+		createdWebsite, err := websiteService.CreateWebsite(context.Background(), website)
+		require.NoError(tb, err)
+		require.NotNil(tb, createdWebsite)
+		assert.Equal(tb, string(pluginDb.WebsiteTargetTypeIPFS), createdWebsite.TargetType)
+
+		testIPNSKey := setupIPNSAutoCreationMocks(t, mockIPNSKey, testUserID1, domain, testCID)
+
+		updates := map[string]interface{}{
+			"target_type": string(pluginDb.WebsiteTargetTypeIPNS),
+		}
+
+		updatedWebsite, err := websiteService.UpdateWebsite(context.Background(), testUserID1, createdWebsite.ID, updates)
+
+		require.NoError(tb, err)
+		require.NotNil(tb, updatedWebsite)
+		assert.Equal(tb, string(pluginDb.WebsiteTargetTypeIPNS), updatedWebsite.TargetType)
+		assert.Equal(tb, testIPNSKey.PeerID().String(), updatedWebsite.TargetHash())
+		require.NotNil(tb, updatedWebsite.IPNSKeyID)
+	}, TestOptions)
+}
+
+func TestWebsiteService_UpdateWebsite_TargetTypeIPNSAlone_DNSRecordsUpdated(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		websiteService := core.GetService[pluginCore.WebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
+		mockDNS := core.GetService[*mocks.MockDNSService](ctx, pluginCore.DNS_SERVICE)
+		mockIPNSKey := core.GetService[*mocks.MockIPNSKeyService](ctx, pluginCore.IPNS_KEY_SERVICE)
+
+		testCID := util.GenerateTestCID(t, "test data")
+		domain := "type-only-dns.com"
+		testZoneID := uint(8001)
+
+		website := createTestIPFSWebsite(testUserID1, domain, testCID.String())
+		website.Enabled = false
+
+		createdWebsite, err := websiteService.CreateWebsite(context.Background(), website)
+		require.NoError(tb, err)
+		require.NotNil(tb, createdWebsite)
+		assert.Equal(tb, string(pluginDb.WebsiteTargetTypeIPFS), createdWebsite.TargetType)
+
+		testIPNSKey := setupIPNSAutoCreationMocks(t, mockIPNSKey, testUserID1, domain, testCID)
+
+		updates := map[string]interface{}{
+			"target_type": string(pluginDb.WebsiteTargetTypeIPNS),
+			"dns_enabled": true,
+		}
+
+		mockDNS.EXPECT().CreateZone(mock.Anything, domain, testUserID1).Return(createMockDNSZone(testZoneID, domain, testUserID1), nil).Once()
+		mockDNS.EXPECT().CreateWebsiteDNSRecords(
+			mock.Anything,
+			testZoneID,
+			testIPNSKey.PeerID().String(),
+			pluginDb.WebsiteTargetTypeIPNS,
+			mock.Anything,
+		).Return(nil).Once()
+
+		updatedWebsite, err := websiteService.UpdateWebsite(context.Background(), testUserID1, createdWebsite.ID, updates)
+
+		require.NoError(tb, err)
+		require.NotNil(tb, updatedWebsite)
+		assert.Equal(tb, string(pluginDb.WebsiteTargetTypeIPNS), updatedWebsite.TargetType)
+	}, TestOptions)
+}
+
+func TestWebsiteService_UpdateWebsite_IPNSTargetTypeWithCID(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		websiteService := core.GetService[pluginCore.WebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
+		mockIPNSKey := core.GetService[*mocks.MockIPNSKeyService](ctx, pluginCore.IPNS_KEY_SERVICE)
+
+		testCID := util.GenerateTestCID(t, "original data")
+		domain := "ipns-with-cid.com"
+
+		website := createTestIPFSWebsite(testUserID1, domain, testCID.String())
+		website.Enabled = false
+
+		createdWebsite, err := websiteService.CreateWebsite(context.Background(), website)
+		require.NoError(tb, err)
+		assert.Equal(tb, string(pluginDb.WebsiteTargetTypeIPFS), createdWebsite.TargetType)
+
+		newCID := util.GenerateTestCID(t, "new data for ipns")
+		testIPNSKey := setupIPNSAutoCreationMocks(t, mockIPNSKey, testUserID1, domain, newCID)
+
+		updates := map[string]interface{}{
+			"target_type": string(pluginDb.WebsiteTargetTypeIPNS),
+			"target_hash": newCID.String(),
+		}
+
+		updatedWebsite, err := websiteService.UpdateWebsite(context.Background(), testUserID1, createdWebsite.ID, updates)
+
+		require.NoError(tb, err)
+		require.NotNil(tb, updatedWebsite)
+		assert.Equal(tb, string(pluginDb.WebsiteTargetTypeIPNS), updatedWebsite.TargetType)
+		assert.Equal(tb, testIPNSKey.PeerID().String(), updatedWebsite.TargetHash())
+	}, TestOptions)
+}
+
+func TestWebsiteService_UpdateWebsite_IPNSToIPFSWithoutCID(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		websiteService := core.GetService[pluginCore.WebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
+		mockDNS := core.GetService[*mocks.MockDNSService](ctx, pluginCore.DNS_SERVICE)
+		mockIPNSKey := core.GetService[*mocks.MockIPNSKeyService](ctx, pluginCore.IPNS_KEY_SERVICE)
+
+		testCID := util.GenerateTestCID(t, "test data")
+		domain := "ipns-to-ipfs-no-cid.com"
+		testZoneID := uint(8002)
+
+		website := createTestIPFSWebsite(testUserID1, domain, testCID.String())
+		website.Enabled = true
+
+		_ = setupIPNSAutoCreationMocks(t, mockIPNSKey, testUserID1, domain, testCID)
+
+		mockDNS.EXPECT().CreateZone(mock.Anything, domain, testUserID1).Return(createMockDNSZone(testZoneID, domain, testUserID1), nil).Once()
+		mockDNS.EXPECT().CreateWebsiteDNSRecords(
+			mock.Anything,
+			testZoneID,
+			mock.Anything,
+			pluginDb.WebsiteTargetTypeIPNS,
+			mock.Anything,
+		).Return(nil).Once()
+
+		createdWebsite, err := websiteService.CreateWebsite(context.Background(), website)
+		require.NoError(tb, err)
+		assert.Equal(tb, string(pluginDb.WebsiteTargetTypeIPNS), createdWebsite.TargetType)
+
+		updates := map[string]interface{}{
+			"target_type": string(pluginDb.WebsiteTargetTypeIPFS),
+		}
+
+		_, err = websiteService.UpdateWebsite(context.Background(), testUserID1, createdWebsite.ID, updates)
+		require.Error(tb, err)
+		assert.Contains(tb, err.Error(), "cannot convert from IPNS to IPFS without specifying a target CID")
+	}, TestOptions)
+}


### PR DESCRIPTION
- Allow target\_type alone (without target\_hash) for IPFS→IPNS conversion
- Auto-create/reuse IPNS key when target\_type=ipns with an IPFS CID hash
- Extract ensureIPNSKey/setIPNSTargetUpdates helpers to DRY key logic
- Block IPNS→IPFS conversion without specifying a target CID
- Add isIPFSCid helper to distinguish CIDs from peer IDs
- Skip redundant republish when ensureIPNSKey already handled it
- Fix DNS update condition logic for same-type IPNS updates
- Add tests for type-only conversion, IPNS+CID, and IPNS→IPFS error

* `develop` <!-- branch-stack -->
  - **fix: allow partial website updates and refactor IPNS key management** :point\_left:

---

<!-- kody-pr-summary:start -->
This PR enables partial website updates by allowing `target_type` to be changed independently of `target_hash`, and refactors IPNS key management into reusable helpers.

**Key changes:**

- **Allow `target_type`-only updates**: The API no longer requires both `target_type` and `target_hash` to be provided together. Users can now specify only `target_type` to convert a website from IPFS to IPNS, while providing `target_hash` without `target_type` still requires the type for validation.

- **Auto-convert IPFS to IPNS via `target_type` alone**: When updating a website with only `target_type: "ipns"`, the system automatically creates or reuses an IPNS key for the domain, publishes the current IPFS CID to it, and updates the website's target to the IPNS peer ID.

- **Auto-convert when `target_type=ipns` with an IPFS CID**: When both `target_type: "ipns"` and a plain IPFS CID as `target_hash` are provided, the system detects the CID is not a peer ID and automatically creates/reuses an IPNS key, publishes the CID, and sets the target to the IPNS peer ID.

- **Prevent IPNS-to-IPFS conversion without a CID**: Explicitly rejects converting from IPNS to IPFS by only providing `target_type: "ipfs"`, requiring a target CID to be specified.

- **Refactor IPNS key management**: Extracted the IPNS key creation/reuse and publishing logic from `CreateWebsite` into a shared `ensureIPNSKey` helper, along with `setIPNSTargetUpdates` and `isIPFSCid` helpers, eliminating code duplication and ensuring consistent behavior across create and update flows.

- **Fix double-publish and DNS update logic**: Added an `ipnsAutoCreated` flag to skip redundant IPNS republishing when `ensureIPNSKey` already handled it, and corrected the DNS update condition to properly trigger updates when the target type changes.
<!-- kody-pr-summary:end -->