### PR TITLE
fix: add companion DHT for FullRT mode and aggregate close errors

### DIFF
--- a/internal/protocol/ipfs/node.go
+++ b/internal/protocol/ipfs/node.go
@@ -171,12 +171,13 @@ type Node struct {
 	log              *core.Logger
 	host             host.Host
 	routing          DHTRouting
+	companionDHT     *dht.IpfsDHT
 	reprovider       *Reprovider
 	blockService     blockservice.BlockService
 	dagService       format.DAGService
 	bitswap          *bitswap.Bitswap
 	reproviderCancel context.CancelFunc
-	datastore        datastore.Batching
+	datastore        datastore.Datastore
 	keystore         keystore.Keystore
 	publisher        *namesys.IPNSPublisher
 }
@@ -189,21 +190,26 @@ func (n *Node) Close() error {
 	if n.reproviderCancel != nil {
 		n.reproviderCancel()
 	}
-	err := n.routing.Close()
-	if err != nil {
-		return err
+	var errs []error
+	if n.companionDHT != nil {
+		if err := n.companionDHT.Close(); err != nil {
+			errs = append(errs, fmt.Errorf("failed to close companion DHT: %w", err))
+		}
 	}
-	err = n.bitswap.Close()
-	if err != nil {
-		return err
+	if err := n.routing.Close(); err != nil {
+		errs = append(errs, fmt.Errorf("failed to close routing: %w", err))
 	}
-	err = n.host.Close()
-	if err != nil {
-		return err
+	if err := n.bitswap.Close(); err != nil {
+		errs = append(errs, fmt.Errorf("failed to close bitswap: %w", err))
 	}
-	err = n.blockService.Close()
-	if err != nil {
-		return err
+	if err := n.host.Close(); err != nil {
+		errs = append(errs, fmt.Errorf("failed to close host: %w", err))
+	}
+	if err := n.blockService.Close(); err != nil {
+		errs = append(errs, fmt.Errorf("failed to close block service: %w", err))
+	}
+	if len(errs) > 0 {
+		return fmt.Errorf("errors during node close: %v", errs)
 	}
 	return nil
 }
@@ -416,9 +422,20 @@ func NewNode(ctx core.Context, cfg *config.ProtocolConfig, rs pluginCore.Reprovi
 		dhtProvider = newBasicDHTProvider(basicDHT)
 		hasProvider = true
 	case config.DHTModeFullRT, "":
-		// Use FullRT (default)
+		// FullRT is a client-only DHT — it does not register protocol handlers
+		// and cannot respond to inbound DHT queries. Per its own docs, a
+		// companion IpfsDHT in server mode must be run alongside it so that
+		// other peers (including the website gateway) can query this node
+		// for IPNS records and content routing.
+		companion, dhtErr := dht.New(ctx, node, dhtOpts...)
+		if dhtErr != nil {
+			return nil, fmt.Errorf("failed to create companion DHT: %w", dhtErr)
+		}
+		if err := companion.Bootstrap(ctx); err != nil {
+			ctx.Logger().Warn("failed to bootstrap companion DHT", zap.Error(err))
+		}
+		ipfsNode.companionDHT = companion
 
-		// FullRT requires specific BucketSize and Concurrency
 		fullRTOpts := []fullrt.Option{
 			fullrt.DHTOption(
 				append(dhtOpts,
@@ -430,10 +447,10 @@ func NewNode(ctx core.Context, cfg *config.ProtocolConfig, rs pluginCore.Reprovi
 
 		frt, dhtErr := fullrt.NewFullRT(node, dht.DefaultPrefix, fullRTOpts...)
 		if dhtErr != nil {
+			companion.Close()
 			return nil, fmt.Errorf("failed to create fullrt: %w", dhtErr)
 		}
 		routingImpl = frt
-		// FullRT already implements pluginCore.Provider
 		dhtProvider = frt
 		hasProvider = true
 	}


### PR DESCRIPTION
FullRT is a client-only DHT that cannot respond to inbound queries. A companion IpfsDHT in server mode must run alongside it so peers can query this node for IPNS records and content routing.

Node.Close() now aggregates all close errors instead of returning on the first failure, ensuring all resources are released. datastore type narrowed from Batching to Datastore.

- `develop` <!-- branch-stack -->
  - **fix: add companion DHT for FullRT mode and aggregate close errors** :point\_left:

---

<!-- kody-pr-summary:start -->
Add companion DHT for FullRT mode and aggregate close errors

- **Companion DHT for FullRT mode**: When running in FullRT DHT mode (the default), a standard `IpfsDHT` in server mode is now created and run alongside the FullRT client. Since FullRT is a client-only DHT that does not register protocol handlers or respond to inbound queries, the companion DHT enables other peers to query this node for IPNS records and content routing. The companion is bootstrapped on creation and properly closed on node shutdown or if FullRT initialization fails.

- **Aggregate close errors**: The `Node.Close()` method now collects errors from all components (companion DHT, routing, bitswap, host, block service) instead of returning on the first failure, ensuring all resources are attempted to be released and all close errors are reported.

- **Datastore type correction**: The `datastore` field type was changed from `datastore.Batching` to `datastore.Datastore`.
<!-- kody-pr-summary:end -->