### PR TITLE
feat: support subdomain websites sharing a parent DNS zone

### DIFF
--- a/core/dns.go
+++ b/core/dns.go
@@ -37,14 +37,17 @@ type DNSService interface {
 	// ValidateNameservers validates that domain's nameservers match approved list
 	ValidateNameservers(ctx context.Context, zoneID uint) (bool, error)
 
-	// CreateWebsiteDNSRecords creates initial DNS records for a new website
-	CreateWebsiteDNSRecords(ctx context.Context, zoneID uint, targetHash string, targetType pluginDb.WebsiteTargetType, validationToken string) error
+	// CreateWebsiteDNSRecords creates initial DNS records for a new website.
+	// websiteDomain is the full domain of the website (may differ from the zone's domain for subdomain websites).
+	CreateWebsiteDNSRecords(ctx context.Context, zoneID uint, websiteDomain string, targetHash string, targetType pluginDb.WebsiteTargetType, validationToken string) error
 
-	// UpdateWebsiteDNSRecords updates DNS records for a website
-	UpdateWebsiteDNSRecords(ctx context.Context, zoneID uint, targetHash string, targetType pluginDb.WebsiteTargetType) error
+	// UpdateWebsiteDNSRecords updates DNS records for a website.
+	// websiteDomain is the full domain of the website (may differ from the zone's domain for subdomain websites).
+	UpdateWebsiteDNSRecords(ctx context.Context, zoneID uint, websiteDomain string, targetHash string, targetType pluginDb.WebsiteTargetType) error
 
-	// DeleteWebsiteDNSRecords removes DNS records for a website
-	DeleteWebsiteDNSRecords(ctx context.Context, zoneID uint) error
+	// DeleteWebsiteDNSRecords removes DNS records for a website.
+	// websiteDomain is the full domain of the website (may differ from the zone's domain for subdomain websites).
+	DeleteWebsiteDNSRecords(ctx context.Context, zoneID uint, websiteDomain string) error
 
 	// GetZoneRecords retrieves DNS records for a zone from PowerDNS
 	// Returns list of DNSRecord DTOs representing PowerDNS RRSets with filtering applied

--- a/internal/api/api_websites.go
+++ b/internal/api/api_websites.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -31,6 +32,17 @@ func (a *API) gatewayDomain() string {
 		return a.dnsConfig.GatewayDomain
 	}
 	return ""
+}
+
+func (a *API) zoneDomain(ctx context.Context, dnsZoneID *uint) string {
+	if dnsZoneID == nil || a.dnsService == nil {
+		return ""
+	}
+	zone, err := a.dnsService.GetZone(ctx, *dnsZoneID)
+	if err != nil || zone == nil {
+		return ""
+	}
+	return zone.Domain
 }
 
 func (a *API) getWebsiteConfig(c echo.Context) error {
@@ -115,6 +127,7 @@ func (a *API) createWebsite(c echo.Context) error {
 		return ctx.Error(apiErr, apiErr.HttpStatus())
 	}
 	resp.GatewayDomain = a.gatewayDomain()
+	resp.SetSubdomainInfo(a.zoneDomain(reqCtx, website.DNSZoneID))
 
 	ctx.Response().Before(func() {
 		ctx.Response().Status = http.StatusCreated
@@ -169,6 +182,7 @@ func (a *API) listWebsites(c echo.Context) error {
 			return ctx.Error(apiErr, apiErr.HttpStatus())
 		}
 		responses[i].GatewayDomain = a.gatewayDomain()
+		responses[i].SetSubdomainInfo(a.zoneDomain(reqCtx, website.DNSZoneID))
 	}
 
 	// Convert to WebsiteItem for list response
@@ -209,6 +223,7 @@ func (a *API) getWebsite(c echo.Context) error {
 		var resp dto.WebsiteResponse
 		if err := resp.FromModel(website); err == nil {
 			resp.GatewayDomain = a.gatewayDomain()
+			resp.SetSubdomainInfo(a.zoneDomain(reqCtx, website.DNSZoneID))
 			ctx.Response().Before(func() {
 				ctx.Response().Status = http.StatusGone
 			})
@@ -218,6 +233,7 @@ func (a *API) getWebsite(c echo.Context) error {
 
 	resp := &dto.WebsiteResponse{}
 	resp.GatewayDomain = a.gatewayDomain()
+	resp.SetSubdomainInfo(a.zoneDomain(reqCtx, website.DNSZoneID))
 	return httputil.EncodeResponse(ctx, website, resp)
 }
 
@@ -278,6 +294,7 @@ func (a *API) updateWebsite(c echo.Context) error {
 		return ctx.Error(apiErr, apiErr.HttpStatus())
 	}
 	resp.GatewayDomain = a.gatewayDomain()
+	resp.SetSubdomainInfo(a.zoneDomain(reqCtx, website.DNSZoneID))
 
 	return httputil.EncodeResponse(ctx, website, &resp)
 }
@@ -377,6 +394,7 @@ func (a *API) getSSLStatus(c echo.Context) error {
 
 	resp := &dto.WebsiteResponse{}
 	resp.GatewayDomain = a.gatewayDomain()
+	resp.SetSubdomainInfo(a.zoneDomain(reqCtx, website.DNSZoneID))
 	return httputil.EncodeResponse(ctx, website, resp)
 }
 
@@ -418,5 +436,6 @@ func (a *API) updateSSLStatus(c echo.Context) error {
 
 	resp := &dto.WebsiteResponse{}
 	resp.GatewayDomain = a.gatewayDomain()
+	resp.SetSubdomainInfo(a.zoneDomain(reqCtx, website.DNSZoneID))
 	return httputil.EncodeResponse(ctx, website, resp)
 }

--- a/internal/api/dto/website.go
+++ b/internal/api/dto/website.go
@@ -343,6 +343,7 @@ type WebsiteResponse struct {
 	LastCheckedAt       *time.Time     `json:"last_checked_at,omitempty"`
 	DNSZoneID           *uint          `json:"dns_zone_id,omitempty"`
 	Enabled             bool           `json:"dns_hosting_enabled"`
+	IsSubdomain         bool           `json:"is_subdomain"`
 	GatewayDomain       string         `json:"gateway_domain,omitempty"`
 	Created             time.Time      `json:"created"`
 	Updated             time.Time      `json:"updated"`
@@ -385,6 +386,12 @@ func (r *WebsiteResponse) FromModel(model *db.Website) error {
 	}
 
 	return nil
+}
+
+// SetSubdomainInfo sets the IsSubdomain flag based on the zone's domain.
+// If zoneDomain is empty, the website is considered a top-level website.
+func (r *WebsiteResponse) SetSubdomainInfo(zoneDomain string) {
+	r.IsSubdomain = zoneDomain != "" && zoneDomain != r.Domain
 }
 
 // WebsiteValidateResponse represents a website validation response

--- a/internal/service/dns/dns_service_test.go
+++ b/internal/service/dns/dns_service_test.go
@@ -445,7 +445,7 @@ func TestDNSServiceCreateWebsiteDNSRecords(t *testing.T) {
 		require.NotNil(tb, zone)
 
 		// Create website DNS records
-		err = svc.CreateWebsiteDNSRecords(ctx, zone.ID, "QmHash123", pluginDb.WebsiteTargetTypeIPFS, "test-validation-token")
+		err = svc.CreateWebsiteDNSRecords(ctx, zone.ID, "example.com", "QmHash123", pluginDb.WebsiteTargetTypeIPFS, "test-validation-token")
 		require.NoError(tb, err)
 	}, getTestOptions())
 }
@@ -461,7 +461,7 @@ func TestDNSServiceDeleteWebsiteDNSRecords(t *testing.T) {
 		require.NotNil(tb, zone)
 
 		// Delete website DNS records
-		err = svc.DeleteWebsiteDNSRecords(ctx, zone.ID)
+		err = svc.DeleteWebsiteDNSRecords(ctx, zone.ID, "example.com")
 		require.NoError(tb, err)
 	}, getTestOptions())
 }

--- a/internal/service/dns/dns_service_zone.go
+++ b/internal/service/dns/dns_service_zone.go
@@ -342,8 +342,10 @@ func buildTargetPath(targetHash string, targetType pluginDb.WebsiteTargetType) D
 	return DNSLinkTarget("dnslink=" + targetType.ToDNSLinkPath(targetHash))
 }
 
-// CreateWebsiteDNSRecords creates initial DNS records for a new website
-func (s *DNSServiceDefault) CreateWebsiteDNSRecords(ctx context.Context, zoneID uint, targetHash string, targetType pluginDb.WebsiteTargetType, validationToken string) error {
+// CreateWebsiteDNSRecords creates initial DNS records for a new website.
+// websiteDomain is the full domain of the website and may differ from the zone's domain
+// when this is a subdomain website sharing a parent zone.
+func (s *DNSServiceDefault) CreateWebsiteDNSRecords(ctx context.Context, zoneID uint, websiteDomain string, targetHash string, targetType pluginDb.WebsiteTargetType, validationToken string) error {
 	ctx, span := core.TraceMethod(ctx, "DNSService.CreateWebsiteDNSRecords")
 	defer span.End()
 
@@ -363,9 +365,12 @@ func (s *DNSServiceDefault) CreateWebsiteDNSRecords(ctx context.Context, zoneID 
 	disabled := false
 	targetPath := string(buildTargetPath(targetHash, targetType))
 
+	dnslinkName := buildFullName("_dnslink", websiteDomain)
+	recordName := buildFullName(websiteDomain, websiteDomain)
+
 	rrsets := []powerdns.RRSet{
 		{
-			Name:       "_dnslink." + zone.Domain + ".",
+			Name:       dnslinkName,
 			Type:       "TXT",
 			Changetype: "REPLACE",
 			Ttl:        &ttl,
@@ -377,7 +382,7 @@ func (s *DNSServiceDefault) CreateWebsiteDNSRecords(ctx context.Context, zoneID 
 			},
 		},
 		{
-			Name:       zone.Domain + ".",
+			Name:       recordName,
 			Type:       "TXT",
 			Changetype: "REPLACE",
 			Ttl:        &ttl,
@@ -392,7 +397,7 @@ func (s *DNSServiceDefault) CreateWebsiteDNSRecords(ctx context.Context, zoneID 
 
 	if s.config.GatewayDomain != "" {
 		rrsets = append(rrsets, powerdns.RRSet{
-			Name:       zone.Domain + ".",
+			Name:       recordName,
 			Type:       "ALIAS",
 			Changetype: "REPLACE",
 			Ttl:        &ttl,
@@ -411,15 +416,17 @@ func (s *DNSServiceDefault) CreateWebsiteDNSRecords(ctx context.Context, zoneID 
 
 	s.Logger().Info("DNS records created for website",
 		zap.Uint("zone_id", zoneID),
-		zap.String("domain", zone.Domain),
+		zap.String("domain", websiteDomain),
 		zap.String("target_hash", targetHash),
 		zap.String("target_type", string(targetType)))
 
 	return nil
 }
 
-// UpdateWebsiteDNSRecords updates DNS records for a website
-func (s *DNSServiceDefault) UpdateWebsiteDNSRecords(ctx context.Context, zoneID uint, targetHash string, targetType pluginDb.WebsiteTargetType) error {
+// UpdateWebsiteDNSRecords updates DNS records for a website.
+// websiteDomain is the full domain of the website and may differ from the zone's domain
+// when this is a subdomain website sharing a parent zone.
+func (s *DNSServiceDefault) UpdateWebsiteDNSRecords(ctx context.Context, zoneID uint, websiteDomain string, targetHash string, targetType pluginDb.WebsiteTargetType) error {
 	ctx, span := core.TraceMethod(ctx, "DNSService.UpdateWebsiteDNSRecords")
 	defer span.End()
 
@@ -439,9 +446,11 @@ func (s *DNSServiceDefault) UpdateWebsiteDNSRecords(ctx context.Context, zoneID 
 	disabled := false
 	targetPath := string(buildTargetPath(targetHash, targetType))
 
+	dnslinkName := buildFullName("_dnslink", websiteDomain)
+
 	rrsets := []powerdns.RRSet{
 		{
-			Name:       "_dnslink." + zone.Domain + ".",
+			Name:       dnslinkName,
 			Type:       "TXT",
 			Changetype: "REPLACE",
 			Ttl:        &ttl,
@@ -460,14 +469,16 @@ func (s *DNSServiceDefault) UpdateWebsiteDNSRecords(ctx context.Context, zoneID 
 
 	s.Logger().Info("DNS records updated for website",
 		zap.Uint("zone_id", zoneID),
-		zap.String("domain", zone.Domain),
+		zap.String("domain", websiteDomain),
 		zap.String("target_hash", targetHash))
 
 	return nil
 }
 
-// DeleteWebsiteDNSRecords removes DNS records for a website
-func (s *DNSServiceDefault) DeleteWebsiteDNSRecords(ctx context.Context, zoneID uint) error {
+// DeleteWebsiteDNSRecords removes DNS records for a website.
+// websiteDomain is the full domain of the website and may differ from the zone's domain
+// when this is a subdomain website sharing a parent zone.
+func (s *DNSServiceDefault) DeleteWebsiteDNSRecords(ctx context.Context, zoneID uint, websiteDomain string) error {
 	ctx, span := core.TraceMethod(ctx, "DNSService.DeleteWebsiteDNSRecords")
 	defer span.End()
 
@@ -483,14 +494,17 @@ func (s *DNSServiceDefault) DeleteWebsiteDNSRecords(ctx context.Context, zoneID 
 		return fmt.Errorf("DNS hosting not enabled")
 	}
 
+	dnslinkName := buildFullName("_dnslink", websiteDomain)
+	recordName := buildFullName(websiteDomain, websiteDomain)
+
 	rrsets := []powerdns.RRSet{
 		{
-			Name:       "_dnslink." + zone.Domain + ".",
+			Name:       dnslinkName,
 			Type:       "TXT",
 			Changetype: "DELETE",
 		},
 		{
-			Name:       zone.Domain + ".",
+			Name:       recordName,
 			Type:       "TXT",
 			Changetype: "DELETE",
 		},
@@ -498,7 +512,7 @@ func (s *DNSServiceDefault) DeleteWebsiteDNSRecords(ctx context.Context, zoneID 
 
 	if s.config.GatewayDomain != "" {
 		rrsets = append(rrsets, powerdns.RRSet{
-			Name:       zone.Domain + ".",
+			Name:       recordName,
 			Type:       "ALIAS",
 			Changetype: "DELETE",
 		})
@@ -513,7 +527,7 @@ func (s *DNSServiceDefault) DeleteWebsiteDNSRecords(ctx context.Context, zoneID 
 
 	s.Logger().Info("DNS records deleted for website",
 		zap.Uint("zone_id", zoneID),
-		zap.String("domain", zone.Domain))
+		zap.String("domain", websiteDomain))
 
 	return nil
 }

--- a/internal/service/website/website.go
+++ b/internal/service/website/website.go
@@ -31,6 +31,14 @@ import (
 
 const sslCertValidity = 90 * 24 * time.Hour
 
+func extractParentDomain(domain string) string {
+	parts := strings.Split(domain, ".")
+	if len(parts) <= 2 {
+		return ""
+	}
+	return strings.Join(parts[1:], ".")
+}
+
 // Validation error types
 var (
 	ErrInvalidCID    = errors.New("invalid CID")
@@ -178,13 +186,34 @@ func (s *WebsiteServiceDefault) CreateWebsite(ctx context.Context, website *plug
 
 			// Create DNS zone if hosting is enabled
 			if website.Enabled && s.dnsSvc != nil {
-				dnsZone, err := s.dnsSvc.CreateZone(ctx, website.Domain, website.UserID)
-				if err != nil {
-					s.Logger().Warn("Failed to create DNS zone for website",
-						zap.Error(err),
-						zap.String("domain", website.Domain))
-					// Continue without DNS zone - website is still created
-				} else {
+				var dnsZone *pluginDb.DNSZone
+
+				// Check if a parent zone already exists for this user (e.g. pinner.xyz for docs.pinner.xyz)
+				if parentDomain := extractParentDomain(website.Domain); parentDomain != "" {
+					existingZone, err := s.dnsSvc.GetZoneByDomain(ctx, parentDomain)
+					if err == nil && existingZone != nil && existingZone.UserID == website.UserID {
+						dnsZone = existingZone
+						s.Logger().Info("Reusing existing parent zone for subdomain website",
+							zap.String("domain", website.Domain),
+							zap.String("parent_zone_domain", parentDomain),
+							zap.Uint("zone_id", existingZone.ID))
+					}
+				}
+
+				// No parent zone found — create one for this domain
+				if dnsZone == nil {
+					var err error
+					dnsZone, err = s.dnsSvc.CreateZone(ctx, website.Domain, website.UserID)
+					if err != nil {
+						s.Logger().Warn("Failed to create DNS zone for website",
+							zap.Error(err),
+							zap.String("domain", website.Domain))
+						// Continue without DNS zone - website is still created
+						dnsZone = nil
+					}
+				}
+
+				if dnsZone != nil {
 					// Update website with DNS zone ID
 					website.DNSZoneID = &dnsZone.ID
 					err = db.RetryableComponentTransaction(s, ctx, func(tx *gorm.DB) *gorm.DB {
@@ -196,25 +225,26 @@ func (s *WebsiteServiceDefault) CreateWebsite(ctx context.Context, website *plug
 							zap.Uint("website_id", website.ID),
 							zap.Uint("dns_zone_id", dnsZone.ID))
 
-						// Attempt to clean up the created zone to prevent orphans.
-						if cleanupErr := s.dnsSvc.DeleteZone(ctx, dnsZone.ID); cleanupErr != nil {
-							s.Logger().Error("Failed to clean up orphaned DNS zone",
-								zap.Error(cleanupErr),
-								zap.Uint("dns_zone_id", dnsZone.ID))
-							// Return a wrapped error to inform the caller that cleanup failed and a resource may be orphaned.
-							return nil, fmt.Errorf("failed to associate DNS zone with website (and cleanup failed: %w): %w", cleanupErr, err)
+						// Only attempt zone cleanup if we created this zone (not reusing a parent)
+						if dnsZone.Domain == website.Domain {
+							if cleanupErr := s.dnsSvc.DeleteZone(ctx, dnsZone.ID); cleanupErr != nil {
+								s.Logger().Error("Failed to clean up orphaned DNS zone",
+									zap.Error(cleanupErr),
+									zap.Uint("dns_zone_id", dnsZone.ID))
+								return nil, fmt.Errorf("failed to associate DNS zone with website (and cleanup failed: %w): %w", cleanupErr, err)
+							}
 						}
 
 						return nil, fmt.Errorf("failed to associate DNS zone with website: %w", err)
 					}
 
-					s.Logger().Info("DNS zone created for website",
+					s.Logger().Info("DNS zone associated with website",
 						zap.Uint("website_id", website.ID),
 						zap.Uint("dns_zone_id", dnsZone.ID),
 						zap.String("domain", website.Domain))
 
 					// Create DNS records for the website
-					if err := s.dnsSvc.CreateWebsiteDNSRecords(ctx, dnsZone.ID, website.TargetHash(), pluginDb.WebsiteTargetType(website.TargetType), fmt.Sprintf("%s=%s", s.config.VerificationTokenKey, website.ValidationToken)); err != nil {
+					if err := s.dnsSvc.CreateWebsiteDNSRecords(ctx, dnsZone.ID, website.Domain, website.TargetHash(), pluginDb.WebsiteTargetType(website.TargetType), fmt.Sprintf("%s=%s", s.config.VerificationTokenKey, website.ValidationToken)); err != nil {
 						s.Logger().Error("Failed to create DNS records for website",
 							zap.Error(err),
 							zap.Uint("website_id", website.ID),
@@ -579,7 +609,7 @@ func (s *WebsiteServiceDefault) UpdateWebsite(ctx context.Context, userID uint, 
 				newTargetType := pluginDb.WebsiteTargetType(website.TargetType)
 				if oldTargetType != pluginDb.WebsiteTargetTypeIPNS || newTargetType != pluginDb.WebsiteTargetTypeIPNS {
 					newTargetHash := website.TargetHash()
-					if err := s.dnsSvc.UpdateWebsiteDNSRecords(ctx, *website.DNSZoneID, newTargetHash, newTargetType); err != nil {
+					if err := s.dnsSvc.UpdateWebsiteDNSRecords(ctx, *website.DNSZoneID, website.Domain, newTargetHash, newTargetType); err != nil {
 						s.Logger().Warn("Failed to update DNS records for website",
 							zap.Error(err),
 							zap.Uint("website_id", websiteID),
@@ -643,26 +673,46 @@ func (s *WebsiteServiceDefault) handleDNSEnabledTransition(ctx context.Context, 
 
 	// Create DNS zone if it doesn't exist
 	if website.DNSZoneID == nil && s.dnsSvc != nil {
-		dnsZone, err := s.dnsSvc.CreateZone(ctx, website.Domain, website.UserID)
-		if err != nil {
-			return fmt.Errorf("failed to create DNS zone: %w", err)
+		var dnsZone *pluginDb.DNSZone
+
+		// Check if a parent zone already exists for this user (e.g. pinner.xyz for docs.pinner.xyz)
+		if parentDomain := extractParentDomain(website.Domain); parentDomain != "" {
+			existingZone, err := s.dnsSvc.GetZoneByDomain(ctx, parentDomain)
+			if err == nil && existingZone != nil && existingZone.UserID == website.UserID {
+				dnsZone = existingZone
+				s.Logger().Info("Reusing existing parent zone for subdomain website",
+					zap.String("domain", website.Domain),
+					zap.String("parent_zone_domain", parentDomain),
+					zap.Uint("zone_id", existingZone.ID))
+			}
+		}
+
+		// No parent zone found — create one for this domain
+		var createErr error
+		if dnsZone == nil {
+			dnsZone, createErr = s.dnsSvc.CreateZone(ctx, website.Domain, website.UserID)
+			if createErr != nil {
+				return fmt.Errorf("failed to create DNS zone: %w", createErr)
+			}
 		}
 
 		// Update website with DNS zone ID
-		err = db.RetryableComponentTransaction(s, ctx, func(tx *gorm.DB) *gorm.DB {
+		err := db.RetryableComponentTransaction(s, ctx, func(tx *gorm.DB) *gorm.DB {
 			return tx.Model(website).Update("dns_zone_id", dnsZone.ID)
 		})
 		if err != nil {
 			s.Logger().Error("Failed to update website with DNS zone ID",
 				zap.Error(err),
 				zap.Uint("website_id", website.ID))
-			// Attempt cleanup
-			_ = s.dnsSvc.DeleteZone(ctx, dnsZone.ID)
+			// Only attempt zone cleanup if we created this zone (not reusing a parent)
+			if dnsZone.Domain == website.Domain {
+				_ = s.dnsSvc.DeleteZone(ctx, dnsZone.ID)
+			}
 			return fmt.Errorf("failed to associate DNS zone with website: %w", err)
 		}
 
 		website.DNSZoneID = &dnsZone.ID
-		s.Logger().Info("DNS zone created for website",
+		s.Logger().Info("DNS zone associated with website",
 			zap.Uint("website_id", website.ID),
 			zap.Uint("dns_zone_id", dnsZone.ID),
 			zap.String("domain", website.Domain))
@@ -683,7 +733,7 @@ func (s *WebsiteServiceDefault) handleDNSEnabledTransition(ctx context.Context, 
 		}
 
 		// Create DNS records
-		err := s.dnsSvc.CreateWebsiteDNSRecords(ctx, *website.DNSZoneID, website.TargetHash(), pluginDb.WebsiteTargetType(website.TargetType), fmt.Sprintf("%s=%s", s.config.VerificationTokenKey, newToken))
+		err := s.dnsSvc.CreateWebsiteDNSRecords(ctx, *website.DNSZoneID, website.Domain, website.TargetHash(), pluginDb.WebsiteTargetType(website.TargetType), fmt.Sprintf("%s=%s", s.config.VerificationTokenKey, newToken))
 		if err != nil {
 			return fmt.Errorf("failed to create DNS records: %w", err)
 		}
@@ -721,10 +771,45 @@ func (s *WebsiteServiceDefault) handleDNSDisabledTransition(ctx context.Context,
 		zap.Uint("website_id", website.ID),
 		zap.String("domain", website.Domain))
 
-	zoneDeleted := false
+	recordsDeleted := false
 
-	// Delete DNS zone if it exists
+	// Delete DNS records for this website (not the zone — other websites may share it)
 	if website.DNSZoneID != nil && s.dnsSvc != nil {
+		err := s.dnsSvc.DeleteWebsiteDNSRecords(ctx, *website.DNSZoneID, website.Domain)
+		if err != nil {
+			s.Logger().Warn("Failed to delete DNS records for website",
+				zap.Error(err),
+				zap.Uint("website_id", website.ID),
+				zap.Uint("dns_zone_id", *website.DNSZoneID))
+		} else {
+			recordsDeleted = true
+			s.Logger().Info("DNS records deleted for website",
+				zap.Uint("website_id", website.ID),
+				zap.Uint("dns_zone_id", *website.DNSZoneID))
+		}
+	}
+
+	// Check if any other websites still reference this zone
+	zoneIsEmpty := false
+	if recordsDeleted && website.DNSZoneID != nil {
+		var count int64
+		err := db.RetryableComponentTransaction(s, ctx, func(tx *gorm.DB) *gorm.DB {
+			return tx.Model(&pluginDb.Website{}).
+				Where("dns_zone_id = ? AND id != ? AND deleted_at IS NULL", *website.DNSZoneID, website.ID).
+				Count(&count)
+		})
+		if err != nil {
+			s.Logger().Warn("Failed to count websites sharing DNS zone",
+				zap.Error(err),
+				zap.Uint("dns_zone_id", *website.DNSZoneID))
+		} else {
+			zoneIsEmpty = count == 0
+		}
+	}
+
+	// Only delete the zone if no other websites are using it
+	zoneDeleted := false
+	if zoneIsEmpty && website.DNSZoneID != nil && s.dnsSvc != nil {
 		err := s.dnsSvc.DeleteZone(ctx, *website.DNSZoneID)
 		if err != nil {
 			s.Logger().Warn("Failed to delete DNS zone for website",
@@ -733,7 +818,7 @@ func (s *WebsiteServiceDefault) handleDNSDisabledTransition(ctx context.Context,
 				zap.Uint("dns_zone_id", *website.DNSZoneID))
 		} else {
 			zoneDeleted = true
-			s.Logger().Info("DNS zone deleted for website",
+			s.Logger().Info("DNS zone deleted (no other websites using it)",
 				zap.Uint("website_id", website.ID),
 				zap.Uint("dns_zone_id", *website.DNSZoneID))
 		}
@@ -777,6 +862,7 @@ func (s *WebsiteServiceDefault) DeleteWebsite(ctx context.Context, userID uint, 
 		func() error {
 			var count int64
 			var dnsZoneID *uint
+			var websiteDomain string
 
 			err := db.RetryableComponentTransaction(s, ctx, func(tx *gorm.DB) *gorm.DB {
 				// First, check if the website exists and is not blocked
@@ -796,8 +882,9 @@ func (s *WebsiteServiceDefault) DeleteWebsite(ctx context.Context, userID uint, 
 					return tx
 				}
 
-				// Store DNS zone ID for cleanup
+				// Store DNS zone ID and domain for cleanup
 				dnsZoneID = website.DNSZoneID
+				websiteDomain = website.Domain
 
 				// Perform the soft delete
 				result := tx.Delete(&website)
@@ -824,7 +911,7 @@ func (s *WebsiteServiceDefault) DeleteWebsite(ctx context.Context, userID uint, 
 			// Clean up DNS records if DNS hosting was enabled
 			// Note: We do NOT delete the zone itself as zones are independent from websites
 			if dnsZoneID != nil && s.dnsSvc != nil {
-				if err := s.dnsSvc.DeleteWebsiteDNSRecords(ctx, *dnsZoneID); err != nil {
+				if err := s.dnsSvc.DeleteWebsiteDNSRecords(ctx, *dnsZoneID, websiteDomain); err != nil {
 					s.Logger().Warn("Failed to delete DNS records for website",
 						zap.Error(err),
 						zap.Uint("website_id", websiteID),

--- a/internal/service/website/website_test.go
+++ b/internal/service/website/website_test.go
@@ -103,6 +103,7 @@ func setupDNSZoneCreationMocks(t *testing.T, mockDNS *mocks.MockDNSService, zone
 		mock.Anything,
 		zoneID,
 		mock.Anything,
+		mock.Anything,
 		mock.AnythingOfType("db.WebsiteTargetType"),
 		mock.Anything,
 	).Return(nil).Once()
@@ -1152,6 +1153,7 @@ func TestWebsiteService_CreateWebsite_DNSZoneCreatedWhenEnabled(t *testing.T) {
 			mock.Anything,
 			testZoneID1,
 			mock.Anything,
+			mock.Anything,
 			pluginDb.WebsiteTargetTypeIPNS,
 			mock.Anything,
 		).Return(nil).Once()
@@ -1169,7 +1171,7 @@ func TestWebsiteService_CreateWebsite_DNSZoneCreatedWhenEnabled(t *testing.T) {
 
 		// Verify critical operations were called
 		mockDNS.AssertCalled(t, "CreateZone", mock.Anything, domain, testUserID1)
-		mockDNS.AssertCalled(t, "CreateWebsiteDNSRecords", mock.Anything, testZoneID1, mock.Anything, pluginDb.WebsiteTargetTypeIPNS, mock.Anything)
+		mockDNS.AssertCalled(t, "CreateWebsiteDNSRecords", mock.Anything, testZoneID1, mock.Anything, mock.Anything, pluginDb.WebsiteTargetTypeIPNS, mock.Anything)
 
 	}, TestOptions)
 }
@@ -1200,6 +1202,7 @@ func TestWebsiteService_CreateWebsite_DNSRecordsCreated(t *testing.T) {
 		mockDNS.EXPECT().CreateWebsiteDNSRecords(
 			mock.Anything,
 			testZoneID2,
+			mock.Anything,
 			mock.MatchedBy(func(targetHash string) bool {
 				capturedTargetHash = targetHash
 				return true
@@ -1281,6 +1284,7 @@ func TestWebsiteService_DeleteWebsite_DNSRecordsCleanedUp(t *testing.T) {
 			mock.Anything,
 			testZoneID4,
 			mock.Anything,
+			mock.Anything,
 			pluginDb.WebsiteTargetTypeIPNS,
 			mock.Anything,
 		).Return(nil).Once()
@@ -1290,7 +1294,7 @@ func TestWebsiteService_DeleteWebsite_DNSRecordsCleanedUp(t *testing.T) {
 		require.NotNil(tb, createdWebsite)
 
 		// Act - Delete website and expect only DNS records to be cleaned up, NOT the zone
-		mockDNS.EXPECT().DeleteWebsiteDNSRecords(mock.Anything, testZoneID4).Return(nil).Once()
+		mockDNS.EXPECT().DeleteWebsiteDNSRecords(mock.Anything, testZoneID4, mock.Anything).Return(nil).Once()
 
 		err = websiteService.DeleteWebsite(context.Background(), testUserID1, createdWebsite.ID)
 
@@ -1326,6 +1330,7 @@ func TestWebsiteService_DeleteWebsite_DNSCleanupFailureDoesNotPreventDeletion(t 
 			mock.Anything,
 			testZoneID5,
 			mock.Anything,
+			mock.Anything,
 			pluginDb.WebsiteTargetTypeIPNS,
 			mock.Anything,
 		).Return(nil).Once()
@@ -1335,7 +1340,7 @@ func TestWebsiteService_DeleteWebsite_DNSCleanupFailureDoesNotPreventDeletion(t 
 		require.NotNil(tb, createdWebsite)
 
 		// Act - Delete website with DNS cleanup failure
-		mockDNS.EXPECT().DeleteWebsiteDNSRecords(mock.Anything, testZoneID5).Return(assert.AnError).Once()
+		mockDNS.EXPECT().DeleteWebsiteDNSRecords(mock.Anything, testZoneID5, mock.Anything).Return(assert.AnError).Once()
 
 		err = websiteService.DeleteWebsite(context.Background(), testUserID1, createdWebsite.ID)
 
@@ -1437,7 +1442,8 @@ func TestWebsiteService_CreateWebsite_DNSHostingEnabled_CreatesZoneAndRecords(t 
 		mockDNS.EXPECT().CreateWebsiteDNSRecords(
 			mock.Anything,
 			testZoneID6,
-			mock.Anything,                  // target hash varies (IPNS peer ID)
+			mock.Anything,
+			mock.Anything,                  // website domain
 			pluginDb.WebsiteTargetTypeIPNS, // Converted to IPNS for managed DNS
 			mock.Anything,
 		).Return(nil).Once()
@@ -1478,7 +1484,8 @@ func TestWebsiteService_UpdateWebsite_DNSHostingEnabled_NoDNSUpdateWhenTargetUnc
 		mockDNS.EXPECT().CreateWebsiteDNSRecords(
 			mock.Anything,
 			testZoneID7,
-			mock.Anything,                  // target hash varies (IPNS peer ID)
+			mock.Anything,
+			mock.Anything,                  // website domain
 			pluginDb.WebsiteTargetTypeIPNS, // Converted to IPNS for managed DNS
 			mock.Anything,
 		).Return(nil).Once()
@@ -1523,7 +1530,8 @@ func TestWebsiteService_DeleteWebsite_DNSHostingEnabled_ZoneRemainsAfterDeletion
 		mockDNS.EXPECT().CreateWebsiteDNSRecords(
 			mock.Anything,
 			testZoneID8,
-			mock.Anything,                  // target hash varies (IPNS peer ID)
+			mock.Anything,
+			mock.Anything,                  // website domain
 			pluginDb.WebsiteTargetTypeIPNS, // Converted to IPNS for managed DNS
 			mock.Anything,
 		).Return(nil).Once()
@@ -1532,7 +1540,7 @@ func TestWebsiteService_DeleteWebsite_DNSHostingEnabled_ZoneRemainsAfterDeletion
 		require.NoError(tb, err)
 
 		// Mock DNS records deletion
-		mockDNS.EXPECT().DeleteWebsiteDNSRecords(mock.Anything, testZoneID8).Return(nil).Once()
+		mockDNS.EXPECT().DeleteWebsiteDNSRecords(mock.Anything, testZoneID8, mock.Anything).Return(nil).Once()
 
 		// Act - Delete website
 		err = websiteService.DeleteWebsite(context.Background(), testUserID1, createdWebsite.ID)
@@ -1720,7 +1728,8 @@ func TestWebsiteService_CreateWebsite_DNSRecordsCreationFailure_ContinuesWithout
 		mockDNS.EXPECT().CreateWebsiteDNSRecords(
 			mock.Anything,
 			testZoneID8,
-			mock.Anything,                  // target hash varies (IPNS peer ID)
+			mock.Anything,
+			mock.Anything,                  // website domain
 			pluginDb.WebsiteTargetTypeIPNS, // Converted to IPNS for managed DNS
 			mock.Anything,
 		).Return(assert.AnError).Once()
@@ -1780,6 +1789,7 @@ func TestWebsiteService_CreateWebsite_IPNSKeyAutoCreation_NoDuplicate(t *testing
 			mock.Anything,
 			testZoneID1,
 			mock.Anything,
+			mock.Anything,
 			pluginDb.WebsiteTargetTypeIPNS,
 			mock.Anything,
 		).Return(nil).Once()
@@ -1796,7 +1806,7 @@ func TestWebsiteService_CreateWebsite_IPNSKeyAutoCreation_NoDuplicate(t *testing
 		assert.Equal(tb, string(pluginDb.WebsiteTargetTypeIPNS), createdWebsite1.TargetType, "First website should use IPNS target")
 
 		// Expect DNS records deletion when website is deleted
-		mockDNS.EXPECT().DeleteWebsiteDNSRecords(mock.Anything, testZoneID1).Return(nil).Once()
+		mockDNS.EXPECT().DeleteWebsiteDNSRecords(mock.Anything, testZoneID1, mock.Anything).Return(nil).Once()
 
 		// Act - Delete first website
 		err = websiteService.DeleteWebsite(context.Background(), testUserID1, createdWebsite1.ID)
@@ -1817,6 +1827,7 @@ func TestWebsiteService_CreateWebsite_IPNSKeyAutoCreation_NoDuplicate(t *testing
 		mockDNS.EXPECT().CreateWebsiteDNSRecords(
 			mock.Anything,
 			testZoneID1,
+			mock.Anything,
 			mock.Anything,
 			pluginDb.WebsiteTargetTypeIPNS,
 			mock.Anything,
@@ -1938,7 +1949,10 @@ func TestWebsiteService_UpdateWebsite_DisableDNSHostingTransition(t *testing.T) 
 		assert.True(t, createdWebsite.Enabled)
 		assert.NotNil(t, createdWebsite.DNSZoneID)
 
-		// Set up mock DNS service expectation for disabling DNS hosting (delete zone)
+		// Set up mock DNS service expectations for disabling DNS hosting
+		// First, DeleteWebsiteDNSRecords is called to remove the website's DNS records
+		mockDNS.EXPECT().DeleteWebsiteDNSRecords(mock.Anything, testZoneID, mock.Anything).Return(nil).Once()
+		// Then, DeleteZone is called because no other websites share the zone
 		setupDeleteZoneMocks(t, mockDNS, testZoneID)
 
 		// Act - Disable DNS hosting
@@ -2010,7 +2024,7 @@ func TestWebsiteService_UpdateWebsite_DNSHostingTransitionWithExistingZone(t *te
 		// Act - Enable DNS hosting when zone already exists
 		// Note: We don't mock CreateWebsiteDNSRecords here because handleDNSEnabledTransition
 		// will add its own expectation when calling the method
-		mockDNS.EXPECT().CreateWebsiteDNSRecords(mock.Anything, testZoneID, mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
+		mockDNS.EXPECT().CreateWebsiteDNSRecords(mock.Anything, testZoneID, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
 		newDNSEnabled := true
 		updates := map[string]interface{}{
 			"dns_enabled": newDNSEnabled,
@@ -2054,6 +2068,9 @@ func TestWebsiteService_UpdateWebsite_DNSEnableToggleOffOn(t *testing.T) {
 		assert.NotNil(t, createdWebsite.DNSZoneID)
 
 		// Toggle DNS off
+		// First, DeleteWebsiteDNSRecords is called to remove the website's DNS records
+		mockDNS.EXPECT().DeleteWebsiteDNSRecords(mock.Anything, *createdWebsite.DNSZoneID, mock.Anything).Return(nil).Once()
+		// Then, DeleteZone is called because no other websites share the zone
 		mockDNS.EXPECT().DeleteZone(mock.Anything, *createdWebsite.DNSZoneID).Return(nil).Once()
 		updatedWebsite, err := websiteService.UpdateWebsite(context.Background(), testUserID1, createdWebsite.ID, map[string]interface{}{
 			"dns_enabled": false,
@@ -2066,7 +2083,7 @@ func TestWebsiteService_UpdateWebsite_DNSEnableToggleOffOn(t *testing.T) {
 		newZoneID := uint(8002)
 		newMockZone := createMockDNSZone(newZoneID, domain, testUserID1)
 		mockDNS.EXPECT().CreateZone(mock.Anything, domain, testUserID1).Return(newMockZone, nil).Once()
-		mockDNS.EXPECT().CreateWebsiteDNSRecords(mock.Anything, newZoneID, mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
+		mockDNS.EXPECT().CreateWebsiteDNSRecords(mock.Anything, newZoneID, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
 
 		updatedWebsite2, err := websiteService.UpdateWebsite(context.Background(), testUserID1, createdWebsite.ID, map[string]interface{}{
 			"dns_enabled": true,
@@ -2101,6 +2118,9 @@ func TestWebsiteService_UpdateWebsite_DisableDNSHostingDeleteZoneFails(t *testin
 		assert.NotNil(t, createdWebsite.DNSZoneID)
 
 		// Toggle DNS off but DeleteZone fails
+		// First, DeleteWebsiteDNSRecords is called and succeeds
+		mockDNS.EXPECT().DeleteWebsiteDNSRecords(mock.Anything, *createdWebsite.DNSZoneID, mock.Anything).Return(nil).Once()
+		// Then, DeleteZone is called but fails
 		mockDNS.EXPECT().DeleteZone(mock.Anything, *createdWebsite.DNSZoneID).Return(errors.New("powerdns unavailable")).Once()
 
 		updatedWebsite, err := websiteService.UpdateWebsite(context.Background(), testUserID1, createdWebsite.ID, map[string]interface{}{
@@ -2242,6 +2262,7 @@ func TestWebsiteService_UpdateWebsite_ConvertIPNSToIPFS_UpdatesDNSRecords(t *tes
 			mock.Anything,
 			testZoneID,
 			mock.Anything,
+			mock.Anything,
 			pluginDb.WebsiteTargetTypeIPNS,
 			mock.Anything,
 		).Return(nil).Once()
@@ -2268,6 +2289,7 @@ func TestWebsiteService_UpdateWebsite_ConvertIPNSToIPFS_UpdatesDNSRecords(t *tes
 		mockDNS.EXPECT().UpdateWebsiteDNSRecords(
 			mock.Anything,
 			testZoneID,
+			mock.Anything,
 			newCID.String(),
 			pluginDb.WebsiteTargetTypeIPFS,
 		).Return(nil).Once()
@@ -2305,6 +2327,7 @@ func TestWebsiteService_UpdateWebsite_IPNSToIPNS_NoDNSUpdate(t *testing.T) {
 		mockDNS.EXPECT().CreateWebsiteDNSRecords(
 			mock.Anything,
 			testZoneID,
+			mock.Anything,
 			mock.Anything,
 			pluginDb.WebsiteTargetTypeIPNS,
 			mock.Anything,
@@ -2360,6 +2383,7 @@ func TestWebsiteService_UpdateWebsite_ConvertIPFSToIPNS_UpdatesDNSRecords(t *tes
 			mock.Anything,
 			testZoneID,
 			mock.Anything,
+			mock.Anything,
 			pluginDb.WebsiteTargetTypeIPNS,
 			mock.Anything,
 		).Return(nil).Once()
@@ -2381,6 +2405,7 @@ func TestWebsiteService_UpdateWebsite_ConvertIPFSToIPNS_UpdatesDNSRecords(t *tes
 		mockDNS.EXPECT().UpdateWebsiteDNSRecords(
 			mock.Anything,
 			testZoneID,
+			mock.Anything,
 			newCID.String(),
 			pluginDb.WebsiteTargetTypeIPFS,
 		).Return(nil).Once()
@@ -2403,6 +2428,7 @@ func TestWebsiteService_UpdateWebsite_ConvertIPFSToIPNS_UpdatesDNSRecords(t *tes
 		mockDNS.EXPECT().UpdateWebsiteDNSRecords(
 			mock.Anything,
 			testZoneID,
+			mock.Anything,
 			testPeerID,
 			pluginDb.WebsiteTargetTypeIPNS,
 		).Return(nil).Once()
@@ -2477,6 +2503,7 @@ func TestWebsiteService_UpdateWebsite_TargetTypeIPNSAlone_DNSRecordsUpdated(t *t
 		mockDNS.EXPECT().CreateWebsiteDNSRecords(
 			mock.Anything,
 			testZoneID,
+			mock.Anything,
 			testIPNSKey.PeerID().String(),
 			pluginDb.WebsiteTargetTypeIPNS,
 			mock.Anything,
@@ -2541,6 +2568,7 @@ func TestWebsiteService_UpdateWebsite_IPNSToIPFSWithoutCID(t *testing.T) {
 		mockDNS.EXPECT().CreateWebsiteDNSRecords(
 			mock.Anything,
 			testZoneID,
+			mock.Anything,
 			mock.Anything,
 			pluginDb.WebsiteTargetTypeIPNS,
 			mock.Anything,

--- a/internal/testing/mocks/MockDNSService.go
+++ b/internal/testing/mocks/MockDNSService.go
@@ -314,16 +314,16 @@ func (_c *MockDNSService_CreateRecord_Call) RunAndReturn(run func(ctx context.Co
 }
 
 // CreateWebsiteDNSRecords provides a mock function for the type MockDNSService
-func (_mock *MockDNSService) CreateWebsiteDNSRecords(ctx context.Context, zoneID uint, targetHash string, targetType db.WebsiteTargetType, validationToken string) error {
-	ret := _mock.Called(ctx, zoneID, targetHash, targetType, validationToken)
+func (_mock *MockDNSService) CreateWebsiteDNSRecords(ctx context.Context, zoneID uint, websiteDomain string, targetHash string, targetType db.WebsiteTargetType, validationToken string) error {
+	ret := _mock.Called(ctx, zoneID, websiteDomain, targetHash, targetType, validationToken)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CreateWebsiteDNSRecords")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, uint, string, db.WebsiteTargetType, string) error); ok {
-		r0 = returnFunc(ctx, zoneID, targetHash, targetType, validationToken)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uint, string, string, db.WebsiteTargetType, string) error); ok {
+		r0 = returnFunc(ctx, zoneID, websiteDomain, targetHash, targetType, validationToken)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -338,14 +338,15 @@ type MockDNSService_CreateWebsiteDNSRecords_Call struct {
 // CreateWebsiteDNSRecords is a helper method to define mock.On call
 //   - ctx context.Context
 //   - zoneID uint
+//   - websiteDomain string
 //   - targetHash string
 //   - targetType db.WebsiteTargetType
 //   - validationToken string
-func (_e *MockDNSService_Expecter) CreateWebsiteDNSRecords(ctx interface{}, zoneID interface{}, targetHash interface{}, targetType interface{}, validationToken interface{}) *MockDNSService_CreateWebsiteDNSRecords_Call {
-	return &MockDNSService_CreateWebsiteDNSRecords_Call{Call: _e.mock.On("CreateWebsiteDNSRecords", ctx, zoneID, targetHash, targetType, validationToken)}
+func (_e *MockDNSService_Expecter) CreateWebsiteDNSRecords(ctx interface{}, zoneID interface{}, websiteDomain interface{}, targetHash interface{}, targetType interface{}, validationToken interface{}) *MockDNSService_CreateWebsiteDNSRecords_Call {
+	return &MockDNSService_CreateWebsiteDNSRecords_Call{Call: _e.mock.On("CreateWebsiteDNSRecords", ctx, zoneID, websiteDomain, targetHash, targetType, validationToken)}
 }
 
-func (_c *MockDNSService_CreateWebsiteDNSRecords_Call) Run(run func(ctx context.Context, zoneID uint, targetHash string, targetType db.WebsiteTargetType, validationToken string)) *MockDNSService_CreateWebsiteDNSRecords_Call {
+func (_c *MockDNSService_CreateWebsiteDNSRecords_Call) Run(run func(ctx context.Context, zoneID uint, websiteDomain string, targetHash string, targetType db.WebsiteTargetType, validationToken string)) *MockDNSService_CreateWebsiteDNSRecords_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -359,13 +360,17 @@ func (_c *MockDNSService_CreateWebsiteDNSRecords_Call) Run(run func(ctx context.
 		if args[2] != nil {
 			arg2 = args[2].(string)
 		}
-		var arg3 db.WebsiteTargetType
+		var arg3 string
 		if args[3] != nil {
-			arg3 = args[3].(db.WebsiteTargetType)
+			arg3 = args[3].(string)
 		}
-		var arg4 string
+		var arg4 db.WebsiteTargetType
 		if args[4] != nil {
-			arg4 = args[4].(string)
+			arg4 = args[4].(db.WebsiteTargetType)
+		}
+		var arg5 string
+		if args[5] != nil {
+			arg5 = args[5].(string)
 		}
 		run(
 			arg0,
@@ -373,6 +378,7 @@ func (_c *MockDNSService_CreateWebsiteDNSRecords_Call) Run(run func(ctx context.
 			arg2,
 			arg3,
 			arg4,
+			arg5,
 		)
 	})
 	return _c
@@ -383,7 +389,7 @@ func (_c *MockDNSService_CreateWebsiteDNSRecords_Call) Return(err error) *MockDN
 	return _c
 }
 
-func (_c *MockDNSService_CreateWebsiteDNSRecords_Call) RunAndReturn(run func(ctx context.Context, zoneID uint, targetHash string, targetType db.WebsiteTargetType, validationToken string) error) *MockDNSService_CreateWebsiteDNSRecords_Call {
+func (_c *MockDNSService_CreateWebsiteDNSRecords_Call) RunAndReturn(run func(ctx context.Context, zoneID uint, websiteDomain string, targetHash string, targetType db.WebsiteTargetType, validationToken string) error) *MockDNSService_CreateWebsiteDNSRecords_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -578,16 +584,16 @@ func (_c *MockDNSService_DeleteRecord_Call) RunAndReturn(run func(ctx context.Co
 }
 
 // DeleteWebsiteDNSRecords provides a mock function for the type MockDNSService
-func (_mock *MockDNSService) DeleteWebsiteDNSRecords(ctx context.Context, zoneID uint) error {
-	ret := _mock.Called(ctx, zoneID)
+func (_mock *MockDNSService) DeleteWebsiteDNSRecords(ctx context.Context, zoneID uint, websiteDomain string) error {
+	ret := _mock.Called(ctx, zoneID, websiteDomain)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteWebsiteDNSRecords")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, uint) error); ok {
-		r0 = returnFunc(ctx, zoneID)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uint, string) error); ok {
+		r0 = returnFunc(ctx, zoneID, websiteDomain)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -602,11 +608,12 @@ type MockDNSService_DeleteWebsiteDNSRecords_Call struct {
 // DeleteWebsiteDNSRecords is a helper method to define mock.On call
 //   - ctx context.Context
 //   - zoneID uint
-func (_e *MockDNSService_Expecter) DeleteWebsiteDNSRecords(ctx interface{}, zoneID interface{}) *MockDNSService_DeleteWebsiteDNSRecords_Call {
-	return &MockDNSService_DeleteWebsiteDNSRecords_Call{Call: _e.mock.On("DeleteWebsiteDNSRecords", ctx, zoneID)}
+//   - websiteDomain string
+func (_e *MockDNSService_Expecter) DeleteWebsiteDNSRecords(ctx interface{}, zoneID interface{}, websiteDomain interface{}) *MockDNSService_DeleteWebsiteDNSRecords_Call {
+	return &MockDNSService_DeleteWebsiteDNSRecords_Call{Call: _e.mock.On("DeleteWebsiteDNSRecords", ctx, zoneID, websiteDomain)}
 }
 
-func (_c *MockDNSService_DeleteWebsiteDNSRecords_Call) Run(run func(ctx context.Context, zoneID uint)) *MockDNSService_DeleteWebsiteDNSRecords_Call {
+func (_c *MockDNSService_DeleteWebsiteDNSRecords_Call) Run(run func(ctx context.Context, zoneID uint, websiteDomain string)) *MockDNSService_DeleteWebsiteDNSRecords_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -616,9 +623,14 @@ func (_c *MockDNSService_DeleteWebsiteDNSRecords_Call) Run(run func(ctx context.
 		if args[1] != nil {
 			arg1 = args[1].(uint)
 		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -629,7 +641,7 @@ func (_c *MockDNSService_DeleteWebsiteDNSRecords_Call) Return(err error) *MockDN
 	return _c
 }
 
-func (_c *MockDNSService_DeleteWebsiteDNSRecords_Call) RunAndReturn(run func(ctx context.Context, zoneID uint) error) *MockDNSService_DeleteWebsiteDNSRecords_Call {
+func (_c *MockDNSService_DeleteWebsiteDNSRecords_Call) RunAndReturn(run func(ctx context.Context, zoneID uint, websiteDomain string) error) *MockDNSService_DeleteWebsiteDNSRecords_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -1483,16 +1495,16 @@ func (_c *MockDNSService_UpdateRecord_Call) RunAndReturn(run func(ctx context.Co
 }
 
 // UpdateWebsiteDNSRecords provides a mock function for the type MockDNSService
-func (_mock *MockDNSService) UpdateWebsiteDNSRecords(ctx context.Context, zoneID uint, targetHash string, targetType db.WebsiteTargetType) error {
-	ret := _mock.Called(ctx, zoneID, targetHash, targetType)
+func (_mock *MockDNSService) UpdateWebsiteDNSRecords(ctx context.Context, zoneID uint, websiteDomain string, targetHash string, targetType db.WebsiteTargetType) error {
+	ret := _mock.Called(ctx, zoneID, websiteDomain, targetHash, targetType)
 
 	if len(ret) == 0 {
 		panic("no return value specified for UpdateWebsiteDNSRecords")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, uint, string, db.WebsiteTargetType) error); ok {
-		r0 = returnFunc(ctx, zoneID, targetHash, targetType)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uint, string, string, db.WebsiteTargetType) error); ok {
+		r0 = returnFunc(ctx, zoneID, websiteDomain, targetHash, targetType)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -1507,13 +1519,14 @@ type MockDNSService_UpdateWebsiteDNSRecords_Call struct {
 // UpdateWebsiteDNSRecords is a helper method to define mock.On call
 //   - ctx context.Context
 //   - zoneID uint
+//   - websiteDomain string
 //   - targetHash string
 //   - targetType db.WebsiteTargetType
-func (_e *MockDNSService_Expecter) UpdateWebsiteDNSRecords(ctx interface{}, zoneID interface{}, targetHash interface{}, targetType interface{}) *MockDNSService_UpdateWebsiteDNSRecords_Call {
-	return &MockDNSService_UpdateWebsiteDNSRecords_Call{Call: _e.mock.On("UpdateWebsiteDNSRecords", ctx, zoneID, targetHash, targetType)}
+func (_e *MockDNSService_Expecter) UpdateWebsiteDNSRecords(ctx interface{}, zoneID interface{}, websiteDomain interface{}, targetHash interface{}, targetType interface{}) *MockDNSService_UpdateWebsiteDNSRecords_Call {
+	return &MockDNSService_UpdateWebsiteDNSRecords_Call{Call: _e.mock.On("UpdateWebsiteDNSRecords", ctx, zoneID, websiteDomain, targetHash, targetType)}
 }
 
-func (_c *MockDNSService_UpdateWebsiteDNSRecords_Call) Run(run func(ctx context.Context, zoneID uint, targetHash string, targetType db.WebsiteTargetType)) *MockDNSService_UpdateWebsiteDNSRecords_Call {
+func (_c *MockDNSService_UpdateWebsiteDNSRecords_Call) Run(run func(ctx context.Context, zoneID uint, websiteDomain string, targetHash string, targetType db.WebsiteTargetType)) *MockDNSService_UpdateWebsiteDNSRecords_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -1527,15 +1540,20 @@ func (_c *MockDNSService_UpdateWebsiteDNSRecords_Call) Run(run func(ctx context.
 		if args[2] != nil {
 			arg2 = args[2].(string)
 		}
-		var arg3 db.WebsiteTargetType
+		var arg3 string
 		if args[3] != nil {
-			arg3 = args[3].(db.WebsiteTargetType)
+			arg3 = args[3].(string)
+		}
+		var arg4 db.WebsiteTargetType
+		if args[4] != nil {
+			arg4 = args[4].(db.WebsiteTargetType)
 		}
 		run(
 			arg0,
 			arg1,
 			arg2,
 			arg3,
+			arg4,
 		)
 	})
 	return _c
@@ -1546,7 +1564,7 @@ func (_c *MockDNSService_UpdateWebsiteDNSRecords_Call) Return(err error) *MockDN
 	return _c
 }
 
-func (_c *MockDNSService_UpdateWebsiteDNSRecords_Call) RunAndReturn(run func(ctx context.Context, zoneID uint, targetHash string, targetType db.WebsiteTargetType) error) *MockDNSService_UpdateWebsiteDNSRecords_Call {
+func (_c *MockDNSService_UpdateWebsiteDNSRecords_Call) RunAndReturn(run func(ctx context.Context, zoneID uint, websiteDomain string, targetHash string, targetType db.WebsiteTargetType) error) *MockDNSService_UpdateWebsiteDNSRecords_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
Enable multiple websites (e.g. docs.pinner.xyz and pinner.xyz) to coexist under a single DNS zone. When a subdomain website is created and a parent zone already exists for the same user, the existing zone is reused instead of creating a new one. DNS records are named using the website's full domain rather than the zone's domain, so subdomain records like \_dnslink.docs.pinner.xyz are created correctly inside the pinner.xyz zone.

- Add websiteDomain parameter to CreateWebsiteDNSRecords, UpdateWebsiteDNSRecords, and DeleteWebsiteDNSRecords
- Auto-detect parent zone in handleDNSEnabledTransition and CreateWebsite when a subdomain website matches an existing zone
- handleDNSDisabledTransition now deletes only DNS records first, then conditionally deletes the zone only when no other websites reference it
- Add is\_subdomain field to WebsiteResponse DTO (computed from zone domain vs website domain comparison)
- Update all mock expectations and test call sites

* `develop` <!-- branch-stack -->
  - **feat: support subdomain websites sharing a parent DNS zone** :point\_left:

---

<!-- kody-pr-summary:start -->
This pull request adds support for subdomain websites that share a parent DNS zone, enabling multiple websites (e.g., `docs.example.com` and `blog.example.com`) to coexist under a single `example.com` DNS zone rather than each requiring their own zone.

**Key changes:**

- **Parent zone reuse**: When creating a website with DNS hosting enabled, the system now checks if a parent DNS zone already exists for the same user (e.g., reusing the `example.com` zone for `docs.example.com`). If found, the existing zone is reused instead of creating a new one.

- **Subdomain-aware DNS record management**: The DNS service methods (`CreateWebsiteDNSRecords`, `UpdateWebsiteDNSRecords`, `DeleteWebsiteDNSRecords`) now accept a `websiteDomain` parameter, allowing DNS records to be created with the full subdomain name (e.g., `_dnslink.docs.example.com`) rather than assuming the website domain matches the zone's root domain.

- **Safe shared zone deletion**: When DNS hosting is disabled for a website, the system now deletes only that website's DNS records first, then checks whether any other websites still reference the zone before deleting the zone itself. This prevents accidentally removing a zone that other subdomain websites depend on.

- **API subdomain indicator**: A new `is_subdomain` boolean field is added to website API responses, set to `true` when the website's domain differs from its DNS zone's domain.
<!-- kody-pr-summary:end -->