### PR TITLE
refactor: move IPNS republish to key-namespaced user route and admin extension

### DIFF
--- a/internal/api/admin_extension.go
+++ b/internal/api/admin_extension.go
@@ -13,6 +13,7 @@ import (
 	"go.lumeweb.com/portal-router"
 	"go.lumeweb.com/portal/config"
 	"go.lumeweb.com/portal/core"
+	"go.lumeweb.com/ipfs-content/paths"
 	"go.uber.org/zap"
 	"gorm.io/gorm"
 )
@@ -24,6 +25,7 @@ type AdminExtension struct {
 	config         config.Manager
 	db             *gorm.DB
 	websiteService pluginCore.WebsiteService
+	ipnsKeyService pluginCore.IPNSKeyService
 }
 
 // NewAdminExtension creates a new Admin API extension for IPFS website management
@@ -37,10 +39,15 @@ func NewAdminExtension() core.APIExtensionFactory {
 			ext.config = ctx.Config()
 
 			// Get and verify required services
-			ext.websiteService = core.GetService[pluginCore.WebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
-			if ext.websiteService == nil {
-				return fmt.Errorf("website service not available")
-			}
+		ext.websiteService = core.GetService[pluginCore.WebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
+		if ext.websiteService == nil {
+			return fmt.Errorf("website service not available")
+		}
+
+		ext.ipnsKeyService = core.GetService[pluginCore.IPNSKeyService](ctx, pluginCore.IPNS_KEY_SERVICE)
+		if ext.ipnsKeyService == nil {
+			return fmt.Errorf("ipns key service not available")
+		}
 
 			return nil
 		})), nil
@@ -54,14 +61,16 @@ func (e *AdminExtension) TargetAPI() string {
 
 // Configure is called to set up routes on the admin API router
 func (e *AdminExtension) Configure(gRouter router.Router, accessSvc core.AccessService) error {
-	// Create a subrouter for IPFS website management
 	ipfsRouter, err := gRouter.Group("/api/ipfs")
 	if err != nil {
 		return err
 	}
 
-	// Register admin website routes
 	if err := e.registerWebsiteHandlers(ipfsRouter, accessSvc); err != nil {
+		return err
+	}
+
+	if err := e.registerIPNSHandlers(ipfsRouter, accessSvc); err != nil {
 		return err
 	}
 
@@ -205,4 +214,78 @@ func (e *AdminExtension) unblockWebsite(c echo.Context) error {
 	}
 
 	return ctx.NoContent(http.StatusOK)
+}
+
+func (e *AdminExtension) registerIPNSHandlers(gRouter router.Router, accessSvc core.AccessService) error {
+	routes := router.DefineRoutes(
+		router.NewRoute(http.MethodPost, "/ipns/republish", e.republishIPNS,
+			router.WithAccess(core.ACCESS_USER_ROLE),
+			router.WithSwagger(
+				router.WithSummary("Trigger IPNS republish"),
+				router.WithDescription(`Triggers IPNS record republishing for all keys on the node.
+
+Admin-only operation that forces all IPNS records to be republished to the network. Useful for ensuring content remains available and records are refreshed.
+
+Prerequisites: Admin access required`),
+				router.WithTags("Admin", "IPNS"),
+				router.WithSuccessResponse(http.StatusOK, "Republish result", router.WithJSONContent(dto.IPNSRepublishResponse{})),
+			),
+		),
+	)
+
+	apiGroup := internal.ProtocolName
+	if err := router.RegisterRoutes(gRouter, accessSvc, apiGroup, routes); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (e *AdminExtension) republishIPNS(c echo.Context) error {
+	ctx := httputil.Context(c)
+	reqCtx := ctx.Context.Request().Context()
+
+	records, err := e.ipnsKeyService.ListPublished(reqCtx)
+	if err != nil {
+		e.logger.Error("Failed to list published records", zap.Error(err))
+		apiErr := NewError(ErrKeyFileProcessingFailed, fmt.Errorf("failed to list published records: %w", err))
+		return ctx.Error(apiErr, apiErr.HttpStatus())
+	}
+
+	var count int
+	for ipnsName, record := range records {
+		peerID := ipnsName.Peer().String()
+
+		privKey, _, err := e.ipnsKeyService.GetPrivateKeyByPeerID(reqCtx, peerID)
+		if err != nil {
+			e.logger.Warn("Failed to get private key for republish, skipping", zap.Error(err), zap.String("peer_id", peerID))
+			continue
+		}
+
+		valuePath, err := record.Value()
+		if err != nil {
+			e.logger.Warn("Failed to get IPNS record value for republish, skipping", zap.Error(err), zap.String("peer_id", peerID))
+			continue
+		}
+
+		cidStr, err := paths.ExtractCIDFromPathStrict(valuePath)
+		if err != nil {
+			e.logger.Warn("Invalid IPNS record path format, skipping", zap.Error(err), zap.String("peer_id", peerID))
+			continue
+		}
+
+		if err := e.ipnsKeyService.PublishWithKey(reqCtx, privKey, cidStr, 0); err != nil {
+			e.logger.Warn("Failed to republish IPNS record, skipping", zap.Error(err), zap.String("peer_id", peerID))
+			continue
+		}
+
+		count++
+	}
+
+	resp := dto.IPNSRepublishResponse{
+		Count:   count,
+		Message: fmt.Sprintf("Successfully republished %d IPNS record(s)", count),
+	}
+
+	return httputil.EncodeResponse(ctx, nil, &resp)
 }

--- a/internal/api/admin_extension_test.go
+++ b/internal/api/admin_extension_test.go
@@ -1,13 +1,18 @@
 package api
 
 import (
+	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/ipfs/boxo/ipns"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	pluginCoreCore "go.lumeweb.com/portal-plugin-ipfs/core"
+	"go.lumeweb.com/portal-plugin-ipfs/internal/api/dto"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/testing/mocks"
 	"go.lumeweb.com/portal/core"
 	coreTesting "go.lumeweb.com/portal/core/testing"
@@ -22,128 +27,171 @@ var AdminTestOptions = coreTesting.CombineOptions(
 
 func TestAdminExtension_TargetAPI(t *testing.T) {
 	coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
-		// Arrange
 		extFactory := NewAdminExtension()
 		ext, _, err := extFactory()
 		assert.NoError(t, err)
 
 		adminExt := ext.(*AdminExtension)
 
-		// Assert
 		assert.Equal(t, "admin", adminExt.TargetAPI())
 	}, AdminTestOptions)
 }
 
 func TestAdminExtension_BlockWebsite_Success(t *testing.T) {
 	coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
-		// Arrange
 		websiteService := core.GetService[*mocks.MockWebsiteService](ctx, pluginCoreCore.WEBSITE_SERVICE)
 		websiteID := uint(123)
 
-		// Mock the BlockWebsite call
 		websiteService.EXPECT().BlockWebsite(mock.Anything, websiteID).Return(nil)
 
-		// Create test request using context helper
 		req := ctx.NewAPIRequest(http.MethodPost, "/api/ipfs/websites/123/block", nil)
 		rec := httptest.NewRecorder()
 
-		// Act
 		ctx.Router().ServeHTTP(rec, req)
 
-		// Assert
 		assert.Equal(t, http.StatusOK, rec.Code)
 	}, AdminTestOptions)
 }
 
 func TestAdminExtension_BlockWebsite_InvalidID(t *testing.T) {
 	coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
-		// Arrange
-		// Create test request with invalid ID
 		req := ctx.NewAPIRequest(http.MethodPost, "/api/ipfs/websites/invalid/block", nil)
 		rec := httptest.NewRecorder()
 
-		// Act
 		ctx.Router().ServeHTTP(rec, req)
 
-		// Assert
 		assert.NotEqual(t, http.StatusOK, rec.Code)
 	}, AdminTestOptions)
 }
 
 func TestAdminExtension_BlockWebsite_ServiceError(t *testing.T) {
 	coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
-		// Arrange
 		websiteService := core.GetService[*mocks.MockWebsiteService](ctx, pluginCoreCore.WEBSITE_SERVICE)
 		websiteID := uint(123)
 
-		// Mock the BlockWebsite call to return an error
 		websiteService.EXPECT().BlockWebsite(mock.Anything, websiteID).Return(assert.AnError)
 
-		// Create test request
 		req := ctx.NewAPIRequest(http.MethodPost, "/api/ipfs/websites/123/block", nil)
 		rec := httptest.NewRecorder()
 
-		// Act
 		ctx.Router().ServeHTTP(rec, req)
 
-		// Assert
 		assert.NotEqual(t, http.StatusOK, rec.Code)
 	}, AdminTestOptions)
 }
 
 func TestAdminExtension_UnblockWebsite_Success(t *testing.T) {
 	coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
-		// Arrange
 		websiteService := core.GetService[*mocks.MockWebsiteService](ctx, pluginCoreCore.WEBSITE_SERVICE)
 		websiteID := uint(123)
 
-		// Mock the UnblockWebsite call
 		websiteService.EXPECT().UnblockWebsite(mock.Anything, websiteID).Return(nil)
 
-		// Create test request using context helper
 		req := ctx.NewAPIRequest(http.MethodPost, "/api/ipfs/websites/123/unblock", nil)
 		rec := httptest.NewRecorder()
 
-		// Act
 		ctx.Router().ServeHTTP(rec, req)
 
-		// Assert
 		assert.Equal(t, http.StatusOK, rec.Code)
 	}, AdminTestOptions)
 }
 
 func TestAdminExtension_UnblockWebsite_InvalidID(t *testing.T) {
 	coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
-		// Arrange
-		// Create test request with invalid ID
 		req := ctx.NewAPIRequest(http.MethodPost, "/api/ipfs/websites/invalid/unblock", nil)
 		rec := httptest.NewRecorder()
 
-		// Act
 		ctx.Router().ServeHTTP(rec, req)
 
-		// Assert
 		assert.NotEqual(t, http.StatusOK, rec.Code)
 	}, AdminTestOptions)
 }
 
 func TestAdminExtension_UnblockWebsite_ServiceError(t *testing.T) {
 	coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
-		// Arrange
 		websiteService := core.GetService[*mocks.MockWebsiteService](ctx, pluginCoreCore.WEBSITE_SERVICE)
 		websiteID := uint(123)
 
-		// Mock the UnblockWebsite call to return an error
 		websiteService.EXPECT().UnblockWebsite(mock.Anything, websiteID).Return(assert.AnError)
 
-		// Create test request
 		req := ctx.NewAPIRequest(http.MethodPost, "/api/ipfs/websites/123/unblock", nil)
 		rec := httptest.NewRecorder()
 
-		// Act
 		ctx.Router().ServeHTTP(rec, req)
 
-		// Assert
 		assert.NotEqual(t, http.StatusOK, rec.Code)
 	}, AdminTestOptions)
+}
+
+func TestAdminExtension_RepublishIPNS(t *testing.T) {
+	t.Run("success_all_keys", func(t *testing.T) {
+		coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+			mockIPNSKeyService := core.GetService[*mocks.MockIPNSKeyService](ctx, pluginCoreCore.IPNS_KEY_SERVICE)
+
+			mockRecord := createMockIPNSRecord(t, TestCID)
+			ipnsName, _ := ipns.NameFromString(TestIPNSName)
+			records := map[ipns.Name]*ipns.Record{
+				ipnsName: mockRecord,
+			}
+
+			mockIPNSKeyService.EXPECT().ListPublished(mock.Anything).Return(records, nil)
+			mockIPNSKeyService.EXPECT().GetPrivateKeyByPeerID(mock.Anything, ipnsName.Peer().String()).Return(nil, uint(1), nil).Times(1)
+			mockIPNSKeyService.EXPECT().PublishWithKey(mock.Anything, nil, TestCID, mock.AnythingOfType("time.Duration")).Return(nil)
+
+			req := ctx.NewAPIRequest(http.MethodPost, "/api/ipfs/ipns/republish", nil)
+			rec := httptest.NewRecorder()
+
+			ctx.Router().ServeHTTP(rec, req)
+
+			assert.Equal(t, http.StatusOK, rec.Code)
+
+			var response dto.IPNSRepublishResponse
+			err := json.Unmarshal(rec.Body.Bytes(), &response)
+			require.NoError(t, err)
+			assert.Equal(t, 1, response.Count)
+		}, AdminTestOptions)
+	})
+
+	t.Run("error_list_published_failed", func(t *testing.T) {
+		coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+			mockIPNSKeyService := core.GetService[*mocks.MockIPNSKeyService](ctx, pluginCoreCore.IPNS_KEY_SERVICE)
+
+			mockIPNSKeyService.EXPECT().ListPublished(mock.Anything).Return(nil, errors.New("republish failed"))
+
+			req := ctx.NewAPIRequest(http.MethodPost, "/api/ipfs/ipns/republish", nil)
+			rec := httptest.NewRecorder()
+
+			ctx.Router().ServeHTTP(rec, req)
+
+			assert.Equal(t, http.StatusInternalServerError, rec.Code)
+		}, AdminTestOptions)
+	})
+
+	t.Run("regression_path_extraction_bulk_keys", func(t *testing.T) {
+		coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+			mockIPNSKeyService := core.GetService[*mocks.MockIPNSKeyService](ctx, pluginCoreCore.IPNS_KEY_SERVICE)
+
+			mockRecord := createMockIPNSRecord(t, TestCID)
+			ipnsName, _ := ipns.NameFromString(TestIPNSName)
+			records := map[ipns.Name]*ipns.Record{
+				ipnsName: mockRecord,
+			}
+
+			mockIPNSKeyService.EXPECT().ListPublished(mock.Anything).Return(records, nil)
+			mockIPNSKeyService.EXPECT().GetPrivateKeyByPeerID(mock.Anything, ipnsName.Peer().String()).Return(nil, uint(1), nil).Times(1)
+			mockIPNSKeyService.EXPECT().PublishWithKey(mock.Anything, nil, TestCID, mock.AnythingOfType("time.Duration")).Return(nil)
+
+			req := ctx.NewAPIRequest(http.MethodPost, "/api/ipfs/ipns/republish", nil)
+			rec := httptest.NewRecorder()
+
+			ctx.Router().ServeHTTP(rec, req)
+
+			assert.Equal(t, http.StatusOK, rec.Code)
+
+			var response dto.IPNSRepublishResponse
+			err := json.Unmarshal(rec.Body.Bytes(), &response)
+			require.NoError(t, err)
+			assert.Equal(t, 1, response.Count)
+		}, AdminTestOptions)
+	})
 }

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -523,17 +523,18 @@ See also:.*`),
 				router.WithSuccessResponse(http.StatusOK, "IPNS resolve result", router.WithJSONContent(dto.IPNSResolveResponse{})),
 			),
 		),
-		router.NewRoute(http.MethodPost, "/ipns/republish", a.republishIPNS,
+		router.NewRoute(http.MethodPost, "/ipns/keys/:id/republish", a.republishIPNS,
 			router.WithAccess(core.ACCESS_USER_ROLE),
 			router.WithSwagger(
-				router.WithSummary("Trigger IPNS republish"),
-				router.WithDescription(`Triggers IPNS record republishing for all keys.
+				router.WithSummary("Republish IPNS record"),
+				router.WithDescription(`Republishes an IPNS record for a specific key owned by the authenticated user.
 
-Forces all IPNS records to be republished to the network. Useful for ensuring content remains available and records are refreshed.
+Re-broadcasts the current IPNS record to the network. Useful for refreshing records that may have fallen out of the DHT.
 
-See also:.*`),
+Prerequisites: User must own the specified IPNS key.`),
 				router.WithTags("IPNS"),
-				router.WithSuccessResponse(http.StatusAccepted, "Republish triggered"),
+				router.WithPathParam("id", "IPNS key ID", ""),
+				router.WithSuccessResponse(http.StatusOK, "Republish result", router.WithJSONContent(dto.IPNSRepublishResponse{})),
 			),
 		),
 	)

--- a/internal/api/api_ipns.go
+++ b/internal/api/api_ipns.go
@@ -343,23 +343,21 @@ func (a *API) resolveIPNS(c echo.Context) error {
 	return httputil.EncodeResponse(ctx, nil, &resp)
 }
 
-// republishIPNS republishes IPNS records to keep them alive in the network.
-// If key_id is provided in request body, republishes only that key.
-// Otherwise republishes all records owned by the authenticated user.
-// Returns 200 OK with IPNSRepublishResponse containing count of republished records.
 func (a *API) republishIPNS(c echo.Context) error {
 	ctx := httputil.Context(c)
 	reqCtx := ctx.Context.Request().Context()
 
-	// Parse optional key_id parameter from request body
-	var req struct {
-		KeyID *uint `json:"key_id,omitempty"`
-	}
-	if err := c.Bind(&req); err != nil {
-		// If body parsing fails, it's okay - key_id is optional
+	user, err := mcontext.GetUserID(c)
+	if err != nil {
+		return err
 	}
 
-	// Get IPNSKeyService
+	keyID, err := strconv.ParseUint(c.Param("id"), 10, 64)
+	if err != nil {
+		apiErr := NewError(ErrKeyInvalidUUIDFormat, err)
+		return ctx.Error(apiErr, apiErr.HttpStatus())
+	}
+
 	ipnsKeyService := core.GetService[pluginCore.IPNSKeyService](a.Context(), pluginCore.IPNS_KEY_SERVICE)
 	if ipnsKeyService == nil {
 		a.Logger().Error("IPNSKeyService not available")
@@ -367,109 +365,53 @@ func (a *API) republishIPNS(c echo.Context) error {
 		return ctx.Error(apiErr, apiErr.HttpStatus())
 	}
 
-	var count int
-
-	if req.KeyID != nil {
-		// Republish a specific key
-		user, err := mcontext.GetUserID(c)
-		if err != nil {
-			return err
-		}
-
-		// Get the IPNS key by ID and verify ownership
-		key, err := a.ipnsKeyService.GetKeyByID(reqCtx, user, *req.KeyID)
-		if err != nil {
-			a.Logger().Error("Failed to get IPNS key", zap.Error(err), zap.Uint("key_id", *req.KeyID), zap.Uint("user_id", user))
-			apiErr := NewError(ErrKeyPinFetchFailed, err)
+	key, err := a.ipnsKeyService.GetKeyByID(reqCtx, user, uint(keyID))
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			apiErr := NewError(ErrKeyUploadNotFound, err)
 			return ctx.Error(apiErr, apiErr.HttpStatus())
 		}
-
-		// Get the current published record
-		record, err := ipnsKeyService.GetPublished(reqCtx, key.PeerID().String(), false)
-		if err != nil {
-			a.Logger().Error("Failed to get published record for republish", zap.Error(err), zap.String("peer_id", key.PeerID().String()))
-			apiErr := NewError(ErrKeyPinFetchFailed, fmt.Errorf("failed to get published record: %w", err))
-			return ctx.Error(apiErr, apiErr.HttpStatus())
-		}
-
-		// Get the value from the record
-		valuePath, err := record.Value()
-		if err != nil {
-			a.Logger().Error("Failed to get IPNS record value for republish", zap.Error(err), zap.String("peer_id", key.PeerID().String()))
-			apiErr := NewError(ErrKeyFileProcessingFailed, fmt.Errorf("failed to get IPNS record value: %w", err))
-			return ctx.Error(apiErr, apiErr.HttpStatus())
-		}
-
-		// Get the private key and republish
-		privKey, _, err := a.ipnsKeyService.GetPrivateKeyByPeerID(reqCtx, key.PeerID().String())
-		if err != nil {
-			a.Logger().Error("Failed to get private key for republish", zap.Error(err), zap.String("peer_id", key.PeerID().String()))
-			apiErr := NewError(ErrKeyFileProcessingFailed, fmt.Errorf("failed to get private key: %w", err))
-			return ctx.Error(apiErr, apiErr.HttpStatus())
-		}
-
-		// Extract CID from the path
-		cidStr, err := paths.ExtractCIDFromPathStrict(valuePath)
-		if err != nil {
-			apiErr := NewError(ErrKeyInvalidRequest, err)
-			return ctx.Error(apiErr, apiErr.HttpStatus())
-		}
-
-		// Republish with the same value
-		err = ipnsKeyService.PublishWithKey(reqCtx, privKey, cidStr, 0)
-		if err != nil {
-			a.Logger().Error("Failed to republish IPNS record", zap.Error(err), zap.String("peer_id", key.PeerID().String()))
-			apiErr := NewError(ErrKeyFileProcessingFailed, fmt.Errorf("failed to republish IPNS record: %w", err))
-			return ctx.Error(apiErr, apiErr.HttpStatus())
-		}
-
-		count = 1
-	} else {
-		// Republish all keys
-		records, err := ipnsKeyService.ListPublished(reqCtx)
-		if err != nil {
-			a.Logger().Error("Failed to list published records", zap.Error(err))
-			apiErr := NewError(ErrKeyFileProcessingFailed, fmt.Errorf("failed to list published records: %w", err))
-			return ctx.Error(apiErr, apiErr.HttpStatus())
-		}
-
-		// Republish each record
-		for ipnsName, record := range records {
-			peerID := ipnsName.Peer().String()
-
-			privKey, _, err := a.ipnsKeyService.GetPrivateKeyByPeerID(reqCtx, peerID)
-			if err != nil {
-				a.Logger().Warn("Failed to get private key for republish, skipping", zap.Error(err), zap.String("peer_id", peerID))
-				continue
-			}
-
-			valuePath, err := record.Value()
-			if err != nil {
-				a.Logger().Warn("Failed to get IPNS record value for republish, skipping", zap.Error(err), zap.String("peer_id", peerID))
-				continue
-			}
-
-			// Extract CID from the path
-			cidStr, err := paths.ExtractCIDFromPathStrict(valuePath)
-			if err != nil {
-				a.Logger().Warn("Invalid IPNS record path format, skipping", zap.Error(err), zap.String("peer_id", peerID))
-				continue
-			}
-
-			err = ipnsKeyService.PublishWithKey(reqCtx, privKey, cidStr, 0)
-			if err != nil {
-				a.Logger().Warn("Failed to republish IPNS record, skipping", zap.Error(err), zap.String("peer_id", peerID))
-				continue
-			}
-
-			count++
-		}
+		a.Logger().Error("Failed to get IPNS key", zap.Error(err), zap.Uint("key_id", uint(keyID)), zap.Uint("user_id", user))
+		apiErr := NewError(ErrKeyPinFetchFailed, err)
+		return ctx.Error(apiErr, apiErr.HttpStatus())
 	}
 
-	// Return response
+	record, err := ipnsKeyService.GetPublished(reqCtx, key.PeerID().String(), false)
+	if err != nil {
+		a.Logger().Error("Failed to get published record for republish", zap.Error(err), zap.String("peer_id", key.PeerID().String()))
+		apiErr := NewError(ErrKeyPinFetchFailed, fmt.Errorf("failed to get published record: %w", err))
+		return ctx.Error(apiErr, apiErr.HttpStatus())
+	}
+
+	valuePath, err := record.Value()
+	if err != nil {
+		a.Logger().Error("Failed to get IPNS record value for republish", zap.Error(err), zap.String("peer_id", key.PeerID().String()))
+		apiErr := NewError(ErrKeyFileProcessingFailed, fmt.Errorf("failed to get IPNS record value: %w", err))
+		return ctx.Error(apiErr, apiErr.HttpStatus())
+	}
+
+	privKey, _, err := a.ipnsKeyService.GetPrivateKeyByPeerID(reqCtx, key.PeerID().String())
+	if err != nil {
+		a.Logger().Error("Failed to get private key for republish", zap.Error(err), zap.String("peer_id", key.PeerID().String()))
+		apiErr := NewError(ErrKeyFileProcessingFailed, fmt.Errorf("failed to get private key: %w", err))
+		return ctx.Error(apiErr, apiErr.HttpStatus())
+	}
+
+	cidStr, err := paths.ExtractCIDFromPathStrict(valuePath)
+	if err != nil {
+		apiErr := NewError(ErrKeyInvalidRequest, err)
+		return ctx.Error(apiErr, apiErr.HttpStatus())
+	}
+
+	if err := ipnsKeyService.PublishWithKey(reqCtx, privKey, cidStr, 0); err != nil {
+		a.Logger().Error("Failed to republish IPNS record", zap.Error(err), zap.String("peer_id", key.PeerID().String()))
+		apiErr := NewError(ErrKeyFileProcessingFailed, fmt.Errorf("failed to republish IPNS record: %w", err))
+		return ctx.Error(apiErr, apiErr.HttpStatus())
+	}
+
 	resp := dto.IPNSRepublishResponse{
-		Count:   count,
-		Message: fmt.Sprintf("Successfully republished %d IPNS record(s)", count),
+		Count:   1,
+		Message: "Successfully republished IPNS record",
 	}
 
 	return httputil.EncodeResponse(ctx, nil, &resp)

--- a/internal/api/api_ipns_test.go
+++ b/internal/api/api_ipns_test.go
@@ -546,36 +546,7 @@ func TestAPI_ResolveIPNS(t *testing.T) {
 }
 
 func TestAPI_RepublishIPNS(t *testing.T) {
-	t.Run("success_all_keys", func(t *testing.T) {
-		coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
-			helper := newMockHelper(t, ctx)
-			token, userID := helper.SetupAuthenticatedTestWithCID(cid.MustParse(TestCID))
-
-			mockIPNSKeyService := helper.SetupIPNSServiceMocksNoDefaults(userID)
-
-			// Create a valid IPNS record with a value
-			mockRecord := createMockIPNSRecord(t, TestCID)
-			ipnsName, _ := ipns.NameFromString(TestIPNSName)
-			records := map[ipns.Name]*ipns.Record{
-				ipnsName: mockRecord,
-			}
-
-			mockIPNSKeyService.EXPECT().ListPublished(mock.Anything).Return(records, nil)
-			mockIPNSKeyService.EXPECT().GetPrivateKeyByPeerID(mock.Anything, ipnsName.Peer().String()).Return(nil, userID, nil).Times(1)
-			mockIPNSKeyService.EXPECT().PublishWithKey(mock.Anything, nil, TestCID, mock.AnythingOfType("time.Duration")).Return(nil)
-
-			rec := helper.makeAuthenticatedRequest(http.MethodPost, "/api/ipns/republish", token, nil)
-
-			assert.Equal(t, http.StatusOK, rec.Code)
-
-			var response dto.IPNSRepublishResponse
-			err := json.Unmarshal(rec.Body.Bytes(), &response)
-			require.NoError(t, err)
-			assert.Equal(t, 1, response.Count)
-		}, TestOptions)
-	})
-
-	t.Run("success_specific_key", func(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
 		coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 			helper := newMockHelper(t, ctx)
 			token, userID := helper.SetupAuthenticatedTestWithCID(cid.MustParse(TestCID))
@@ -583,8 +554,6 @@ func TestAPI_RepublishIPNS(t *testing.T) {
 			mockIPNSKeyService := helper.SetupIPNSServiceMocks(userID)
 
 			mockKey := createTestIPNSKey(1, userID, "test-key", TestPeerID)
-
-			// Create a valid IPNS record with a value
 			mockRecord := createMockIPNSRecord(t, TestCID)
 
 			mockIPNSKeyService.EXPECT().GetKeyByID(mock.Anything, userID, uint(1)).Return(&mockKey, nil)
@@ -592,8 +561,7 @@ func TestAPI_RepublishIPNS(t *testing.T) {
 			mockIPNSKeyService.EXPECT().GetPrivateKeyByPeerID(mock.Anything, mockKey.PeerID().String()).Return(nil, userID, nil)
 			mockIPNSKeyService.EXPECT().PublishWithKey(mock.Anything, nil, TestCID, mock.AnythingOfType("time.Duration")).Return(nil)
 
-			reqBody := `{"key_id":1}`
-			rec := helper.makeAuthenticatedRequest(http.MethodPost, "/api/ipns/republish", token, []byte(reqBody))
+			rec := helper.makeAuthenticatedRequest(http.MethodPost, "/api/ipns/keys/1/republish", token, nil)
 
 			assert.Equal(t, http.StatusOK, rec.Code)
 
@@ -613,97 +581,29 @@ func TestAPI_RepublishIPNS(t *testing.T) {
 
 			mockIPNSKeyService.EXPECT().GetKeyByID(mock.Anything, userID, uint(999)).Return(nil, gorm.ErrRecordNotFound)
 
-			reqBody := `{"key_id":999}`
-			rec := helper.makeAuthenticatedRequest(http.MethodPost, "/api/ipns/republish", token, []byte(reqBody))
+			rec := helper.makeAuthenticatedRequest(http.MethodPost, "/api/ipns/keys/999/republish", token, nil)
 
-			assert.Equal(t, http.StatusInternalServerError, rec.Code)
+			assert.Equal(t, http.StatusNotFound, rec.Code)
 		}, TestOptions)
 	})
 
-	t.Run("error_republish_failed", func(t *testing.T) {
+	t.Run("error_invalid_key_id", func(t *testing.T) {
 		coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 			helper := newMockHelper(t, ctx)
-			token, userID := helper.SetupAuthenticatedTestWithCID(cid.MustParse(TestCID))
+			token, _ := helper.SetupAuthenticatedTestWithCID(cid.MustParse(TestCID))
 
-			mockIPNSKeyService := helper.SetupIPNSServiceMocks(userID)
+			rec := helper.makeAuthenticatedRequest(http.MethodPost, "/api/ipns/keys/invalid/republish", token, nil)
 
-			mockIPNSKeyService.EXPECT().ListPublished(mock.Anything).Return(nil, errors.New("republish failed"))
-
-			rec := helper.makeAuthenticatedRequest(http.MethodPost, "/api/ipns/republish", token, nil)
-
-			assert.Equal(t, http.StatusInternalServerError, rec.Code)
+			assert.Equal(t, http.StatusBadRequest, rec.Code)
 		}, TestOptions)
 	})
 
 	t.Run("unauthorized", func(t *testing.T) {
 		coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
-			req := ctx.NewAPIRequest(http.MethodPost, "/api/ipns/republish", nil)
+			req := ctx.NewAPIRequest(http.MethodPost, "/api/ipns/keys/1/republish", nil)
 			rec := httptest.NewRecorder()
 			ctx.Router().ServeHTTP(rec, req)
 			assert.Equal(t, http.StatusUnauthorized, rec.Code)
-		}, TestOptions)
-	})
-
-	t.Run("regression_path_extraction_single_key", func(t *testing.T) {
-		// Regression test: Ensures CID is extracted from path, not full path string passed to PublishWithKey
-		// This tests the fix for the bug where valuePath.String() was passed instead of just the CID
-		coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
-			helper := newMockHelper(t, ctx)
-			token, userID := helper.SetupAuthenticatedTestWithCID(cid.MustParse(TestCID))
-
-			mockIPNSKeyService := helper.SetupIPNSServiceMocks(userID)
-
-			mockKey := createTestIPNSKey(1, userID, "test-key", TestPeerID)
-
-			// Create a mock IPNS record that will return a path like /ipfs/{cid}
-			mockRecord := createMockIPNSRecord(t, TestCID)
-
-			mockIPNSKeyService.EXPECT().GetKeyByID(mock.Anything, userID, uint(1)).Return(&mockKey, nil)
-			mockIPNSKeyService.EXPECT().GetPublished(mock.Anything, mockKey.PeerID().String(), false).Return(mockRecord, nil)
-			mockIPNSKeyService.EXPECT().GetPrivateKeyByPeerID(mock.Anything, mockKey.PeerID().String()).Return(nil, userID, nil)
-			// Important: This test expects the CID string, NOT the full path string (/ipfs/{cid})
-			mockIPNSKeyService.EXPECT().PublishWithKey(mock.Anything, nil, TestCID, mock.AnythingOfType("time.Duration")).Return(nil)
-
-			reqBody := `{"key_id":1}`
-			rec := helper.makeAuthenticatedRequest(http.MethodPost, "/api/ipns/republish", token, []byte(reqBody))
-
-			assert.Equal(t, http.StatusOK, rec.Code)
-
-			var response dto.IPNSRepublishResponse
-			err := json.Unmarshal(rec.Body.Bytes(), &response)
-			require.NoError(t, err)
-			assert.Equal(t, 1, response.Count)
-		}, TestOptions)
-	})
-
-	t.Run("regression_path_extraction_bulk_keys", func(t *testing.T) {
-		// Regression test: Ensures CID extraction from path works correctly in bulk republish loop
-		coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
-			helper := newMockHelper(t, ctx)
-			token, userID := helper.SetupAuthenticatedTestWithCID(cid.MustParse(TestCID))
-
-			mockIPNSKeyService := helper.SetupIPNSServiceMocksNoDefaults(userID)
-
-			// Create a mock IPNS record
-			mockRecord := createMockIPNSRecord(t, TestCID)
-			ipnsName, _ := ipns.NameFromString(TestIPNSName)
-			records := map[ipns.Name]*ipns.Record{
-				ipnsName: mockRecord,
-			}
-
-			mockIPNSKeyService.EXPECT().ListPublished(mock.Anything).Return(records, nil)
-			mockIPNSKeyService.EXPECT().GetPrivateKeyByPeerID(mock.Anything, ipnsName.Peer().String()).Return(nil, userID, nil).Times(1)
-			// Important: This test expects the CID string, NOT the full path string (/ipfs/{cid})
-			mockIPNSKeyService.EXPECT().PublishWithKey(mock.Anything, nil, TestCID, mock.AnythingOfType("time.Duration")).Return(nil)
-
-			rec := helper.makeAuthenticatedRequest(http.MethodPost, "/api/ipns/republish", token, nil)
-
-			assert.Equal(t, http.StatusOK, rec.Code)
-
-			var response dto.IPNSRepublishResponse
-			err := json.Unmarshal(rec.Body.Bytes(), &response)
-			require.NoError(t, err)
-			assert.Equal(t, 1, response.Count)
 		}, TestOptions)
 	})
 }

--- a/internal/api/dto/website.go
+++ b/internal/api/dto/website.go
@@ -157,8 +157,8 @@ func (r *IPNSResolveResponse) FromModel(any) error {
 
 // IPNSRepublishResponse represents an IPNS republish response
 type IPNSRepublishResponse struct {
-	Count   int    `json:"count"`   // Number of records republished
-	Message string `json:"message"` // Status message
+	Count   int    `json:"count"`
+	Message string `json:"message"`
 }
 
 func (r *IPNSRepublishResponse) FromModel(any) error {


### PR DESCRIPTION
- POST /api/ipns/keys/:id/republish: user-scoped, single key, ownership-verified
- POST /api/ipfs/ipns/republish: admin-only, node-wide bulk republish

* `develop` <!-- branch-stack -->
  - **refactor: move IPNS republish to key-namespaced user route and admin extension** :point\_left:

---

<!-- kody-pr-summary:start -->
This PR refactors the IPNS republish functionality by splitting it into two distinct endpoints based on access scope:

- **User API**: The republish endpoint is now scoped to a specific key via a URL path parameter (`/ipns/keys/:id/republish`), replacing the previous body-based optional `key_id` approach. Users can only republish individual keys they own, and the bulk "republish all" option has been removed from the user-facing API.

- **Admin API**: A new admin extension endpoint (`/api/ipfs/ipns/republish`) handles bulk republishing of all IPNS records on the node. This functionality was previously available through the user API when no `key_id` was provided, and is now properly restricted to admin access only.

The admin extension now depends on the `IPNSKeyService` to support the bulk republish operation. Tests have been updated accordingly, with bulk republish and path extraction regression tests moved to the admin extension test suite.
<!-- kody-pr-summary:end -->