### PR TITLE
fix: prevent nil pointer panic in IPNS republish by tracking last published CID

### DIFF
--- a/internal/api/admin_extension.go
+++ b/internal/api/admin_extension.go
@@ -256,6 +256,11 @@ func (e *AdminExtension) republishIPNS(c echo.Context) error {
 	for ipnsName, record := range records {
 		peerID := ipnsName.Peer().String()
 
+		if record == nil {
+			e.logger.Warn("Nil record in published list, skipping", zap.String("peer_id", peerID))
+			continue
+		}
+
 		privKey, _, err := e.ipnsKeyService.GetPrivateKeyByPeerID(reqCtx, peerID)
 		if err != nil {
 			e.logger.Warn("Failed to get private key for republish, skipping", zap.Error(err), zap.String("peer_id", peerID))

--- a/internal/api/api_ipns.go
+++ b/internal/api/api_ipns.go
@@ -231,6 +231,15 @@ func (a *API) publishIPNS(c echo.Context) error {
 		return httputil.EncodeResponse(ctx, nil, &resp)
 	}
 
+	if record == nil {
+		resp := dto.IPNSPublishResponse{
+			Name:      key.PeerID().String(),
+			Value:     req.CID,
+			Published: time.Now(),
+		}
+		return httputil.EncodeResponse(ctx, nil, &resp)
+	}
+
 	// Convert IPNS record to response
 	valuePath, err := record.Value()
 	if err != nil {
@@ -383,23 +392,52 @@ func (a *API) republishIPNS(c echo.Context) error {
 		return ctx.Error(apiErr, apiErr.HttpStatus())
 	}
 
-	valuePath, err := record.Value()
-	if err != nil {
-		a.Logger().Error("Failed to get IPNS record value for republish", zap.Error(err), zap.String("peer_id", key.PeerID().String()))
-		apiErr := NewError(ErrKeyFileProcessingFailed, fmt.Errorf("failed to get IPNS record value: %w", err))
-		return ctx.Error(apiErr, apiErr.HttpStatus())
+	var cidStr string
+	if record != nil {
+		valuePath, err := record.Value()
+		if err != nil {
+			a.Logger().Error("Failed to get IPNS record value for republish", zap.Error(err), zap.String("peer_id", key.PeerID().String()))
+			apiErr := NewError(ErrKeyFileProcessingFailed, fmt.Errorf("failed to get IPNS record value: %w", err))
+			return ctx.Error(apiErr, apiErr.HttpStatus())
+		}
+		cidStr, err = paths.ExtractCIDFromPathStrict(valuePath)
+		if err != nil {
+			apiErr := NewError(ErrKeyInvalidRequest, err)
+			return ctx.Error(apiErr, apiErr.HttpStatus())
+		}
+	} else {
+		if key.LastPublishedCID != "" {
+			a.Logger().Debug("No local record found, using last published CID from database", zap.String("peer_id", key.PeerID().String()), zap.String("cid", key.LastPublishedCID))
+			cidStr = key.LastPublishedCID
+		} else {
+			a.Logger().Debug("No local record found, checking DHT", zap.String("peer_id", key.PeerID().String()))
+			record, err = ipnsKeyService.GetPublished(reqCtx, key.PeerID().String(), true)
+			if err != nil {
+				a.Logger().Error("Failed to get published record from DHT", zap.Error(err), zap.String("peer_id", key.PeerID().String()))
+				apiErr := NewError(ErrKeyPinFetchFailed, fmt.Errorf("failed to get published record from routing: %w", err))
+				return ctx.Error(apiErr, apiErr.HttpStatus())
+			}
+			if record == nil {
+				apiErr := NewError(ErrKeyPinFetchFailed, fmt.Errorf("no published record found for key %d", keyID))
+				return ctx.Error(apiErr, apiErr.HttpStatus())
+			}
+			valuePath, err := record.Value()
+			if err != nil {
+				apiErr := NewError(ErrKeyFileProcessingFailed, fmt.Errorf("failed to get IPNS record value from DHT: %w", err))
+				return ctx.Error(apiErr, apiErr.HttpStatus())
+			}
+			cidStr, err = paths.ExtractCIDFromPathStrict(valuePath)
+			if err != nil {
+				apiErr := NewError(ErrKeyInvalidRequest, err)
+				return ctx.Error(apiErr, apiErr.HttpStatus())
+			}
+		}
 	}
 
 	privKey, _, err := a.ipnsKeyService.GetPrivateKeyByPeerID(reqCtx, key.PeerID().String())
 	if err != nil {
 		a.Logger().Error("Failed to get private key for republish", zap.Error(err), zap.String("peer_id", key.PeerID().String()))
 		apiErr := NewError(ErrKeyFileProcessingFailed, fmt.Errorf("failed to get private key: %w", err))
-		return ctx.Error(apiErr, apiErr.HttpStatus())
-	}
-
-	cidStr, err := paths.ExtractCIDFromPathStrict(valuePath)
-	if err != nil {
-		apiErr := NewError(ErrKeyInvalidRequest, err)
 		return ctx.Error(apiErr, apiErr.HttpStatus())
 	}
 

--- a/internal/api/api_ipns_test.go
+++ b/internal/api/api_ipns_test.go
@@ -598,6 +598,78 @@ func TestAPI_RepublishIPNS(t *testing.T) {
 		}, TestOptions)
 	})
 
+	t.Run("success_nil_local_record_falls_back_to_db_cid", func(t *testing.T) {
+		coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+			helper := newMockHelper(t, ctx)
+			token, userID := helper.SetupAuthenticatedTestWithCID(cid.MustParse(TestCID))
+
+			mockIPNSKeyService := helper.SetupIPNSServiceMocksNoDefaults(userID)
+
+			mockKey := createTestIPNSKey(1, userID, "test-key", TestPeerID)
+			mockKey.LastPublishedCID = TestCID
+
+			mockIPNSKeyService.EXPECT().GetKeyByID(mock.Anything, userID, uint(1)).Return(&mockKey, nil)
+			mockIPNSKeyService.EXPECT().GetPublished(mock.Anything, mockKey.PeerID().String(), false).Return((*ipns.Record)(nil), nil)
+			mockIPNSKeyService.EXPECT().GetPrivateKeyByPeerID(mock.Anything, mockKey.PeerID().String()).Return(nil, userID, nil)
+			mockIPNSKeyService.EXPECT().PublishWithKey(mock.Anything, nil, TestCID, mock.AnythingOfType("time.Duration")).Return(nil)
+
+			rec := helper.makeAuthenticatedRequest(http.MethodPost, "/api/ipns/keys/1/republish", token, nil)
+
+			assert.Equal(t, http.StatusOK, rec.Code)
+
+			var response dto.IPNSRepublishResponse
+			err := json.Unmarshal(rec.Body.Bytes(), &response)
+			require.NoError(t, err)
+			assert.Equal(t, 1, response.Count)
+		}, TestOptions)
+	})
+
+	t.Run("success_nil_local_and_db_falls_back_to_dht", func(t *testing.T) {
+		coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+			helper := newMockHelper(t, ctx)
+			token, userID := helper.SetupAuthenticatedTestWithCID(cid.MustParse(TestCID))
+
+			mockIPNSKeyService := helper.SetupIPNSServiceMocksNoDefaults(userID)
+
+			mockKey := createTestIPNSKey(1, userID, "test-key", TestPeerID)
+			mockRecord := createMockIPNSRecord(t, TestCID)
+
+			mockIPNSKeyService.EXPECT().GetKeyByID(mock.Anything, userID, uint(1)).Return(&mockKey, nil)
+			mockIPNSKeyService.EXPECT().GetPublished(mock.Anything, mockKey.PeerID().String(), false).Return((*ipns.Record)(nil), nil)
+			mockIPNSKeyService.EXPECT().GetPublished(mock.Anything, mockKey.PeerID().String(), true).Return(mockRecord, nil)
+			mockIPNSKeyService.EXPECT().GetPrivateKeyByPeerID(mock.Anything, mockKey.PeerID().String()).Return(nil, userID, nil)
+			mockIPNSKeyService.EXPECT().PublishWithKey(mock.Anything, nil, TestCID, mock.AnythingOfType("time.Duration")).Return(nil)
+
+			rec := helper.makeAuthenticatedRequest(http.MethodPost, "/api/ipns/keys/1/republish", token, nil)
+
+			assert.Equal(t, http.StatusOK, rec.Code)
+
+			var response dto.IPNSRepublishResponse
+			err := json.Unmarshal(rec.Body.Bytes(), &response)
+			require.NoError(t, err)
+			assert.Equal(t, 1, response.Count)
+		}, TestOptions)
+	})
+
+	t.Run("error_nil_record_local_db_and_dht", func(t *testing.T) {
+		coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+			helper := newMockHelper(t, ctx)
+			token, userID := helper.SetupAuthenticatedTestWithCID(cid.MustParse(TestCID))
+
+			mockIPNSKeyService := helper.SetupIPNSServiceMocksNoDefaults(userID)
+
+			mockKey := createTestIPNSKey(1, userID, "test-key", TestPeerID)
+
+			mockIPNSKeyService.EXPECT().GetKeyByID(mock.Anything, userID, uint(1)).Return(&mockKey, nil)
+			mockIPNSKeyService.EXPECT().GetPublished(mock.Anything, mockKey.PeerID().String(), false).Return((*ipns.Record)(nil), nil)
+			mockIPNSKeyService.EXPECT().GetPublished(mock.Anything, mockKey.PeerID().String(), true).Return((*ipns.Record)(nil), nil)
+
+			rec := helper.makeAuthenticatedRequest(http.MethodPost, "/api/ipns/keys/1/republish", token, nil)
+
+			assert.Equal(t, http.StatusInternalServerError, rec.Code)
+		}, TestOptions)
+	})
+
 	t.Run("unauthorized", func(t *testing.T) {
 		coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 			req := ctx.NewAPIRequest(http.MethodPost, "/api/ipns/keys/1/republish", nil)

--- a/internal/db/ipfs_ipns_key.go
+++ b/internal/db/ipfs_ipns_key.go
@@ -15,13 +15,15 @@ var _ schema.Tabler = (*IPFSIPNSKey)(nil)
 
 // IPFSIPNSKey represents an IPNS key stored in the database
 type IPFSIPNSKey struct {
-	ID                  uint           `gorm:"primaryKey;autoIncrement"`
-	UserID              uint           `gorm:"index:idx_ipfs_ipns_keys_user_id;not null"`
-	Name                string         `gorm:"type:varchar(255);not null"` // User-friendly name
-	PeerIDMultihash     mh.Multihash   `gorm:"type:varbinary(64);uniqueIndex:user_peer;not null"`
-	PrivateKeyEncrypted []byte         `gorm:"type:blob;not null"` // Encrypted with portal seed
-	CreatedAt           time.Time      `gorm:"autoCreateTime"`
-	DeletedAt           gorm.DeletedAt `gorm:"index:idx_ipfs_ipns_keys_deleted_at"`
+	ID                   uint           `gorm:"primaryKey;autoIncrement"`
+	UserID               uint           `gorm:"index:idx_ipfs_ipns_keys_user_id;not null"`
+	Name                 string         `gorm:"type:varchar(255);not null"`
+	PeerIDMultihash      mh.Multihash   `gorm:"type:varbinary(64);uniqueIndex:user_peer;not null"`
+	PrivateKeyEncrypted  []byte         `gorm:"type:blob;not null"`
+	LastPublishedCID     string         `gorm:"column:last_published_cid;type:varchar(255)"`
+	LastPublishedAt      *time.Time     `gorm:"column:last_published_at"`
+	CreatedAt            time.Time      `gorm:"autoCreateTime"`
+	DeletedAt            gorm.DeletedAt `gorm:"index:idx_ipfs_ipns_keys_deleted_at"`
 }
 
 func (I IPFSIPNSKey) TableName() string {

--- a/internal/db/migrations/mysql/20260207010815_add_ipns_keys_and_websites_tables.sql
+++ b/internal/db/migrations/mysql/20260207010815_add_ipns_keys_and_websites_tables.sql
@@ -6,6 +6,8 @@ CREATE TABLE IF NOT EXISTS ipfs_ipns_keys (
     name VARCHAR(255) NOT NULL,
     peer_id_multihash VARBINARY(64) NOT NULL,
     private_key_encrypted BLOB NOT NULL,
+    last_published_cid VARCHAR(255) DEFAULT NULL,
+    last_published_at TIMESTAMP NULL DEFAULT NULL,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     deleted_at TIMESTAMP NULL DEFAULT NULL,
 

--- a/internal/db/migrations/sqlite/20260207010815_add_ipns_keys_and_websites_tables.sql
+++ b/internal/db/migrations/sqlite/20260207010815_add_ipns_keys_and_websites_tables.sql
@@ -6,6 +6,8 @@ CREATE TABLE IF NOT EXISTS ipfs_ipns_keys (
     name TEXT NOT NULL,
     peer_id_multihash BLOB NOT NULL,
     private_key_encrypted BLOB NOT NULL,
+    last_published_cid TEXT DEFAULT NULL,
+    last_published_at TIMESTAMP NULL DEFAULT NULL,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     deleted_at TIMESTAMP NULL DEFAULT NULL
 );

--- a/internal/service/ipns_key/ipns_key.go
+++ b/internal/service/ipns_key/ipns_key.go
@@ -892,6 +892,22 @@ func (s *IPNSKeyServiceDefault) PublishWithKey(ctx context.Context, privKey ic.P
 		zap.String("cid", cidStr),
 	)
 
+	now := time.Now()
+	err = db.RetryableComponentTransaction(s, ctx, func(tx *gorm.DB) *gorm.DB {
+		return tx.Model(&pluginDb.IPFSIPNSKey{}).
+			Where("peer_id_multihash = ?", mh.Multihash(peerID)).
+			Updates(map[string]any{
+				"last_published_cid": cidStr,
+				"last_published_at":  now,
+			})
+	})
+	if err != nil {
+		s.Logger().Warn("Failed to update last published CID in database",
+			zap.Error(err),
+			zap.String("peer_id", peerID.String()),
+		)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
When GetPublished returns a nil record (key exists but never published or record expired from datastore), calling record.Value() panics. Track the last published CID in the ipfs\_ipns\_keys table so republish can recover even when the libp2p datastore has no record.

Fallback chain: local record -> DB LastPublishedCID -> DHT query -> error

- `develop` <!-- branch-stack -->
  - **fix: prevent nil pointer panic in IPNS republish by tracking last published CID** :point\_left:

---

<!-- kody-pr-summary:start -->
Fix nil pointer panic in IPNS republish by tracking last published CID

This PR prevents a nil pointer panic that occurs during IPNS republish operations when the local IPNS record is nil. It implements a fallback chain for resolving the CID to republish:

1. **Local record** – If the local IPNS record exists, extract the CID from it as before
2. **Database fallback** – If the local record is nil, use the `LastPublishedCID` stored in the database
3. **DHT fallback** – If neither the local record nor the database has a CID, query the DHT for the published record
4. **Error** – If all three sources are nil, return an appropriate error instead of panicking

To support the database fallback, two new columns (`last_published_cid`, `last_published_at`) are added to the `ipfs_ipns_keys` table. These are updated in `PublishWithKey` after each successful publish operation. The same nil-check protection is also applied to the `publishIPNS` and admin `republishIPNS` endpoints.
<!-- kody-pr-summary:end -->