### PR TITLE
fix: update LastPublishedCID in DB using fetched record to satisfy BeforeSave

### DIFF
--- a/internal/service/dns/dns_service_zone.go
+++ b/internal/service/dns/dns_service_zone.go
@@ -282,8 +282,7 @@ func (s *DNSServiceDefault) ValidateNameservers(ctx context.Context, zoneID uint
 	dnsNameservers, err := s.dnsLookup.LookupNS(zone.Domain)
 	if err != nil {
 		// Update check timestamp even on failure to prevent retry loops
-		now := time.Now()
-		zone.LastNameserverCheckAt = &now
+		zone.LastNameserverCheckAt = new(time.Now())
 		_ = db.RetryableComponentTransaction(s, ctx, func(tx *gorm.DB) *gorm.DB {
 			return tx.Save(zone)
 		})
@@ -309,16 +308,14 @@ func (s *DNSServiceDefault) ValidateNameservers(ctx context.Context, zoneID uint
 	}
 
 	if !valid {
-		now := time.Now()
-		zone.LastNameserverCheckAt = &now
+		zone.LastNameserverCheckAt = new(time.Now())
 		_ = db.RetryableComponentTransaction(s, ctx, func(tx *gorm.DB) *gorm.DB {
 			return tx.Save(zone)
 		})
 		return false, fmt.Errorf("no approved nameservers found in DNS for domain %s", zone.Domain)
 	}
 
-	now := time.Now()
-	zone.NameserversVerifiedAt = &now
+	zone.NameserversVerifiedAt = new(time.Now())
 
 	err = db.RetryableComponentTransaction(s, ctx, func(tx *gorm.DB) *gorm.DB {
 		zone.Status = string(pluginDb.DNSZoneStatusActive)

--- a/internal/service/ipns_key/ipns_key.go
+++ b/internal/service/ipns_key/ipns_key.go
@@ -892,14 +892,15 @@ func (s *IPNSKeyServiceDefault) PublishWithKey(ctx context.Context, privKey ic.P
 		zap.String("cid", cidStr),
 	)
 
-	now := time.Now()
+	now := new(time.Now())
 	err = db.RetryableComponentTransaction(s, ctx, func(tx *gorm.DB) *gorm.DB {
-		return tx.Model(&pluginDb.IPFSIPNSKey{}).
-			Where("peer_id_multihash = ?", mh.Multihash(peerID)).
-			Updates(map[string]any{
-				"last_published_cid": cidStr,
-				"last_published_at":  now,
-			})
+		var key pluginDb.IPFSIPNSKey
+		if findResult := tx.Where("peer_id_multihash = ?", mh.Multihash(peerID)).First(&key); findResult.Error != nil {
+			return findResult
+		}
+		key.LastPublishedCID = cidStr
+		key.LastPublishedAt = now
+		return tx.Model(&key).Select("last_published_cid", "last_published_at").Updates(&key)
 	})
 	if err != nil {
 		s.Logger().Warn("Failed to update last published CID in database",

--- a/internal/service/ipns_key/ipns_key_test.go
+++ b/internal/service/ipns_key/ipns_key_test.go
@@ -9,17 +9,20 @@ import (
 	"github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	pluginCore "go.lumeweb.com/portal-plugin-ipfs/core"
 	"go.lumeweb.com/portal-plugin-ipfs/internal"
 	pluginConfig "go.lumeweb.com/portal-plugin-ipfs/internal/config"
-	"go.lumeweb.com/portal-plugin-ipfs/internal/db/migrations"
 	pluginDb "go.lumeweb.com/portal-plugin-ipfs/internal/db"
+	"go.lumeweb.com/portal-plugin-ipfs/internal/db/migrations"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/testing/mocks"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/testing/util"
 	"go.lumeweb.com/portal/core"
 	coreTesting "go.lumeweb.com/portal/core/testing"
+	portalDb "go.lumeweb.com/portal/db"
 	"go.uber.org/zap/zaptest"
+	"gorm.io/gorm"
 )
 
 var TestOptions = coreTesting.CombineOptions(
@@ -727,5 +730,77 @@ func TestSafeRepublisherKeystore_ListFiltersNilKeys(t *testing.T) {
 	assert.Len(t, names, 1, "Should only list the valid key")
 	assert.Contains(t, names, "valid-key", "Should contain valid key")
 	assert.NotContains(t, names, "corrupted-key", "Should not contain corrupted key")
+}
+
+func TestIPNSKeyService_PublishWithKey_UpdatesLastPublishedCID(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		keyService := core.GetService[pluginCore.IPNSKeyService](ctx, pluginCore.IPNS_KEY_SERVICE)
+		require.NotNil(tb, keyService)
+
+		userID := uint(1)
+
+		createdKey, err := keyService.CreateKey(context.Background(), userID, "test-publish-key", KeyType_Ed25519)
+		require.NoError(tb, err)
+		require.Empty(tb, createdKey.LastPublishedCID)
+
+		testCID := "bafybeieffnocaq7t4w4daagvydl32igft5oziyyaebqr6vx6rb3fwh2ab4"
+
+		privKey, _, err := keyService.GetPrivateKeyByPeerID(context.Background(), createdKey.PeerID().String())
+		require.NoError(tb, err)
+
+		proto := core.GetProtocol(internal.ProtocolName)
+		ipnsAccess := proto.(pluginCore.IPNSBoxoServices)
+		mockPublisher := ipnsAccess.GetIPNSNode().GetPublisher().(*mocks.MockIPNSPublisher)
+		mockPublisher.EXPECT().Publish(mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
+
+		err = keyService.PublishWithKey(context.Background(), privKey, testCID, 0)
+		require.NoError(tb, err)
+
+		// Re-read the key directly from DB to verify the update
+		var dbKey pluginDb.IPFSIPNSKey
+		dbErr := portalDb.RetryableTransaction(context.Background(), ctx.DB(), func(tx *gorm.DB) *gorm.DB {
+			return tx.Where("id = ?", createdKey.ID).First(&dbKey)
+		})
+		require.NoError(tb, dbErr, "Failed to read key from DB")
+		assert.Equal(tb, testCID, dbKey.LastPublishedCID, "LastPublishedCID should be updated in DB")
+		assert.NotNil(tb, dbKey.LastPublishedAt, "LastPublishedAt should be set in DB")
+
+		// Also verify via the service method
+		updatedKey, err := keyService.GetKeyByID(context.Background(), userID, createdKey.ID)
+		require.NoError(tb, err)
+		assert.Equal(tb, testCID, updatedKey.LastPublishedCID)
+	}, TestOptions)
+}
+
+func TestIPNSKeyService_PublishCID_UpdatesLastPublishedCID(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		keyService := core.GetService[pluginCore.IPNSKeyService](ctx, pluginCore.IPNS_KEY_SERVICE)
+		require.NotNil(tb, keyService)
+
+		userID := uint(1)
+
+		createdKey, err := keyService.CreateKey(context.Background(), userID, "test-publishcid-key", KeyType_Ed25519)
+		require.NoError(tb, err)
+		require.Empty(tb, createdKey.LastPublishedCID)
+
+		testCID := "bafybeieffnocaq7t4w4daagvydl32igft5oziyyaebqr6vx6rb3fwh2ab4"
+
+		proto := core.GetProtocol(internal.ProtocolName)
+		ipnsAccess := proto.(pluginCore.IPNSBoxoServices)
+		mockPublisher := ipnsAccess.GetIPNSNode().GetPublisher().(*mocks.MockIPNSPublisher)
+		mockPublisher.EXPECT().Publish(mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
+
+		err = keyService.PublishCID(context.Background(), createdKey.PeerID().String(), testCID, 0)
+		require.NoError(tb, err)
+
+		// Re-read the key directly from DB to verify the update
+		var dbKey pluginDb.IPFSIPNSKey
+		dbErr := portalDb.RetryableTransaction(context.Background(), ctx.DB(), func(tx *gorm.DB) *gorm.DB {
+			return tx.Where("id = ?", createdKey.ID).First(&dbKey)
+		})
+		require.NoError(tb, dbErr, "Failed to read key from DB")
+		assert.Equal(tb, testCID, dbKey.LastPublishedCID, "LastPublishedCID should be updated in DB")
+		assert.NotNil(tb, dbKey.LastPublishedAt, "LastPublishedAt should be set in DB")
+	}, TestOptions)
 }
 

--- a/internal/service/website/janitor.go
+++ b/internal/service/website/janitor.go
@@ -203,8 +203,7 @@ func (j *WebsiteJanitorJob) validateWebsite(ctx context.Context, website *plugin
 	}
 
 	// Update last_checked_at timestamp
-	now := time.Now()
-	website.LastCheckedAt = &now
+	website.LastCheckedAt = new(time.Now())
 
 	// Save changes
 	if err := j.db.WithContext(ctx).Save(website).Error; err != nil {
@@ -260,8 +259,7 @@ func (j *WebsiteJanitorJob) validateIPNSTarget(ctx context.Context, website *plu
 			zap.String("peer_id", website.TargetHash()),
 		)
 		website.Status = string(pluginDb.WebsiteStatusBroken)
-		now := time.Now()
-		website.LastCheckedAt = &now
+		website.LastCheckedAt = new(time.Now())
 		return nil
 	}
 
@@ -274,8 +272,7 @@ func (j *WebsiteJanitorJob) validateIPNSTarget(ctx context.Context, website *plu
 			zap.Uint("key_user_id", userID),
 		)
 		website.Status = string(pluginDb.WebsiteStatusBroken)
-		now := time.Now()
-		website.LastCheckedAt = &now
+		website.LastCheckedAt = new(time.Now())
 		return nil
 	}
 
@@ -291,8 +288,7 @@ func (j *WebsiteJanitorJob) validateIPNSTarget(ctx context.Context, website *plu
 			zap.String("peer_id", website.TargetHash()),
 		)
 		website.Status = string(pluginDb.WebsiteStatusBroken)
-		now := time.Now()
-		website.LastCheckedAt = &now
+		website.LastCheckedAt = new(time.Now())
 		return nil
 	}
 
@@ -304,8 +300,7 @@ func (j *WebsiteJanitorJob) validateIPNSTarget(ctx context.Context, website *plu
 			zap.String("peer_id", website.TargetHash()),
 		)
 		website.Status = string(pluginDb.WebsiteStatusBroken)
-		now := time.Now()
-		website.LastCheckedAt = &now
+		website.LastCheckedAt = new(time.Now())
 		return nil
 	}
 
@@ -319,8 +314,7 @@ func (j *WebsiteJanitorJob) validateIPNSTarget(ctx context.Context, website *plu
 			zap.String("peer_id", website.TargetHash()),
 		)
 		website.Status = string(pluginDb.WebsiteStatusBroken)
-		now := time.Now()
-		website.LastCheckedAt = &now
+		website.LastCheckedAt = new(time.Now())
 		return nil
 	}
 
@@ -335,8 +329,7 @@ func (j *WebsiteJanitorJob) validateIPNSTarget(ctx context.Context, website *plu
 			zap.String("cid", cidStr),
 		)
 		website.Status = string(pluginDb.WebsiteStatusBroken)
-		now := time.Now()
-		website.LastCheckedAt = &now
+		website.LastCheckedAt = new(time.Now())
 		return nil
 	}
 
@@ -347,8 +340,7 @@ func (j *WebsiteJanitorJob) validateIPNSTarget(ctx context.Context, website *plu
 			zap.String("cid", cidStr),
 		)
 		website.Status = string(pluginDb.WebsiteStatusBroken)
-		now := time.Now()
-		website.LastCheckedAt = &now
+		website.LastCheckedAt = new(time.Now())
 		return nil
 	}
 
@@ -362,8 +354,7 @@ func (j *WebsiteJanitorJob) validateIPNSTarget(ctx context.Context, website *plu
 			zap.String("peer_id", website.TargetHash()),
 		)
 		website.Status = string(pluginDb.WebsiteStatusBroken)
-		now := time.Now()
-		website.LastCheckedAt = &now
+		website.LastCheckedAt = new(time.Now())
 		return nil
 	}
 
@@ -375,15 +366,13 @@ func (j *WebsiteJanitorJob) validateIPNSTarget(ctx context.Context, website *plu
 			zap.Time("validity", validity),
 		)
 		website.Status = string(pluginDb.WebsiteStatusBroken)
-		now := time.Now()
-		website.LastCheckedAt = &now
+		website.LastCheckedAt = new(time.Now())
 		return nil
 	}
 
 	// All validations passed
 	website.Status = string(pluginDb.WebsiteStatusActive)
-	now := time.Now()
-	website.LastCheckedAt = &now
+	website.LastCheckedAt = new(time.Now())
 
 	j.logger.Debug("IPNS target validated successfully",
 		zap.Uint("website_id", website.ID),
@@ -426,7 +415,6 @@ func (j *WebsiteJanitorJob) validateDNSZones(ctx context.Context) error {
 		validated, err := j.dnsService.ValidateNameservers(ctx, zone.ID)
 
 		// Always update the timestamp to avoid re-checking immediately
-		now := time.Now()
 
 		if err != nil {
 			j.logger.Warn("Failed to validate DNS zone nameservers",
@@ -434,14 +422,14 @@ func (j *WebsiteJanitorJob) validateDNSZones(ctx context.Context) error {
 				zap.Uint("zone_id", zone.ID),
 				zap.String("domain", zone.Domain))
 			// Still save the timestamp to prevent a fast retry loop
-			zone.LastNameserverCheckAt = &now
+			zone.LastNameserverCheckAt = new(time.Now())
 			if err := j.db.WithContext(ctx).Model(&zone).Select("LastNameserverCheckAt").Updates(&zone).Error; err != nil {
 				j.logger.Error("Failed to update zone timestamp", zap.Error(err), zap.Uint("zone_id", zone.ID))
 			}
 			continue
 		}
 
-		zone.LastNameserverCheckAt = &now
+		zone.LastNameserverCheckAt = new(time.Now())
 		updateCols := []string{"LastNameserverCheckAt"}
 
 		if validated {


### PR DESCRIPTION
PublishWithKey was silently failing to write LastPublishedCID because
GORM's BeforeSave hook rejected the empty-model update (PeerIDMultihash
not set). Fix by fetching the key record first, then updating the
populated struct with Select to scope the columns.

Adds DB integration tests for PublishWithKey and PublishCID to verify
LastPublishedCID is persisted correctly.

Also replaces all now := time.Now() + \&now patterns with new(time.Now())
(Go 1.26) across dns\_service\_zone, janitor, and ipns\_key services.

- `develop` <!-- branch-stack -->
  - **fix: update LastPublishedCID in DB using fetched record to satisfy BeforeSave** :point\_left:

---

<!-- kody-pr-summary:start -->
## Fix: Update LastPublishedCID in DB by fetching record first to bypass BeforeSave hook

### Problem
When publishing an IPNS key, the `LastPublishedCID` field was not being properly persisted to the database. The previous implementation used map-based GORM updates (`Updates(map[string]any{...})`), which bypassed the `BeforeSave` hook, potentially causing the field update to be lost or not applied correctly.

### Changes

**Core Fix (`internal/service/ipns_key/ipns_key.go`)**
- Changed the `PublishWithKey` method to first fetch the `IPFSIPNSKey` record from the database, then update the struct fields (`LastPublishedCID`, `LastPublishedAt`) directly on the fetched model, and persist using `Select().Updates(&struct)` instead of map-based updates. This ensures the `BeforeSave` hook runs properly and the CID is correctly saved.

**Refactoring: Simplified `time.Time` pointer creation**
- Across `dns_service_zone.go`, `janitor.go`, and `ipns_key.go`, replaced the two-line pattern of creating a `time.Now()` variable and taking its address (`now := time.Now(); field = &now`) with the concise `new(time.Now())` helper call.

**New Tests (`internal/service/ipns_key/ipns_key_test.go`)**
- Added `TestIPNSKeyService_PublishWithKey_UpdatesLastPublishedCID` — verifies that `PublishWithKey` correctly persists `LastPublishedCID` and `LastPublishedAt` to the database.
- Added `TestIPNSKeyService_PublishCID_UpdatesLastPublishedCID` — verifies the same for the `PublishCID` method.
<!-- kody-pr-summary:end -->