### PR TITLE
fix: pass configured announce addresses through AnnouncementAddresses and ConnectionAddresses

### DIFF
--- a/internal/api/api_blocks.go
+++ b/internal/api/api_blocks.go
@@ -62,7 +62,7 @@ func (a *API) handleGetBlockMetaBatch(c echo.Context) error {
 func (a *API) handleGetInfo(c echo.Context) error {
 	ctx := httputil.Context(c)
 
-	addrs, err := ipfs.AnnouncementAddresses()
+	addrs, err := ipfs.AnnouncementAddresses(a.ipfs.GetNode().GetAnnounceAddrs())
 	if err != nil {
 		a.Logger().Error("Failed to get announcement addresses", zap.Error(err))
 		apiErr := NewError(ErrKeyMetadataFetchFailed, err)

--- a/internal/config/protocol.go
+++ b/internal/config/protocol.go
@@ -16,6 +16,7 @@ var _ config.Defaults = (*ProtocolConfig)(nil)
 
 type ProtocolConfig struct {
 	ListenAddresses         []string        `config:"listen_addresses"`
+	AnnounceAddresses       []string        `config:"announce_addresses"`
 	Peers                   []IPFSPeer      `config:"peers"`
 	BootstrapPeers          []IPFSPeer      `config:"bootstrap_peers"`
 	Provider                IPFSProvider    `config:"provider"`

--- a/internal/protocol/ipfs/node.go
+++ b/internal/protocol/ipfs/node.go
@@ -86,6 +86,7 @@ type IPFSNode interface {
 	GetKeystore() keystore.Keystore
 	GetDatastore() datastore.Datastore
 	GetPrivateKey() crypto.PrivKey
+	GetAnnounceAddrs() []string
 }
 
 // NopExchange wraps an exchange.Interface and disables NotifyNewBlocks.
@@ -180,6 +181,7 @@ type Node struct {
 	datastore        datastore.Datastore
 	keystore         keystore.Keystore
 	publisher        *namesys.IPNSPublisher
+	announceAddrs    []string
 }
 
 // Close closes the node
@@ -255,7 +257,11 @@ func (n *Node) PeerID() peer.ID {
 }
 
 func (n *Node) ConnectionAddresses() ([]multiaddr.Multiaddr, error) {
-	return ConnectionAddresses(n)
+	return ConnectionAddresses(n, n.announceAddrs)
+}
+
+func (n *Node) GetAnnounceAddrs() []string {
+	return n.announceAddrs
 }
 
 // DelegateAddresses returns the multiaddr addresses that can be used as delegates
@@ -363,9 +369,15 @@ func NewNode(ctx core.Context, cfg *config.ProtocolConfig, rs pluginCore.Reprovi
 		libp2p.DefaultTransports,
 		libp2p.PrometheusRegisterer(prometheus.WrapRegistererWithPrefix("libp2p_", core.PluginMetricsRegistry(internal.ProtocolName))),
 		libp2p.AddrsFactory(func(addrs []multiaddr.Multiaddr) []multiaddr.Multiaddr {
-			announceAddresses, err := AnnouncementAddresses()
+			announceAddresses, err := AnnouncementAddresses(cfg.AnnounceAddresses)
 			if err != nil {
 				ctx.Logger().Error("failed to get announcement addresses", zap.Error(err))
+				return lo.Filter(addrs, func(addr multiaddr.Multiaddr, _ int) bool {
+					return addr != nil
+				})
+			}
+
+			if len(announceAddresses) == 0 {
 				return lo.Filter(addrs, func(addr multiaddr.Multiaddr, _ int) bool {
 					return addr != nil
 				})
@@ -392,8 +404,9 @@ func NewNode(ctx core.Context, cfg *config.ProtocolConfig, rs pluginCore.Reprovi
 
 	// Create node with minimal fields
 	ipfsNode := &Node{
-		host: node,
-		log:  ctx.Logger(),
+		host:          node,
+		log:           ctx.Logger(),
+		announceAddrs: cfg.AnnounceAddresses,
 	}
 
 	// Build common DHT options using factory's GetBootstrapPeers()
@@ -532,7 +545,17 @@ func (n *Node) TriggerReprovider() {
 	n.reprovider.Trigger()
 }
 
-func AnnouncementAddresses() ([]multiaddr.Multiaddr, error) {
+func AnnouncementAddresses(announceAddrs []string) ([]multiaddr.Multiaddr, error) {
+	if len(announceAddrs) > 0 {
+		return lo.MapErr(announceAddrs, func(addrStr string, _ int) (multiaddr.Multiaddr, error) {
+			ma, err := multiaddr.NewMultiaddr(addrStr)
+			if err != nil {
+				return nil, fmt.Errorf("invalid announce address %q: %w", addrStr, err)
+			}
+			return ma, nil
+		})
+	}
+
 	cacheMutex.RLock()
 	if len(cachedAnnouncementAddresses) > 0 {
 		cached := cachedAnnouncementAddresses
@@ -574,8 +597,8 @@ func AnnouncementAddresses() ([]multiaddr.Multiaddr, error) {
 	return announcementAddrs, nil
 }
 
-func ConnectionAddresses(node IPFSNode) ([]multiaddr.Multiaddr, error) {
-	annAddrs, err := AnnouncementAddresses()
+func ConnectionAddresses(node IPFSNode, announceAddrs []string) ([]multiaddr.Multiaddr, error) {
+	annAddrs, err := AnnouncementAddresses(announceAddrs)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/testing/mocks/MockIPFSNode.go
+++ b/internal/testing/mocks/MockIPFSNode.go
@@ -344,6 +344,52 @@ func (_c *MockIPFSNode_DelegateAddresses_Call) RunAndReturn(run func() ([]multia
 	return _c
 }
 
+// GetAnnounceAddrs provides a mock function for the type MockIPFSNode
+func (_mock *MockIPFSNode) GetAnnounceAddrs() []string {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetAnnounceAddrs")
+	}
+
+	var r0 []string
+	if returnFunc, ok := ret.Get(0).(func() []string); ok {
+		r0 = returnFunc()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
+	}
+	return r0
+}
+
+// MockIPFSNode_GetAnnounceAddrs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetAnnounceAddrs'
+type MockIPFSNode_GetAnnounceAddrs_Call struct {
+	*mock.Call
+}
+
+// GetAnnounceAddrs is a helper method to define mock.On call
+func (_e *MockIPFSNode_Expecter) GetAnnounceAddrs() *MockIPFSNode_GetAnnounceAddrs_Call {
+	return &MockIPFSNode_GetAnnounceAddrs_Call{Call: _e.mock.On("GetAnnounceAddrs")}
+}
+
+func (_c *MockIPFSNode_GetAnnounceAddrs_Call) Run(run func()) *MockIPFSNode_GetAnnounceAddrs_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockIPFSNode_GetAnnounceAddrs_Call) Return(strings []string) *MockIPFSNode_GetAnnounceAddrs_Call {
+	_c.Call.Return(strings)
+	return _c
+}
+
+func (_c *MockIPFSNode_GetAnnounceAddrs_Call) RunAndReturn(run func() []string) *MockIPFSNode_GetAnnounceAddrs_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetBlock provides a mock function for the type MockIPFSNode
 func (_mock *MockIPFSNode) GetBlock(ctx context.Context, c cid.Cid) (format.Node, error) {
 	ret := _mock.Called(ctx, c)

--- a/internal/testing/util/util.go
+++ b/internal/testing/util/util.go
@@ -142,7 +142,7 @@ func GetProtocolMock() coreTesting.TestContextBuilderOption {
 		ipfsNode := mocks.NewMockIPFSNode(ctx.T())
 		mockPeer := config.BootstrapPeers[0].ToAddrInfo()
 		ipfsNode.EXPECT().PeerID().Return(mockPeer.ID).Maybe()
-		ipfsNode.EXPECT().DelegateAddresses().Return(ipfs.ConnectionAddresses(ipfsNode)).Maybe()
+		ipfsNode.EXPECT().DelegateAddresses().Return(ipfs.ConnectionAddresses(ipfsNode, nil)).Maybe()
 		protoMock.EXPECT().GetNode().Return(ipfsNode).Maybe()
 		protoMock.EXPECT().GetIPNSNode().Return(ipfsNode).Maybe()
 		ipfsNode.EXPECT().GetKeystore().Return(mockKeystore).Maybe()
@@ -154,8 +154,10 @@ func GetProtocolMock() coreTesting.TestContextBuilderOption {
 		require.NoError(ctx.T(), err, "Failed to generate test private key")
 		ipfsNode.EXPECT().GetPrivateKey().Return(privKey).Maybe()
 
+		ipfsNode.EXPECT().GetAnnounceAddrs().Return(nil).Maybe()
+
 		ipfsNode.EXPECT().ConnectionAddresses().RunAndReturn(func() ([]multiaddr.Multiaddr, error) {
-			return ipfs.ConnectionAddresses(ipfsNode)
+			return ipfs.ConnectionAddresses(ipfsNode, nil)
 		}).Maybe()
 
 		// Mock AddBlock to return nil (success)


### PR DESCRIPTION
- `develop` <!-- branch-stack -->
  - **fix: pass configured announce addresses through AnnouncementAddresses and ConnectionAddresses** :point\_left:

***

<!-- kody-pr-summary:start -->

Pass configured announce addresses through AnnouncementAddresses and ConnectionAddresses

This change ensures that user-configured announce addresses are properly passed through and used by the `AnnouncementAddresses()` and `ConnectionAddresses()` functions, rather than relying solely on auto-detected addresses.

Key changes:

- Added `AnnounceAddresses` field to `ProtocolConfig` (via `announce_addresses` config key)
- `AnnouncementAddresses()` and `ConnectionAddresses()` now accept an `announceAddrs` parameter; when configured addresses are provided, they are parsed and returned directly instead of auto-detecting
- Added `GetAnnounceAddrs()` method to the `IPFSNode` interface and `Node` implementation to expose the configured addresses
- In the libp2p `AddrsFactory`, if no announce addresses are resolved, the default libp2p addresses are used as a fallback
- Updated the API info handler to pass configured announce addresses through to `AnnouncementAddresses()`
- Updated test mocks and utilities to accommodate the new interface method and function signatures

<!-- kody-pr-summary:end -->
