### PR TITLE
fix: auto-convert bare host:port announce addresses to multiaddr format

### DIFF
--- a/internal/protocol/ipfs/node.go
+++ b/internal/protocol/ipfs/node.go
@@ -5,6 +5,8 @@ import (
 	"crypto/ed25519"
 	"crypto/sha256"
 	"fmt"
+	"net"
+	"strconv"
 	"io"
 	"sync"
 	"time"
@@ -545,14 +547,32 @@ func (n *Node) TriggerReprovider() {
 	n.reprovider.Trigger()
 }
 
+func parseAnnounceAddr(addrStr string) (multiaddr.Multiaddr, error) {
+	if ma, err := multiaddr.NewMultiaddr(addrStr); err == nil {
+		return ma, nil
+	}
+	host, portStr, err := net.SplitHostPort(addrStr)
+	if err != nil {
+		return nil, fmt.Errorf("invalid announce address %q: %w", addrStr, err)
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		return nil, fmt.Errorf("invalid port in announce address %q: %w", addrStr, err)
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return nil, fmt.Errorf("invalid IP in announce address %q", addrStr)
+	}
+	if ip.To4() != nil {
+		return multiaddr.NewMultiaddr(fmt.Sprintf("/ip4/%s/tcp/%d", host, port))
+	}
+	return multiaddr.NewMultiaddr(fmt.Sprintf("/ip6/%s/tcp/%d", host, port))
+}
+
 func AnnouncementAddresses(announceAddrs []string) ([]multiaddr.Multiaddr, error) {
 	if len(announceAddrs) > 0 {
 		return lo.MapErr(announceAddrs, func(addrStr string, _ int) (multiaddr.Multiaddr, error) {
-			ma, err := multiaddr.NewMultiaddr(addrStr)
-			if err != nil {
-				return nil, fmt.Errorf("invalid announce address %q: %w", addrStr, err)
-			}
-			return ma, nil
+			return parseAnnounceAddr(addrStr)
 		})
 	}
 


### PR DESCRIPTION
- `develop` <!-- branch-stack -->
  - **fix: auto-convert bare host:port announce addresses to multiaddr format** :point\_left:

---

<!-- kody-pr-summary:start -->
This pull request adds automatic conversion of bare `host:port` announce addresses to the proper multiaddr format. Previously, announce addresses had to be specified in multiaddr format (e.g., `/ip4/1.2.3.4/tcp/4001`), and providing a simple `host:port` string would result in an error. The new `parseAnnounceAddr` function first attempts to parse the address as a multiaddr (preserving backward compatibility), and if that fails, it attempts to parse it as a `host:port` string, automatically detecting whether the host is IPv4 or IPv6 and constructing the appropriate multiaddr format (`/ip4/<host>/tcp/<port>` or `/ip6/<host>/tcp/<port>`).
<!-- kody-pr-summary:end -->