### PR TITLE
feat: add multi-transport support (WSS, QUIC, WebTransport)

### DIFF
--- a/internal/api/api_blocks.go
+++ b/internal/api/api_blocks.go
@@ -62,7 +62,7 @@ func (a *API) handleGetBlockMetaBatch(c echo.Context) error {
 func (a *API) handleGetInfo(c echo.Context) error {
 	ctx := httputil.Context(c)
 
-	addrs, err := ipfs.AnnouncementAddresses(a.ipfs.GetNode().GetAnnounceAddrs())
+	addrs, err := ipfs.AnnouncementAddresses(a.ipfs.GetNode().GetAnnounceAddrs(), a.ipfs.GetNode().GetAnnounceDomain())
 	if err != nil {
 		a.Logger().Error("Failed to get announcement addresses", zap.Error(err))
 		apiErr := NewError(ErrKeyMetadataFetchFailed, err)

--- a/internal/config/protocol.go
+++ b/internal/config/protocol.go
@@ -28,7 +28,16 @@ type ProtocolConfig struct {
 
 func (c ProtocolConfig) Defaults() map[string]any {
 	return map[string]any{
-		"ListenAddresses": []string{"/ip4/0.0.0.0/tcp/4001"},
+		"ListenAddresses": []string{
+			"/ip4/0.0.0.0/tcp/4001",
+			"/ip4/0.0.0.0/tcp/4002/ws",
+			"/ip4/0.0.0.0/udp/443/quic-v1",
+			"/ip4/0.0.0.0/udp/443/quic-v1/webtransport",
+			"/ip6/::/tcp/4001",
+			"/ip6/::/tcp/4002/ws",
+			"/ip6/::/udp/443/quic-v1",
+			"/ip6/::/udp/443/quic-v1/webtransport",
+		},
 		"BootstrapPeers":  BootstrapPeers,
 		"DHTMode":         "fullrt",
 	}

--- a/internal/protocol/ipfs/node.go
+++ b/internal/protocol/ipfs/node.go
@@ -396,7 +396,11 @@ func NewNode(ctx core.Context, cfg *config.ProtocolConfig, rs pluginCore.Reprovi
 		libp2p.Transport(webtransport.New),
 		libp2p.PrometheusRegisterer(prometheus.WrapRegistererWithPrefix("libp2p_", core.PluginMetricsRegistry(internal.ProtocolName))),
 		libp2p.AddrsFactory(func(addrs []multiaddr.Multiaddr) []multiaddr.Multiaddr {
-			domain := core.GetService[core.HTTPService](ctx, core.HTTP_SERVICE).APISubdomain(internal.ProtocolName, false)
+			httpSvc := core.GetService[core.HTTPService](ctx, core.HTTP_SERVICE)
+			var domain string
+			if httpSvc != nil {
+				domain = httpSvc.APISubdomain(internal.ProtocolName, false)
+			}
 			announceAddresses, err := AnnouncementAddresses(cfg.AnnounceAddresses, domain)
 			if err != nil {
 				ctx.Logger().Error("failed to get announcement addresses", zap.Error(err))
@@ -633,8 +637,10 @@ func resolvePublicAddresses() ([]multiaddr.Multiaddr, error) {
 	unspecAddrs := []multiaddr.Multiaddr{
 		multiaddr.StringCast("/ip4/0.0.0.0/tcp/4001"),
 		multiaddr.StringCast("/ip6/::/tcp/4001"),
-		multiaddr.StringCast("/ip4/0.0.0.0/udp/4001/quic-v1"),
-		multiaddr.StringCast("/ip6/::/udp/4001/quic-v1"),
+		multiaddr.StringCast("/ip4/0.0.0.0/udp/443/quic-v1"),
+		multiaddr.StringCast("/ip6/::/udp/443/quic-v1"),
+		multiaddr.StringCast("/ip4/0.0.0.0/udp/443/quic-v1/webtransport"),
+		multiaddr.StringCast("/ip6/::/udp/443/quic-v1/webtransport"),
 		multiaddr.StringCast("/ip4/0.0.0.0/tcp/4002/ws"),
 		multiaddr.StringCast("/ip6/::/tcp/4002/ws"),
 	}

--- a/internal/protocol/ipfs/node.go
+++ b/internal/protocol/ipfs/node.go
@@ -45,6 +45,10 @@ import (
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/peerstore"
+	quic "github.com/libp2p/go-libp2p/p2p/transport/quic"
+	"github.com/libp2p/go-libp2p/p2p/transport/tcp"
+	ws "github.com/libp2p/go-libp2p/p2p/transport/websocket"
+	webtransport "github.com/libp2p/go-libp2p/p2p/transport/webtransport"
 	rcmgr "github.com/libp2p/go-libp2p/p2p/host/resource-manager"
 	"github.com/libp2p/go-libp2p/p2p/net/connmgr"
 )
@@ -89,6 +93,7 @@ type IPFSNode interface {
 	GetDatastore() datastore.Datastore
 	GetPrivateKey() crypto.PrivKey
 	GetAnnounceAddrs() []string
+	GetAnnounceDomain() string
 }
 
 // NopExchange wraps an exchange.Interface and disables NotifyNewBlocks.
@@ -172,6 +177,7 @@ func (f *NodeFactory) CreateNode() (*Node, error) {
 // A Node is a minimal IPFS node
 type Node struct {
 	log              *core.Logger
+	ctx              core.Context
 	host             host.Host
 	routing          DHTRouting
 	companionDHT     *dht.IpfsDHT
@@ -259,11 +265,26 @@ func (n *Node) PeerID() peer.ID {
 }
 
 func (n *Node) ConnectionAddresses() ([]multiaddr.Multiaddr, error) {
-	return ConnectionAddresses(n, n.announceAddrs)
+	return ConnectionAddresses(n, n.announceAddrs, n.announceDomain())
+}
+
+func (n *Node) announceDomain() string {
+	if n.ctx == nil {
+		return ""
+	}
+	httpSvc := core.GetService[core.HTTPService](n.ctx, core.HTTP_SERVICE)
+	if httpSvc == nil {
+		return ""
+	}
+	return httpSvc.APISubdomain(internal.ProtocolName, false)
 }
 
 func (n *Node) GetAnnounceAddrs() []string {
 	return n.announceAddrs
+}
+
+func (n *Node) GetAnnounceDomain() string {
+	return n.announceDomain()
 }
 
 // DelegateAddresses returns the multiaddr addresses that can be used as delegates
@@ -368,10 +389,15 @@ func NewNode(ctx core.Context, cfg *config.ProtocolConfig, rs pluginCore.Reprovi
 		libp2p.EnableRelay(),
 		libp2p.ResourceManager(rm),
 		libp2p.DefaultPeerstore,
-		libp2p.DefaultTransports,
+		libp2p.Transport(tcp.NewTCPTransport),
+		libp2p.Transport(ws.New),
+		libp2p.ShareTCPListener(),
+		libp2p.Transport(quic.NewTransport),
+		libp2p.Transport(webtransport.New),
 		libp2p.PrometheusRegisterer(prometheus.WrapRegistererWithPrefix("libp2p_", core.PluginMetricsRegistry(internal.ProtocolName))),
 		libp2p.AddrsFactory(func(addrs []multiaddr.Multiaddr) []multiaddr.Multiaddr {
-			announceAddresses, err := AnnouncementAddresses(cfg.AnnounceAddresses)
+			domain := core.GetService[core.HTTPService](ctx, core.HTTP_SERVICE).APISubdomain(internal.ProtocolName, false)
+			announceAddresses, err := AnnouncementAddresses(cfg.AnnounceAddresses, domain)
 			if err != nil {
 				ctx.Logger().Error("failed to get announcement addresses", zap.Error(err))
 				return lo.Filter(addrs, func(addr multiaddr.Multiaddr, _ int) bool {
@@ -408,6 +434,7 @@ func NewNode(ctx core.Context, cfg *config.ProtocolConfig, rs pluginCore.Reprovi
 	ipfsNode := &Node{
 		host:          node,
 		log:           ctx.Logger(),
+		ctx:           ctx,
 		announceAddrs: cfg.AnnounceAddresses,
 	}
 
@@ -569,13 +596,25 @@ func parseAnnounceAddr(addrStr string) (multiaddr.Multiaddr, error) {
 	return multiaddr.NewMultiaddr(fmt.Sprintf("/ip6/%s/tcp/%d", host, port))
 }
 
-func AnnouncementAddresses(announceAddrs []string) ([]multiaddr.Multiaddr, error) {
+func AnnouncementAddresses(announceAddrs []string, domain string) ([]multiaddr.Multiaddr, error) {
 	if len(announceAddrs) > 0 {
 		return lo.MapErr(announceAddrs, func(addrStr string, _ int) (multiaddr.Multiaddr, error) {
 			return parseAnnounceAddr(addrStr)
 		})
 	}
 
+	if domain != "" {
+		return []multiaddr.Multiaddr{
+			multiaddr.StringCast(fmt.Sprintf("/dns/%s/tcp/443/wss", domain)),
+			multiaddr.StringCast(fmt.Sprintf("/dns/%s/udp/443/quic-v1", domain)),
+			multiaddr.StringCast(fmt.Sprintf("/dns/%s/udp/443/quic-v1/webtransport", domain)),
+		}, nil
+	}
+
+	return resolvePublicAddresses()
+}
+
+func resolvePublicAddresses() ([]multiaddr.Multiaddr, error) {
 	cacheMutex.RLock()
 	if len(cachedAnnouncementAddresses) > 0 {
 		cached := cachedAnnouncementAddresses
@@ -592,13 +631,10 @@ func AnnouncementAddresses(announceAddrs []string) ([]multiaddr.Multiaddr, error
 	}
 
 	unspecAddrs := []multiaddr.Multiaddr{
-		// TCP
 		multiaddr.StringCast("/ip4/0.0.0.0/tcp/4001"),
 		multiaddr.StringCast("/ip6/::/tcp/4001"),
-		// QUIC v1
 		multiaddr.StringCast("/ip4/0.0.0.0/udp/4001/quic-v1"),
 		multiaddr.StringCast("/ip6/::/udp/4001/quic-v1"),
-		// WebSocket
 		multiaddr.StringCast("/ip4/0.0.0.0/tcp/4002/ws"),
 		multiaddr.StringCast("/ip6/::/tcp/4002/ws"),
 	}
@@ -617,8 +653,8 @@ func AnnouncementAddresses(announceAddrs []string) ([]multiaddr.Multiaddr, error
 	return announcementAddrs, nil
 }
 
-func ConnectionAddresses(node IPFSNode, announceAddrs []string) ([]multiaddr.Multiaddr, error) {
-	annAddrs, err := AnnouncementAddresses(announceAddrs)
+func ConnectionAddresses(node IPFSNode, announceAddrs []string, domain string) ([]multiaddr.Multiaddr, error) {
+	annAddrs, err := AnnouncementAddresses(announceAddrs, domain)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/testing/mocks/MockIPFSNode.go
+++ b/internal/testing/mocks/MockIPFSNode.go
@@ -390,6 +390,50 @@ func (_c *MockIPFSNode_GetAnnounceAddrs_Call) RunAndReturn(run func() []string) 
 	return _c
 }
 
+// GetAnnounceDomain provides a mock function for the type MockIPFSNode
+func (_mock *MockIPFSNode) GetAnnounceDomain() string {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetAnnounceDomain")
+	}
+
+	var r0 string
+	if returnFunc, ok := ret.Get(0).(func() string); ok {
+		r0 = returnFunc()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+	return r0
+}
+
+// MockIPFSNode_GetAnnounceDomain_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetAnnounceDomain'
+type MockIPFSNode_GetAnnounceDomain_Call struct {
+	*mock.Call
+}
+
+// GetAnnounceDomain is a helper method to define mock.On call
+func (_e *MockIPFSNode_Expecter) GetAnnounceDomain() *MockIPFSNode_GetAnnounceDomain_Call {
+	return &MockIPFSNode_GetAnnounceDomain_Call{Call: _e.mock.On("GetAnnounceDomain")}
+}
+
+func (_c *MockIPFSNode_GetAnnounceDomain_Call) Run(run func()) *MockIPFSNode_GetAnnounceDomain_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockIPFSNode_GetAnnounceDomain_Call) Return(s string) *MockIPFSNode_GetAnnounceDomain_Call {
+	_c.Call.Return(s)
+	return _c
+}
+
+func (_c *MockIPFSNode_GetAnnounceDomain_Call) RunAndReturn(run func() string) *MockIPFSNode_GetAnnounceDomain_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetBlock provides a mock function for the type MockIPFSNode
 func (_mock *MockIPFSNode) GetBlock(ctx context.Context, c cid.Cid) (format.Node, error) {
 	ret := _mock.Called(ctx, c)

--- a/internal/testing/util/util.go
+++ b/internal/testing/util/util.go
@@ -142,7 +142,7 @@ func GetProtocolMock() coreTesting.TestContextBuilderOption {
 		ipfsNode := mocks.NewMockIPFSNode(ctx.T())
 		mockPeer := config.BootstrapPeers[0].ToAddrInfo()
 		ipfsNode.EXPECT().PeerID().Return(mockPeer.ID).Maybe()
-		ipfsNode.EXPECT().DelegateAddresses().Return(ipfs.ConnectionAddresses(ipfsNode, nil)).Maybe()
+		ipfsNode.EXPECT().DelegateAddresses().Return(ipfs.ConnectionAddresses(ipfsNode, nil, "")).Maybe()
 		protoMock.EXPECT().GetNode().Return(ipfsNode).Maybe()
 		protoMock.EXPECT().GetIPNSNode().Return(ipfsNode).Maybe()
 		ipfsNode.EXPECT().GetKeystore().Return(mockKeystore).Maybe()
@@ -155,9 +155,10 @@ func GetProtocolMock() coreTesting.TestContextBuilderOption {
 		ipfsNode.EXPECT().GetPrivateKey().Return(privKey).Maybe()
 
 		ipfsNode.EXPECT().GetAnnounceAddrs().Return(nil).Maybe()
+		ipfsNode.EXPECT().GetAnnounceDomain().Return("").Maybe()
 
 		ipfsNode.EXPECT().ConnectionAddresses().RunAndReturn(func() ([]multiaddr.Multiaddr, error) {
-			return ipfs.ConnectionAddresses(ipfsNode, nil)
+			return ipfs.ConnectionAddresses(ipfsNode, nil, "")
 		}).Maybe()
 
 		// Mock AddBlock to return nil (success)


### PR DESCRIPTION
- Replace DefaultTransports with explicit transports (TCP, WS, QUIC, WebTransport)
- Add ShareTCPListener so WS and TCP share the same port
- Add default listen addresses for WS (tcp/4002), QUIC (udp/443), and WebTransport (udp/443)
- Auto-generate DNS-based announce addresses from HTTPService.APISubdomain
- When domain is set, announce /dns/domain/tcp/443/wss, /dns/domain/udp/443/quic-v1, and /dns/domain/udp/443/quic-v1/webtransport
- Fall back to IP-based auto-discovery when no domain is configured
- Add GetAnnounceDomain to IPFSNode interface
- Store core.Context on Node for service lookups
- Keep parseAnnounceAddr for bare host:port config values

* `develop` <!-- branch-stack -->
  - **feat: add multi-transport support (WSS, QUIC, WebTransport)** :point\_left:

***

<!-- kody-pr-summary:start -->

This pull request adds multi-transport support to the IPFS node, enabling connections via WebSocket (WSS), QUIC, and WebTransport in addition to the existing TCP transport.

Key changes:

- **Explicit transport configuration**: Replaces `libp2p.DefaultTransports` with individually configured transports (TCP, WebSocket, QUIC, and WebTransport), including `ShareTCPListener` to allow TCP and WebSocket to share the same listener.

- **Expanded default listen addresses**: Adds default listen addresses for WebSocket (`/tcp/4002/ws`), QUIC (`/udp/443/quic-v1`), and WebTransport (`/udp/443/quic-v1/webtransport`) on both IPv4 and IPv6.

- **Domain-based announcement addresses**: Introduces a `GetAnnounceDomain()` method that retrieves the API subdomain from the HTTP service. When a domain is available, the node announces DNS-based multiaddresses (`/dns/{domain}/tcp/443/wss`, `/dns/{domain}/udp/443/quic-v1`, `/dns/{domain}/udp/443/quic-v1/webtransport`) instead of resolving public IP addresses. This enables browser clients to connect via WSS and WebTransport.

- **Updated interface and mocks**: The `IPFSNode` interface now includes `GetAnnounceDomain()`, with corresponding mock and test utility updates.

<!-- kody-pr-summary:end -->
