### PR TITLE
feat: derive announce addresses from host listen addrs with AnnounceWeb DNS substitution

### DIFF
--- a/internal/api/api_blocks.go
+++ b/internal/api/api_blocks.go
@@ -62,7 +62,7 @@ func (a *API) handleGetBlockMetaBatch(c echo.Context) error {
 func (a *API) handleGetInfo(c echo.Context) error {
 	ctx := httputil.Context(c)
 
-	addrs, err := ipfs.AnnouncementAddresses(a.ipfs.GetNode().GetAnnounceAddrs(), a.ipfs.GetNode().GetAnnounceDomain())
+	addrs, err := ipfs.AnnouncementAddresses(a.ipfs.GetNode().AnnounceWeb(), a.ipfs.GetNode().AnnounceDomain(), a.ipfs.GetNode().HostAddrs())
 	if err != nil {
 		a.Logger().Error("Failed to get announcement addresses", zap.Error(err))
 		apiErr := NewError(ErrKeyMetadataFetchFailed, err)

--- a/internal/config/protocol.go
+++ b/internal/config/protocol.go
@@ -1,49 +1,45 @@
 package config
 
 import (
+	"fmt"
+
 	z "github.com/Oudwins/zog"
 	"go.lumeweb.com/portal/config"
 )
 
 const (
-	// DHTModeBasic represents a standard libp2p Kademlia DHT
-	DHTModeBasic = "basic"
-	// DHTModeFullRT represents the FullRT DHT with full network visibility
+	DefaultPort = 4002
+
+	DHTModeBasic  = "basic"
 	DHTModeFullRT = "fullrt"
 )
 
 var _ config.Defaults = (*ProtocolConfig)(nil)
 
 type ProtocolConfig struct {
-	ListenAddresses         []string        `config:"listen_addresses"`
-	AnnounceAddresses       []string        `config:"announce_addresses"`
-	Peers                   []IPFSPeer      `config:"peers"`
-	BootstrapPeers          []IPFSPeer      `config:"bootstrap_peers"`
-	Provider                IPFSProvider    `config:"provider"`
-	BlockStore              BlockStore      `config:"blockstore"`
-	LogLevel                string          `config:"log_level"`
-	AutoScaleResourceLimits bool            `config:"auto_scale_resource_limits"`
-	DHTMode                 string          `config:"dht_mode"`
+	Port                    int          `config:"port"`
+	AnnounceWeb             bool         `config:"announce_web"`
+	ListenAddresses         []string     `config:"listen_addresses"`
+	Peers                   []IPFSPeer   `config:"peers"`
+	BootstrapPeers          []IPFSPeer   `config:"bootstrap_peers"`
+	Provider                IPFSProvider `config:"provider"`
+	BlockStore              BlockStore   `config:"blockstore"`
+	LogLevel                string       `config:"log_level"`
+	AutoScaleResourceLimits bool         `config:"auto_scale_resource_limits"`
+	DHTMode                 string       `config:"dht_mode"`
 }
 
 func (c ProtocolConfig) Defaults() map[string]any {
 	return map[string]any{
-		"ListenAddresses": []string{
-			"/ip4/0.0.0.0/tcp/4001",
-			"/ip4/0.0.0.0/tcp/4002/ws",
-			"/ip4/0.0.0.0/udp/443/quic-v1",
-			"/ip4/0.0.0.0/udp/443/quic-v1/webtransport",
-			"/ip6/::/tcp/4001",
-			"/ip6/::/tcp/4002/ws",
-			"/ip6/::/udp/443/quic-v1",
-			"/ip6/::/udp/443/quic-v1/webtransport",
-		},
-		"BootstrapPeers":  BootstrapPeers,
-		"DHTMode":         "fullrt",
+		"Port":           DefaultPort,
+		"BootstrapPeers": BootstrapPeers,
+		"DHTMode":        "fullrt",
 	}
 }
+
 func (l ProtocolConfig) Schema() z.ZogSchema {
 	return z.Struct(z.Shape{
+		"Port": z.Int().Default(DefaultPort).GT(0, z.Message("port must be positive")),
 		"LogLevel": z.String().
 			Default("info").
 			OneOf([]string{"debug", "info", "warn", "error", "fatal"}, z.Message("log level must be one of: debug, info, warn, error, fatal")),
@@ -51,4 +47,22 @@ func (l ProtocolConfig) Schema() z.ZogSchema {
 			Default(DHTModeFullRT).
 			OneOf([]string{DHTModeBasic, DHTModeFullRT}, z.Message("dht mode must be one of: basic, fullrt")),
 	})
+}
+
+func (c ProtocolConfig) ListenAddrs() []string {
+	port := c.Port
+	if port == 0 {
+		port = DefaultPort
+	}
+
+	base := []string{
+		fmt.Sprintf("/ip4/0.0.0.0/tcp/%d/ws", port),
+		fmt.Sprintf("/ip4/0.0.0.0/udp/%d/quic-v1", port),
+		fmt.Sprintf("/ip4/0.0.0.0/udp/%d/quic-v1/webtransport", port),
+		fmt.Sprintf("/ip6/::/tcp/%d/ws", port),
+		fmt.Sprintf("/ip6/::/udp/%d/quic-v1", port),
+		fmt.Sprintf("/ip6/::/udp/%d/quic-v1/webtransport", port),
+	}
+
+	return append(base, c.ListenAddresses...)
 }

--- a/internal/protocol/ipfs/announce_test.go
+++ b/internal/protocol/ipfs/announce_test.go
@@ -1,0 +1,184 @@
+package ipfs
+
+import (
+	"testing"
+
+	"github.com/multiformats/go-multiaddr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAnnouncementAddresses_AnnounceWeb(t *testing.T) {
+	hostAddrs := []multiaddr.Multiaddr{
+		multiaddr.StringCast("/ip4/1.2.3.4/tcp/4002/ws"),
+		multiaddr.StringCast("/ip4/1.2.3.4/udp/4002/quic-v1"),
+		multiaddr.StringCast("/ip4/1.2.3.4/udp/4002/quic-v1/webtransport"),
+	}
+
+	result, err := AnnouncementAddresses(true, "ipfs.example.com", hostAddrs)
+	require.NoError(t, err)
+
+	expected := []string{
+		"/dns/web.ipfs.example.com/tcp/4002/wss",
+		"/dns/web.ipfs.example.com/udp/4002/quic-v1",
+		"/dns/web.ipfs.example.com/udp/4002/quic-v1/webtransport",
+	}
+	require.Len(t, result, len(expected))
+	for i, addr := range result {
+		assert.Equal(t, expected[i], addr.String())
+	}
+}
+
+func TestAnnouncementAddresses_AnnounceWebFalse(t *testing.T) {
+	hostAddrs := []multiaddr.Multiaddr{
+		multiaddr.StringCast("/ip4/1.2.3.4/tcp/4002/ws"),
+		multiaddr.StringCast("/ip4/1.2.3.4/udp/4002/quic-v1"),
+		multiaddr.StringCast("/ip4/192.168.1.1/tcp/4002/ws"),
+		multiaddr.StringCast("/ip4/127.0.0.1/tcp/4002/ws"),
+	}
+
+	result, err := AnnouncementAddresses(false, "ipfs.example.com", hostAddrs)
+	require.NoError(t, err)
+
+	require.Len(t, result, 2)
+	assert.Equal(t, "/ip4/1.2.3.4/tcp/4002/ws", result[0].String())
+	assert.Equal(t, "/ip4/1.2.3.4/udp/4002/quic-v1", result[1].String())
+}
+
+func TestAnnouncementAddresses_AnnounceWebConvertsWSToWSS(t *testing.T) {
+	hostAddrs := []multiaddr.Multiaddr{
+		multiaddr.StringCast("/ip4/1.2.3.4/tcp/4002/ws"),
+	}
+
+	result, err := AnnouncementAddresses(true, "ipfs.example.com", hostAddrs)
+	require.NoError(t, err)
+
+	require.Len(t, result, 1)
+	assert.Equal(t, "/dns/web.ipfs.example.com/tcp/4002/wss", result[0].String())
+}
+
+func TestAnnouncementAddresses_AnnounceWebWSSPassthrough(t *testing.T) {
+	hostAddrs := []multiaddr.Multiaddr{
+		multiaddr.StringCast("/ip4/1.2.3.4/tcp/443/wss"),
+	}
+
+	result, err := AnnouncementAddresses(true, "ipfs.example.com", hostAddrs)
+	require.NoError(t, err)
+
+	require.Len(t, result, 1)
+	assert.Equal(t, "/dns/web.ipfs.example.com/tcp/443/wss", result[0].String())
+}
+
+func TestAnnouncementAddresses_DeduplicatesByProtoAndPort(t *testing.T) {
+	hostAddrs := []multiaddr.Multiaddr{
+		multiaddr.StringCast("/ip4/1.2.3.4/tcp/4002/ws"),
+		multiaddr.StringCast("/ip6/::/tcp/4002/ws"),
+		multiaddr.StringCast("/ip4/10.0.0.1/tcp/4002/ws"),
+	}
+
+	result, err := AnnouncementAddresses(true, "ipfs.example.com", hostAddrs)
+	require.NoError(t, err)
+
+	require.Len(t, result, 1)
+	assert.Equal(t, "/dns/web.ipfs.example.com/tcp/4002/wss", result[0].String())
+}
+
+func TestAnnouncementAddresses_CertHashPreserved(t *testing.T) {
+	hostAddrs := []multiaddr.Multiaddr{
+		multiaddr.StringCast("/ip4/1.2.3.4/udp/4002/quic-v1/webtransport/certhash/uEiBzadLZbQCvscarMZg74tDg1l0trRpbTcWQOipBLFmSGg"),
+	}
+
+	result, err := AnnouncementAddresses(true, "ipfs.example.com", hostAddrs)
+	require.NoError(t, err)
+
+	require.Len(t, result, 1)
+	assert.Contains(t, result[0].String(), "/dns/web.ipfs.example.com/udp/4002/quic-v1/webtransport/certhash/")
+}
+
+func TestAnnouncementAddresses_EmptyHostAddrs(t *testing.T) {
+	result, err := AnnouncementAddresses(true, "ipfs.example.com", nil)
+	require.NoError(t, err)
+	assert.Empty(t, result)
+}
+
+func TestAnnouncementAddresses_EmptyHostAddrsNoWeb(t *testing.T) {
+	result, err := AnnouncementAddresses(false, "", nil)
+	require.NoError(t, err)
+	assert.Empty(t, result)
+}
+
+func TestAnnouncementAddresses_AnnounceWebNoDomain(t *testing.T) {
+	hostAddrs := []multiaddr.Multiaddr{
+		multiaddr.StringCast("/ip4/1.2.3.4/tcp/4002/ws"),
+	}
+
+	result, err := AnnouncementAddresses(true, "", hostAddrs)
+	require.NoError(t, err)
+
+	require.Len(t, result, 1)
+	assert.Equal(t, "/ip4/1.2.3.4/tcp/4002/ws", result[0].String())
+}
+
+func TestFilterPublicAddrs(t *testing.T) {
+	addrs := []multiaddr.Multiaddr{
+		multiaddr.StringCast("/ip4/1.2.3.4/tcp/4002/ws"),
+		multiaddr.StringCast("/ip4/127.0.0.1/tcp/4002/ws"),
+		multiaddr.StringCast("/ip4/10.0.0.1/tcp/4002/ws"),
+		multiaddr.StringCast("/ip4/0.0.0.0/tcp/4002/ws"),
+		multiaddr.StringCast("/ip4/192.168.1.1/tcp/4002/ws"),
+		multiaddr.StringCast("/ip4/172.16.0.1/tcp/4002/ws"),
+	}
+
+	result := filterPublicAddrs(addrs)
+	require.Len(t, result, 1)
+	assert.Equal(t, "/ip4/1.2.3.4/tcp/4002/ws", result[0].String())
+}
+
+func TestAnnouncementAddresses_IPv6Replaced(t *testing.T) {
+	hostAddrs := []multiaddr.Multiaddr{
+		multiaddr.StringCast("/ip6/::1/tcp/4002/ws"),
+		multiaddr.StringCast("/ip6/2001:db8::1/udp/4002/quic-v1"),
+	}
+
+	result, err := AnnouncementAddresses(true, "ipfs.example.com", hostAddrs)
+	require.NoError(t, err)
+
+	require.Len(t, result, 2)
+	assert.Equal(t, "/dns/web.ipfs.example.com/tcp/4002/wss", result[0].String())
+	assert.Equal(t, "/dns/web.ipfs.example.com/udp/4002/quic-v1", result[1].String())
+}
+
+func TestAnnouncementAddresses_DNSHostAddrReplaced(t *testing.T) {
+	hostAddrs := []multiaddr.Multiaddr{
+		multiaddr.StringCast("/dns4/old.example.com/tcp/4002/ws"),
+	}
+
+	result, err := AnnouncementAddresses(true, "ipfs.example.com", hostAddrs)
+	require.NoError(t, err)
+
+	require.Len(t, result, 1)
+	assert.Equal(t, "/dns/web.ipfs.example.com/tcp/4002/wss", result[0].String())
+}
+
+func TestAnnouncementAddresses_MultiplePorts(t *testing.T) {
+	hostAddrs := []multiaddr.Multiaddr{
+		multiaddr.StringCast("/ip4/1.2.3.4/tcp/4002/ws"),
+		multiaddr.StringCast("/ip4/1.2.3.4/tcp/443/wss"),
+		multiaddr.StringCast("/ip4/1.2.3.4/udp/4002/quic-v1"),
+		multiaddr.StringCast("/ip4/1.2.3.4/udp/4002/quic-v1/webtransport"),
+	}
+
+	result, err := AnnouncementAddresses(true, "ipfs.example.com", hostAddrs)
+	require.NoError(t, err)
+
+	expected := []string{
+		"/dns/web.ipfs.example.com/tcp/4002/wss",
+		"/dns/web.ipfs.example.com/tcp/443/wss",
+		"/dns/web.ipfs.example.com/udp/4002/quic-v1",
+		"/dns/web.ipfs.example.com/udp/4002/quic-v1/webtransport",
+	}
+	require.Len(t, result, len(expected))
+	for i, addr := range result {
+		assert.Equal(t, expected[i], addr.String())
+	}
+}

--- a/internal/protocol/ipfs/node.go
+++ b/internal/protocol/ipfs/node.go
@@ -5,9 +5,8 @@ import (
 	"crypto/ed25519"
 	"crypto/sha256"
 	"fmt"
-	"net"
-	"strconv"
 	"io"
+	"strings"
 	"sync"
 	"time"
 
@@ -54,13 +53,8 @@ import (
 )
 
 const (
-	// libp2pProtocolPrefix is the protocol prefix for libp2p multiaddresses
 	libp2pProtocolPrefix = "/p2p/"
-)
-
-var (
-	cachedAnnouncementAddresses []multiaddr.Multiaddr
-	cacheMutex                  sync.RWMutex
+	webSubdomainPrefix   = "web."
 )
 
 // DHTRouting combines the interfaces needed from a DHT routing implementation
@@ -92,8 +86,9 @@ type IPFSNode interface {
 	GetKeystore() keystore.Keystore
 	GetDatastore() datastore.Datastore
 	GetPrivateKey() crypto.PrivKey
-	GetAnnounceAddrs() []string
-	GetAnnounceDomain() string
+	AnnounceWeb() bool
+	AnnounceDomain() string
+	HostAddrs() []multiaddr.Multiaddr
 }
 
 // NopExchange wraps an exchange.Interface and disables NotifyNewBlocks.
@@ -189,7 +184,7 @@ type Node struct {
 	datastore        datastore.Datastore
 	keystore         keystore.Keystore
 	publisher        *namesys.IPNSPublisher
-	announceAddrs    []string
+	announceWeb      bool
 }
 
 // Close closes the node
@@ -265,7 +260,24 @@ func (n *Node) PeerID() peer.ID {
 }
 
 func (n *Node) ConnectionAddresses() ([]multiaddr.Multiaddr, error) {
-	return ConnectionAddresses(n, n.announceAddrs, n.announceDomain())
+	annAddrs, err := AnnouncementAddresses(n.announceWeb, n.announceDomain(), n.host.Addrs())
+	if err != nil {
+		return nil, err
+	}
+
+	connAddrs := lo.Map(annAddrs, func(addr multiaddr.Multiaddr, _ int) multiaddr.Multiaddr {
+		return addr.Encapsulate(multiaddr.StringCast(libp2pProtocolPrefix + n.PeerID().String()))
+	})
+
+	return connAddrs, nil
+}
+
+func (n *Node) AnnounceWeb() bool {
+	return n.announceWeb
+}
+
+func (n *Node) AnnounceDomain() string {
+	return n.announceDomain()
 }
 
 func (n *Node) announceDomain() string {
@@ -279,12 +291,11 @@ func (n *Node) announceDomain() string {
 	return httpSvc.APISubdomain(internal.ProtocolName, false)
 }
 
-func (n *Node) GetAnnounceAddrs() []string {
-	return n.announceAddrs
-}
-
-func (n *Node) GetAnnounceDomain() string {
-	return n.announceDomain()
+func (n *Node) HostAddrs() []multiaddr.Multiaddr {
+	if n.host == nil {
+		return nil
+	}
+	return n.host.Addrs()
 }
 
 // DelegateAddresses returns the multiaddr addresses that can be used as delegates
@@ -383,7 +394,7 @@ func NewNode(ctx core.Context, cfg *config.ProtocolConfig, rs pluginCore.Reprovi
 	}
 
 	opts := []libp2p.Option{
-		libp2p.ListenAddrStrings(cfg.ListenAddresses...),
+		libp2p.ListenAddrStrings(cfg.ListenAddrs()...),
 		libp2p.ConnectionManager(cmgr),
 		libp2p.Identity(privateKey),
 		libp2p.EnableRelay(),
@@ -396,12 +407,14 @@ func NewNode(ctx core.Context, cfg *config.ProtocolConfig, rs pluginCore.Reprovi
 		libp2p.Transport(webtransport.New),
 		libp2p.PrometheusRegisterer(prometheus.WrapRegistererWithPrefix("libp2p_", core.PluginMetricsRegistry(internal.ProtocolName))),
 		libp2p.AddrsFactory(func(addrs []multiaddr.Multiaddr) []multiaddr.Multiaddr {
-			httpSvc := core.GetService[core.HTTPService](ctx, core.HTTP_SERVICE)
 			var domain string
-			if httpSvc != nil {
-				domain = httpSvc.APISubdomain(internal.ProtocolName, false)
+			if cfg.AnnounceWeb {
+				httpSvc := core.GetService[core.HTTPService](ctx, core.HTTP_SERVICE)
+				if httpSvc != nil {
+					domain = httpSvc.APISubdomain(internal.ProtocolName, false)
+				}
 			}
-			announceAddresses, err := AnnouncementAddresses(cfg.AnnounceAddresses, domain)
+			announceAddresses, err := AnnouncementAddresses(cfg.AnnounceWeb, domain, addrs)
 			if err != nil {
 				ctx.Logger().Error("failed to get announcement addresses", zap.Error(err))
 				return lo.Filter(addrs, func(addr multiaddr.Multiaddr, _ int) bool {
@@ -436,10 +449,10 @@ func NewNode(ctx core.Context, cfg *config.ProtocolConfig, rs pluginCore.Reprovi
 
 	// Create node with minimal fields
 	ipfsNode := &Node{
-		host:          node,
-		log:           ctx.Logger(),
-		ctx:           ctx,
-		announceAddrs: cfg.AnnounceAddresses,
+		host:        node,
+		log:         ctx.Logger(),
+		ctx:         ctx,
+		announceWeb: cfg.AnnounceWeb,
 	}
 
 	// Build common DHT options using factory's GetBootstrapPeers()
@@ -578,98 +591,80 @@ func (n *Node) TriggerReprovider() {
 	n.reprovider.Trigger()
 }
 
-func parseAnnounceAddr(addrStr string) (multiaddr.Multiaddr, error) {
-	if ma, err := multiaddr.NewMultiaddr(addrStr); err == nil {
-		return ma, nil
+func AnnouncementAddresses(announceWeb bool, domain string, hostAddrs []multiaddr.Multiaddr) ([]multiaddr.Multiaddr, error) {
+	if announceWeb && domain != "" {
+		webDomain := webSubdomainPrefix + domain
+		return announceFromDomainAndHostAddrs(webDomain, hostAddrs)
 	}
-	host, portStr, err := net.SplitHostPort(addrStr)
-	if err != nil {
-		return nil, fmt.Errorf("invalid announce address %q: %w", addrStr, err)
-	}
-	port, err := strconv.Atoi(portStr)
-	if err != nil {
-		return nil, fmt.Errorf("invalid port in announce address %q: %w", addrStr, err)
-	}
-	ip := net.ParseIP(host)
-	if ip == nil {
-		return nil, fmt.Errorf("invalid IP in announce address %q", addrStr)
-	}
-	if ip.To4() != nil {
-		return multiaddr.NewMultiaddr(fmt.Sprintf("/ip4/%s/tcp/%d", host, port))
-	}
-	return multiaddr.NewMultiaddr(fmt.Sprintf("/ip6/%s/tcp/%d", host, port))
+
+	return filterPublicAddrs(hostAddrs), nil
 }
 
-func AnnouncementAddresses(announceAddrs []string, domain string) ([]multiaddr.Multiaddr, error) {
-	if len(announceAddrs) > 0 {
-		return lo.MapErr(announceAddrs, func(addrStr string, _ int) (multiaddr.Multiaddr, error) {
-			return parseAnnounceAddr(addrStr)
+func announceFromDomainAndHostAddrs(domain string, hostAddrs []multiaddr.Multiaddr) ([]multiaddr.Multiaddr, error) {
+	type addrKey struct {
+		proto string
+		port  string
+	}
+
+	seen := make(map[addrKey]bool)
+	var result []multiaddr.Multiaddr
+
+	for _, addr := range hostAddrs {
+		var components []string
+		var proto string
+		var port string
+
+		multiaddr.ForEach(addr, func(c multiaddr.Component) bool {
+			switch c.Protocol().Code {
+			case multiaddr.P_IP4, multiaddr.P_IP6, multiaddr.P_DNS, multiaddr.P_DNS4, multiaddr.P_DNS6:
+				components = append(components, fmt.Sprintf("/dns/%s", domain))
+			case multiaddr.P_TCP:
+				port = c.Value()
+				components = append(components, fmt.Sprintf("/tcp/%s", c.Value()))
+			case multiaddr.P_UDP:
+				port = c.Value()
+				components = append(components, fmt.Sprintf("/udp/%s", c.Value()))
+			case multiaddr.P_WS:
+				proto = "wss"
+				components = append(components, "/wss")
+			case multiaddr.P_WSS:
+				proto = "wss"
+				components = append(components, "/wss")
+			case multiaddr.P_QUIC_V1:
+				proto = "quic-v1"
+				components = append(components, "/quic-v1")
+			case multiaddr.P_WEBTRANSPORT:
+				proto = "webtransport"
+				components = append(components, "/webtransport")
+			case multiaddr.P_CERTHASH:
+				components = append(components, fmt.Sprintf("/certhash/%s", c.Value()))
+			default:
+				components = append(components, fmt.Sprintf("/%s/%s", c.Protocol().Name, c.Value()))
+			}
+			return true
 		})
+
+		key := addrKey{proto: proto, port: port}
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+
+		replaced, err := multiaddr.NewMultiaddr(strings.Join(components, ""))
+		if err != nil {
+			continue
+		}
+
+		result = append(result, replaced)
 	}
 
-	if domain != "" {
-		return []multiaddr.Multiaddr{
-			multiaddr.StringCast(fmt.Sprintf("/dns/%s/tcp/443/wss", domain)),
-			multiaddr.StringCast(fmt.Sprintf("/dns/%s/udp/443/quic-v1", domain)),
-			multiaddr.StringCast(fmt.Sprintf("/dns/%s/udp/443/quic-v1/webtransport", domain)),
-		}, nil
-	}
-
-	return resolvePublicAddresses()
+	return result, nil
 }
 
-func resolvePublicAddresses() ([]multiaddr.Multiaddr, error) {
-	cacheMutex.RLock()
-	if len(cachedAnnouncementAddresses) > 0 {
-		cached := cachedAnnouncementAddresses
-		cacheMutex.RUnlock()
-		return cached, nil
-	}
-	cacheMutex.RUnlock()
-
-	cacheMutex.Lock()
-	defer cacheMutex.Unlock()
-
-	if len(cachedAnnouncementAddresses) > 0 {
-		return cachedAnnouncementAddresses, nil
-	}
-
-	unspecAddrs := []multiaddr.Multiaddr{
-		multiaddr.StringCast("/ip4/0.0.0.0/tcp/4001"),
-		multiaddr.StringCast("/ip6/::/tcp/4001"),
-		multiaddr.StringCast("/ip4/0.0.0.0/udp/443/quic-v1"),
-		multiaddr.StringCast("/ip6/::/udp/443/quic-v1"),
-		multiaddr.StringCast("/ip4/0.0.0.0/udp/443/quic-v1/webtransport"),
-		multiaddr.StringCast("/ip6/::/udp/443/quic-v1/webtransport"),
-		multiaddr.StringCast("/ip4/0.0.0.0/tcp/4002/ws"),
-		multiaddr.StringCast("/ip6/::/tcp/4002/ws"),
-	}
-
-	announcementAddrs, err := manet.ResolveUnspecifiedAddresses(unspecAddrs, nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to resolve announcement addresses: %w", err)
-	}
-
-	announcementAddrs = lo.Filter(announcementAddrs, func(addr multiaddr.Multiaddr, i int) bool {
+func filterPublicAddrs(addrs []multiaddr.Multiaddr) []multiaddr.Multiaddr {
+	return lo.Filter(addrs, func(addr multiaddr.Multiaddr, _ int) bool {
 		return !manet.IsIPLoopback(addr) && !manet.IsIPUnspecified(addr) && !manet.IsPrivateAddr(addr)
 	})
-
-	cachedAnnouncementAddresses = announcementAddrs
-
-	return announcementAddrs, nil
-}
-
-func ConnectionAddresses(node IPFSNode, announceAddrs []string, domain string) ([]multiaddr.Multiaddr, error) {
-	annAddrs, err := AnnouncementAddresses(announceAddrs, domain)
-	if err != nil {
-		return nil, err
-	}
-
-	connAddrs := lo.Map(annAddrs, func(addr multiaddr.Multiaddr, _ int) multiaddr.Multiaddr {
-		return addr.Encapsulate(multiaddr.StringCast(libp2pProtocolPrefix + node.PeerID().String()))
-	})
-
-	return connAddrs, nil
 }
 
 // GetKeystore returns the node's keystore

--- a/internal/testing/mocks/MockIPFSNode.go
+++ b/internal/testing/mocks/MockIPFSNode.go
@@ -144,6 +144,94 @@ func (_c *MockIPFSNode_AddPeer_Call) RunAndReturn(run func(addr peer.AddrInfo)) 
 	return _c
 }
 
+// AnnounceDomain provides a mock function for the type MockIPFSNode
+func (_mock *MockIPFSNode) AnnounceDomain() string {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for AnnounceDomain")
+	}
+
+	var r0 string
+	if returnFunc, ok := ret.Get(0).(func() string); ok {
+		r0 = returnFunc()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+	return r0
+}
+
+// MockIPFSNode_AnnounceDomain_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AnnounceDomain'
+type MockIPFSNode_AnnounceDomain_Call struct {
+	*mock.Call
+}
+
+// AnnounceDomain is a helper method to define mock.On call
+func (_e *MockIPFSNode_Expecter) AnnounceDomain() *MockIPFSNode_AnnounceDomain_Call {
+	return &MockIPFSNode_AnnounceDomain_Call{Call: _e.mock.On("AnnounceDomain")}
+}
+
+func (_c *MockIPFSNode_AnnounceDomain_Call) Run(run func()) *MockIPFSNode_AnnounceDomain_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockIPFSNode_AnnounceDomain_Call) Return(s string) *MockIPFSNode_AnnounceDomain_Call {
+	_c.Call.Return(s)
+	return _c
+}
+
+func (_c *MockIPFSNode_AnnounceDomain_Call) RunAndReturn(run func() string) *MockIPFSNode_AnnounceDomain_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// AnnounceWeb provides a mock function for the type MockIPFSNode
+func (_mock *MockIPFSNode) AnnounceWeb() bool {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for AnnounceWeb")
+	}
+
+	var r0 bool
+	if returnFunc, ok := ret.Get(0).(func() bool); ok {
+		r0 = returnFunc()
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+	return r0
+}
+
+// MockIPFSNode_AnnounceWeb_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AnnounceWeb'
+type MockIPFSNode_AnnounceWeb_Call struct {
+	*mock.Call
+}
+
+// AnnounceWeb is a helper method to define mock.On call
+func (_e *MockIPFSNode_Expecter) AnnounceWeb() *MockIPFSNode_AnnounceWeb_Call {
+	return &MockIPFSNode_AnnounceWeb_Call{Call: _e.mock.On("AnnounceWeb")}
+}
+
+func (_c *MockIPFSNode_AnnounceWeb_Call) Run(run func()) *MockIPFSNode_AnnounceWeb_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockIPFSNode_AnnounceWeb_Call) Return(b bool) *MockIPFSNode_AnnounceWeb_Call {
+	_c.Call.Return(b)
+	return _c
+}
+
+func (_c *MockIPFSNode_AnnounceWeb_Call) RunAndReturn(run func() bool) *MockIPFSNode_AnnounceWeb_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Close provides a mock function for the type MockIPFSNode
 func (_mock *MockIPFSNode) Close() error {
 	ret := _mock.Called()
@@ -340,96 +428,6 @@ func (_c *MockIPFSNode_DelegateAddresses_Call) Return(multiaddrs []multiaddr.Mul
 }
 
 func (_c *MockIPFSNode_DelegateAddresses_Call) RunAndReturn(run func() ([]multiaddr.Multiaddr, error)) *MockIPFSNode_DelegateAddresses_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// GetAnnounceAddrs provides a mock function for the type MockIPFSNode
-func (_mock *MockIPFSNode) GetAnnounceAddrs() []string {
-	ret := _mock.Called()
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetAnnounceAddrs")
-	}
-
-	var r0 []string
-	if returnFunc, ok := ret.Get(0).(func() []string); ok {
-		r0 = returnFunc()
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]string)
-		}
-	}
-	return r0
-}
-
-// MockIPFSNode_GetAnnounceAddrs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetAnnounceAddrs'
-type MockIPFSNode_GetAnnounceAddrs_Call struct {
-	*mock.Call
-}
-
-// GetAnnounceAddrs is a helper method to define mock.On call
-func (_e *MockIPFSNode_Expecter) GetAnnounceAddrs() *MockIPFSNode_GetAnnounceAddrs_Call {
-	return &MockIPFSNode_GetAnnounceAddrs_Call{Call: _e.mock.On("GetAnnounceAddrs")}
-}
-
-func (_c *MockIPFSNode_GetAnnounceAddrs_Call) Run(run func()) *MockIPFSNode_GetAnnounceAddrs_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run()
-	})
-	return _c
-}
-
-func (_c *MockIPFSNode_GetAnnounceAddrs_Call) Return(strings []string) *MockIPFSNode_GetAnnounceAddrs_Call {
-	_c.Call.Return(strings)
-	return _c
-}
-
-func (_c *MockIPFSNode_GetAnnounceAddrs_Call) RunAndReturn(run func() []string) *MockIPFSNode_GetAnnounceAddrs_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// GetAnnounceDomain provides a mock function for the type MockIPFSNode
-func (_mock *MockIPFSNode) GetAnnounceDomain() string {
-	ret := _mock.Called()
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetAnnounceDomain")
-	}
-
-	var r0 string
-	if returnFunc, ok := ret.Get(0).(func() string); ok {
-		r0 = returnFunc()
-	} else {
-		r0 = ret.Get(0).(string)
-	}
-	return r0
-}
-
-// MockIPFSNode_GetAnnounceDomain_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetAnnounceDomain'
-type MockIPFSNode_GetAnnounceDomain_Call struct {
-	*mock.Call
-}
-
-// GetAnnounceDomain is a helper method to define mock.On call
-func (_e *MockIPFSNode_Expecter) GetAnnounceDomain() *MockIPFSNode_GetAnnounceDomain_Call {
-	return &MockIPFSNode_GetAnnounceDomain_Call{Call: _e.mock.On("GetAnnounceDomain")}
-}
-
-func (_c *MockIPFSNode_GetAnnounceDomain_Call) Run(run func()) *MockIPFSNode_GetAnnounceDomain_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run()
-	})
-	return _c
-}
-
-func (_c *MockIPFSNode_GetAnnounceDomain_Call) Return(s string) *MockIPFSNode_GetAnnounceDomain_Call {
-	_c.Call.Return(s)
-	return _c
-}
-
-func (_c *MockIPFSNode_GetAnnounceDomain_Call) RunAndReturn(run func() string) *MockIPFSNode_GetAnnounceDomain_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -794,6 +792,52 @@ func (_c *MockIPFSNode_HasBlock_Call) Return(b bool, err error) *MockIPFSNode_Ha
 }
 
 func (_c *MockIPFSNode_HasBlock_Call) RunAndReturn(run func(ctx context.Context, c cid.Cid) (bool, error)) *MockIPFSNode_HasBlock_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// HostAddrs provides a mock function for the type MockIPFSNode
+func (_mock *MockIPFSNode) HostAddrs() []multiaddr.Multiaddr {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for HostAddrs")
+	}
+
+	var r0 []multiaddr.Multiaddr
+	if returnFunc, ok := ret.Get(0).(func() []multiaddr.Multiaddr); ok {
+		r0 = returnFunc()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]multiaddr.Multiaddr)
+		}
+	}
+	return r0
+}
+
+// MockIPFSNode_HostAddrs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'HostAddrs'
+type MockIPFSNode_HostAddrs_Call struct {
+	*mock.Call
+}
+
+// HostAddrs is a helper method to define mock.On call
+func (_e *MockIPFSNode_Expecter) HostAddrs() *MockIPFSNode_HostAddrs_Call {
+	return &MockIPFSNode_HostAddrs_Call{Call: _e.mock.On("HostAddrs")}
+}
+
+func (_c *MockIPFSNode_HostAddrs_Call) Run(run func()) *MockIPFSNode_HostAddrs_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockIPFSNode_HostAddrs_Call) Return(multiaddrs []multiaddr.Multiaddr) *MockIPFSNode_HostAddrs_Call {
+	_c.Call.Return(multiaddrs)
+	return _c
+}
+
+func (_c *MockIPFSNode_HostAddrs_Call) RunAndReturn(run func() []multiaddr.Multiaddr) *MockIPFSNode_HostAddrs_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/testing/util/util.go
+++ b/internal/testing/util/util.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/ipfs/go-cid"
 	"github.com/libp2p/go-libp2p/core/crypto"
-	"github.com/multiformats/go-multiaddr"
 	"github.com/multiformats/go-multihash"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -16,7 +15,6 @@ import (
 	"go.lumeweb.com/portal-plugin-ipfs/internal/config"
 	pluginDb "go.lumeweb.com/portal-plugin-ipfs/internal/db"
 	protocol "go.lumeweb.com/portal-plugin-ipfs/internal/protocol"
-	"go.lumeweb.com/portal-plugin-ipfs/internal/protocol/ipfs"
 	"go.lumeweb.com/portal/core"
 	coreTesting "go.lumeweb.com/portal/core/testing"
 	"go.lumeweb.com/portal/db"
@@ -142,7 +140,7 @@ func GetProtocolMock() coreTesting.TestContextBuilderOption {
 		ipfsNode := mocks.NewMockIPFSNode(ctx.T())
 		mockPeer := config.BootstrapPeers[0].ToAddrInfo()
 		ipfsNode.EXPECT().PeerID().Return(mockPeer.ID).Maybe()
-		ipfsNode.EXPECT().DelegateAddresses().Return(ipfs.ConnectionAddresses(ipfsNode, nil, "")).Maybe()
+		ipfsNode.EXPECT().DelegateAddresses().Return(nil, nil).Maybe()
 		protoMock.EXPECT().GetNode().Return(ipfsNode).Maybe()
 		protoMock.EXPECT().GetIPNSNode().Return(ipfsNode).Maybe()
 		ipfsNode.EXPECT().GetKeystore().Return(mockKeystore).Maybe()
@@ -154,12 +152,10 @@ func GetProtocolMock() coreTesting.TestContextBuilderOption {
 		require.NoError(ctx.T(), err, "Failed to generate test private key")
 		ipfsNode.EXPECT().GetPrivateKey().Return(privKey).Maybe()
 
-		ipfsNode.EXPECT().GetAnnounceAddrs().Return(nil).Maybe()
-		ipfsNode.EXPECT().GetAnnounceDomain().Return("").Maybe()
-
-		ipfsNode.EXPECT().ConnectionAddresses().RunAndReturn(func() ([]multiaddr.Multiaddr, error) {
-			return ipfs.ConnectionAddresses(ipfsNode, nil, "")
-		}).Maybe()
+		ipfsNode.EXPECT().ConnectionAddresses().Return(nil, nil).Maybe()
+		ipfsNode.EXPECT().HostAddrs().Return(nil).Maybe()
+		ipfsNode.EXPECT().AnnounceWeb().Return(false).Maybe()
+		ipfsNode.EXPECT().AnnounceDomain().Return("").Maybe()
 
 		// Mock AddBlock to return nil (success)
 		ipfsNode.EXPECT().AddBlock(mock.Anything, mock.Anything).Return(nil).Maybe()


### PR DESCRIPTION
- Add Port config that generates ws/quic-v1/webtransport listen addresses
  ProtocolConfig.ListenAddrs() that generates ws/quic-v1/webtransport
  addresses from the port
- Add AnnounceWeb bool config — when true, walks host listen multiaddrs
  component-by-component, replacing IP with web.{APISubdomain} DNS domain
  and converting /ws to /wss (TLS terminated by Caddy on web subdomain)
- Deduplicate announce addrs by protocol+port pair
- Preserve certhash components from WebTransport multiaddrs
- Add webSubdomainPrefix const
- Add AnnounceWeb(), AnnounceDomain(), HostAddrs() to IPFSNode interface
- Store core.Context and announceWeb on Node for service lookups
- Remove old AnnounceAddresses config, parseAnnounceAddr,
  resolvePublicAddresses, cached announcement addrs, and
  ConnectionAddresses free function
- Simplify test mocks
- Add tests for announcement address logic

* `develop` <!-- branch-stack -->
  - **feat: derive announce addresses from host listen addrs with AnnounceWeb DNS substitution** :point\_left:

---

<!-- kody-pr-summary:start -->
## Summary

This PR redesigns how IPFS announce addresses are derived, moving from a manually-configured list of announce addresses to automatically deriving them from the host's actual listen addresses with DNS substitution for web announcements.

### Key Changes

- **New `AnnounceWeb` config option** replaces the old `AnnounceAddresses` list. When enabled with a configured domain, announce addresses are automatically constructed by replacing IP/host components in listen addresses with a `web.` subdomain prefix (e.g., `web.ipfs.example.com`), converting `ws` to `wss`, and preserving the actual port numbers and protocols (QUIC, WebTransport, cert hashes) from the host addresses.

- **New `Port` config option** (default 4002) replaces hardcoded listen addresses. Listen addresses are now dynamically generated based on the configured port, with additional custom listen addresses appended.

- **Simplified announcement logic**: The old approach required either explicit announce address strings or DNS resolution of unspecified addresses with caching. The new approach derives everything from the host's actual listen addresses — when `AnnounceWeb` is off, it simply filters to public addresses; when on, it performs the DNS substitution with deduplication by protocol and port.

- **Interface updates**: `IPFSNode` interface methods `GetAnnounceAddrs()` and `GetAnnounceDomain()` are replaced with `AnnounceWeb()`, `AnnounceDomain()`, and `HostAddrs()` to reflect the new derivation-based approach.

- **Comprehensive test coverage**: New test suite validates WS→WSS conversion, WSS passthrough, deduplication, cert hash preservation, IPv6/DNS replacement, public address filtering, and edge cases.
<!-- kody-pr-summary:end -->