### PR TITLE
fix: correct AnnounceWeb announcement addresses

### DIFF
--- a/internal/config/protocol.go
+++ b/internal/config/protocol.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	DefaultPort = 4002
+	DefaultPort = 4001
 
 	DHTModeBasic  = "basic"
 	DHTModeFullRT = "fullrt"

--- a/internal/protocol/ipfs/announce_test.go
+++ b/internal/protocol/ipfs/announce_test.go
@@ -10,18 +10,18 @@ import (
 
 func TestAnnouncementAddresses_AnnounceWeb(t *testing.T) {
 	hostAddrs := []multiaddr.Multiaddr{
-		multiaddr.StringCast("/ip4/1.2.3.4/tcp/4002/ws"),
-		multiaddr.StringCast("/ip4/1.2.3.4/udp/4002/quic-v1"),
-		multiaddr.StringCast("/ip4/1.2.3.4/udp/4002/quic-v1/webtransport"),
+		multiaddr.StringCast("/ip4/1.2.3.4/tcp/4001/ws"),
+		multiaddr.StringCast("/ip4/1.2.3.4/udp/4001/quic-v1"),
+		multiaddr.StringCast("/ip4/1.2.3.4/udp/4001/quic-v1/webtransport"),
 	}
 
 	result, err := AnnouncementAddresses(true, "ipfs.example.com", hostAddrs)
 	require.NoError(t, err)
 
 	expected := []string{
-		"/dns/web.ipfs.example.com/tcp/4002/wss",
-		"/dns/web.ipfs.example.com/udp/4002/quic-v1",
-		"/dns/web.ipfs.example.com/udp/4002/quic-v1/webtransport",
+		"/dns/web.ipfs.example.com/tcp/443/wss",
+		"/dns/ipfs.example.com/udp/4001/quic-v1",
+		"/dns/ipfs.example.com/udp/4001/quic-v1/webtransport",
 	}
 	require.Len(t, result, len(expected))
 	for i, addr := range result {
@@ -31,30 +31,30 @@ func TestAnnouncementAddresses_AnnounceWeb(t *testing.T) {
 
 func TestAnnouncementAddresses_AnnounceWebFalse(t *testing.T) {
 	hostAddrs := []multiaddr.Multiaddr{
-		multiaddr.StringCast("/ip4/1.2.3.4/tcp/4002/ws"),
-		multiaddr.StringCast("/ip4/1.2.3.4/udp/4002/quic-v1"),
-		multiaddr.StringCast("/ip4/192.168.1.1/tcp/4002/ws"),
-		multiaddr.StringCast("/ip4/127.0.0.1/tcp/4002/ws"),
+		multiaddr.StringCast("/ip4/1.2.3.4/tcp/4001/ws"),
+		multiaddr.StringCast("/ip4/1.2.3.4/udp/4001/quic-v1"),
+		multiaddr.StringCast("/ip4/192.168.1.1/tcp/4001/ws"),
+		multiaddr.StringCast("/ip4/127.0.0.1/tcp/4001/ws"),
 	}
 
 	result, err := AnnouncementAddresses(false, "ipfs.example.com", hostAddrs)
 	require.NoError(t, err)
 
 	require.Len(t, result, 2)
-	assert.Equal(t, "/ip4/1.2.3.4/tcp/4002/ws", result[0].String())
-	assert.Equal(t, "/ip4/1.2.3.4/udp/4002/quic-v1", result[1].String())
+	assert.Equal(t, "/ip4/1.2.3.4/tcp/4001/ws", result[0].String())
+	assert.Equal(t, "/ip4/1.2.3.4/udp/4001/quic-v1", result[1].String())
 }
 
-func TestAnnouncementAddresses_AnnounceWebConvertsWSToWSS(t *testing.T) {
+func TestAnnouncementAddresses_AnnounceWebWSSToPort443(t *testing.T) {
 	hostAddrs := []multiaddr.Multiaddr{
-		multiaddr.StringCast("/ip4/1.2.3.4/tcp/4002/ws"),
+		multiaddr.StringCast("/ip4/1.2.3.4/tcp/4001/ws"),
 	}
 
 	result, err := AnnouncementAddresses(true, "ipfs.example.com", hostAddrs)
 	require.NoError(t, err)
 
 	require.Len(t, result, 1)
-	assert.Equal(t, "/dns/web.ipfs.example.com/tcp/4002/wss", result[0].String())
+	assert.Equal(t, "/dns/web.ipfs.example.com/tcp/443/wss", result[0].String())
 }
 
 func TestAnnouncementAddresses_AnnounceWebWSSPassthrough(t *testing.T) {
@@ -69,30 +69,45 @@ func TestAnnouncementAddresses_AnnounceWebWSSPassthrough(t *testing.T) {
 	assert.Equal(t, "/dns/web.ipfs.example.com/tcp/443/wss", result[0].String())
 }
 
-func TestAnnouncementAddresses_DeduplicatesByProtoAndPort(t *testing.T) {
+func TestAnnouncementAddresses_DeduplicatesWSS(t *testing.T) {
 	hostAddrs := []multiaddr.Multiaddr{
-		multiaddr.StringCast("/ip4/1.2.3.4/tcp/4002/ws"),
-		multiaddr.StringCast("/ip6/::/tcp/4002/ws"),
-		multiaddr.StringCast("/ip4/10.0.0.1/tcp/4002/ws"),
+		multiaddr.StringCast("/ip4/1.2.3.4/tcp/4001/ws"),
+		multiaddr.StringCast("/ip6/::/tcp/4001/ws"),
+		multiaddr.StringCast("/ip4/10.0.0.1/tcp/4001/ws"),
 	}
 
 	result, err := AnnouncementAddresses(true, "ipfs.example.com", hostAddrs)
 	require.NoError(t, err)
 
 	require.Len(t, result, 1)
-	assert.Equal(t, "/dns/web.ipfs.example.com/tcp/4002/wss", result[0].String())
+	assert.Equal(t, "/dns/web.ipfs.example.com/tcp/443/wss", result[0].String())
 }
 
-func TestAnnouncementAddresses_CertHashPreserved(t *testing.T) {
+func TestAnnouncementAddresses_QUICUsesApexDomain(t *testing.T) {
 	hostAddrs := []multiaddr.Multiaddr{
-		multiaddr.StringCast("/ip4/1.2.3.4/udp/4002/quic-v1/webtransport/certhash/uEiBzadLZbQCvscarMZg74tDg1l0trRpbTcWQOipBLFmSGg"),
+		multiaddr.StringCast("/ip4/1.2.3.4/udp/4001/quic-v1"),
+		multiaddr.StringCast("/ip4/10.0.0.1/udp/4001/quic-v1"),
+		multiaddr.StringCast("/ip4/127.0.0.1/udp/4001/quic-v1"),
 	}
 
 	result, err := AnnouncementAddresses(true, "ipfs.example.com", hostAddrs)
 	require.NoError(t, err)
 
 	require.Len(t, result, 1)
-	assert.Contains(t, result[0].String(), "/dns/web.ipfs.example.com/udp/4002/quic-v1/webtransport/certhash/")
+	assert.Equal(t, "/dns/ipfs.example.com/udp/4001/quic-v1", result[0].String())
+}
+
+func TestAnnouncementAddresses_WEBTRANSPORTWithCertHash(t *testing.T) {
+	hostAddrs := []multiaddr.Multiaddr{
+		multiaddr.StringCast("/ip4/1.2.3.4/udp/4001/quic-v1/webtransport/certhash/uEiBzadLZbQCvscarMZg74tDg1l0trRpbTcWQOipBLFmSGg"),
+		multiaddr.StringCast("/ip4/10.0.0.1/udp/4001/quic-v1/webtransport/certhash/uEiBzadLZbQCvscarMZg74tDg1l0trRpbTcWQOipBLFmSGg"),
+	}
+
+	result, err := AnnouncementAddresses(true, "ipfs.example.com", hostAddrs)
+	require.NoError(t, err)
+
+	require.Len(t, result, 1)
+	assert.Contains(t, result[0].String(), "/dns/ipfs.example.com/udp/4001/quic-v1/webtransport/certhash/")
 }
 
 func TestAnnouncementAddresses_EmptyHostAddrs(t *testing.T) {
@@ -109,76 +124,101 @@ func TestAnnouncementAddresses_EmptyHostAddrsNoWeb(t *testing.T) {
 
 func TestAnnouncementAddresses_AnnounceWebNoDomain(t *testing.T) {
 	hostAddrs := []multiaddr.Multiaddr{
-		multiaddr.StringCast("/ip4/1.2.3.4/tcp/4002/ws"),
+		multiaddr.StringCast("/ip4/1.2.3.4/tcp/4001/ws"),
 	}
 
 	result, err := AnnouncementAddresses(true, "", hostAddrs)
 	require.NoError(t, err)
 
 	require.Len(t, result, 1)
-	assert.Equal(t, "/ip4/1.2.3.4/tcp/4002/ws", result[0].String())
+	assert.Equal(t, "/ip4/1.2.3.4/tcp/4001/ws", result[0].String())
 }
 
 func TestFilterPublicAddrs(t *testing.T) {
 	addrs := []multiaddr.Multiaddr{
-		multiaddr.StringCast("/ip4/1.2.3.4/tcp/4002/ws"),
-		multiaddr.StringCast("/ip4/127.0.0.1/tcp/4002/ws"),
-		multiaddr.StringCast("/ip4/10.0.0.1/tcp/4002/ws"),
-		multiaddr.StringCast("/ip4/0.0.0.0/tcp/4002/ws"),
-		multiaddr.StringCast("/ip4/192.168.1.1/tcp/4002/ws"),
-		multiaddr.StringCast("/ip4/172.16.0.1/tcp/4002/ws"),
+		multiaddr.StringCast("/ip4/1.2.3.4/tcp/4001/ws"),
+		multiaddr.StringCast("/ip4/127.0.0.1/tcp/4001/ws"),
+		multiaddr.StringCast("/ip4/10.0.0.1/tcp/4001/ws"),
+		multiaddr.StringCast("/ip4/0.0.0.0/tcp/4001/ws"),
+		multiaddr.StringCast("/ip4/192.168.1.1/tcp/4001/ws"),
+		multiaddr.StringCast("/ip4/172.16.0.1/tcp/4001/ws"),
 	}
 
 	result := filterPublicAddrs(addrs)
 	require.Len(t, result, 1)
-	assert.Equal(t, "/ip4/1.2.3.4/tcp/4002/ws", result[0].String())
+	assert.Equal(t, "/ip4/1.2.3.4/tcp/4001/ws", result[0].String())
 }
 
-func TestAnnouncementAddresses_IPv6Replaced(t *testing.T) {
+func TestAnnouncementAddresses_IPv6WSReplaced(t *testing.T) {
 	hostAddrs := []multiaddr.Multiaddr{
-		multiaddr.StringCast("/ip6/::1/tcp/4002/ws"),
-		multiaddr.StringCast("/ip6/2001:db8::1/udp/4002/quic-v1"),
+		multiaddr.StringCast("/ip6/2607:f8b0:4004:800::200e/tcp/4001/ws"),
+		multiaddr.StringCast("/ip6/2607:f8b0:4004:800::200e/udp/4001/quic-v1"),
 	}
 
 	result, err := AnnouncementAddresses(true, "ipfs.example.com", hostAddrs)
 	require.NoError(t, err)
 
 	require.Len(t, result, 2)
-	assert.Equal(t, "/dns/web.ipfs.example.com/tcp/4002/wss", result[0].String())
-	assert.Equal(t, "/dns/web.ipfs.example.com/udp/4002/quic-v1", result[1].String())
+	assert.Equal(t, "/dns/web.ipfs.example.com/tcp/443/wss", result[0].String())
+	assert.Equal(t, "/dns/ipfs.example.com/udp/4001/quic-v1", result[1].String())
 }
 
 func TestAnnouncementAddresses_DNSHostAddrReplaced(t *testing.T) {
 	hostAddrs := []multiaddr.Multiaddr{
-		multiaddr.StringCast("/dns4/old.example.com/tcp/4002/ws"),
+		multiaddr.StringCast("/dns4/old.example.com/tcp/4001/ws"),
 	}
 
 	result, err := AnnouncementAddresses(true, "ipfs.example.com", hostAddrs)
 	require.NoError(t, err)
 
 	require.Len(t, result, 1)
-	assert.Equal(t, "/dns/web.ipfs.example.com/tcp/4002/wss", result[0].String())
+	assert.Equal(t, "/dns/web.ipfs.example.com/tcp/443/wss", result[0].String())
 }
 
-func TestAnnouncementAddresses_MultiplePorts(t *testing.T) {
+func TestAnnouncementAddresses_MixedTransports(t *testing.T) {
 	hostAddrs := []multiaddr.Multiaddr{
-		multiaddr.StringCast("/ip4/1.2.3.4/tcp/4002/ws"),
-		multiaddr.StringCast("/ip4/1.2.3.4/tcp/443/wss"),
-		multiaddr.StringCast("/ip4/1.2.3.4/udp/4002/quic-v1"),
-		multiaddr.StringCast("/ip4/1.2.3.4/udp/4002/quic-v1/webtransport"),
+		multiaddr.StringCast("/ip4/1.2.3.4/tcp/4001/ws"),
+		multiaddr.StringCast("/ip4/1.2.3.4/udp/4001/quic-v1"),
+		multiaddr.StringCast("/ip4/1.2.3.4/udp/4001/quic-v1/webtransport/certhash/uEiBzadLZbQCvscarMZg74tDg1l0trRpbTcWQOipBLFmSGg"),
 	}
 
 	result, err := AnnouncementAddresses(true, "ipfs.example.com", hostAddrs)
 	require.NoError(t, err)
 
 	expected := []string{
-		"/dns/web.ipfs.example.com/tcp/4002/wss",
 		"/dns/web.ipfs.example.com/tcp/443/wss",
-		"/dns/web.ipfs.example.com/udp/4002/quic-v1",
-		"/dns/web.ipfs.example.com/udp/4002/quic-v1/webtransport",
+		"/dns/ipfs.example.com/udp/4001/quic-v1",
+		"/dns/ipfs.example.com/udp/4001/quic-v1/webtransport/certhash/uEiBzadLZbQCvscarMZg74tDg1l0trRpbTcWQOipBLFmSGg",
 	}
 	require.Len(t, result, len(expected))
 	for i, addr := range result {
 		assert.Equal(t, expected[i], addr.String())
 	}
+}
+
+func TestAnnouncementAddresses_NoWSFallback(t *testing.T) {
+	hostAddrs := []multiaddr.Multiaddr{
+		multiaddr.StringCast("/ip4/1.2.3.4/udp/4001/quic-v1"),
+	}
+
+	result, err := AnnouncementAddresses(true, "ipfs.example.com", hostAddrs)
+	require.NoError(t, err)
+
+	require.Len(t, result, 1)
+	assert.Equal(t, "/dns/ipfs.example.com/udp/4001/quic-v1", result[0].String())
+}
+
+func TestAnnouncementAddresses_QUICDeduplicatesByPort(t *testing.T) {
+	hostAddrs := []multiaddr.Multiaddr{
+		multiaddr.StringCast("/ip4/1.2.3.4/udp/4001/quic-v1"),
+		multiaddr.StringCast("/ip4/5.6.7.8/udp/4001/quic-v1"),
+		multiaddr.StringCast("/ip4/1.2.3.4/udp/4002/quic-v1"),
+	}
+
+	result, err := AnnouncementAddresses(true, "ipfs.example.com", hostAddrs)
+	require.NoError(t, err)
+
+	require.Len(t, result, 2)
+	assert.Equal(t, "/dns/ipfs.example.com/udp/4001/quic-v1", result[0].String())
+	assert.Equal(t, "/dns/ipfs.example.com/udp/4002/quic-v1", result[1].String())
 }

--- a/internal/protocol/ipfs/node.go
+++ b/internal/protocol/ipfs/node.go
@@ -593,72 +593,80 @@ func (n *Node) TriggerReprovider() {
 
 func AnnouncementAddresses(announceWeb bool, domain string, hostAddrs []multiaddr.Multiaddr) ([]multiaddr.Multiaddr, error) {
 	if announceWeb && domain != "" {
-		webDomain := webSubdomainPrefix + domain
-		return announceFromDomainAndHostAddrs(webDomain, hostAddrs)
+		return announceFromDomainAndHostAddrs(domain, hostAddrs)
 	}
 
 	return filterPublicAddrs(hostAddrs), nil
 }
 
 func announceFromDomainAndHostAddrs(domain string, hostAddrs []multiaddr.Multiaddr) ([]multiaddr.Multiaddr, error) {
-	type addrKey struct {
-		proto string
-		port  string
-	}
-
-	seen := make(map[addrKey]bool)
-	var result []multiaddr.Multiaddr
+	var wssAddrs []multiaddr.Multiaddr
+	var udpAddrs []multiaddr.Multiaddr
+	seenWSS := make(map[string]bool)
+	seenUDP := make(map[string]bool)
 
 	for _, addr := range hostAddrs {
-		var components []string
-		var proto string
+		var hasWS bool
+		var hasQUIC bool
 		var port string
-
+		var quicProtos []string
+		var certhashes []string
 		multiaddr.ForEach(addr, func(c multiaddr.Component) bool {
 			switch c.Protocol().Code {
-			case multiaddr.P_IP4, multiaddr.P_IP6, multiaddr.P_DNS, multiaddr.P_DNS4, multiaddr.P_DNS6:
-				components = append(components, fmt.Sprintf("/dns/%s", domain))
-			case multiaddr.P_TCP:
-				port = c.Value()
-				components = append(components, fmt.Sprintf("/tcp/%s", c.Value()))
+			case multiaddr.P_WS, multiaddr.P_WSS:
+				hasWS = true
 			case multiaddr.P_UDP:
 				port = c.Value()
-				components = append(components, fmt.Sprintf("/udp/%s", c.Value()))
-			case multiaddr.P_WS:
-				proto = "wss"
-				components = append(components, "/wss")
-			case multiaddr.P_WSS:
-				proto = "wss"
-				components = append(components, "/wss")
 			case multiaddr.P_QUIC_V1:
-				proto = "quic-v1"
-				components = append(components, "/quic-v1")
+				hasQUIC = true
+				quicProtos = append(quicProtos, "quic-v1")
 			case multiaddr.P_WEBTRANSPORT:
-				proto = "webtransport"
-				components = append(components, "/webtransport")
+				quicProtos = append(quicProtos, "webtransport")
 			case multiaddr.P_CERTHASH:
-				components = append(components, fmt.Sprintf("/certhash/%s", c.Value()))
-			default:
-				components = append(components, fmt.Sprintf("/%s/%s", c.Protocol().Name, c.Value()))
+				certhashes = append(certhashes, c.Value())
 			}
 			return true
 		})
 
-		key := addrKey{proto: proto, port: port}
-		if seen[key] {
-			continue
-		}
-		seen[key] = true
-
-		replaced, err := multiaddr.NewMultiaddr(strings.Join(components, ""))
-		if err != nil {
+		if !manet.IsPublicAddr(addr) || manet.IsIPLoopback(addr) || manet.IsIPUnspecified(addr) || manet.IsPrivateAddr(addr) {
 			continue
 		}
 
-		result = append(result, replaced)
+		if hasWS {
+			ma, err := multiaddr.NewMultiaddr(fmt.Sprintf("/dns/%s%s/tcp/443/wss", webSubdomainPrefix, domain))
+			if err != nil {
+				continue
+			}
+			if !seenWSS[ma.String()] {
+				seenWSS[ma.String()] = true
+				wssAddrs = append(wssAddrs, ma)
+			}
+		} else if hasQUIC {
+			var parts []string
+			parts = append(parts, fmt.Sprintf("/dns/%s/udp/%s", domain, port))
+			for _, p := range quicProtos {
+				parts = append(parts, "/"+p)
+			}
+			for _, ch := range certhashes {
+				parts = append(parts, fmt.Sprintf("/certhash/%s", ch))
+			}
+			ma, err := multiaddr.NewMultiaddr(strings.Join(parts, ""))
+			if err != nil {
+				continue
+			}
+			if !seenUDP[ma.String()] {
+				seenUDP[ma.String()] = true
+				udpAddrs = append(udpAddrs, ma)
+			}
+		}
 	}
 
-	return result, nil
+	result := append(wssAddrs, udpAddrs...)
+	if len(result) > 0 {
+		return result, nil
+	}
+
+	return filterPublicAddrs(hostAddrs), nil
 }
 
 func filterPublicAddrs(addrs []multiaddr.Multiaddr) []multiaddr.Multiaddr {


### PR DESCRIPTION
- Change default port from 4002 to 4001 (libp2p convention)
- WSS addresses now announce on port 443 via web. subdomain (Caddy TLS)
- QUIC/WebTransport addresses now announce via apex domain DNS (direct UDP, not proxied through Caddy)
- WebTransport preserves quic-v1/webtransport protocol chain and certhashes
- Fix double web. prefix bug in announce domain construction
- Deduplicate UDP addrs by full multiaddr string
- Skip non-public addresses for DNS substitution

* `develop` <!-- branch-stack -->
  - **fix: correct AnnounceWeb announcement addresses** :point\_left:

---

<!-- kody-pr-summary:start -->
Fix IPFS announcement addresses for web transport protocols

This PR corrects how IPFS announcement addresses are generated when web announcement is enabled:

- **Default port corrected** from 4002 to 4001 (the standard IPFS swarm port)
- **WSS addresses** now always announce on port 443 with the `web.` subdomain prefix, reflecting a reverse-proxy deployment where WSS traffic is served over standard HTTPS
- **QUIC/WebTransport addresses** now announce using the apex domain (no `web.` prefix) while preserving the original port, since these protocols connect directly to the node rather than through a web proxy
- **Deduplication improved** to use the full multiaddr string instead of just (protocol, port), allowing different ports of the same protocol to be announced separately
- **Fallback behavior added**: if no valid web announcement addresses can be generated from the host addresses, the function falls back to returning filtered public addresses
<!-- kody-pr-summary:end -->