### PR TITLE
fix: filter ephemeral UDP ports from announce addresses

### DIFF
--- a/internal/api/api_blocks.go
+++ b/internal/api/api_blocks.go
@@ -62,7 +62,7 @@ func (a *API) handleGetBlockMetaBatch(c echo.Context) error {
 func (a *API) handleGetInfo(c echo.Context) error {
 	ctx := httputil.Context(c)
 
-	addrs, err := ipfs.AnnouncementAddresses(a.ipfs.GetNode().AnnounceWeb(), a.ipfs.GetNode().AnnounceDomain(), a.ipfs.GetNode().HostAddrs())
+	addrs, err := ipfs.AnnouncementAddresses(a.ipfs.GetNode().AnnounceWeb(), a.ipfs.GetNode().AnnounceDomain(), a.ipfs.GetNode().HostAddrs(), a.ipfs.GetNode().Port())
 	if err != nil {
 		a.Logger().Error("Failed to get announcement addresses", zap.Error(err))
 		apiErr := NewError(ErrKeyMetadataFetchFailed, err)

--- a/internal/config/protocol.go
+++ b/internal/config/protocol.go
@@ -60,10 +60,12 @@ func (c ProtocolConfig) ListenAddrs() []string {
 		fmt.Sprintf("/ip4/0.0.0.0/tcp/%d/ws", port),
 		fmt.Sprintf("/ip4/0.0.0.0/udp/%d/quic-v1", port),
 		fmt.Sprintf("/ip4/0.0.0.0/udp/%d/quic-v1/webtransport", port),
+		fmt.Sprintf("/ip4/0.0.0.0/udp/%d/webrtc-direct", port),
 		fmt.Sprintf("/ip6/::/tcp/%d", port),
 		fmt.Sprintf("/ip6/::/tcp/%d/ws", port),
 		fmt.Sprintf("/ip6/::/udp/%d/quic-v1", port),
 		fmt.Sprintf("/ip6/::/udp/%d/quic-v1/webtransport", port),
+		fmt.Sprintf("/ip6/::/udp/%d/webrtc-direct", port),
 	}
 
 	return append(base, c.ListenAddresses...)

--- a/internal/config/protocol.go
+++ b/internal/config/protocol.go
@@ -56,9 +56,11 @@ func (c ProtocolConfig) ListenAddrs() []string {
 	}
 
 	base := []string{
+		fmt.Sprintf("/ip4/0.0.0.0/tcp/%d", port),
 		fmt.Sprintf("/ip4/0.0.0.0/tcp/%d/ws", port),
 		fmt.Sprintf("/ip4/0.0.0.0/udp/%d/quic-v1", port),
 		fmt.Sprintf("/ip4/0.0.0.0/udp/%d/quic-v1/webtransport", port),
+		fmt.Sprintf("/ip6/::/tcp/%d", port),
 		fmt.Sprintf("/ip6/::/tcp/%d/ws", port),
 		fmt.Sprintf("/ip6/::/udp/%d/quic-v1", port),
 		fmt.Sprintf("/ip6/::/udp/%d/quic-v1/webtransport", port),

--- a/internal/protocol/ipfs/announce_test.go
+++ b/internal/protocol/ipfs/announce_test.go
@@ -15,7 +15,7 @@ func TestAnnouncementAddresses_AnnounceWeb(t *testing.T) {
 		multiaddr.StringCast("/ip4/1.2.3.4/udp/4001/quic-v1/webtransport"),
 	}
 
-	result, err := AnnouncementAddresses(true, "ipfs.example.com", hostAddrs)
+	result, err := AnnouncementAddresses(true, "ipfs.example.com", hostAddrs, 4001)
 	require.NoError(t, err)
 
 	expected := []string{
@@ -37,7 +37,7 @@ func TestAnnouncementAddresses_AnnounceWebFalse(t *testing.T) {
 		multiaddr.StringCast("/ip4/127.0.0.1/tcp/4001/ws"),
 	}
 
-	result, err := AnnouncementAddresses(false, "ipfs.example.com", hostAddrs)
+	result, err := AnnouncementAddresses(false, "ipfs.example.com", hostAddrs, 4001)
 	require.NoError(t, err)
 
 	require.Len(t, result, 2)
@@ -50,7 +50,7 @@ func TestAnnouncementAddresses_AnnounceWebWSSToPort443(t *testing.T) {
 		multiaddr.StringCast("/ip4/1.2.3.4/tcp/4001/ws"),
 	}
 
-	result, err := AnnouncementAddresses(true, "ipfs.example.com", hostAddrs)
+	result, err := AnnouncementAddresses(true, "ipfs.example.com", hostAddrs, 4001)
 	require.NoError(t, err)
 
 	require.Len(t, result, 1)
@@ -62,7 +62,7 @@ func TestAnnouncementAddresses_AnnounceWebWSSPassthrough(t *testing.T) {
 		multiaddr.StringCast("/ip4/1.2.3.4/tcp/443/wss"),
 	}
 
-	result, err := AnnouncementAddresses(true, "ipfs.example.com", hostAddrs)
+	result, err := AnnouncementAddresses(true, "ipfs.example.com", hostAddrs, 4001)
 	require.NoError(t, err)
 
 	require.Len(t, result, 1)
@@ -76,7 +76,7 @@ func TestAnnouncementAddresses_DeduplicatesWSS(t *testing.T) {
 		multiaddr.StringCast("/ip4/10.0.0.1/tcp/4001/ws"),
 	}
 
-	result, err := AnnouncementAddresses(true, "ipfs.example.com", hostAddrs)
+	result, err := AnnouncementAddresses(true, "ipfs.example.com", hostAddrs, 4001)
 	require.NoError(t, err)
 
 	require.Len(t, result, 1)
@@ -90,7 +90,21 @@ func TestAnnouncementAddresses_QUICUsesApexDomain(t *testing.T) {
 		multiaddr.StringCast("/ip4/127.0.0.1/udp/4001/quic-v1"),
 	}
 
-	result, err := AnnouncementAddresses(true, "ipfs.example.com", hostAddrs)
+	result, err := AnnouncementAddresses(true, "ipfs.example.com", hostAddrs, 4001)
+	require.NoError(t, err)
+
+	require.Len(t, result, 1)
+	assert.Equal(t, "/dns/ipfs.example.com/udp/4001/quic-v1", result[0].String())
+}
+
+func TestAnnouncementAddresses_EphemeralUDPPortFiltered(t *testing.T) {
+	hostAddrs := []multiaddr.Multiaddr{
+		multiaddr.StringCast("/ip4/1.2.3.4/udp/4001/quic-v1"),
+		multiaddr.StringCast("/ip4/1.2.3.4/udp/42966/quic-v1"),
+		multiaddr.StringCast("/ip4/1.2.3.4/udp/42966/quic-v1/webtransport/certhash/uEiBzadLZbQCvscarMZg74tDg1l0trRpbTcWQOipBLFmSGg"),
+	}
+
+	result, err := AnnouncementAddresses(true, "ipfs.example.com", hostAddrs, 4001)
 	require.NoError(t, err)
 
 	require.Len(t, result, 1)
@@ -103,7 +117,7 @@ func TestAnnouncementAddresses_WEBTRANSPORTWithCertHash(t *testing.T) {
 		multiaddr.StringCast("/ip4/10.0.0.1/udp/4001/quic-v1/webtransport/certhash/uEiBzadLZbQCvscarMZg74tDg1l0trRpbTcWQOipBLFmSGg"),
 	}
 
-	result, err := AnnouncementAddresses(true, "ipfs.example.com", hostAddrs)
+	result, err := AnnouncementAddresses(true, "ipfs.example.com", hostAddrs, 4001)
 	require.NoError(t, err)
 
 	require.Len(t, result, 1)
@@ -111,13 +125,13 @@ func TestAnnouncementAddresses_WEBTRANSPORTWithCertHash(t *testing.T) {
 }
 
 func TestAnnouncementAddresses_EmptyHostAddrs(t *testing.T) {
-	result, err := AnnouncementAddresses(true, "ipfs.example.com", nil)
+	result, err := AnnouncementAddresses(true, "ipfs.example.com", nil, 4001)
 	require.NoError(t, err)
 	assert.Empty(t, result)
 }
 
 func TestAnnouncementAddresses_EmptyHostAddrsNoWeb(t *testing.T) {
-	result, err := AnnouncementAddresses(false, "", nil)
+	result, err := AnnouncementAddresses(false, "", nil, 4001)
 	require.NoError(t, err)
 	assert.Empty(t, result)
 }
@@ -127,7 +141,7 @@ func TestAnnouncementAddresses_AnnounceWebNoDomain(t *testing.T) {
 		multiaddr.StringCast("/ip4/1.2.3.4/tcp/4001/ws"),
 	}
 
-	result, err := AnnouncementAddresses(true, "", hostAddrs)
+	result, err := AnnouncementAddresses(true, "", hostAddrs, 4001)
 	require.NoError(t, err)
 
 	require.Len(t, result, 1)
@@ -155,7 +169,7 @@ func TestAnnouncementAddresses_IPv6WSReplaced(t *testing.T) {
 		multiaddr.StringCast("/ip6/2607:f8b0:4004:800::200e/udp/4001/quic-v1"),
 	}
 
-	result, err := AnnouncementAddresses(true, "ipfs.example.com", hostAddrs)
+	result, err := AnnouncementAddresses(true, "ipfs.example.com", hostAddrs, 4001)
 	require.NoError(t, err)
 
 	require.Len(t, result, 2)
@@ -168,7 +182,7 @@ func TestAnnouncementAddresses_DNSHostAddrReplaced(t *testing.T) {
 		multiaddr.StringCast("/dns4/old.example.com/tcp/4001/ws"),
 	}
 
-	result, err := AnnouncementAddresses(true, "ipfs.example.com", hostAddrs)
+	result, err := AnnouncementAddresses(true, "ipfs.example.com", hostAddrs, 4001)
 	require.NoError(t, err)
 
 	require.Len(t, result, 1)
@@ -182,7 +196,7 @@ func TestAnnouncementAddresses_MixedTransports(t *testing.T) {
 		multiaddr.StringCast("/ip4/1.2.3.4/udp/4001/quic-v1/webtransport/certhash/uEiBzadLZbQCvscarMZg74tDg1l0trRpbTcWQOipBLFmSGg"),
 	}
 
-	result, err := AnnouncementAddresses(true, "ipfs.example.com", hostAddrs)
+	result, err := AnnouncementAddresses(true, "ipfs.example.com", hostAddrs, 4001)
 	require.NoError(t, err)
 
 	expected := []string{
@@ -201,24 +215,9 @@ func TestAnnouncementAddresses_NoWSFallback(t *testing.T) {
 		multiaddr.StringCast("/ip4/1.2.3.4/udp/4001/quic-v1"),
 	}
 
-	result, err := AnnouncementAddresses(true, "ipfs.example.com", hostAddrs)
+	result, err := AnnouncementAddresses(true, "ipfs.example.com", hostAddrs, 4001)
 	require.NoError(t, err)
 
 	require.Len(t, result, 1)
 	assert.Equal(t, "/dns/ipfs.example.com/udp/4001/quic-v1", result[0].String())
-}
-
-func TestAnnouncementAddresses_QUICDeduplicatesByPort(t *testing.T) {
-	hostAddrs := []multiaddr.Multiaddr{
-		multiaddr.StringCast("/ip4/1.2.3.4/udp/4001/quic-v1"),
-		multiaddr.StringCast("/ip4/5.6.7.8/udp/4001/quic-v1"),
-		multiaddr.StringCast("/ip4/1.2.3.4/udp/4002/quic-v1"),
-	}
-
-	result, err := AnnouncementAddresses(true, "ipfs.example.com", hostAddrs)
-	require.NoError(t, err)
-
-	require.Len(t, result, 2)
-	assert.Equal(t, "/dns/ipfs.example.com/udp/4001/quic-v1", result[0].String())
-	assert.Equal(t, "/dns/ipfs.example.com/udp/4002/quic-v1", result[1].String())
 }

--- a/internal/protocol/ipfs/announce_test.go
+++ b/internal/protocol/ipfs/announce_test.go
@@ -239,3 +239,15 @@ func TestAnnouncementAddresses_NoWSFallback(t *testing.T) {
 	require.Len(t, result, 1)
 	assert.Equal(t, "/dns/ipfs.example.com/udp/4001/quic-v1", result[0].String())
 }
+
+func TestAnnouncementAddresses_WebRTCDirect(t *testing.T) {
+	hostAddrs := []multiaddr.Multiaddr{
+		multiaddr.StringCast("/ip4/1.2.3.4/udp/4001/webrtc-direct"),
+	}
+
+	result, err := AnnouncementAddresses(true, "ipfs.example.com", hostAddrs, 4001)
+	require.NoError(t, err)
+
+	require.Len(t, result, 1)
+	assert.Equal(t, "/dns/ipfs.example.com/udp/4001/webrtc-direct", result[0].String())
+}

--- a/internal/protocol/ipfs/announce_test.go
+++ b/internal/protocol/ipfs/announce_test.go
@@ -10,6 +10,7 @@ import (
 
 func TestAnnouncementAddresses_AnnounceWeb(t *testing.T) {
 	hostAddrs := []multiaddr.Multiaddr{
+		multiaddr.StringCast("/ip4/1.2.3.4/tcp/4001"),
 		multiaddr.StringCast("/ip4/1.2.3.4/tcp/4001/ws"),
 		multiaddr.StringCast("/ip4/1.2.3.4/udp/4001/quic-v1"),
 		multiaddr.StringCast("/ip4/1.2.3.4/udp/4001/quic-v1/webtransport"),
@@ -19,6 +20,7 @@ func TestAnnouncementAddresses_AnnounceWeb(t *testing.T) {
 	require.NoError(t, err)
 
 	expected := []string{
+		"/dns/ipfs.example.com/tcp/4001",
 		"/dns/web.ipfs.example.com/tcp/443/wss",
 		"/dns/ipfs.example.com/udp/4001/quic-v1",
 		"/dns/ipfs.example.com/udp/4001/quic-v1/webtransport",
@@ -31,6 +33,7 @@ func TestAnnouncementAddresses_AnnounceWeb(t *testing.T) {
 
 func TestAnnouncementAddresses_AnnounceWebFalse(t *testing.T) {
 	hostAddrs := []multiaddr.Multiaddr{
+		multiaddr.StringCast("/ip4/1.2.3.4/tcp/4001"),
 		multiaddr.StringCast("/ip4/1.2.3.4/tcp/4001/ws"),
 		multiaddr.StringCast("/ip4/1.2.3.4/udp/4001/quic-v1"),
 		multiaddr.StringCast("/ip4/192.168.1.1/tcp/4001/ws"),
@@ -40,9 +43,22 @@ func TestAnnouncementAddresses_AnnounceWebFalse(t *testing.T) {
 	result, err := AnnouncementAddresses(false, "ipfs.example.com", hostAddrs, 4001)
 	require.NoError(t, err)
 
-	require.Len(t, result, 2)
-	assert.Equal(t, "/ip4/1.2.3.4/tcp/4001/ws", result[0].String())
-	assert.Equal(t, "/ip4/1.2.3.4/udp/4001/quic-v1", result[1].String())
+	require.Len(t, result, 3)
+	assert.Equal(t, "/ip4/1.2.3.4/tcp/4001", result[0].String())
+	assert.Equal(t, "/ip4/1.2.3.4/tcp/4001/ws", result[1].String())
+	assert.Equal(t, "/ip4/1.2.3.4/udp/4001/quic-v1", result[2].String())
+}
+
+func TestAnnouncementAddresses_PlainTCP(t *testing.T) {
+	hostAddrs := []multiaddr.Multiaddr{
+		multiaddr.StringCast("/ip4/1.2.3.4/tcp/4001"),
+	}
+
+	result, err := AnnouncementAddresses(true, "ipfs.example.com", hostAddrs, 4001)
+	require.NoError(t, err)
+
+	require.Len(t, result, 1)
+	assert.Equal(t, "/dns/ipfs.example.com/tcp/4001", result[0].String())
 }
 
 func TestAnnouncementAddresses_AnnounceWebWSSToPort443(t *testing.T) {
@@ -191,6 +207,7 @@ func TestAnnouncementAddresses_DNSHostAddrReplaced(t *testing.T) {
 
 func TestAnnouncementAddresses_MixedTransports(t *testing.T) {
 	hostAddrs := []multiaddr.Multiaddr{
+		multiaddr.StringCast("/ip4/1.2.3.4/tcp/4001"),
 		multiaddr.StringCast("/ip4/1.2.3.4/tcp/4001/ws"),
 		multiaddr.StringCast("/ip4/1.2.3.4/udp/4001/quic-v1"),
 		multiaddr.StringCast("/ip4/1.2.3.4/udp/4001/quic-v1/webtransport/certhash/uEiBzadLZbQCvscarMZg74tDg1l0trRpbTcWQOipBLFmSGg"),
@@ -200,6 +217,7 @@ func TestAnnouncementAddresses_MixedTransports(t *testing.T) {
 	require.NoError(t, err)
 
 	expected := []string{
+		"/dns/ipfs.example.com/tcp/4001",
 		"/dns/web.ipfs.example.com/tcp/443/wss",
 		"/dns/ipfs.example.com/udp/4001/quic-v1",
 		"/dns/ipfs.example.com/udp/4001/quic-v1/webtransport/certhash/uEiBzadLZbQCvscarMZg74tDg1l0trRpbTcWQOipBLFmSGg",

--- a/internal/protocol/ipfs/node.go
+++ b/internal/protocol/ipfs/node.go
@@ -47,6 +47,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/peerstore"
 	quic "github.com/libp2p/go-libp2p/p2p/transport/quic"
 	"github.com/libp2p/go-libp2p/p2p/transport/tcp"
+	webrtc "github.com/libp2p/go-libp2p/p2p/transport/webrtc"
 	ws "github.com/libp2p/go-libp2p/p2p/transport/websocket"
 	webtransport "github.com/libp2p/go-libp2p/p2p/transport/webtransport"
 	rcmgr "github.com/libp2p/go-libp2p/p2p/host/resource-manager"
@@ -412,6 +413,7 @@ func NewNode(ctx core.Context, cfg *config.ProtocolConfig, rs pluginCore.Reprovi
 		libp2p.ShareTCPListener(),
 		libp2p.Transport(quic.NewTransport),
 		libp2p.Transport(webtransport.New),
+		libp2p.Transport(webrtc.New),
 		libp2p.PrometheusRegisterer(prometheus.WrapRegistererWithPrefix("libp2p_", core.PluginMetricsRegistry(internal.ProtocolName))),
 		libp2p.AddrsFactory(func(addrs []multiaddr.Multiaddr) []multiaddr.Multiaddr {
 			var domain string
@@ -621,7 +623,7 @@ func announceFromDomainAndHostAddrs(domain string, hostAddrs []multiaddr.Multiad
 		var hasQUIC bool
 		var hasTCP bool
 		var port string
-		var quicProtos []string
+		var udpProtos []string
 		var certhashes []string
 		multiaddr.ForEach(addr, func(c multiaddr.Component) bool {
 			switch c.Protocol().Code {
@@ -634,9 +636,12 @@ func announceFromDomainAndHostAddrs(domain string, hostAddrs []multiaddr.Multiad
 				port = c.Value()
 			case multiaddr.P_QUIC_V1:
 				hasQUIC = true
-				quicProtos = append(quicProtos, "quic-v1")
+				udpProtos = append(udpProtos, "quic-v1")
 			case multiaddr.P_WEBTRANSPORT:
-				quicProtos = append(quicProtos, "webtransport")
+				udpProtos = append(udpProtos, "webtransport")
+			case multiaddr.P_WEBRTC_DIRECT:
+				hasQUIC = true
+				udpProtos = append(udpProtos, "webrtc-direct")
 			case multiaddr.P_CERTHASH:
 				certhashes = append(certhashes, c.Value())
 			}
@@ -663,7 +668,7 @@ func announceFromDomainAndHostAddrs(domain string, hostAddrs []multiaddr.Multiad
 		} else if hasQUIC {
 			var parts []string
 			parts = append(parts, fmt.Sprintf("/dns/%s/udp/%s", domain, port))
-			for _, p := range quicProtos {
+			for _, p := range udpProtos {
 				parts = append(parts, "/"+p)
 			}
 			for _, ch := range certhashes {

--- a/internal/protocol/ipfs/node.go
+++ b/internal/protocol/ipfs/node.go
@@ -609,19 +609,25 @@ func AnnouncementAddresses(announceWeb bool, domain string, hostAddrs []multiadd
 
 func announceFromDomainAndHostAddrs(domain string, hostAddrs []multiaddr.Multiaddr, configPort int) ([]multiaddr.Multiaddr, error) {
 	configPortStr := strconv.Itoa(configPort)
+	var tcpAddrs []multiaddr.Multiaddr
 	var wssAddrs []multiaddr.Multiaddr
 	var udpAddrs []multiaddr.Multiaddr
+	seenTCP := make(map[string]bool)
 	seenWSS := make(map[string]bool)
 	seenUDP := make(map[string]bool)
 
 	for _, addr := range hostAddrs {
 		var hasWS bool
 		var hasQUIC bool
+		var hasTCP bool
 		var port string
 		var quicProtos []string
 		var certhashes []string
 		multiaddr.ForEach(addr, func(c multiaddr.Component) bool {
 			switch c.Protocol().Code {
+			case multiaddr.P_TCP:
+				port = c.Value()
+				hasTCP = true
 			case multiaddr.P_WS, multiaddr.P_WSS:
 				hasWS = true
 			case multiaddr.P_UDP:
@@ -671,10 +677,19 @@ func announceFromDomainAndHostAddrs(domain string, hostAddrs []multiaddr.Multiad
 				seenUDP[ma.String()] = true
 				udpAddrs = append(udpAddrs, ma)
 			}
+		} else if hasTCP {
+			ma, err := multiaddr.NewMultiaddr(fmt.Sprintf("/dns/%s/tcp/%s", domain, port))
+			if err != nil {
+				continue
+			}
+			if !seenTCP[ma.String()] {
+				seenTCP[ma.String()] = true
+				tcpAddrs = append(tcpAddrs, ma)
+			}
 		}
 	}
 
-	result := append(wssAddrs, udpAddrs...)
+	result := append(tcpAddrs, append(wssAddrs, udpAddrs...)...)
 	if len(result) > 0 {
 		return result, nil
 	}

--- a/internal/protocol/ipfs/node.go
+++ b/internal/protocol/ipfs/node.go
@@ -647,7 +647,7 @@ func announceFromDomainAndHostAddrs(domain string, hostAddrs []multiaddr.Multiad
 			continue
 		}
 
-		if hasQUIC && port != configPortStr {
+		if hasQUIC && configPort != 0 && port != configPortStr {
 			continue
 		}
 

--- a/internal/protocol/ipfs/node.go
+++ b/internal/protocol/ipfs/node.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -89,6 +90,7 @@ type IPFSNode interface {
 	AnnounceWeb() bool
 	AnnounceDomain() string
 	HostAddrs() []multiaddr.Multiaddr
+	Port() int
 }
 
 // NopExchange wraps an exchange.Interface and disables NotifyNewBlocks.
@@ -185,6 +187,7 @@ type Node struct {
 	keystore         keystore.Keystore
 	publisher        *namesys.IPNSPublisher
 	announceWeb      bool
+	port             int
 }
 
 // Close closes the node
@@ -260,7 +263,7 @@ func (n *Node) PeerID() peer.ID {
 }
 
 func (n *Node) ConnectionAddresses() ([]multiaddr.Multiaddr, error) {
-	annAddrs, err := AnnouncementAddresses(n.announceWeb, n.announceDomain(), n.host.Addrs())
+	annAddrs, err := AnnouncementAddresses(n.announceWeb, n.announceDomain(), n.host.Addrs(), n.port)
 	if err != nil {
 		return nil, err
 	}
@@ -278,6 +281,10 @@ func (n *Node) AnnounceWeb() bool {
 
 func (n *Node) AnnounceDomain() string {
 	return n.announceDomain()
+}
+
+func (n *Node) Port() int {
+	return n.port
 }
 
 func (n *Node) announceDomain() string {
@@ -414,7 +421,7 @@ func NewNode(ctx core.Context, cfg *config.ProtocolConfig, rs pluginCore.Reprovi
 					domain = httpSvc.APISubdomain(internal.ProtocolName, false)
 				}
 			}
-			announceAddresses, err := AnnouncementAddresses(cfg.AnnounceWeb, domain, addrs)
+			announceAddresses, err := AnnouncementAddresses(cfg.AnnounceWeb, domain, addrs, cfg.Port)
 			if err != nil {
 				ctx.Logger().Error("failed to get announcement addresses", zap.Error(err))
 				return lo.Filter(addrs, func(addr multiaddr.Multiaddr, _ int) bool {
@@ -453,6 +460,7 @@ func NewNode(ctx core.Context, cfg *config.ProtocolConfig, rs pluginCore.Reprovi
 		log:         ctx.Logger(),
 		ctx:         ctx,
 		announceWeb: cfg.AnnounceWeb,
+		port:        cfg.Port,
 	}
 
 	// Build common DHT options using factory's GetBootstrapPeers()
@@ -591,15 +599,16 @@ func (n *Node) TriggerReprovider() {
 	n.reprovider.Trigger()
 }
 
-func AnnouncementAddresses(announceWeb bool, domain string, hostAddrs []multiaddr.Multiaddr) ([]multiaddr.Multiaddr, error) {
+func AnnouncementAddresses(announceWeb bool, domain string, hostAddrs []multiaddr.Multiaddr, configPort int) ([]multiaddr.Multiaddr, error) {
 	if announceWeb && domain != "" {
-		return announceFromDomainAndHostAddrs(domain, hostAddrs)
+		return announceFromDomainAndHostAddrs(domain, hostAddrs, configPort)
 	}
 
 	return filterPublicAddrs(hostAddrs), nil
 }
 
-func announceFromDomainAndHostAddrs(domain string, hostAddrs []multiaddr.Multiaddr) ([]multiaddr.Multiaddr, error) {
+func announceFromDomainAndHostAddrs(domain string, hostAddrs []multiaddr.Multiaddr, configPort int) ([]multiaddr.Multiaddr, error) {
+	configPortStr := strconv.Itoa(configPort)
 	var wssAddrs []multiaddr.Multiaddr
 	var udpAddrs []multiaddr.Multiaddr
 	seenWSS := make(map[string]bool)
@@ -629,6 +638,10 @@ func announceFromDomainAndHostAddrs(domain string, hostAddrs []multiaddr.Multiad
 		})
 
 		if !manet.IsPublicAddr(addr) || manet.IsIPLoopback(addr) || manet.IsIPUnspecified(addr) || manet.IsPrivateAddr(addr) {
+			continue
+		}
+
+		if hasQUIC && port != configPortStr {
 			continue
 		}
 

--- a/internal/testing/mocks/MockIPFSNode.go
+++ b/internal/testing/mocks/MockIPFSNode.go
@@ -995,6 +995,50 @@ func (_c *MockIPFSNode_Pin_Call) RunAndReturn(run func(ctx context.Context, root
 	return _c
 }
 
+// Port provides a mock function for the type MockIPFSNode
+func (_mock *MockIPFSNode) Port() int {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for Port")
+	}
+
+	var r0 int
+	if returnFunc, ok := ret.Get(0).(func() int); ok {
+		r0 = returnFunc()
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+	return r0
+}
+
+// MockIPFSNode_Port_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Port'
+type MockIPFSNode_Port_Call struct {
+	*mock.Call
+}
+
+// Port is a helper method to define mock.On call
+func (_e *MockIPFSNode_Expecter) Port() *MockIPFSNode_Port_Call {
+	return &MockIPFSNode_Port_Call{Call: _e.mock.On("Port")}
+}
+
+func (_c *MockIPFSNode_Port_Call) Run(run func()) *MockIPFSNode_Port_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockIPFSNode_Port_Call) Return(n int) *MockIPFSNode_Port_Call {
+	_c.Call.Return(n)
+	return _c
+}
+
+func (_c *MockIPFSNode_Port_Call) RunAndReturn(run func() int) *MockIPFSNode_Port_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // TriggerReprovider provides a mock function for the type MockIPFSNode
 func (_mock *MockIPFSNode) TriggerReprovider() {
 	_mock.Called()

--- a/internal/testing/util/util.go
+++ b/internal/testing/util/util.go
@@ -156,6 +156,7 @@ func GetProtocolMock() coreTesting.TestContextBuilderOption {
 		ipfsNode.EXPECT().HostAddrs().Return(nil).Maybe()
 		ipfsNode.EXPECT().AnnounceWeb().Return(false).Maybe()
 		ipfsNode.EXPECT().AnnounceDomain().Return("").Maybe()
+		ipfsNode.EXPECT().Port().Return(4001).Maybe()
 
 		// Mock AddBlock to return nil (success)
 		ipfsNode.EXPECT().AddBlock(mock.Anything, mock.Anything).Return(nil).Maybe()


### PR DESCRIPTION
- Add configPort parameter to AnnouncementAddresses to filter non-configured UDP ports (ephemeral WebTransport ports)
- Add Port() to IPFSNode interface and Node struct
- Add port field to Node, populated from config during construction
- Only announce QUIC/WebTransport on the configured port
- Update API handler and test helpers for new signature
- Add test for ephemeral port filtering

* `develop` <!-- branch-stack -->
  - **fix: filter ephemeral UDP ports from announce addresses** :point\_left:

***

<!-- kody-pr-summary:start -->

This pull request fixes the announcement of IPFS node addresses by filtering out ephemeral UDP ports. Previously, the node could announce QUIC/WebTransport addresses on random ephemeral ports (e.g., 42966) that the OS assigned, which are not stable or reachable. Now, only QUIC-based addresses on the configured port are included in announcements.

Key changes:

- Added a `Port()` method to the `IPFSNode` interface and its implementation, exposing the configured port from the node's config.
- Updated `AnnouncementAddresses` and `announceFromDomainAndHostAddrs` to accept a `configPort` parameter, which is used to filter out any QUIC address whose UDP port doesn't match the configured port.
- Added a test (`TestAnnouncementAddresses_EphemeralUDPPortFiltered`) verifying that ephemeral UDP ports are excluded from announced addresses.
- Removed the `TestAnnouncementAddresses_QUICDeduplicatesByPort` test, as the new port-based filtering supersedes the previous deduplication-by-port logic.
- Updated all callers and mocks to pass the new port parameter.

<!-- kody-pr-summary:end -->
