### PR TITLE
fix: nil-guard host addrs in debug logging

### DIFF
--- a/internal/protocol/ipfs/node.go
+++ b/internal/protocol/ipfs/node.go
@@ -419,7 +419,7 @@ func NewNode(ctx core.Context, cfg *config.ProtocolConfig, rs pluginCore.Reprovi
 			ctx.Logger().Debug("ipfs AddrsFactory invoked",
 				zap.Int("host_addr_count", len(addrs)),
 				zap.Int("config_port", cfg.Port),
-				zap.Strings("host_addrs", lo.Map(addrs, func(a multiaddr.Multiaddr, _ int) string {
+				zap.Strings("host_addrs", lo.Map(lo.Filter(addrs, func(a multiaddr.Multiaddr, _ int) bool { return a != nil }), func(a multiaddr.Multiaddr, _ int) string {
 					return a.String()
 				})),
 			)


### PR DESCRIPTION
lo.Map over addrs without filtering nils causes panic when evaluating log arguments even when debug logging is disabled.

---

<!-- kody-pr-summary:start -->


Fixes a potential nil pointer panic in debug logging by filtering out nil multiaddresses before converting them to strings. When the `AddrsFactory` is invoked, any nil entries in the address slice would cause a panic during `a.String()` conversion; the added filter ensures only non-nil addresses are processed.
<!-- kody-pr-summary:end -->