### PR TITLE
fix: allow private IPs when AnnounceWeb with domain

### DIFF
--- a/internal/protocol/ipfs/announce_test.go
+++ b/internal/protocol/ipfs/announce_test.go
@@ -10,10 +10,10 @@ import (
 
 func TestAnnouncementAddresses_AnnounceWeb(t *testing.T) {
 	hostAddrs := []multiaddr.Multiaddr{
-		multiaddr.StringCast("/ip4/1.2.3.4/tcp/4001"),
-		multiaddr.StringCast("/ip4/1.2.3.4/tcp/4001/ws"),
-		multiaddr.StringCast("/ip4/1.2.3.4/udp/4001/quic-v1"),
-		multiaddr.StringCast("/ip4/1.2.3.4/udp/4001/quic-v1/webtransport"),
+		multiaddr.StringCast("/ip4/172.18.0.19/tcp/4001"),
+		multiaddr.StringCast("/ip4/172.18.0.19/tcp/4001/ws"),
+		multiaddr.StringCast("/ip4/172.18.0.19/udp/4001/quic-v1"),
+		multiaddr.StringCast("/ip4/172.18.0.19/udp/4001/quic-v1/webtransport"),
 	}
 
 	result, err := AnnouncementAddresses(true, "ipfs.example.com", hostAddrs, 4001)
@@ -238,6 +238,30 @@ func TestAnnouncementAddresses_NoWSFallback(t *testing.T) {
 
 	require.Len(t, result, 1)
 	assert.Equal(t, "/dns/ipfs.example.com/udp/4001/quic-v1", result[0].String())
+}
+
+func TestAnnouncementAddresses_PrivateIPsWithDomain(t *testing.T) {
+	hostAddrs := []multiaddr.Multiaddr{
+		multiaddr.StringCast("/ip4/127.0.0.1/tcp/4001"),
+		multiaddr.StringCast("/ip4/127.0.0.1/tcp/4001/ws"),
+		multiaddr.StringCast("/ip4/172.18.0.19/udp/4001/quic-v1"),
+		multiaddr.StringCast("/ip4/172.18.0.19/udp/4001/webrtc-direct"),
+		multiaddr.StringCast("/ip6/::1/tcp/4001/ws"),
+	}
+
+	result, err := AnnouncementAddresses(true, "ipfs.dev.pinner.xyz", hostAddrs, 4001)
+	require.NoError(t, err)
+
+	expected := []string{
+		"/dns/ipfs.dev.pinner.xyz/tcp/4001",
+		"/dns/web.ipfs.dev.pinner.xyz/tcp/443/wss",
+		"/dns/ipfs.dev.pinner.xyz/udp/4001/quic-v1",
+		"/dns/ipfs.dev.pinner.xyz/udp/4001/webrtc-direct",
+	}
+	require.Len(t, result, len(expected))
+	for i, addr := range result {
+		assert.Equal(t, expected[i], addr.String())
+	}
 }
 
 func TestAnnouncementAddresses_WebRTCDirect(t *testing.T) {

--- a/internal/protocol/ipfs/node.go
+++ b/internal/protocol/ipfs/node.go
@@ -665,10 +665,6 @@ func announceFromDomainAndHostAddrs(domain string, hostAddrs []multiaddr.Multiad
 			return true
 		})
 
-		if !manet.IsPublicAddr(addr) || manet.IsIPLoopback(addr) || manet.IsIPUnspecified(addr) || manet.IsPrivateAddr(addr) {
-			continue
-		}
-
 		if hasQUIC && configPort != 0 && port != configPortStr {
 			continue
 		}


### PR DESCRIPTION
When AnnounceWeb=true and a domain is set, the point is to substitute DNS for IPs — private IPs like 172.18.0.19 and 127.0.0.1 are expected. The IsPublic/IsPrivate/IsLoopback check was filtering all addrs in container deployments where only private IPs are observable, producing zero announce addrs.

Remove the public-only filter from announceFromDomainAndHostAddrs; dedup maps already handle multiple IPs mapping to the same DNS addr.

- `develop` <!-- branch-stack -->
  - **fix: allow private IPs when AnnounceWeb with domain** :point\_left:

---

<!-- kody-pr-summary:start -->
## Description

This pull request fixes an issue where private IP addresses were being filtered out when announcing web addresses with a domain name.

### Changes Made

**Core Fix (`internal/protocol/ipfs/node.go`):**
- Removed the check that skipped private, loopback, and unspecified IP addresses in the `announceFromDomainAndHostAddrs` function. Previously, addresses that weren't public or were private/loopback/unspecified were discarded, preventing announcement when the node only had private IPs (common in Docker containers or private network deployments).

**Test Updates (`internal/protocol/ipfs/announce_test.go`):**
- Updated the existing `TestAnnouncementAddresses_AnnounceWeb` test to use a private IP (`172.18.0.19`) instead of a public IP (`1.2.3.4`), confirming the fix works correctly.
- Added a new test `TestAnnouncementAddresses_PrivateIPsWithDomain` that validates announcement works with various private IPs (127.0.0.1, 172.18.0.19, ::1) when a domain is provided, ensuring the domain correctly replaces the private IP in the announced addresses.

### Rationale

When a domain is configured for announcement, the actual IP address is replaced with the domain name in the resulting multiaddresses. Therefore, filtering out private IPs is unnecessary and counterproductive—it prevents nodes running in private networks or containers from properly announcing their addresses via a public domain.
<!-- kody-pr-summary:end -->