### PR TITLE
fix: filter non-configured TCP ports from announce addrs

### DIFF
--- a/internal/protocol/ipfs/node.go
+++ b/internal/protocol/ipfs/node.go
@@ -665,7 +665,7 @@ func announceFromDomainAndHostAddrs(domain string, hostAddrs []multiaddr.Multiad
 			return true
 		})
 
-		if hasQUIC && configPort != 0 && port != configPortStr {
+		if !hasWS && configPort != 0 && port != configPortStr {
 			continue
 		}
 


### PR DESCRIPTION
TCP addrs on non-configured ports (e.g. 20995 from public IP) were passing through to DNS-substituted announce addrs. Extend the existing UDP ephemeral port filter to also cover TCP, with an exemption for WS/WSS which always use port 443 via Caddy.

- `develop` <!-- branch-stack -->
  - **fix: filter non-configured TCP ports from announce addrs** :point\_left:

---

<!-- kody-pr-summary:start -->
This pull request fixes the address filtering logic for IPFS announce addresses. Previously, the code specifically filtered out QUIC addresses that did not match the configured port. The updated logic changes this condition to filter out all non-WebSocket addresses (such as plain TCP) that use non-configured ports, while allowing WebSocket addresses to bypass this port filter. This ensures that only addresses with the correct configured ports are announced, except for WebSocket addresses which may operate behind reverse proxies on different ports.
<!-- kody-pr-summary:end -->