### PR TITLE
fix: force public reachability for libp2p node

### DIFF
--- a/internal/protocol/ipfs/node.go
+++ b/internal/protocol/ipfs/node.go
@@ -406,6 +406,7 @@ func NewNode(ctx core.Context, cfg *config.ProtocolConfig, rs pluginCore.Reprovi
 		libp2p.ConnectionManager(cmgr),
 		libp2p.Identity(privateKey),
 		libp2p.EnableRelay(),
+		libp2p.ForceReachabilityPublic(),
 		libp2p.ResourceManager(rm),
 		libp2p.DefaultPeerstore,
 		libp2p.Transport(tcp.NewTCPTransport),


### PR DESCRIPTION
Node with only private IPs observable was self-assessing as private/unreachable, potentially rejecting noise handshakes from remote peers. ForceReachabilityPublic() overrides AutoNAT detection since AnnounceWeb already substitutes DNS for private IPs.

- `develop` <!-- branch-stack -->
  - **fix: force public reachability for libp2p node** :point\_left:

---

<!-- kody-pr-summary:start -->
Force the libp2p node to be configured as publicly reachable by adding `libp2p.ForceReachabilityPublic()` to the node options. This ensures the node always operates in public reachability mode rather than relying on auto-detection, which may incorrectly classify the node as private or behind NAT/firewall.
<!-- kody-pr-summary:end -->