### PR TITLE
fix: disable TCP reuseport for Docker NAT compatibility

### DIFF
--- a/internal/protocol/ipfs/node.go
+++ b/internal/protocol/ipfs/node.go
@@ -409,7 +409,7 @@ func NewNode(ctx core.Context, cfg *config.ProtocolConfig, rs pluginCore.Reprovi
 		libp2p.ForceReachabilityPublic(),
 		libp2p.ResourceManager(rm),
 		libp2p.DefaultPeerstore,
-		libp2p.Transport(tcp.NewTCPTransport),
+		libp2p.Transport(tcp.NewTCPTransport, tcp.DisableReuseport()),
 		libp2p.Transport(ws.New),
 		libp2p.ShareTCPListener(),
 		libp2p.Transport(quic.NewTransport),


### PR DESCRIPTION
Reuseport causes the kernel to distribute connections across multiple sockets, which breaks multistream-select negotiation behind Docker NAT/proxy. Confirmed fix from libp2p issue #2339.

- `develop` <!-- branch-stack -->
  - **fix: disable TCP reuseport for Docker NAT compatibility** :point\_left:

---

<!-- kody-pr-summary:start -->
This pull request disables the `SO_REUSEPORT` socket option for the TCP transport in the IPFS libp2p node configuration. This change is made to ensure compatibility with Docker NAT environments, where reuseport can cause issues with port mapping and network address translation.
<!-- kody-pr-summary:end -->