### PR TITLE
fix: exempt private IP ranges from rcmgr per-IP limits

### DIFF
--- a/internal/protocol/ipfs/node.go
+++ b/internal/protocol/ipfs/node.go
@@ -6,6 +6,8 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io"
+	"math"
+	"net/netip"
 	"strconv"
 	"strings"
 	"sync"
@@ -52,6 +54,7 @@ import (
 	webtransport "github.com/libp2p/go-libp2p/p2p/transport/webtransport"
 	rcmgr "github.com/libp2p/go-libp2p/p2p/host/resource-manager"
 	"github.com/libp2p/go-libp2p/p2p/net/connmgr"
+	"github.com/libp2p/go-libp2p/x/rate"
 )
 
 const (
@@ -389,9 +392,33 @@ func NewNode(ctx core.Context, cfg *config.ProtocolConfig, rs pluginCore.Reprovi
 	if cfg.AutoScaleResourceLimits {
 		limits = scalingLimits.AutoScale()
 	}
-
 	limiter := rcmgr.NewFixedLimiter(limits)
-	rm, err := rcmgr.NewResourceManager(limiter, rcmgr.WithMetricsDisabled())
+
+	rm, err := rcmgr.NewResourceManager(limiter,
+		rcmgr.WithConnRateLimiters(&rate.Limiter{
+			NetworkPrefixLimits: []rate.PrefixLimit{
+				{Prefix: netip.MustParsePrefix("127.0.0.0/8"), Limit: rate.Limit{}},
+				{Prefix: netip.MustParsePrefix("::1/128"), Limit: rate.Limit{}},
+				{Prefix: netip.MustParsePrefix("172.16.0.0/12"), Limit: rate.Limit{}},
+				{Prefix: netip.MustParsePrefix("10.0.0.0/8"), Limit: rate.Limit{}},
+				{Prefix: netip.MustParsePrefix("192.168.0.0/16"), Limit: rate.Limit{}},
+			},
+			GlobalLimit: rate.Limit{},
+		}),
+		rcmgr.WithNetworkPrefixLimit(
+			[]rcmgr.NetworkPrefixLimit{
+				{Network: netip.MustParsePrefix("127.0.0.0/8"), ConnCount: math.MaxInt},
+				{Network: netip.MustParsePrefix("::1/128"), ConnCount: math.MaxInt},
+				{Network: netip.MustParsePrefix("172.16.0.0/12"), ConnCount: math.MaxInt},
+				{Network: netip.MustParsePrefix("10.0.0.0/8"), ConnCount: math.MaxInt},
+				{Network: netip.MustParsePrefix("192.168.0.0/16"), ConnCount: math.MaxInt},
+			},
+			[]rcmgr.NetworkPrefixLimit{
+				{Network: netip.MustParsePrefix("::1/128"), ConnCount: math.MaxInt},
+				{Network: netip.MustParsePrefix("fc00::/7"), ConnCount: math.MaxInt},
+			},
+		),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create resource manager: %w", err)
 	}
@@ -409,7 +436,7 @@ func NewNode(ctx core.Context, cfg *config.ProtocolConfig, rs pluginCore.Reprovi
 		libp2p.ForceReachabilityPublic(),
 		libp2p.ResourceManager(rm),
 		libp2p.DefaultPeerstore,
-		libp2p.Transport(tcp.NewTCPTransport, tcp.DisableReuseport()),
+		libp2p.Transport(tcp.NewTCPTransport),
 		libp2p.Transport(ws.New),
 		libp2p.ShareTCPListener(),
 		libp2p.Transport(quic.NewTransport),

--- a/internal/protocol/ipfs/node.go
+++ b/internal/protocol/ipfs/node.go
@@ -402,6 +402,7 @@ func NewNode(ctx core.Context, cfg *config.ProtocolConfig, rs pluginCore.Reprovi
 				{Prefix: netip.MustParsePrefix("172.16.0.0/12"), Limit: rate.Limit{}},
 				{Prefix: netip.MustParsePrefix("10.0.0.0/8"), Limit: rate.Limit{}},
 				{Prefix: netip.MustParsePrefix("192.168.0.0/16"), Limit: rate.Limit{}},
+				{Prefix: netip.MustParsePrefix("fc00::/7"), Limit: rate.Limit{}},
 			},
 			GlobalLimit: rate.Limit{},
 		}),


### PR DESCRIPTION
When running behind a reverse proxy (nginx stream), all inbound connections appear from the proxy's internal IP. rcmgr's default per-IP rate limiter (0.2 RPS per /32) and connection limiter (8 conns per /32) silently block all DHT traffic after the initial burst. InfiniteLimits only affects FixedLimiter, not the per-IP limiters -- they must be exempted explicitly.

This replaces the DisableReuseport workaround (reverts #605) and makes the ForceReachabilityPublic/announce-port-filter fixes (#603, #604) effective by ensuring connections actually reach the node instead of being dropped by rcmgr.

Changes:

- Add WithConnRateLimiters exempting loopback and RFC 1918/4193 prefixes from per-IP rate limiting
- Add WithNetworkPrefixLimit with unlimited ConnCount for same prefixes, bypassing per-IP connection count limits
- Remove WithMetricsDisabled to enable rcmgr Prometheus metrics (libp2p\_rcmgr\_\* namespace) for observability into blocked connections and resource exhaustion

* `develop` <!-- branch-stack -->
  - **fix: exempt private IP ranges from rcmgr per-IP limits** :point\_left:

***

<!-- kody-pr-summary:start -->

Exempt private IP address ranges from the libp2p resource manager's per-IP rate limits and connection count limits. This prevents internal/Docker network connections (e.g., between containers on the same host) from being throttled or rejected by per-IP resource constraints.

Specifically, the following private IP ranges are exempted with unlimited connection allowances:

- **IPv4**: `127.0.0.0/8` (loopback), `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`
- **IPv6**: `::1/128` (loopback), `fc00::/7` (unique local)

Additionally, TCP port reuse (`SO_REUSEPORT`) has been re-enabled by removing the `tcp.DisableReuseport()` option from the TCP transport configuration.

<!-- kody-pr-summary:end -->
