### PR TITLE
fix: set libp2p identify user agent to lumeweb-ipfs

### DIFF
--- a/internal/protocol/ipfs/node.go
+++ b/internal/protocol/ipfs/node.go
@@ -21,6 +21,7 @@ import (
 	manet "github.com/multiformats/go-multiaddr/net"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/samber/lo"
+	pluginBuild "go.lumeweb.com/portal-plugin-ipfs/build"
 	pluginCore "go.lumeweb.com/portal-plugin-ipfs/core"
 	"go.lumeweb.com/portal-plugin-ipfs/internal"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/config"
@@ -437,6 +438,7 @@ func NewNode(ctx core.Context, cfg *config.ProtocolConfig, rs pluginCore.Reprovi
 		libp2p.ForceReachabilityPublic(),
 		libp2p.ResourceManager(rm),
 		libp2p.DefaultPeerstore,
+		libp2p.UserAgent("lumeweb-ipfs/" + pluginBuild.GetInfo().Short()),
 		libp2p.Transport(tcp.NewTCPTransport),
 		libp2p.Transport(ws.New),
 		libp2p.ShareTCPListener(),


### PR DESCRIPTION
The default user agent was derived from the binary name and build info, producing unhelpful values like 'portal@<vcs-revision>'. Set an explicit UserAgent using the plugin build version so peers see 'lumeweb-ipfs/<version>' following the IPFS convention of agent-name/version.

- `develop` <!-- branch-stack -->
  - **fix: set libp2p identify user agent to lumeweb-ipfs** :point\_left:

---

<!-- kody-pr-summary:start -->
Set the libp2p identify protocol user agent to `lumeweb-ipfs/` followed by the plugin's short build version, allowing the node to properly identify itself on the libp2p network instead of using the default user agent string.
<!-- kody-pr-summary:end -->