### PR TITLE
feat: add ipns_key_id and active_cid to website response

### DIFF
--- a/internal/api/api_websites.go
+++ b/internal/api/api_websites.go
@@ -12,6 +12,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"go.lumeweb.com/httputil"
 	mcontext "go.lumeweb.com/portal-middleware/context"
+	pluginCore "go.lumeweb.com/portal-plugin-ipfs/core"
 	pluginEvents "go.lumeweb.com/portal-plugin-ipfs/internal/errors"
 	pluginservice "go.lumeweb.com/portal-plugin-ipfs/internal/service/website"
 	pluginDb "go.lumeweb.com/portal-plugin-ipfs/internal/db"
@@ -21,10 +22,22 @@ import (
 	"go.uber.org/zap"
 )
 
+// ipnsKeyCIDResolver adapts IPNSKeyService to satisfy dto.IPNSKeyCIDResolver
+type ipnsKeyCIDResolver struct {
+	svc pluginCore.IPNSKeyService
+	ctx context.Context
+}
+
+func (r ipnsKeyCIDResolver) GetKeyLastPublishedCID(userID uint, keyID uint) string {
+	key, err := r.svc.GetKeyByID(r.ctx, userID, keyID)
+	if err != nil || key == nil {
+		return ""
+	}
+	return key.LastPublishedCID
+}
+
 // Website Handlers
 
-// DefaultWebsiteEnabled is the default value for website DNS hosting enabled field
-// Applications should use this constant to ensure consistency across the codebase
 const DefaultWebsiteEnabled = true
 
 func (a *API) gatewayDomain() string {
@@ -128,6 +141,7 @@ func (a *API) createWebsite(c echo.Context) error {
 	}
 	resp.GatewayDomain = a.gatewayDomain()
 	resp.SetSubdomainInfo(a.zoneDomain(reqCtx, website.DNSZoneID))
+	resp.EnrichActiveCID(ipnsKeyCIDResolver{svc: a.ipnsKeyService, ctx: reqCtx}, user, website)
 
 	ctx.Response().Before(func() {
 		ctx.Response().Status = http.StatusCreated
@@ -183,6 +197,7 @@ func (a *API) listWebsites(c echo.Context) error {
 		}
 		responses[i].GatewayDomain = a.gatewayDomain()
 		responses[i].SetSubdomainInfo(a.zoneDomain(reqCtx, website.DNSZoneID))
+		responses[i].EnrichActiveCID(ipnsKeyCIDResolver{svc: a.ipnsKeyService, ctx: reqCtx}, user, website)
 	}
 
 	// Convert to WebsiteItem for list response
@@ -224,6 +239,7 @@ func (a *API) getWebsite(c echo.Context) error {
 		if err := resp.FromModel(website); err == nil {
 			resp.GatewayDomain = a.gatewayDomain()
 			resp.SetSubdomainInfo(a.zoneDomain(reqCtx, website.DNSZoneID))
+			resp.EnrichActiveCID(ipnsKeyCIDResolver{svc: a.ipnsKeyService, ctx: reqCtx}, user, website)
 			ctx.Response().Before(func() {
 				ctx.Response().Status = http.StatusGone
 			})
@@ -234,6 +250,7 @@ func (a *API) getWebsite(c echo.Context) error {
 	resp := &dto.WebsiteResponse{}
 	resp.GatewayDomain = a.gatewayDomain()
 	resp.SetSubdomainInfo(a.zoneDomain(reqCtx, website.DNSZoneID))
+	resp.EnrichActiveCID(ipnsKeyCIDResolver{svc: a.ipnsKeyService, ctx: reqCtx}, user, website)
 	return httputil.EncodeResponse(ctx, website, resp)
 }
 
@@ -295,6 +312,7 @@ func (a *API) updateWebsite(c echo.Context) error {
 	}
 	resp.GatewayDomain = a.gatewayDomain()
 	resp.SetSubdomainInfo(a.zoneDomain(reqCtx, website.DNSZoneID))
+	resp.EnrichActiveCID(ipnsKeyCIDResolver{svc: a.ipnsKeyService, ctx: reqCtx}, user, website)
 
 	return httputil.EncodeResponse(ctx, website, &resp)
 }
@@ -395,6 +413,7 @@ func (a *API) getSSLStatus(c echo.Context) error {
 	resp := &dto.WebsiteResponse{}
 	resp.GatewayDomain = a.gatewayDomain()
 	resp.SetSubdomainInfo(a.zoneDomain(reqCtx, website.DNSZoneID))
+	resp.EnrichActiveCID(ipnsKeyCIDResolver{svc: a.ipnsKeyService, ctx: reqCtx}, website.UserID, website)
 	return httputil.EncodeResponse(ctx, website, resp)
 }
 
@@ -437,5 +456,6 @@ func (a *API) updateSSLStatus(c echo.Context) error {
 	resp := &dto.WebsiteResponse{}
 	resp.GatewayDomain = a.gatewayDomain()
 	resp.SetSubdomainInfo(a.zoneDomain(reqCtx, website.DNSZoneID))
+	resp.EnrichActiveCID(ipnsKeyCIDResolver{svc: a.ipnsKeyService, ctx: reqCtx}, website.UserID, website)
 	return httputil.EncodeResponse(ctx, website, resp)
 }

--- a/internal/api/dto/website.go
+++ b/internal/api/dto/website.go
@@ -337,6 +337,8 @@ type WebsiteResponse struct {
 	Domain              string         `json:"domain"`
 	TargetType          string         `json:"target_type"`
 	TargetHash          string         `json:"target_hash"`
+	IPNSKeyID           *uint          `json:"ipns_key_id,omitempty"`  // FK to the linked IPNS key (set when DNS hosting auto-creates a key)
+	ActiveCID           string         `json:"active_cid,omitempty"`   // The currently-published IPFS content CID (distinct from target_hash when target is IPNS)
 	Status              string         `json:"status"`
 	ValidationToken     string         `json:"validation_token"`
 	ValidationExpiresAt *time.Time     `json:"validation_expires_at,omitempty"`
@@ -361,6 +363,7 @@ func (r *WebsiteResponse) FromModel(model *db.Website) error {
 	r.ValidationExpiresAt = model.ValidationExpiresAt
 	r.LastCheckedAt = model.LastCheckedAt
 	r.DNSZoneID = model.DNSZoneID
+	r.IPNSKeyID = model.IPNSKeyID
 	r.Enabled = model.Enabled
 	r.Created = model.CreatedAt
 	r.Updated = model.UpdatedAt
@@ -386,6 +389,23 @@ func (r *WebsiteResponse) FromModel(model *db.Website) error {
 	}
 
 	return nil
+}
+
+// IPNSKeyCIDResolver resolves the last-published CID for an IPNS key.
+type IPNSKeyCIDResolver interface {
+	GetKeyLastPublishedCID(userID uint, keyID uint) string
+}
+
+// EnrichActiveCID populates the ActiveCID field by resolving the linked IPNS key's
+// last-published CID from the resolver. This is separate from FromModel because
+// it requires a service lookup beyond the DB model.
+func (r *WebsiteResponse) EnrichActiveCID(resolver IPNSKeyCIDResolver, userID uint, model *db.Website) {
+	if model.IPNSKeyID == nil {
+		return
+	}
+	if cid := resolver.GetKeyLastPublishedCID(userID, *model.IPNSKeyID); cid != "" {
+		r.ActiveCID = cid
+	}
 }
 
 // SetSubdomainInfo sets the IsSubdomain flag based on the zone's domain.


### PR DESCRIPTION
Expose the linked IPNS key and currently-published IPFS content CID in the WebsiteItem/WebsiteResponse DTO so consumers can traverse a website's IPNS key and determine the active CID to unpin.

- `develop` <!-- branch-stack -->
  - **feat: add ipns\_key\_id and active\_cid to website response** :point\_left:

---

<!-- kody-pr-summary:start -->
Add `ipns_key_id` and `active_cid` fields to the website API response

This PR enriches the website response DTO with two new fields:
- **`ipns_key_id`**: The foreign key to the linked IPNS key (populated from the database model when DNS hosting auto-creates a key).
- **`active_cid`**: The currently-published IPFS content CID for the linked IPNS key, which is distinct from `target_hash` when the target is IPNS.

The `active_cid` is resolved at response time via a new `IPNSKeyCIDResolver` interface, implemented by an adapter around the existing `IPNSKeyService`. This resolution is kept separate from `FromModel` since it requires a service lookup beyond the database model. The enrichment is applied consistently across all website response paths: create, list, get, update, and both SSL status endpoints.
<!-- kody-pr-summary:end -->