### PR TITLE
feat: return ValidateDNSResult from ValidateDNS, return 200 for expected outcomes

### DIFF
--- a/core/website.go
+++ b/core/website.go
@@ -12,6 +12,22 @@ import (
 
 const WEBSITE_SERVICE = "ipfs.website"
 
+type ValidationReason string
+
+const (
+	ValidationReasonValidated    ValidationReason = "validated"
+	ValidationReasonTokenExpired ValidationReason = "token_expired"
+	ValidationReasonDNSMissing   ValidationReason = "dns_missing"
+	ValidationReasonDNSMismatch  ValidationReason = "dns_mismatch"
+	ValidationReasonTokenMissing ValidationReason = "token_missing"
+)
+
+type ValidateDNSResult struct {
+	Valid   bool
+	Message string
+	Reason  ValidationReason // machine-readable: "validated", "token_expired", "dns_missing", "dns_mismatch", "token_missing"
+}
+
 // WebsiteService defines the interface for managing website configurations
 type WebsiteService interface {
 	core.Service
@@ -42,7 +58,7 @@ type WebsiteService interface {
 	UnblockWebsite(ctx context.Context, websiteID uint) error
 
 	// ValidateDNS validates the DNS TXT record for a website domain
-	ValidateDNS(ctx context.Context, userID uint, websiteID uint) (bool, error)
+	ValidateDNS(ctx context.Context, userID uint, websiteID uint) (ValidateDNSResult, error)
 
 	// CheckStatus checks the status of a website by validating its target
 	CheckStatus(ctx context.Context, website *pluginDb.Website) (pluginDb.WebsiteStatus, error)

--- a/internal/api/api_websites.go
+++ b/internal/api/api_websites.go
@@ -354,14 +354,13 @@ func (a *API) validateWebsiteDNS(c echo.Context) error {
 		return ctx.Error(apiErr, apiErr.HttpStatus())
 	}
 
-	valid, err := a.websiteService.ValidateDNS(reqCtx, user, uint(websiteID))
+	result, err := a.websiteService.ValidateDNS(reqCtx, user, uint(websiteID))
 	if err != nil {
 		a.Logger().Error("Failed to validate website DNS", zap.Error(err), zap.Uint("website_id", uint(websiteID)), zap.Uint("user_id", user))
 		apiErr := NewError(ErrKeyFileProcessingFailed, err)
 		return ctx.Error(apiErr, apiErr.HttpStatus())
 	}
 
-	// Get website for response
 	website, err := a.websiteService.GetWebsite(reqCtx, user, uint(websiteID))
 	if err != nil {
 		a.Logger().Error("Failed to get website after validation", zap.Error(err))
@@ -369,16 +368,12 @@ func (a *API) validateWebsiteDNS(c echo.Context) error {
 		return ctx.Error(apiErr, apiErr.HttpStatus())
 	}
 
-	message := "DNS validation failed"
-	if valid {
-		message = "DNS validation successful"
-	}
-
 	resp := dto.WebsiteValidateResponse{
 		ID:      website.ID,
 		Domain:  website.Domain,
-		Valid:   valid,
-		Message: message,
+		Valid:   result.Valid,
+		Message: result.Message,
+		Reason:  string(result.Reason),
 	}
 
 	return ctx.JSON(http.StatusOK, resp)

--- a/internal/api/api_websites_test.go
+++ b/internal/api/api_websites_test.go
@@ -1096,7 +1096,7 @@ func TestAPI_ValidateWebsiteDNS(t *testing.T) {
 
 			mockWebsite := createMockIPFSWebsite(1, userID, TestDomain, TestCID, db.WebsiteStatusActive, "")
 
-			mockWebsiteService.EXPECT().ValidateDNS(mock.Anything, userID, uint(1)).Return(true, nil)
+			mockWebsiteService.EXPECT().ValidateDNS(mock.Anything, userID, uint(1)).Return(pluginCore.ValidateDNSResult{Valid: true, Message: "DNS validation successful for test.example.com", Reason: pluginCore.ValidationReasonValidated}, nil)
 			mockWebsiteService.EXPECT().GetWebsite(mock.Anything, userID, uint(1)).Return(mockWebsite, nil)
 
 			rec := helper.makeAuthenticatedRequest(http.MethodPost, "/api/websites/1/validate", token, nil)
@@ -1109,7 +1109,7 @@ func TestAPI_ValidateWebsiteDNS(t *testing.T) {
 			assert.Equal(t, uint(1), response.ID)
 			assert.Equal(t, TestDomain, response.Domain)
 			assert.True(t, response.Valid)
-			assert.Equal(t, "DNS validation successful", response.Message)
+			assert.Equal(t, "validated", response.Reason)
 		}, TestOptions)
 	})
 
@@ -1122,7 +1122,7 @@ func TestAPI_ValidateWebsiteDNS(t *testing.T) {
 
 			mockWebsite := createMockIPFSWebsite(1, userID, TestDomain, TestCID, db.WebsiteStatusPendingValidation, "")
 
-			mockWebsiteService.EXPECT().ValidateDNS(mock.Anything, userID, uint(1)).Return(false, nil)
+			mockWebsiteService.EXPECT().ValidateDNS(mock.Anything, userID, uint(1)).Return(pluginCore.ValidateDNSResult{Valid: false, Message: "DNS validation failed: missing validation token for test.example.com", Reason: pluginCore.ValidationReasonTokenMissing}, nil)
 			mockWebsiteService.EXPECT().GetWebsite(mock.Anything, userID, uint(1)).Return(mockWebsite, nil)
 
 			rec := helper.makeAuthenticatedRequest(http.MethodPost, "/api/websites/1/validate", token, nil)
@@ -1135,7 +1135,7 @@ func TestAPI_ValidateWebsiteDNS(t *testing.T) {
 			assert.Equal(t, uint(1), response.ID)
 			assert.Equal(t, TestDomain, response.Domain)
 			assert.False(t, response.Valid)
-			assert.Equal(t, "DNS validation failed", response.Message)
+			assert.Equal(t, "token_missing", response.Reason)
 		}, TestOptions)
 	})
 
@@ -1157,7 +1157,7 @@ func TestAPI_ValidateWebsiteDNS(t *testing.T) {
 
 			mockWebsiteService := core.GetService[*mocks.MockWebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
 
-			mockWebsiteService.EXPECT().ValidateDNS(mock.Anything, userID, uint(1)).Return(false, errors.New("validation failed"))
+			mockWebsiteService.EXPECT().ValidateDNS(mock.Anything, userID, uint(1)).Return(pluginCore.ValidateDNSResult{}, errors.New("validation failed"))
 
 			rec := helper.makeAuthenticatedRequest(http.MethodPost, "/api/websites/1/validate", token, nil)
 
@@ -1172,7 +1172,7 @@ func TestAPI_ValidateWebsiteDNS(t *testing.T) {
 
 			mockWebsiteService := core.GetService[*mocks.MockWebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
 
-			mockWebsiteService.EXPECT().ValidateDNS(mock.Anything, userID, uint(1)).Return(true, nil)
+			mockWebsiteService.EXPECT().ValidateDNS(mock.Anything, userID, uint(1)).Return(pluginCore.ValidateDNSResult{Valid: true, Message: "DNS validation successful", Reason: pluginCore.ValidationReasonValidated}, nil)
 			mockWebsiteService.EXPECT().GetWebsite(mock.Anything, userID, uint(1)).Return(nil, errors.New("get failed"))
 
 			rec := helper.makeAuthenticatedRequest(http.MethodPost, "/api/websites/1/validate", token, nil)

--- a/internal/api/dto/website.go
+++ b/internal/api/dto/website.go
@@ -420,6 +420,7 @@ type WebsiteValidateResponse struct {
 	Domain  string `json:"domain"`
 	Valid   bool   `json:"valid"`
 	Message string `json:"message"`
+	Reason  string `json:"reason"`
 }
 
 // WebsiteItem represents a website listing item (used in list responses)

--- a/internal/service/website/validate_dns_test.go
+++ b/internal/service/website/validate_dns_test.go
@@ -26,7 +26,7 @@ func setMockResolver(ws pluginCore.WebsiteService, r DNSResolver) {
 	svc.resolver = r
 }
 
-func TestValidateDNS_PendingValidation_ValidDNSLinkAndToken_ReturnsTrue(t *testing.T) {
+func TestValidateDNS_PendingValidation_ValidDNSLinkAndToken_ReturnsValidated(t *testing.T) {
 	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 		ws := core.GetService[pluginCore.WebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
 		require.NotNil(tb, ws)
@@ -48,17 +48,19 @@ func TestValidateDNS_PendingValidation_ValidDNSLinkAndToken_ReturnsTrue(t *testi
 		}, nil)
 		setMockResolver(ws, mockResolver)
 
-		validated, err := ws.ValidateDNS(context.Background(), testUserID1, created.ID)
+		result, err := ws.ValidateDNS(context.Background(), testUserID1, created.ID)
 		require.NoError(tb, err)
-		assert.True(tb, validated)
+		assert.True(tb, result.Valid)
+		assert.Equal(tb, pluginCore.ValidationReasonValidated, result.Reason)
 
 		final, err := ws.GetWebsite(context.Background(), testUserID1, created.ID)
 		require.NoError(tb, err)
 		assert.Equal(tb, string(pluginDb.WebsiteStatusActive), final.Status)
+		assert.False(tb, final.IsExpired(), "validation expiry should be refreshed after successful validation")
 	}, TestOptions)
 }
 
-func TestValidateDNS_PendingValidation_MissingDNSLink_ReturnsFalse(t *testing.T) {
+func TestValidateDNS_PendingValidation_MissingDNSLink_ReturnsDNSMismatch(t *testing.T) {
 	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 		ws := core.GetService[pluginCore.WebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
 		require.NotNil(tb, ws)
@@ -74,14 +76,15 @@ func TestValidateDNS_PendingValidation_MissingDNSLink_ReturnsFalse(t *testing.T)
 		}, nil)
 		setMockResolver(ws, mockResolver)
 
-		validated, err := ws.ValidateDNS(context.Background(), testUserID1, created.ID)
-		require.Error(tb, err)
-		assert.False(tb, validated)
-		assert.Contains(tb, err.Error(), "missing or incorrect dnslink record")
+		result, err := ws.ValidateDNS(context.Background(), testUserID1, created.ID)
+		require.NoError(tb, err)
+		assert.False(tb, result.Valid)
+		assert.Equal(tb, pluginCore.ValidationReasonDNSMismatch, result.Reason)
+		assert.Contains(tb, result.Message, "missing or incorrect dnslink record")
 	}, TestOptions)
 }
 
-func TestValidateDNS_PendingValidation_MissingToken_ReturnsFalse(t *testing.T) {
+func TestValidateDNS_PendingValidation_MissingToken_ReturnsTokenMissing(t *testing.T) {
 	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 		ws := core.GetService[pluginCore.WebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
 		require.NotNil(tb, ws)
@@ -100,14 +103,15 @@ func TestValidateDNS_PendingValidation_MissingToken_ReturnsFalse(t *testing.T) {
 		mockResolver.EXPECT().LookupTXT("missing-token.com").Return([]string{"some-other-txt-record=foo"}, nil)
 		setMockResolver(ws, mockResolver)
 
-		validated, err := ws.ValidateDNS(context.Background(), testUserID1, created.ID)
-		require.Error(tb, err)
-		assert.False(tb, validated)
-		assert.Contains(tb, err.Error(), "missing validation token")
+		result, err := ws.ValidateDNS(context.Background(), testUserID1, created.ID)
+		require.NoError(tb, err)
+		assert.False(tb, result.Valid)
+		assert.Equal(tb, pluginCore.ValidationReasonTokenMissing, result.Reason)
+		assert.Contains(tb, result.Message, "missing validation token")
 	}, TestOptions)
 }
 
-func TestValidateDNS_ActiveSite_ExpiredToken_SkipsTokenCheck(t *testing.T) {
+func TestValidateDNS_ActiveSite_ExpiredToken_SkipsTokenCheckAndValidates(t *testing.T) {
 	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 		ws := core.GetService[pluginCore.WebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
 		require.NotNil(tb, ws)
@@ -141,17 +145,19 @@ func TestValidateDNS_ActiveSite_ExpiredToken_SkipsTokenCheck(t *testing.T) {
 		}, nil)
 		setMockResolver(ws, mockResolver)
 
-		validated, err := ws.ValidateDNS(context.Background(), testUserID1, created.ID)
+		result, err := ws.ValidateDNS(context.Background(), testUserID1, created.ID)
 		require.NoError(tb, err)
-		assert.True(tb, validated)
+		assert.True(tb, result.Valid)
+		assert.Equal(tb, pluginCore.ValidationReasonValidated, result.Reason)
 
 		final, err := ws.GetWebsite(context.Background(), testUserID1, created.ID)
 		require.NoError(tb, err)
 		assert.Equal(tb, string(pluginDb.WebsiteStatusActive), final.Status)
+		assert.False(tb, final.IsExpired(), "validation expiry should be refreshed after successful validation of expired active site")
 	}, TestOptions)
 }
 
-func TestValidateDNS_BrokenSite_ExpiredToken_SkipsTokenCheck(t *testing.T) {
+func TestValidateDNS_BrokenSite_ExpiredToken_SkipsTokenCheckAndValidates(t *testing.T) {
 	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 		ws := core.GetService[pluginCore.WebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
 		require.NotNil(tb, ws)
@@ -184,17 +190,19 @@ func TestValidateDNS_BrokenSite_ExpiredToken_SkipsTokenCheck(t *testing.T) {
 		}, nil)
 		setMockResolver(ws, mockResolver)
 
-		validated, err := ws.ValidateDNS(context.Background(), testUserID1, created.ID)
+		result, err := ws.ValidateDNS(context.Background(), testUserID1, created.ID)
 		require.NoError(tb, err)
-		assert.True(tb, validated)
+		assert.True(tb, result.Valid)
+		assert.Equal(tb, pluginCore.ValidationReasonValidated, result.Reason)
 
 		final, err := ws.GetWebsite(context.Background(), testUserID1, created.ID)
 		require.NoError(tb, err)
 		assert.Equal(tb, string(pluginDb.WebsiteStatusActive), final.Status)
+		assert.False(tb, final.IsExpired(), "validation expiry should be refreshed after successful validation of expired broken site")
 	}, TestOptions)
 }
 
-func TestValidateDNS_PendingValidation_ExpiredToken_RolledBackOnFailure(t *testing.T) {
+func TestValidateDNS_PendingValidation_ExpiredToken_ReturnsTokenExpiredWithRegen(t *testing.T) {
 	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 		ws := core.GetService[pluginCore.WebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
 		require.NotNil(tb, ws)
@@ -214,22 +222,18 @@ func TestValidateDNS_PendingValidation_ExpiredToken_RolledBackOnFailure(t *testi
 		require.NoError(tb, err)
 		assert.True(tb, expiredWebsite.IsExpired())
 
-		mockResolver := mocks.NewMockDNSResolver(t)
-		mockResolver.EXPECT().ResolveDNSLink("regen-token.com").Return(dnslink.Result{
-			Links: map[string]dnslink.NamespaceEntries{},
-		}, nil)
-		setMockResolver(ws, mockResolver)
-
-		_, err = ws.ValidateDNS(context.Background(), testUserID1, created.ID)
-		require.Error(tb, err)
+		result, err := ws.ValidateDNS(context.Background(), testUserID1, created.ID)
+		require.NoError(tb, err)
+		assert.False(tb, result.Valid)
+		assert.Equal(tb, pluginCore.ValidationReasonTokenExpired, result.Reason)
 
 		afterWebsite, err := ws.GetWebsite(context.Background(), testUserID1, created.ID)
 		require.NoError(tb, err)
-		assert.True(tb, afterWebsite.IsExpired(), "token should remain expired when validation fails")
+		assert.False(tb, afterWebsite.IsExpired(), "token should be refreshed after regeneration")
 	}, TestOptions)
 }
 
-func TestValidateDNS_NXDOMAIN_ReturnsError(t *testing.T) {
+func TestValidateDNS_NXDOMAIN_ReturnsDNSMissing(t *testing.T) {
 	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 		ws := core.GetService[pluginCore.WebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
 		require.NotNil(tb, ws)
@@ -248,10 +252,11 @@ func TestValidateDNS_NXDOMAIN_ReturnsError(t *testing.T) {
 		})
 		setMockResolver(ws, mockResolver)
 
-		validated, err := ws.ValidateDNS(context.Background(), testUserID1, created.ID)
-		require.Error(tb, err)
-		assert.False(tb, validated)
-		assert.Contains(tb, err.Error(), "no DNS records found")
+		result, err := ws.ValidateDNS(context.Background(), testUserID1, created.ID)
+		require.NoError(tb, err)
+		assert.False(tb, result.Valid)
+		assert.Equal(tb, pluginCore.ValidationReasonDNSMissing, result.Reason)
+		assert.Contains(tb, result.Message, "No DNS records found")
 	}, TestOptions)
 }
 
@@ -269,9 +274,9 @@ func TestValidateDNS_DNSLinkLookupFailure_ReturnsError(t *testing.T) {
 		mockResolver.EXPECT().ResolveDNSLink("dns-fail-test.com").Return(dnslink.Result{}, fmt.Errorf("network error"))
 		setMockResolver(ws, mockResolver)
 
-		validated, err := ws.ValidateDNS(context.Background(), testUserID1, created.ID)
+		result, err := ws.ValidateDNS(context.Background(), testUserID1, created.ID)
 		require.Error(tb, err)
-		assert.False(tb, validated)
+		assert.False(tb, result.Valid)
 		assert.Contains(tb, err.Error(), "DNS lookup failed")
 	}, TestOptions)
 }
@@ -295,14 +300,14 @@ func TestValidateDNS_TxTTLookupFailure_ReturnsError(t *testing.T) {
 		mockResolver.EXPECT().LookupTXT("txt-fail-test.com").Return(nil, fmt.Errorf("TXT lookup timeout"))
 		setMockResolver(ws, mockResolver)
 
-		validated, err := ws.ValidateDNS(context.Background(), testUserID1, created.ID)
+		result, err := ws.ValidateDNS(context.Background(), testUserID1, created.ID)
 		require.Error(tb, err)
-		assert.False(tb, validated)
+		assert.False(tb, result.Valid)
 		assert.Contains(tb, err.Error(), "DNS TXT lookup failed")
 	}, TestOptions)
 }
 
-func TestValidateDNS_WrongDNSLink_ReturnsError(t *testing.T) {
+func TestValidateDNS_WrongDNSLink_ReturnsDNSMismatch(t *testing.T) {
 	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 		ws := core.GetService[pluginCore.WebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
 		require.NotNil(tb, ws)
@@ -321,10 +326,11 @@ func TestValidateDNS_WrongDNSLink_ReturnsError(t *testing.T) {
 		}, nil)
 		setMockResolver(ws, mockResolver)
 
-		validated, err := ws.ValidateDNS(context.Background(), testUserID1, created.ID)
-		require.Error(tb, err)
-		assert.False(tb, validated)
-		assert.Contains(tb, err.Error(), "missing or incorrect dnslink record")
+		result, err := ws.ValidateDNS(context.Background(), testUserID1, created.ID)
+		require.NoError(tb, err)
+		assert.False(tb, result.Valid)
+		assert.Equal(tb, pluginCore.ValidationReasonDNSMismatch, result.Reason)
+		assert.Contains(tb, result.Message, "missing or incorrect dnslink record")
 	}, TestOptions)
 }
 
@@ -349,13 +355,14 @@ func TestValidateDNS_IPNSTarget_ValidDNSLinkAndToken(t *testing.T) {
 		}, nil)
 		setMockResolver(ws, mockResolver)
 
-		validated, err := ws.ValidateDNS(context.Background(), testUserID1, created.ID)
+		result, err := ws.ValidateDNS(context.Background(), testUserID1, created.ID)
 		require.NoError(tb, err)
-		assert.True(tb, validated)
+		assert.True(tb, result.Valid)
+		assert.Equal(tb, pluginCore.ValidationReasonValidated, result.Reason)
 	}, TestOptions)
 }
 
-func TestValidateDNS_PendingValidation_ExpiredToken_ManagedDNS_CreatesDNSRecordsWithNewToken(t *testing.T) {
+func TestValidateDNS_PendingValidation_ExpiredToken_ManagedDNS_RegeneratesToken(t *testing.T) {
 	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 		ws := core.GetService[pluginCore.WebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
 		mockDNS := core.GetService[*mocks.MockDNSService](ctx, pluginCore.DNS_SERVICE)
@@ -408,25 +415,15 @@ func TestValidateDNS_PendingValidation_ExpiredToken_ManagedDNS_CreatesDNSRecords
 			}),
 		).Return(nil).Once()
 
-		mockResolver := mocks.NewMockDNSResolver(t)
-		mockResolver.EXPECT().ResolveDNSLink(domain).Return(dnslink.Result{
-			Links: map[string]dnslink.NamespaceEntries{
-				"ipns": {{Identifier: expiredWebsite.TargetHash()}},
-			},
-		}, nil)
-		mockResolver.EXPECT().LookupTXT(domain).RunAndReturn(func(d string) ([]string, error) {
-			return []string{capturedToken}, nil
-		})
-		setMockResolver(ws, mockResolver)
-
-		validated, err := ws.ValidateDNS(context.Background(), testUserID1, created.ID)
+		result, err := ws.ValidateDNS(context.Background(), testUserID1, created.ID)
 		require.NoError(tb, err)
-		assert.True(tb, validated)
+		assert.False(tb, result.Valid)
+		assert.Equal(tb, pluginCore.ValidationReasonTokenExpired, result.Reason)
 		assert.Contains(tb, capturedToken, "lumeweb-verify=", "DNS token record should contain the verification key prefix")
 
-		final, err := ws.GetWebsite(context.Background(), testUserID1, created.ID)
+		afterWebsite, err := ws.GetWebsite(context.Background(), testUserID1, created.ID)
 		require.NoError(tb, err)
-		assert.Equal(tb, string(pluginDb.WebsiteStatusActive), final.Status)
+		assert.False(tb, afterWebsite.IsExpired(), "token should be refreshed after regeneration")
 	}, TestOptions)
 }
 
@@ -435,9 +432,9 @@ func TestValidateDNS_WebsiteNotFound_ReturnsError(t *testing.T) {
 		ws := core.GetService[pluginCore.WebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
 		require.NotNil(tb, ws)
 
-		validated, err := ws.ValidateDNS(context.Background(), testUserID1, 99999)
+		result, err := ws.ValidateDNS(context.Background(), testUserID1, 99999)
 		require.Error(tb, err)
-		assert.False(tb, validated)
+		assert.False(tb, result.Valid)
 		assert.Contains(tb, err.Error(), "website not found")
 	}, TestOptions)
 }

--- a/internal/service/website/website.go
+++ b/internal/service/website/website.go
@@ -30,6 +30,14 @@ import (
 
 const sslCertValidity = 90 * 24 * time.Hour
 
+const (
+	msgTokenExpired  = "Validation token expired for %s — a new token has been generated. Please add the updated TXT record to your DNS configuration"
+	msgDNSMissing    = "No DNS records found for %s. Please add the required TXT records to your DNS configuration"
+	msgDNSMismatch   = "DNS validation failed: missing or incorrect dnslink record (expected: %s, found: %s)"
+	msgTokenMissing  = "DNS validation failed: missing validation token for %s"
+	msgValidated     = "DNS validation successful for %s"
+)
+
 func extractParentDomain(domain string) string {
 	parts := strings.Split(domain, ".")
 	if len(parts) <= 2 {
@@ -1044,7 +1052,7 @@ func (s *WebsiteServiceDefault) ValidateDNS(ctx context.Context, userID uint, we
 				}
 				return pluginCore.ValidateDNSResult{
 					Valid:   false,
-					Message: fmt.Sprintf("Validation token expired for %s — a new token has been generated. Please add the updated TXT record to your DNS configuration", website.Domain),
+					Message: fmt.Sprintf(msgTokenExpired, website.Domain),
 					Reason:  pluginCore.ValidationReasonTokenExpired,
 				}, nil
 			}
@@ -1058,7 +1066,7 @@ func (s *WebsiteServiceDefault) ValidateDNS(ctx context.Context, userID uint, we
 						zap.Uint("website_id", website.ID))
 					return pluginCore.ValidateDNSResult{
 						Valid:   false,
-						Message: fmt.Sprintf("No DNS records found for %s. Please add the required TXT records to your DNS configuration", website.Domain),
+						Message: fmt.Sprintf(msgDNSMissing, website.Domain),
 						Reason:  pluginCore.ValidationReasonDNSMissing,
 					}, nil
 				}
@@ -1097,7 +1105,7 @@ func (s *WebsiteServiceDefault) ValidateDNS(ctx context.Context, userID uint, we
 					zap.String("found", foundDNSlink))
 				return pluginCore.ValidateDNSResult{
 					Valid:   false,
-					Message: fmt.Sprintf("DNS validation failed: missing or incorrect dnslink record (expected: %s, found: %s)", expectedDNSlink, foundDNSlink),
+					Message: fmt.Sprintf(msgDNSMismatch, expectedDNSlink, foundDNSlink),
 					Reason:  pluginCore.ValidationReasonDNSMismatch,
 				}, nil
 			}
@@ -1126,7 +1134,7 @@ func (s *WebsiteServiceDefault) ValidateDNS(ctx context.Context, userID uint, we
 						zap.String("expected_token", website.ValidationToken))
 					return pluginCore.ValidateDNSResult{
 						Valid:   false,
-						Message: fmt.Sprintf("DNS validation failed: missing validation token for %s", website.Domain),
+						Message: fmt.Sprintf(msgTokenMissing, website.Domain),
 						Reason:  pluginCore.ValidationReasonTokenMissing,
 					}, nil
 				}
@@ -1148,7 +1156,7 @@ func (s *WebsiteServiceDefault) ValidateDNS(ctx context.Context, userID uint, we
 
 			return pluginCore.ValidateDNSResult{
 				Valid:   true,
-				Message: fmt.Sprintf("DNS validation successful for %s", website.Domain),
+				Message: fmt.Sprintf(msgValidated, website.Domain),
 				Reason:  pluginCore.ValidationReasonValidated,
 			}, nil
 		},

--- a/internal/service/website/website.go
+++ b/internal/service/website/website.go
@@ -1018,178 +1018,182 @@ func (s *WebsiteServiceDefault) UnblockWebsite(ctx context.Context, websiteID ui
 }
 
 // ValidateDNS validates the DNS TXT record for a website domain
-func (s *WebsiteServiceDefault) ValidateDNS(ctx context.Context, userID uint, websiteID uint) (bool, error) {
+func (s *WebsiteServiceDefault) ValidateDNS(ctx context.Context, userID uint, websiteID uint) (pluginCore.ValidateDNSResult, error) {
 	ctx, span := core.TraceMethod(ctx, "WebsiteServiceDefault.ValidateDNS")
 	defer span.End()
 
 	return core.MetricTrackResult(
 		ValidateDNSDuration.WithLabelValues(),
 		ValidateDNSTotal.WithLabelValues(LabelStatusError),
-		func() (bool, error) {
-			var validated bool
-
-			err := db.RetryableComponentTransaction(s, ctx, func(tx *gorm.DB) *gorm.DB {
-				// Get the website
-				var website pluginDb.Website
-				if err := tx.Where("user_id = ? AND id = ?", userID, websiteID).First(&website).Error; err != nil {
-					if err == gorm.ErrRecordNotFound {
-						_ = tx.AddError(fmt.Errorf("website not found"))
-						return tx
-					}
-					_ = tx.AddError(fmt.Errorf("failed to get website: %w", err))
-					return tx
+		func() (pluginCore.ValidateDNSResult, error) {
+			var website pluginDb.Website
+			if err := db.RetryableComponentTransaction(s, ctx, func(tx *gorm.DB) *gorm.DB {
+				return tx.Where("user_id = ? AND id = ?", userID, websiteID).First(&website)
+			}); err != nil {
+				if errors.Is(err, gorm.ErrRecordNotFound) {
+					return pluginCore.ValidateDNSResult{}, fmt.Errorf("website not found")
 				}
+				return pluginCore.ValidateDNSResult{}, fmt.Errorf("failed to get website: %w", err)
+			}
 
-				// The validation token proves domain ownership. Once a site has been
-				// validated (status != pending_validation), an expired token should NOT
-				// block re-validation — only the dnslink record matters for ongoing validity.
-				needsTokenCheck := website.Status == string(pluginDb.WebsiteStatusPendingValidation)
+			needsTokenCheck := website.Status == string(pluginDb.WebsiteStatusPendingValidation)
 
-				if needsTokenCheck && website.IsExpired() {
-					newToken, err := s.generateValidationToken()
-					if err != nil {
-						_ = tx.AddError(fmt.Errorf("failed to regenerate expired validation token: %w", err))
-						return tx
-					}
-
-					// Managed DNS: update DNS records with the new verification token
-					if website.DNSZoneID != nil && s.dnsSvc != nil {
-						tokenRecord := fmt.Sprintf("%s=%s", s.config.VerificationTokenKey, newToken)
-						if err := s.dnsSvc.CreateWebsiteDNSRecords(ctx, *website.DNSZoneID, website.Domain, website.TargetHash(), pluginDb.WebsiteTargetType(website.TargetType), tokenRecord); err != nil {
-							s.Logger().Warn("Failed to update DNS records with new validation token",
-								zap.Error(err),
-								zap.Uint("website_id", website.ID),
-								zap.String("domain", website.Domain))
-						}
-					}
-
-					expiresAt := time.Now().Add(s.config.ValidationTokenTTL)
-					website.ValidationToken = newToken
-					website.ValidationExpiresAt = &expiresAt
-					if err := tx.Save(&website).Error; err != nil {
-						_ = tx.AddError(fmt.Errorf("failed to save regenerated validation token: %w", err))
-						return tx
-					}
-
-					s.Logger().Info("Regenerated expired validation token",
-						zap.Uint("website_id", website.ID),
-						zap.String("domain", website.Domain),
-						zap.Time("new_expiry", expiresAt))
+			if needsTokenCheck && website.IsExpired() {
+				if err := s.regenerateExpiredToken(ctx, &website); err != nil {
+					return pluginCore.ValidateDNSResult{}, err
 				}
+				return pluginCore.ValidateDNSResult{
+					Valid:   false,
+					Message: fmt.Sprintf("Validation token expired for %s — a new token has been generated. Please add the updated TXT record to your DNS configuration", website.Domain),
+					Reason:  pluginCore.ValidationReasonTokenExpired,
+				}, nil
+			}
 
-				// Query DNS for DNSlink records using dnslink library
-				result, err := s.resolver.ResolveDNSLink(website.Domain)
-				if err != nil {
-					if dnsErr, ok := errors.AsType[dnslink.DNSRCodeError](err); ok && dnsErr.DNSRCode == 3 {
-						s.Logger().Debug("DNS validation failed: no DNS records found (NXDOMAIN)",
-							zap.Error(err),
-							zap.String("domain", website.Domain),
-							zap.Uint("website_id", website.ID))
-						_ = tx.AddError(fmt.Errorf("DNS validation failed: no DNS records found for %s. Please add the required TXT records to your DNS configuration", website.Domain))
-						return tx
-					}
-
-					s.Logger().Debug("DNS lookup failed",
+			result, err := s.resolver.ResolveDNSLink(website.Domain)
+			if err != nil {
+				if dnsErr, ok := errors.AsType[dnslink.DNSRCodeError](err); ok && dnsErr.DNSRCode == 3 {
+					s.Logger().Debug("DNS validation failed: no DNS records found (NXDOMAIN)",
 						zap.Error(err),
 						zap.String("domain", website.Domain),
 						zap.Uint("website_id", website.ID))
-					_ = tx.AddError(fmt.Errorf("DNS lookup failed for %s: %w", website.Domain, err))
-					return tx
+					return pluginCore.ValidateDNSResult{
+						Valid:   false,
+						Message: fmt.Sprintf("No DNS records found for %s. Please add the required TXT records to your DNS configuration", website.Domain),
+						Reason:  pluginCore.ValidationReasonDNSMissing,
+					}, nil
 				}
 
-				expectedDNSlink := pluginDb.WebsiteTargetType(website.TargetType).ToDNSLinkPath(website.TargetHash())
+				return pluginCore.ValidateDNSResult{}, fmt.Errorf("DNS lookup failed for %s: %w", website.Domain, err)
+			}
 
-				var hasDNSlink bool
-				var foundDNSlink string
+			expectedDNSlink := pluginDb.WebsiteTargetType(website.TargetType).ToDNSLinkPath(website.TargetHash())
 
-				if ipfsLinks, ok := result.Links["ipfs"]; ok && len(ipfsLinks) > 0 {
-					foundDNSlink = dto.IPFSPath(ipfsLinks[0].Identifier)
-					if foundDNSlink == expectedDNSlink {
-						hasDNSlink = true
-						s.Logger().Debug("Found valid DNSlink record",
-							zap.String("domain", website.Domain),
-							zap.String("dnslink", foundDNSlink))
-					}
-				}
-				if ipnsLinks, ok := result.Links["ipns"]; ok && len(ipnsLinks) > 0 {
-					foundDNSlink = dto.IPNSPath(ipnsLinks[0].Identifier)
-					if foundDNSlink == expectedDNSlink {
-						hasDNSlink = true
-						s.Logger().Debug("Found valid DNSlink record",
-							zap.String("domain", website.Domain),
-							zap.String("dnslink", foundDNSlink))
-					}
-				}
+			var hasDNSlink bool
+			var foundDNSlink string
 
-				if !hasDNSlink {
-					s.Logger().Warn("DNS validation failed: missing or incorrect dnslink record",
+			if ipfsLinks, ok := result.Links["ipfs"]; ok && len(ipfsLinks) > 0 {
+				foundDNSlink = dto.IPFSPath(ipfsLinks[0].Identifier)
+				if foundDNSlink == expectedDNSlink {
+					hasDNSlink = true
+					s.Logger().Debug("Found valid DNSlink record",
 						zap.String("domain", website.Domain),
-						zap.String("expected", expectedDNSlink),
-						zap.String("found", foundDNSlink))
-					_ = tx.AddError(fmt.Errorf("DNS validation failed: missing or incorrect dnslink record (expected: %s, found: %s)", expectedDNSlink, foundDNSlink))
-					return tx
+						zap.String("dnslink", foundDNSlink))
 				}
-
-				if needsTokenCheck {
-					expectedTokenRecord := fmt.Sprintf("%s=%s", s.config.VerificationTokenKey, website.ValidationToken)
-					txtRecords, err := s.resolver.LookupTXT(website.Domain)
-					if err != nil {
-						s.Logger().Debug("DNS TXT lookup failed for validation token",
-							zap.Error(err),
-							zap.String("domain", website.Domain))
-						_ = tx.AddError(fmt.Errorf("DNS TXT lookup failed for %s: %w", website.Domain, err))
-						return tx
-					}
-
-					var hasToken bool
-					for _, txtRecord := range txtRecords {
-						if strings.Contains(txtRecord, expectedTokenRecord) {
-							hasToken = true
-							s.Logger().Debug("Found valid validation token",
-								zap.String("domain", website.Domain),
-								zap.String("token", website.ValidationToken))
-							break
-						}
-					}
-
-					if !hasToken {
-						s.Logger().Warn("DNS validation failed: missing validation token",
-							zap.String("domain", website.Domain),
-							zap.String("expected_token", website.ValidationToken))
-						_ = tx.AddError(fmt.Errorf("DNS validation failed: missing validation token"))
-						return tx
-					}
+			}
+			if ipnsLinks, ok := result.Links["ipns"]; ok && len(ipnsLinks) > 0 {
+				foundDNSlink = dto.IPNSPath(ipnsLinks[0].Identifier)
+				if foundDNSlink == expectedDNSlink {
+					hasDNSlink = true
+					s.Logger().Debug("Found valid DNSlink record",
+						zap.String("domain", website.Domain),
+						zap.String("dnslink", foundDNSlink))
 				}
+			}
 
-				// Validation passes - both records are present and correct
-				validated = true
-				s.Logger().Info("DNS validation successful",
+			if !hasDNSlink {
+				s.Logger().Warn("DNS validation failed: missing or incorrect dnslink record",
 					zap.String("domain", website.Domain),
-					zap.Uint("website_id", website.ID),
-					zap.String("dnslink", foundDNSlink))
+					zap.String("expected", expectedDNSlink),
+					zap.String("found", foundDNSlink))
+				return pluginCore.ValidateDNSResult{
+					Valid:   false,
+					Message: fmt.Sprintf("DNS validation failed: missing or incorrect dnslink record (expected: %s, found: %s)", expectedDNSlink, foundDNSlink),
+					Reason:  pluginCore.ValidationReasonDNSMismatch,
+				}, nil
+			}
 
-				// Update status to active
-				website.Status = string(pluginDb.WebsiteStatusActive)
-				if err := tx.Save(&website).Error; err != nil {
-					_ = tx.AddError(fmt.Errorf("failed to update website status: %w", err))
-					return tx
+			if needsTokenCheck {
+				expectedTokenRecord := fmt.Sprintf("%s=%s", s.config.VerificationTokenKey, website.ValidationToken)
+				txtRecords, err := s.resolver.LookupTXT(website.Domain)
+				if err != nil {
+					return pluginCore.ValidateDNSResult{}, fmt.Errorf("DNS TXT lookup failed for %s: %w", website.Domain, err)
 				}
 
-				return tx
-			})
+				var hasToken bool
+				for _, txtRecord := range txtRecords {
+					if strings.Contains(txtRecord, expectedTokenRecord) {
+						hasToken = true
+						s.Logger().Debug("Found valid validation token",
+							zap.String("domain", website.Domain),
+							zap.String("token", website.ValidationToken))
+						break
+					}
+				}
 
-			if err != nil {
-				return false, err
+				if !hasToken {
+					s.Logger().Warn("DNS validation failed: missing validation token",
+						zap.String("domain", website.Domain),
+						zap.String("expected_token", website.ValidationToken))
+					return pluginCore.ValidateDNSResult{
+						Valid:   false,
+						Message: fmt.Sprintf("DNS validation failed: missing validation token for %s", website.Domain),
+						Reason:  pluginCore.ValidationReasonTokenMissing,
+					}, nil
+				}
+			}
+
+			s.Logger().Info("DNS validation successful",
+				zap.String("domain", website.Domain),
+				zap.Uint("website_id", website.ID),
+				zap.String("dnslink", foundDNSlink))
+
+			if err := s.activateValidatedWebsite(ctx, &website); err != nil {
+				return pluginCore.ValidateDNSResult{}, err
 			}
 
 			s.Logger().Info("DNS validation completed",
 				zap.Uint("website_id", websiteID),
 				zap.Uint("user_id", userID),
-				zap.Bool("validated", validated))
+				zap.Bool("validated", true))
 
-			return validated, nil
+			return pluginCore.ValidateDNSResult{
+				Valid:   true,
+				Message: fmt.Sprintf("DNS validation successful for %s", website.Domain),
+				Reason:  pluginCore.ValidationReasonValidated,
+			}, nil
 		},
 	)
+}
+
+func (s *WebsiteServiceDefault) regenerateExpiredToken(ctx context.Context, website *pluginDb.Website) error {
+	newToken, err := s.generateValidationToken()
+	if err != nil {
+		return fmt.Errorf("failed to regenerate expired validation token: %w", err)
+	}
+
+	if website.DNSZoneID != nil && s.dnsSvc != nil {
+		tokenRecord := fmt.Sprintf("%s=%s", s.config.VerificationTokenKey, newToken)
+		if err := s.dnsSvc.CreateWebsiteDNSRecords(ctx, *website.DNSZoneID, website.Domain, website.TargetHash(), pluginDb.WebsiteTargetType(website.TargetType), tokenRecord); err != nil {
+			s.Logger().Warn("Failed to update DNS records with new validation token",
+				zap.Error(err),
+				zap.Uint("website_id", website.ID),
+				zap.String("domain", website.Domain))
+		}
+	}
+
+	if err := db.RetryableComponentTransaction(s, ctx, func(tx *gorm.DB) *gorm.DB {
+		expiresAt := time.Now().Add(s.config.ValidationTokenTTL)
+		website.ValidationToken = newToken
+		website.ValidationExpiresAt = &expiresAt
+		return tx.Save(website)
+	}); err != nil {
+		return fmt.Errorf("failed to save regenerated validation token: %w", err)
+	}
+
+	s.Logger().Info("Regenerated expired validation token",
+		zap.Uint("website_id", website.ID),
+		zap.String("domain", website.Domain))
+
+	return nil
+}
+
+func (s *WebsiteServiceDefault) activateValidatedWebsite(ctx context.Context, website *pluginDb.Website) error {
+	return db.RetryableComponentTransaction(s, ctx, func(tx *gorm.DB) *gorm.DB {
+		website.Status = string(pluginDb.WebsiteStatusActive)
+		newExpiry := time.Now().Add(s.config.ValidationTokenTTL)
+		website.ValidationExpiresAt = &newExpiry
+		return tx.Save(website)
+	})
 }
 
 // CheckStatus checks the status of a website by validating its target

--- a/internal/testing/mocks/MockWebsiteService.go
+++ b/internal/testing/mocks/MockWebsiteService.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	mock "github.com/stretchr/testify/mock"
+	core0 "go.lumeweb.com/portal-plugin-ipfs/core"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/db"
 	"go.lumeweb.com/portal/config"
 	"go.lumeweb.com/portal/core"
@@ -1199,22 +1200,22 @@ func (_c *MockWebsiteService_UpdateWebsite_Call) RunAndReturn(run func(ctx conte
 }
 
 // ValidateDNS provides a mock function for the type MockWebsiteService
-func (_mock *MockWebsiteService) ValidateDNS(ctx context.Context, userID uint, websiteID uint) (bool, error) {
+func (_mock *MockWebsiteService) ValidateDNS(ctx context.Context, userID uint, websiteID uint) (core0.ValidateDNSResult, error) {
 	ret := _mock.Called(ctx, userID, websiteID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ValidateDNS")
 	}
 
-	var r0 bool
+	var r0 core0.ValidateDNSResult
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, uint, uint) (bool, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uint, uint) (core0.ValidateDNSResult, error)); ok {
 		return returnFunc(ctx, userID, websiteID)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, uint, uint) bool); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uint, uint) core0.ValidateDNSResult); ok {
 		r0 = returnFunc(ctx, userID, websiteID)
 	} else {
-		r0 = ret.Get(0).(bool)
+		r0 = ret.Get(0).(core0.ValidateDNSResult)
 	}
 	if returnFunc, ok := ret.Get(1).(func(context.Context, uint, uint) error); ok {
 		r1 = returnFunc(ctx, userID, websiteID)
@@ -1260,12 +1261,12 @@ func (_c *MockWebsiteService_ValidateDNS_Call) Run(run func(ctx context.Context,
 	return _c
 }
 
-func (_c *MockWebsiteService_ValidateDNS_Call) Return(b bool, err error) *MockWebsiteService_ValidateDNS_Call {
-	_c.Call.Return(b, err)
+func (_c *MockWebsiteService_ValidateDNS_Call) Return(validateDNSResult core0.ValidateDNSResult, err error) *MockWebsiteService_ValidateDNS_Call {
+	_c.Call.Return(validateDNSResult, err)
 	return _c
 }
 
-func (_c *MockWebsiteService_ValidateDNS_Call) RunAndReturn(run func(ctx context.Context, userID uint, websiteID uint) (bool, error)) *MockWebsiteService_ValidateDNS_Call {
+func (_c *MockWebsiteService_ValidateDNS_Call) RunAndReturn(run func(ctx context.Context, userID uint, websiteID uint) (core0.ValidateDNSResult, error)) *MockWebsiteService_ValidateDNS_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
- Add ValidateDNSResult struct with Valid, Message, Reason fields
- Add ValidationReason enum: validated, token\_expired, dns\_missing, dns\_mismatch, token\_missing
- Refactor ValidateDNS to return (ValidateDNSResult, error) — error is only for infrastructure failures (DB down, DNS network error)
- All expected validation outcomes return error=nil with a Reason
- Expired token: auto-regenerate and return token\_expired reason
- Active/broken sites skip token check, validate dnslink only
- Refresh ValidationExpiresAt on successful validation (was stale)
- API handler returns 200 for all expected outcomes, not just success
- Add Reason field to WebsiteValidateResponse DTO
- Update all service and API tests for new return type

* `develop` <!-- branch-stack -->
  - **feat: return ValidateDNSResult from ValidateDNS, return 200 for expected outcomes** :point\_left:

***

<!-- kody-pr-summary:start -->

This pull request refactors the DNS validation flow to return structured, machine-readable results and fixes a bug where the validation expiry was not refreshed upon successful validation.

Key changes:

- **Structured validation results**: The `ValidateDNS` method now returns a `ValidateDNSResult` struct (containing `Valid`, `Message`, and `Reason` fields) instead of a simple boolean. This introduces machine-readable reason codes (`validated`, `token_expired`, `dns_missing`, `dns_mismatch`, `token_missing`) that are exposed in the API response via a new `reason` field.

- **Validation expiry refresh fix**: When a website is successfully validated, the `ValidationExpiresAt` timestamp is now properly refreshed to `now + ValidationTokenTTL`. Previously, the expiry was not updated on successful validation, causing sites to incorrectly appear expired.

- **Expected validation failures return HTTP 200**: Validation failures that are expected outcomes (missing DNS records, mismatched dnslink, missing/expired tokens) no longer return Go errors. Instead, they return `ValidateDNSResult{Valid: false, ...}` with an appropriate reason, and the API responds with HTTP 200. Only actual system errors (DNS lookup failures, database errors) return error HTTP responses.

- **Expired token handling for pending sites**: When a pending-validation site has an expired token, the token is regenerated and persisted, but validation returns `token_expired` with `Valid: false` rather than attempting to validate with the newly generated token in the same request. This gives the user a chance to update their DNS TXT record with the new token before re-validating.

<!-- kody-pr-summary:end -->
