### PR TITLE
refactor(janitor): use DB-stored LastPublishedCID for IPNS validation

### DIFF
--- a/internal/api/dto/website.go
+++ b/internal/api/dto/website.go
@@ -48,11 +48,13 @@ func (r *IPNSKeyRequest) ToModel() (*db.IPFSIPNSKey, error) {
 
 // IPNSKeyResponse represents an IPNS key response
 type IPNSKeyResponse struct {
-	ID       uint      `json:"id"`
-	Name     string    `json:"name"`
-	IPNSName string    `json:"ipns_name"`
-	PeerID   string    `json:"peer_id"`
-	Created  time.Time `json:"created"`
+	ID               uint       `json:"id"`
+	Name             string     `json:"name"`
+	IPNSName         string     `json:"ipns_name"`
+	PeerID           string     `json:"peer_id"`
+	Value            string     `json:"value,omitempty"`
+	LastPublishedAt  *time.Time `json:"last_published_at,omitempty"`
+	Created          time.Time  `json:"created"`
 }
 
 func (r *IPNSKeyResponse) FromModel(model *db.IPFSIPNSKey) error {
@@ -60,17 +62,21 @@ func (r *IPNSKeyResponse) FromModel(model *db.IPFSIPNSKey) error {
 	r.Name = model.Name
 	r.IPNSName = model.IPNSName()
 	r.PeerID = model.PeerID().String()
+	r.Value = model.LastPublishedCID
+	r.LastPublishedAt = model.LastPublishedAt
 	r.Created = model.CreatedAt
 	return nil
 }
 
 // IPNSKeyListResponse represents an IPNS key in a list response
 type IPNSKeyListResponse struct {
-	ID       uint      `json:"id"`
-	Name     string    `json:"name"`
-	IPNSName string    `json:"ipns_name"`
-	PeerID   string    `json:"peer_id"`
-	Created  time.Time `json:"created"`
+	ID               uint       `json:"id"`
+	Name             string     `json:"name"`
+	IPNSName         string     `json:"ipns_name"`
+	PeerID           string     `json:"peer_id"`
+	Value            string     `json:"value,omitempty"`
+	LastPublishedAt  *time.Time `json:"last_published_at,omitempty"`
+	Created          time.Time  `json:"created"`
 }
 
 func (r *IPNSKeyListResponse) FromModel(model *db.IPFSIPNSKey) error {
@@ -78,6 +84,8 @@ func (r *IPNSKeyListResponse) FromModel(model *db.IPFSIPNSKey) error {
 	r.Name = model.Name
 	r.IPNSName = model.IPNSName()
 	r.PeerID = model.PeerID().String()
+	r.Value = model.LastPublishedCID
+	r.LastPublishedAt = model.LastPublishedAt
 	r.Created = model.CreatedAt
 	return nil
 }

--- a/internal/service/website/janitor.go
+++ b/internal/service/website/janitor.go
@@ -11,7 +11,6 @@ import (
 	"go.lumeweb.com/portal/core"
 	"go.uber.org/zap"
 	"gorm.io/gorm"
-	"go.lumeweb.com/ipfs-content/paths"
 	pluginCore "go.lumeweb.com/portal-plugin-ipfs/core"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/config"
 	pluginDb "go.lumeweb.com/portal-plugin-ipfs/internal/db"
@@ -249,21 +248,23 @@ func (j *WebsiteJanitorJob) validateIPNSTarget(ctx context.Context, website *plu
 	ctx, span := core.TraceMethod(ctx, "WebsiteJanitorJob.validateIPNSTarget")
 	defer span.End()
 
-	// Check if IPNS key exists in database by trying to get the private key
-	privKey, userID, err := j.ipnsKeyService.GetPrivateKeyByPeerID(ctx, website.TargetHash())
+	peerID := website.TargetHash()
+
+	privKey, userID, err := j.ipnsKeyService.GetPrivateKeyByPeerID(ctx, peerID)
 	if err != nil {
 		j.logger.Error("IPNS key not found in database",
 			zap.Error(err),
 			zap.Uint("website_id", website.ID),
 			zap.String("domain", website.Domain),
-			zap.String("peer_id", website.TargetHash()),
+			zap.String("peer_id", peerID),
 		)
 		website.Status = string(pluginDb.WebsiteStatusBroken)
 		website.LastCheckedAt = new(time.Now())
 		return nil
 	}
 
-	// Verify user ownership
+	_ = privKey
+
 	if website.UserID != userID {
 		j.logger.Error("IPNS key belongs to different user",
 			zap.Uint("website_id", website.ID),
@@ -276,57 +277,37 @@ func (j *WebsiteJanitorJob) validateIPNSTarget(ctx context.Context, website *plu
 		return nil
 	}
 
-	_ = privKey
-
-	// Resolve IPNS record
-	record, err := j.ipnsKeyService.GetPublished(ctx, website.TargetHash(), true)
-	if err != nil {
-		j.logger.Error("Failed to resolve IPNS record",
+	var key pluginDb.IPFSIPNSKey
+	if err := j.db.WithContext(ctx).Where("user_id = ? AND peer_id_multihash = ?", userID, []byte(website.TargetMultihash)).First(&key).Error; err != nil {
+		j.logger.Error("Failed to look up IPNS key record",
 			zap.Error(err),
 			zap.Uint("website_id", website.ID),
 			zap.String("domain", website.Domain),
-			zap.String("peer_id", website.TargetHash()),
+			zap.String("peer_id", peerID),
 		)
 		website.Status = string(pluginDb.WebsiteStatusBroken)
 		website.LastCheckedAt = new(time.Now())
 		return nil
 	}
 
-	// Check if record is nil (key not yet published)
-	if record == nil {
-		j.logger.Warn("IPNS record not found",
+	if key.LastPublishedCID == "" {
+		j.logger.Warn("IPNS key has no published CID",
 			zap.Uint("website_id", website.ID),
 			zap.String("domain", website.Domain),
-			zap.String("peer_id", website.TargetHash()),
+			zap.String("peer_id", peerID),
 		)
 		website.Status = string(pluginDb.WebsiteStatusBroken)
 		website.LastCheckedAt = new(time.Now())
 		return nil
 	}
 
-	// Extract target path from IPNS record
-	targetPath, err := record.Value()
+	cidValid, err := j.validateCIDTarget(ctx, key.LastPublishedCID)
 	if err != nil {
-		j.logger.Error("Failed to extract target path from IPNS record",
+		j.logger.Warn("Failed to validate last published CID",
 			zap.Error(err),
 			zap.Uint("website_id", website.ID),
 			zap.String("domain", website.Domain),
-			zap.String("peer_id", website.TargetHash()),
-		)
-		website.Status = string(pluginDb.WebsiteStatusBroken)
-		website.LastCheckedAt = new(time.Now())
-		return nil
-	}
-
-	// Extract CID from path using lenient matcher that handles both /ipfs/{cid} and plain CID strings
-	cidStr := paths.ExtractCIDFromPathLenient(targetPath)
-	cidValid, err := j.validateCIDTarget(ctx, cidStr)
-	if err != nil {
-		j.logger.Warn("Failed to validate resolved CID",
-			zap.Error(err),
-			zap.Uint("website_id", website.ID),
-			zap.String("domain", website.Domain),
-			zap.String("cid", cidStr),
+			zap.String("cid", key.LastPublishedCID),
 		)
 		website.Status = string(pluginDb.WebsiteStatusBroken)
 		website.LastCheckedAt = new(time.Now())
@@ -334,50 +315,24 @@ func (j *WebsiteJanitorJob) validateIPNSTarget(ctx context.Context, website *plu
 	}
 
 	if !cidValid {
-		j.logger.Warn("Resolved CID is not pinned",
+		j.logger.Warn("Last published CID is not pinned",
 			zap.Uint("website_id", website.ID),
 			zap.String("domain", website.Domain),
-			zap.String("cid", cidStr),
+			zap.String("cid", key.LastPublishedCID),
 		)
 		website.Status = string(pluginDb.WebsiteStatusBroken)
 		website.LastCheckedAt = new(time.Now())
 		return nil
 	}
 
-	// Check record validity timestamp
-	validity, err := record.Validity()
-	if err != nil {
-		j.logger.Warn("Failed to get IPNS record validity",
-			zap.Error(err),
-			zap.Uint("website_id", website.ID),
-			zap.String("domain", website.Domain),
-			zap.String("peer_id", website.TargetHash()),
-		)
-		website.Status = string(pluginDb.WebsiteStatusBroken)
-		website.LastCheckedAt = new(time.Now())
-		return nil
-	}
-
-	if validity.Before(time.Now()) {
-		j.logger.Warn("IPNS record has expired",
-			zap.Uint("website_id", website.ID),
-			zap.String("domain", website.Domain),
-			zap.String("peer_id", website.TargetHash()),
-			zap.Time("validity", validity),
-		)
-		website.Status = string(pluginDb.WebsiteStatusBroken)
-		website.LastCheckedAt = new(time.Now())
-		return nil
-	}
-
-	// All validations passed
 	website.Status = string(pluginDb.WebsiteStatusActive)
 	website.LastCheckedAt = new(time.Now())
 
 	j.logger.Debug("IPNS target validated successfully",
 		zap.Uint("website_id", website.ID),
 		zap.String("domain", website.Domain),
-		zap.String("peer_id", website.TargetHash()),
+		zap.String("peer_id", peerID),
+		zap.String("cid", key.LastPublishedCID),
 	)
 
 	return nil

--- a/internal/service/website/janitor_test.go
+++ b/internal/service/website/janitor_test.go
@@ -6,11 +6,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ipfs/boxo/path"
-	"github.com/ipfs/go-cid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.lumeweb.com/ipfs-content/paths"
 	pluginCore "go.lumeweb.com/portal-plugin-ipfs/core"
 	pluginConfig "go.lumeweb.com/portal-plugin-ipfs/internal/config"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/db/migrations"
@@ -32,10 +29,8 @@ var JanitorTestOptions = coreTesting.CombineOptions(
 )
 
 func TestWebsiteJanitorJob_NewWebsiteJanitorJob(t *testing.T) {
-	// Act
 	job := NewWebsiteJanitorJob()
 
-	// Assert
 	assert.NotNil(t, job)
 	assert.NotEmpty(t, job.ID())
 	assert.Equal(t, core.JobOriginPlugin, job.Origin())
@@ -45,34 +40,27 @@ func TestWebsiteJanitorJob_NewWebsiteJanitorJob(t *testing.T) {
 
 func TestWebsiteJanitorJob_Run_Disabled(t *testing.T) {
 	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
-		// Arrange
 		job := NewWebsiteJanitorJob()
 
-		// Configure janitor as disabled
 		websiteConfig := &pluginConfig.WebsiteConfig{
 			JanitorEnabled: false,
 		}
 
-		// Inject config into job
 		janitorJob := job.(*WebsiteJanitorJob)
 		janitorJob.config = websiteConfig
 		janitorJob.db = ctx.DB()
 		janitorJob.logger = nil
 
-		// Act
 		err := job.Run(ctx, context.Background())
 
-		// Assert - Should not return error when disabled
 		require.NoError(tb, err)
 	}, JanitorTestOptions)
 }
 
 func TestWebsiteJanitorJob_Run_NoWebsites(t *testing.T) {
 	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
-		// Arrange
 		job := NewWebsiteJanitorJob()
 
-		// Configure janitor
 		websiteConfig := &pluginConfig.WebsiteConfig{
 			JanitorEnabled:     true,
 			CheckInterval:      30 * time.Minute,
@@ -80,90 +68,31 @@ func TestWebsiteJanitorJob_Run_NoWebsites(t *testing.T) {
 			JanitorBatchSize:   10,
 		}
 
-		// Inject dependencies
 		janitorJob := job.(*WebsiteJanitorJob)
 		janitorJob.config = websiteConfig
 		janitorJob.db = ctx.DB()
 		janitorJob.logger = nil
 
-		// Act
 		err := job.Run(ctx, context.Background())
 
-		// Assert
 		require.NoError(tb, err)
 	}, JanitorTestOptions)
 }
 
 func TestWebsiteJanitorJob_ID(t *testing.T) {
-	// Arrange
 	job := NewWebsiteJanitorJob()
-
-	// Act
 	jobID := job.ID()
 
-	// Assert
 	assert.NotEmpty(t, jobID)
 	assert.IsType(t, jobID, jobID)
 }
 
 func TestWebsiteJanitorJob_DisplayName(t *testing.T) {
-	// Arrange
 	job := NewWebsiteJanitorJob()
-
-	// Act
-	jobName := job.DisplayName()
-
-	// Assert
-	assert.Equal(t, "IPFS Website Janitor", jobName)
+	assert.Equal(t, "IPFS Website Janitor", job.DisplayName())
 }
 
 func TestWebsiteJanitorJob_Origin(t *testing.T) {
-	// Arrange
 	job := NewWebsiteJanitorJob()
-
-	// Act
-	origin := job.Origin()
-
-	// Assert
-	assert.Equal(t, core.JobOriginPlugin, origin)
-}
-
-
-func TestWebsiteJanitorJob_ValidateIPNSTarget_FullPath(t *testing.T) {
-	// This test verifies that IPNS path prefixes are extracted correctly.
-	// When an IPNS record returns a path like "/ipfs/bafy...", the janitor should
-	// use paths.ExtractCIDFromPathLenient() to extract the CID.
-
-	tests := []struct {
-		name         string
-		cid          string
-	}{
-		{
-			name: "Path with /ipfs/ prefix",
-			cid:  "bafybeieffnocaq7t4w4daagvydl32igft5oziyyaebqr6vx6rb3fwh2ab4",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// Arrange - create path.Path from CID
-			// Decode CID and create full path from it (which represents /ipfs/{cid})
-			// This is the format returned by ipns.Record.Value()
-			targetCID, err := cid.Decode(tt.cid)
-			require.NoError(t, err, "CID should be valid")
-			targetPath := path.FromCid(targetCID)
-
-			// Verify the path has the /ipfs/ prefix
-			assert.Equal(t, "/ipfs/"+tt.cid, targetPath.String(),
-				"path.FromCid() should create path with /ipfs/ prefix")
-			
-			// Act - use the same helper as the production code
-			// The helper extracts CID from the path by examining segments
-			cidStr := paths.ExtractCIDFromPathLenient(targetPath)
-
-			// Assert - verify the CID was extracted correctly
-			assert.Equal(t, tt.cid, cidStr,
-				"CID should be extracted correctly from path")
-		})
-	}
+	assert.Equal(t, core.JobOriginPlugin, job.Origin())
 }


### PR DESCRIPTION
- validateIPNSTarget now reads LastPublishedCID from IPFSIPNSKey DB row instead of resolving from DHT via GetPublished()
- Removes DHT dependency (record.Value(), paths.ExtractCIDFromPathLenient, record validity expiry checks) from janitor
- Adds Value and LastPublishedAt fields to IPNS key DTOs
- Cleans up janitor tests: removes DHT-dependent integration tests, simplifies boilerplate

* `develop` <!-- branch-stack -->
  - **refactor(janitor): use DB-stored LastPublishedCID for IPNS validation** :point\_left:

---

<!-- kody-pr-summary:start -->
Refactor the website janitor to use the database-stored `LastPublishedCID` for IPNS validation instead of resolving IPNS records from the network.

Previously, the janitor resolved IPNS records via `GetPublished()`, extracted the CID from the record's value path using `paths.ExtractCIDFromPathLenient()`, and checked the record's validity/expiration timestamp. This has been replaced with a direct database lookup of the `IPFSIPNSKey` record, validating the `LastPublishedCID` field directly. This removes the dependency on `go.lumeweb.com/ipfs-content/paths` and eliminates network-based IPNS resolution, path extraction, and expiration checks from the janitor's validation flow.

Additionally, the `Value` (last published CID) and `LastPublishedAt` fields are now exposed in the `IPNSKeyResponse` and `IPNSKeyListResponse` API DTOs, and the related path-extraction test has been removed since that logic is no longer used.
<!-- kody-pr-summary:end -->