### PR TITLE
fix: route IPNS PutValue through companion DHT instead of FullRT

### DIFF
--- a/internal/api/admin_extension.go
+++ b/internal/api/admin_extension.go
@@ -280,7 +280,7 @@ func (e *AdminExtension) republishIPNS(c echo.Context) error {
 		}
 
 		if err := e.ipnsKeyService.PublishWithKey(reqCtx, privKey, cidStr, 0); err != nil {
-			e.logger.Warn("Failed to republish IPNS record, skipping", zap.Error(err), zap.String("peer_id", peerID))
+			e.logger.Error("Failed to republish IPNS record, skipping", zap.Error(err), zap.String("peer_id", peerID))
 			continue
 		}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -59,6 +59,12 @@ type (
 		// RecordLifetime is how long republished IPNS records remain valid.
 		// Default is 48h which is the DHT hard cap — records are dropped after 48h regardless.
 		RecordLifetime time.Duration `config:"record_lifetime"`
+		// PubSubRebroadcastInterval is how frequently IPNS records are rebroadcast over PubSub.
+		// Default is 10m.
+		PubSubRebroadcastInterval time.Duration `config:"pubsub_rebroadcast_interval"`
+		// PubSubRebroadcastInitialDelay is the delay before the first PubSub rebroadcast.
+		// Default is 1m.
+		PubSubRebroadcastInitialDelay time.Duration `config:"pubsub_rebroadcast_initial_delay"`
 	}
 )
 
@@ -82,7 +88,9 @@ func (I IPFSProvider) Defaults() map[string]any {
 
 func (i IPNS) Defaults() map[string]any {
 	return map[string]any{
-		"RepublishInterval": time.Hour,
-		"RecordLifetime":    48 * time.Hour,
+		"RepublishInterval":             time.Hour,
+		"RecordLifetime":                48 * time.Hour,
+		"PubSubRebroadcastInterval":     10 * time.Minute,
+		"PubSubRebroadcastInitialDelay": 1 * time.Minute,
 	}
 }

--- a/internal/protocol/ipfs/composite_routing.go
+++ b/internal/protocol/ipfs/composite_routing.go
@@ -2,43 +2,110 @@ package ipfs
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/libp2p/go-libp2p/core/routing"
+	"go.lumeweb.com/portal/core"
+	"go.uber.org/zap"
 )
 
 // compositeValueStore publishes IPNS records to multiple routing backends
-// simultaneously (e.g. DHT + PubSub). Writes go to all stores; reads come
-// from the primary store.
+// and splits read/write paths for optimal DHT behavior.
+//
+// In FullRT mode, the primary (FullRT) is excellent for reads but a
+// client-only DHT that does not reliably publish records to the network.
+// The companion (server-mode IpfsDHT) handles PutValue so records are
+// properly propagated. When no companion is provided, PutValue falls back
+// to the primary (basic DHT or FullRT without companion).
 type compositeValueStore struct {
 	primary   routing.ValueStore
+	companion routing.ValueStore // server-mode DHT for writes; nil falls back to primary
 	secondary routing.ValueStore
+	log       *core.Logger
 }
 
 var _ routing.ValueStore = (*compositeValueStore)(nil)
 
-func newCompositeValueStore(primary, secondary routing.ValueStore) *compositeValueStore {
-	return &compositeValueStore{primary: primary, secondary: secondary}
+func newCompositeValueStore(primary, secondary routing.ValueStore, log *core.Logger) *compositeValueStore {
+	return &compositeValueStore{primary: primary, secondary: secondary, log: log}
+}
+
+func newCompositeValueStoreWithCompanion(primary, companion, secondary routing.ValueStore, log *core.Logger) *compositeValueStore {
+	return &compositeValueStore{primary: primary, companion: companion, secondary: secondary, log: log}
+}
+
+// writeTarget returns the routing.ValueStore that PutValue should write to.
+// When a companion (server-mode DHT) is available, writes go there instead
+// of the primary (which may be a client-only FullRT).
+func (c *compositeValueStore) writeTarget() routing.ValueStore {
+	if c.companion != nil {
+		return c.companion
+	}
+	return c.primary
+}
+
+func (c *compositeValueStore) writeTargetName() string {
+	if c.companion != nil {
+		return "companion"
+	}
+	return "primary"
 }
 
 func (c *compositeValueStore) PutValue(ctx context.Context, key string, value []byte, opts ...routing.Option) error {
-	errs := make(chan error, 2)
+	target := c.writeTarget()
+	targetName := c.writeTargetName()
+
+	type putResult struct {
+		err error
+	}
+	dhtCh := make(chan putResult, 1)
+	pubsubCh := make(chan putResult, 1)
 
 	go func() {
-		errs <- c.primary.PutValue(ctx, key, value, opts...)
+		dhtCh <- putResult{err: target.PutValue(ctx, key, value, opts...)}
 	}()
 
 	go func() {
-		errs <- c.secondary.PutValue(ctx, key, value, opts...)
+		pubsubCh <- putResult{err: c.secondary.PutValue(ctx, key, value, opts...)}
 	}()
 
-	var firstErr error
-	for i := 0; i < 2; i++ {
-		if err := <-errs; err != nil && firstErr == nil {
-			firstErr = err
-		}
+	dhtRes := <-dhtCh
+	pubsubRes := <-pubsubCh
+
+	if dhtRes.err != nil && pubsubRes.err != nil {
+		c.debug("PutValue failed on both backends",
+			zap.String("key", key),
+			zap.String("write_target", targetName),
+			zap.Error(dhtRes.err),
+			zap.NamedError("pubsub_err", pubsubRes.err),
+		)
+		return fmt.Errorf("%s: %w; pubsub: %v", targetName, dhtRes.err, pubsubRes.err)
 	}
 
-	return firstErr
+	if dhtRes.err != nil {
+		c.debug("PutValue failed on DHT backend",
+			zap.String("key", key),
+			zap.String("write_target", targetName),
+			zap.Error(dhtRes.err),
+		)
+		return dhtRes.err
+	}
+
+	if pubsubRes.err != nil {
+		c.debug("PutValue succeeded on DHT, failed on PubSub",
+			zap.String("key", key),
+			zap.String("write_target", targetName),
+			zap.Error(pubsubRes.err),
+		)
+		return nil
+	}
+
+	c.debug("PutValue succeeded on both backends",
+		zap.String("key", key),
+		zap.String("write_target", targetName),
+	)
+
+	return nil
 }
 
 func (c *compositeValueStore) GetValue(ctx context.Context, key string, opts ...routing.Option) ([]byte, error) {
@@ -94,4 +161,10 @@ func (c *compositeValueStore) SearchValue(ctx context.Context, key string, opts 
 	}()
 
 	return merged, nil
+}
+
+func (c *compositeValueStore) debug(msg string, fields ...zap.Field) {
+	if c.log != nil {
+		c.log.Debug(msg, fields...)
+	}
 }

--- a/internal/protocol/ipfs/composite_routing_test.go
+++ b/internal/protocol/ipfs/composite_routing_test.go
@@ -68,7 +68,7 @@ func TestCompositeValueStore_PutValue_WritesToBoth(t *testing.T) {
 		},
 	}
 
-	c := newCompositeValueStore(primary, secondary)
+	c := newCompositeValueStore(primary, secondary, nil)
 	err := c.PutValue(context.Background(), "test-key", []byte("test-value"))
 	if err != nil {
 		t.Fatalf("PutValue returned error: %v", err)
@@ -79,6 +79,95 @@ func TestCompositeValueStore_PutValue_WritesToBoth(t *testing.T) {
 	}
 	if !secondaryCalled {
 		t.Error("secondary PutValue was not called")
+	}
+}
+
+func TestCompositeValueStore_PutValue_WithCompanion_WritesToCompanion(t *testing.T) {
+	var companionCalled, secondaryCalled bool
+	var primaryCalled bool
+
+	primary := &mockValueStore{
+		putValueFn: func(_ context.Context, _ string, _ []byte, _ ...routing.Option) error {
+			primaryCalled = true
+			return nil
+		},
+	}
+
+	companion := &mockValueStore{
+		putValueFn: func(_ context.Context, key string, value []byte, _ ...routing.Option) error {
+			companionCalled = true
+			if key != "test-key" {
+				t.Errorf("companion got key %q, want %q", key, "test-key")
+			}
+			if string(value) != "test-value" {
+				t.Errorf("companion got value %q, want %q", value, "test-value")
+			}
+			return nil
+		},
+	}
+
+	secondary := &mockValueStore{
+		putValueFn: func(_ context.Context, key string, value []byte, _ ...routing.Option) error {
+			secondaryCalled = true
+			return nil
+		},
+	}
+
+	c := newCompositeValueStoreWithCompanion(primary, companion, secondary, nil)
+	err := c.PutValue(context.Background(), "test-key", []byte("test-value"))
+	if err != nil {
+		t.Fatalf("PutValue returned error: %v", err)
+	}
+
+	if primaryCalled {
+		t.Error("primary PutValue should NOT be called when companion is present")
+	}
+	if !companionCalled {
+		t.Error("companion PutValue was not called")
+	}
+	if !secondaryCalled {
+		t.Error("secondary PutValue was not called")
+	}
+}
+
+func TestCompositeValueStore_PutValue_WithCompanion_CompanionError(t *testing.T) {
+	testErr := errors.New("companion failed")
+
+	primary := &mockValueStore{}
+	companion := &mockValueStore{
+		putValueFn: func(_ context.Context, _ string, _ []byte, _ ...routing.Option) error {
+			return testErr
+		},
+	}
+	secondary := &mockValueStore{}
+
+	c := newCompositeValueStoreWithCompanion(primary, companion, secondary, nil)
+	err := c.PutValue(context.Background(), "key", []byte("value"))
+	if err != testErr {
+		t.Fatalf("got error %v, want %v", err, testErr)
+	}
+}
+
+func TestCompositeValueStore_PutValue_WithCompanion_FallsBackToPrimaryOnNilCompanion(t *testing.T) {
+	var primaryCalled bool
+
+	primary := &mockValueStore{
+		putValueFn: func(_ context.Context, _ string, _ []byte, _ ...routing.Option) error {
+			primaryCalled = true
+			return nil
+		},
+	}
+
+	secondary := &mockValueStore{}
+
+	c := newCompositeValueStoreWithCompanion(primary, nil, secondary, nil)
+	err := c.PutValue(context.Background(), "key", []byte("value"))
+	if err != nil {
+		t.Fatalf("PutValue returned error: %v", err)
+	}
+
+	if !primaryCalled {
+		t.Error("primary PutValue was not called when companion is nil")
 	}
 }
 
@@ -93,7 +182,7 @@ func TestCompositeValueStore_PutValue_PropagatesFirstError(t *testing.T) {
 
 	secondary := &mockValueStore{}
 
-	c := newCompositeValueStore(primary, secondary)
+	c := newCompositeValueStore(primary, secondary, nil)
 	err := c.PutValue(context.Background(), "key", []byte("value"))
 	if err != testErr {
 		t.Fatalf("got error %v, want %v", err, testErr)
@@ -111,10 +200,10 @@ func TestCompositeValueStore_PutValue_SecondaryErrorOnly(t *testing.T) {
 		},
 	}
 
-	c := newCompositeValueStore(primary, secondary)
+	c := newCompositeValueStore(primary, secondary, nil)
 	err := c.PutValue(context.Background(), "key", []byte("value"))
-	if err != testErr {
-		t.Fatalf("got error %v, want %v", err, testErr)
+	if err != nil {
+		t.Fatalf("PutValue should succeed when DHT write succeeds, even if PubSub fails; got error: %v", err)
 	}
 }
 
@@ -134,13 +223,13 @@ func TestCompositeValueStore_PutValue_BothFail(t *testing.T) {
 		},
 	}
 
-	c := newCompositeValueStore(primary, secondary)
+	c := newCompositeValueStore(primary, secondary, nil)
 	err := c.PutValue(context.Background(), "key", []byte("value"))
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
-	if err != err1 && err != err2 {
-		t.Fatalf("got error %v, want either %v or %v", err, err1, err2)
+	if !errors.Is(err, err1) {
+		t.Fatalf("expected error to wrap primary error %v, got %v", err1, err)
 	}
 }
 
@@ -157,13 +246,42 @@ func TestCompositeValueStore_GetValue_UsesPrimary(t *testing.T) {
 		},
 	}
 
-	c := newCompositeValueStore(primary, secondary)
+	c := newCompositeValueStore(primary, secondary, nil)
 	val, err := c.GetValue(context.Background(), "key")
 	if err != nil {
 		t.Fatalf("GetValue returned error: %v", err)
 	}
 	if string(val) != "from-primary" {
 		t.Fatalf("got value %q, want %q", val, "from-primary")
+	}
+}
+
+func TestCompositeValueStore_GetValue_WithCompanion_StillUsesPrimary(t *testing.T) {
+	primary := &mockValueStore{
+		getValueFn: func(_ context.Context, _ string, _ ...routing.Option) ([]byte, error) {
+			return []byte("from-primary"), nil
+		},
+	}
+
+	companion := &mockValueStore{
+		getValueFn: func(_ context.Context, _ string, _ ...routing.Option) ([]byte, error) {
+			return []byte("from-companion"), nil
+		},
+	}
+
+	secondary := &mockValueStore{
+		getValueFn: func(_ context.Context, _ string, _ ...routing.Option) ([]byte, error) {
+			return []byte("from-secondary"), nil
+		},
+	}
+
+	c := newCompositeValueStoreWithCompanion(primary, companion, secondary, nil)
+	val, err := c.GetValue(context.Background(), "key")
+	if err != nil {
+		t.Fatalf("GetValue returned error: %v", err)
+	}
+	if string(val) != "from-primary" {
+		t.Fatalf("got value %q, want %q — GetValue should always use primary", val, "from-primary")
 	}
 }
 
@@ -188,7 +306,7 @@ func TestCompositeValueStore_SearchValue_MergesBothChannels(t *testing.T) {
 		},
 	}
 
-	c := newCompositeValueStore(primary, secondary)
+	c := newCompositeValueStore(primary, secondary, nil)
 	ch, err := c.SearchValue(context.Background(), "key")
 	if err != nil {
 		t.Fatalf("SearchValue returned error: %v", err)
@@ -223,7 +341,7 @@ func TestCompositeValueStore_SearchValue_DeliversPrimaryWhenSecondaryEmpty(t *te
 		},
 	}
 
-	c := newCompositeValueStore(primary, secondary)
+	c := newCompositeValueStore(primary, secondary, nil)
 	ch, err := c.SearchValue(context.Background(), "key")
 	if err != nil {
 		t.Fatalf("SearchValue returned error: %v", err)
@@ -251,7 +369,7 @@ func TestCompositeValueStore_SearchValue_BothFail(t *testing.T) {
 		},
 	}
 
-	c := newCompositeValueStore(primary, secondary)
+	c := newCompositeValueStore(primary, secondary, nil)
 	_, err := c.SearchValue(context.Background(), "key")
 	if err == nil {
 		t.Fatal("expected error, got nil")
@@ -277,7 +395,7 @@ func TestCompositeValueStore_SearchValue_FallsBackToPrimary(t *testing.T) {
 		},
 	}
 
-	c := newCompositeValueStore(primary, secondary)
+	c := newCompositeValueStore(primary, secondary, nil)
 	ch, err := c.SearchValue(context.Background(), "key")
 	if err != nil {
 		t.Fatalf("SearchValue returned error: %v", err)
@@ -307,7 +425,7 @@ func TestCompositeValueStore_SearchValue_Regression_PubSubEmptyChannelDoesNotBlo
 		},
 	}
 
-	c := newCompositeValueStore(primary, secondary)
+	c := newCompositeValueStore(primary, secondary, nil)
 	ch, err := c.SearchValue(context.Background(), "key")
 	if err != nil {
 		t.Fatalf("SearchValue returned error: %v", err)

--- a/internal/protocol/ipfs/node.go
+++ b/internal/protocol/ipfs/node.go
@@ -645,8 +645,8 @@ func NewNode(ctx core.Context, cfg *config.ProtocolConfig, rs pluginCore.Reprovi
 
 	// Create IPNS PubSub value store for near-instant propagation to subscribers
 	pubsubValueStore, err := pubsubrouter.NewPubsubValueStore(ctx, node, gossipsub, ipns.Validator{KeyBook: node.Peerstore()},
-		pubsubrouter.WithRebroadcastInterval(10*time.Minute),
-		pubsubrouter.WithRebroadcastInitialDelay(1*time.Minute),
+		pubsubrouter.WithRebroadcastInterval(cfg.IPNS.PubSubRebroadcastInterval),
+		pubsubrouter.WithRebroadcastInitialDelay(cfg.IPNS.PubSubRebroadcastInitialDelay),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create pubsub value store: %w", err)
@@ -655,7 +655,14 @@ func NewNode(ctx core.Context, cfg *config.ProtocolConfig, rs pluginCore.Reprovi
 	ipfsNode.pubsubValueStore = pubsubValueStore
 
 	// Create boxo IPNS publisher with composite routing (DHT + PubSub)
-	compositeRouting := newCompositeValueStore(routingImpl, pubsubValueStore)
+	// When a companion (server-mode) DHT exists, writes go there since FullRT
+	// is client-only and does not reliably put records into the DHT network.
+	var compositeRouting *compositeValueStore
+	if ipfsNode.companionDHT != nil {
+		compositeRouting = newCompositeValueStoreWithCompanion(routingImpl, ipfsNode.companionDHT, pubsubValueStore, ctx.Logger())
+	} else {
+		compositeRouting = newCompositeValueStore(routingImpl, pubsubValueStore, ctx.Logger())
+	}
 	boxoPublisher := namesys.NewIPNSPublisher(compositeRouting, ds)
 
 	// Update the IPFS node with remaining fields

--- a/internal/service/website/website.go
+++ b/internal/service/website/website.go
@@ -601,7 +601,7 @@ func (s *WebsiteServiceDefault) UpdateWebsite(ctx context.Context, userID uint, 
 						ttl := 24 * time.Hour
 						err = s.ipnsKeySvc.PublishCID(ctx, ipnsKey.PeerID().String(), publishHash, ttl)
 						if err != nil {
-							s.Logger().Warn("Failed to republish new CID to IPNS key",
+							s.Logger().Error("Failed to republish new CID to IPNS key",
 								zap.Error(err),
 								zap.String("domain", website.Domain),
 								zap.String("peer_id", ipnsKey.PeerID().String()),
@@ -1348,7 +1348,7 @@ func (s *WebsiteServiceDefault) ensureIPNSKey(ctx context.Context, userID uint, 
 		ttl := 24 * time.Hour
 		err = s.ipnsKeySvc.PublishCID(ctx, ipnsKey.PeerID().String(), publishCID, ttl)
 		if err != nil {
-			s.Logger().Warn("Failed to publish CID to IPNS key",
+			s.Logger().Error("Failed to publish CID to IPNS key",
 				zap.Error(err),
 				zap.String("domain", domain),
 				zap.String("peer_id", ipnsKey.PeerID().String()),


### PR DESCRIPTION
FullRT is a client-only DHT that does not reliably publish records to the network. The companion (server-mode IpfsDHT) was already running alongside FullRT but was not wired to the publisher, causing IPNS records to never reach the DHT.

- Add companion field to compositeValueStore; PutValue writes to companion when available, falls back to primary
- Pass companionDHT to composite routing in node.go
- Add debug logging for PutValue outcomes (success/fail per backend)
- Move PubSub rebroadcast intervals to IPNS config struct
- Upgrade publish failure logs from Warn to Error in website service and admin extension
- Add tests for companion-aware PutValue behavior

* `develop` <!-- branch-stack -->
  - **fix: route IPNS PutValue through companion DHT instead of FullRT** :point\_left:

---

<!-- kody-pr-summary:start -->
Route IPNS PutValue operations through the companion (server-mode) DHT instead of the primary FullRT DHT, which is client-only and does not reliably publish records to the network. When a companion DHT is available, writes go there while reads continue to use the primary; when no companion exists, PutValue falls back to the primary as before. Also makes PubSub rebroadcast interval and initial delay configurable, and upgrades IPNS publish/republish failure log levels from Warn to Error.
<!-- kody-pr-summary:end -->