### PR TITLE
fix: use detached context for IPNS publish and add boot-time republish

### DIFF
--- a/core/ipns_key.go
+++ b/core/ipns_key.go
@@ -92,4 +92,7 @@ type IPNSKeyService interface {
 
 	// ListPublished returns all IPNS records published by this node
 	ListPublished(ctx context.Context) (map[ipns.Name]*ipns.Record, error)
+
+	// RepublishAllKeysOnBoot force-publishes all IPNS keys with a known CID
+	RepublishAllKeysOnBoot(ctx context.Context)
 }

--- a/internal/api/admin_extension.go
+++ b/internal/api/admin_extension.go
@@ -279,7 +279,7 @@ func (e *AdminExtension) republishIPNS(c echo.Context) error {
 			continue
 		}
 
-		if err := e.ipnsKeyService.PublishWithKey(reqCtx, privKey, cidStr, 0); err != nil {
+		if err := e.ipnsKeyService.PublishWithKey(core.DetachContext(reqCtx), privKey, cidStr, 0); err != nil {
 			e.logger.Error("Failed to republish IPNS record, skipping", zap.Error(err), zap.String("peer_id", peerID))
 			continue
 		}

--- a/internal/api/api_ipns.go
+++ b/internal/api/api_ipns.go
@@ -441,7 +441,7 @@ func (a *API) republishIPNS(c echo.Context) error {
 		return ctx.Error(apiErr, apiErr.HttpStatus())
 	}
 
-	if err := ipnsKeyService.PublishWithKey(reqCtx, privKey, cidStr, 0); err != nil {
+	if err := ipnsKeyService.PublishWithKey(core.DetachContext(reqCtx), privKey, cidStr, 0); err != nil {
 		a.Logger().Error("Failed to republish IPNS record", zap.Error(err), zap.String("peer_id", key.PeerID().String()))
 		apiErr := NewError(ErrKeyFileProcessingFailed, fmt.Errorf("failed to republish IPNS record: %w", err))
 		return ctx.Error(apiErr, apiErr.HttpStatus())

--- a/internal/protocol/ipfs/composite_routing.go
+++ b/internal/protocol/ipfs/composite_routing.go
@@ -73,7 +73,7 @@ func (c *compositeValueStore) PutValue(ctx context.Context, key string, value []
 	pubsubRes := <-pubsubCh
 
 	if dhtRes.err != nil && pubsubRes.err != nil {
-		c.debug("PutValue failed on both backends",
+		c.logError("PutValue failed on both backends",
 			zap.String("key", key),
 			zap.String("write_target", targetName),
 			zap.Error(dhtRes.err),
@@ -83,7 +83,7 @@ func (c *compositeValueStore) PutValue(ctx context.Context, key string, value []
 	}
 
 	if dhtRes.err != nil {
-		c.debug("PutValue failed on DHT backend",
+		c.logError("PutValue failed on DHT backend",
 			zap.String("key", key),
 			zap.String("write_target", targetName),
 			zap.Error(dhtRes.err),
@@ -92,7 +92,7 @@ func (c *compositeValueStore) PutValue(ctx context.Context, key string, value []
 	}
 
 	if pubsubRes.err != nil {
-		c.debug("PutValue succeeded on DHT, failed on PubSub",
+		c.logError("PutValue succeeded on DHT, failed on PubSub",
 			zap.String("key", key),
 			zap.String("write_target", targetName),
 			zap.Error(pubsubRes.err),
@@ -166,5 +166,11 @@ func (c *compositeValueStore) SearchValue(ctx context.Context, key string, opts 
 func (c *compositeValueStore) debug(msg string, fields ...zap.Field) {
 	if c.log != nil {
 		c.log.Debug(msg, fields...)
+	}
+}
+
+func (c *compositeValueStore) logError(msg string, fields ...zap.Field) {
+	if c.log != nil {
+		c.log.Error(msg, fields...)
 	}
 }

--- a/internal/service/ipns_key/ipns_key.go
+++ b/internal/service/ipns_key/ipns_key.go
@@ -191,6 +191,8 @@ func NewIPNSKeyService() (core.Service, []core.ContextBuilderOption, error) {
 				// Don't fail startup - log and continue
 			}
 
+			svc.RepublishAllKeysOnBoot(ctx)
+
 			return nil
 		}),
 		core.ContextWithExitFunc(func(ctx core.Context) error {
@@ -720,6 +722,74 @@ func (s *IPNSKeyServiceDefault) SyncToBoxoKeystore(ctx context.Context) error {
 	)
 
 	return nil
+}
+
+// RepublishAllKeysOnBoot force-publishes all IPNS keys that have a known CID
+// in the database. This seeds the boxo datastore with a record for each key
+// so the republisher doesn't silently skip them (errNoEntry → return nil).
+// Publishes are fire-and-forget with detached context — they must not block
+// or be canceled by the caller's context.
+func (s *IPNSKeyServiceDefault) RepublishAllKeysOnBoot(ctx context.Context) {
+	ctx, span := core.TraceMethod(ctx, "IPNSKeyServiceDefault.RepublishAllKeysOnBoot")
+	defer span.End()
+
+	var keys []pluginDb.IPFSIPNSKey
+	err := db.RetryableComponentTransaction(s, ctx, func(tx *gorm.DB) *gorm.DB {
+		return tx.Where("last_published_cid != '' AND last_published_cid IS NOT NULL").Find(&keys)
+	})
+	if err != nil {
+		s.Logger().Error("Failed to list IPNS keys for boot republish", zap.Error(err))
+		return
+	}
+
+	if len(keys) == 0 {
+		s.Logger().Info("No IPNS keys with published CID to republish on boot")
+		return
+	}
+
+	publishedCount := 0
+	failedCount := 0
+
+	for _, key := range keys {
+		privKey, err := s.decryptPrivateKey(key.PrivateKeyEncrypted)
+		if err != nil {
+			s.Logger().Error("Failed to decrypt private key for boot republish",
+				zap.Error(err),
+				zap.Uint("key_id", key.ID),
+				zap.Stringer("peer_id", key.PeerID()),
+			)
+			failedCount++
+			continue
+		}
+
+		if privKey == nil {
+			s.Logger().Error("Decrypted private key is nil, skipping boot republish",
+				zap.Uint("key_id", key.ID),
+				zap.Stringer("peer_id", key.PeerID()),
+			)
+			failedCount++
+			continue
+		}
+
+		publishCtx := core.DetachContext(ctx)
+		if err := s.PublishWithKey(publishCtx, privKey, key.LastPublishedCID, 0); err != nil {
+			s.Logger().Error("Failed to republish IPNS key on boot",
+				zap.Error(err),
+				zap.Stringer("peer_id", key.PeerID()),
+				zap.String("cid", key.LastPublishedCID),
+			)
+			failedCount++
+			continue
+		}
+
+		publishedCount++
+	}
+
+	s.Logger().Info("Completed IPNS boot republish",
+		zap.Int("published", publishedCount),
+		zap.Int("failed", failedCount),
+		zap.Int("total", len(keys)),
+	)
 }
 
 // GetPrivateKeyByPeerID decrypts and returns the private key for a given peer ID

--- a/internal/service/ipns_key/ipns_key_test.go
+++ b/internal/service/ipns_key/ipns_key_test.go
@@ -772,6 +772,66 @@ func TestIPNSKeyService_PublishWithKey_UpdatesLastPublishedCID(t *testing.T) {
 	}, TestOptions)
 }
 
+func TestIPNSKeyService_RepublishAllKeysOnBoot_NoKeysWithCID(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		keyService := core.GetService[pluginCore.IPNSKeyService](ctx, pluginCore.IPNS_KEY_SERVICE)
+		require.NotNil(tb, keyService)
+
+		userID := uint(1)
+		_, err := keyService.CreateKey(context.Background(), userID, "no-cid-key", KeyType_Ed25519)
+		require.NoError(tb, err)
+
+		keyService.RepublishAllKeysOnBoot(context.Background())
+	}, TestOptions)
+}
+
+func TestIPNSKeyService_RepublishAllKeysOnBoot_PublishesKeysWithCID(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		keyService := core.GetService[pluginCore.IPNSKeyService](ctx, pluginCore.IPNS_KEY_SERVICE)
+		require.NotNil(tb, keyService)
+
+		userID := uint(1)
+
+		key1, err := keyService.CreateKey(context.Background(), userID, "boot-repub1", KeyType_Ed25519)
+		require.NoError(tb, err)
+
+		key2, err := keyService.CreateKey(context.Background(), userID, "boot-repub2", KeyType_Ed25519)
+		require.NoError(tb, err)
+
+		testCID := "bafybeieffnocaq7t4w4daagvydl32igft5oziyyaebqr6vx6rb3ffq2ab4"
+
+		proto := core.GetProtocol(internal.ProtocolName)
+		ipnsAccess := proto.(pluginCore.IPNSBoxoServices)
+		mockPublisher := ipnsAccess.GetIPNSNode().GetPublisher().(*mocks.MockIPNSPublisher)
+
+		mockPublisher.EXPECT().Publish(mock.Anything, mock.Anything, mock.Anything).Return(nil).Twice()
+
+		privKey1, _, err := keyService.GetPrivateKeyByPeerID(context.Background(), key1.PeerID().String())
+		require.NoError(tb, err)
+		err = keyService.PublishWithKey(context.Background(), privKey1, testCID, 0)
+		require.NoError(tb, err)
+
+		privKey2, _, err := keyService.GetPrivateKeyByPeerID(context.Background(), key2.PeerID().String())
+		require.NoError(tb, err)
+		err = keyService.PublishWithKey(context.Background(), privKey2, testCID, 0)
+		require.NoError(tb, err)
+
+		var dbKey1, dbKey2 pluginDb.IPFSIPNSKey
+		portalDb.RetryableTransaction(context.Background(), ctx.DB(), func(tx *gorm.DB) *gorm.DB {
+			return tx.Where("id = ?", key1.ID).First(&dbKey1)
+		})
+		portalDb.RetryableTransaction(context.Background(), ctx.DB(), func(tx *gorm.DB) *gorm.DB {
+			return tx.Where("id = ?", key2.ID).First(&dbKey2)
+		})
+		require.NotEmpty(tb, dbKey1.LastPublishedCID)
+		require.NotEmpty(tb, dbKey2.LastPublishedCID)
+
+		mockPublisher.EXPECT().Publish(mock.Anything, mock.Anything, mock.Anything).Return(nil).Twice()
+
+		keyService.RepublishAllKeysOnBoot(context.Background())
+	}, TestOptions)
+}
+
 func TestIPNSKeyService_PublishCID_UpdatesLastPublishedCID(t *testing.T) {
 	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 		keyService := core.GetService[pluginCore.IPNSKeyService](ctx, pluginCore.IPNS_KEY_SERVICE)

--- a/internal/testing/mocks/MockIPNSKeyService.go
+++ b/internal/testing/mocks/MockIPNSKeyService.go
@@ -1298,6 +1298,46 @@ func (_c *MockIPNSKeyService_PublishWithKey_Call) RunAndReturn(run func(ctx cont
 	return _c
 }
 
+// RepublishAllKeysOnBoot provides a mock function for the type MockIPNSKeyService
+func (_mock *MockIPNSKeyService) RepublishAllKeysOnBoot(ctx context.Context) {
+	_mock.Called(ctx)
+	return
+}
+
+// MockIPNSKeyService_RepublishAllKeysOnBoot_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RepublishAllKeysOnBoot'
+type MockIPNSKeyService_RepublishAllKeysOnBoot_Call struct {
+	*mock.Call
+}
+
+// RepublishAllKeysOnBoot is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *MockIPNSKeyService_Expecter) RepublishAllKeysOnBoot(ctx interface{}) *MockIPNSKeyService_RepublishAllKeysOnBoot_Call {
+	return &MockIPNSKeyService_RepublishAllKeysOnBoot_Call{Call: _e.mock.On("RepublishAllKeysOnBoot", ctx)}
+}
+
+func (_c *MockIPNSKeyService_RepublishAllKeysOnBoot_Call) Run(run func(ctx context.Context)) *MockIPNSKeyService_RepublishAllKeysOnBoot_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockIPNSKeyService_RepublishAllKeysOnBoot_Call) Return() *MockIPNSKeyService_RepublishAllKeysOnBoot_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *MockIPNSKeyService_RepublishAllKeysOnBoot_Call) RunAndReturn(run func(ctx context.Context)) *MockIPNSKeyService_RepublishAllKeysOnBoot_Call {
+	_c.Run(run)
+	return _c
+}
+
 // SetConfig provides a mock function for the type MockIPNSKeyService
 func (_mock *MockIPNSKeyService) SetConfig(cfg config.Manager) {
 	_mock.Called(cfg)


### PR DESCRIPTION
- Use core.DetachContext for PublishWithKey in api\_ipns.go and admin\_extension.go to prevent HTTP request context from canceling DHT PutValue before it completes
- Add RepublishAllKeysOnBoot to force-publish all IPNS keys with a known CID on startup, seeding the boxo datastore so the republisher doesn't silently skip keys with no existing record (errNoEntry)
- Fix composite routing log levels: errors at Error, success at Debug

* `develop` <!-- branch-stack -->
  - **fix: use detached context for IPNS publish and add boot-time republish** :point\_left:

---

<!-- kody-pr-summary:start -->
## Summary

This PR fixes IPNS record republishing by ensuring records are force-published at boot time and that publish operations use detached contexts to prevent premature cancellation.

### Key Changes

- **Boot-time IPNS republish**: Adds a new `RepublishAllKeysOnBoot` method that force-publishes all IPNS keys with a known CID during service startup. This seeds the boxo datastore with records for each key so the standard republisher doesn't silently skip them (due to `errNoEntry` resulting in a no-op return).

- **Detached context for IPNS publishing**: All `PublishWithKey` calls now use `core.DetachContext()` to decouple the publish operation from the caller's context lifecycle. This prevents long-running publish operations from being canceled when the originating HTTP request context ends.

- **Improved logging for routing failures**: Upgraded `PutValue` failure logs in the composite value store from debug to error level, making DHT and PubSub backend failures more visible for troubleshooting.

- **Tests**: Added test coverage for the boot republish behavior, including cases with no publishable keys and with keys that have a published CID.
<!-- kody-pr-summary:end -->