### PR TITLE
refactor: replace boxo keystore/datastore with DB-backed IPNS key storage

### DIFF
--- a/core/ipns_key.go
+++ b/core/ipns_key.go
@@ -16,15 +16,10 @@ import (
 )
 
 const (
-	// IPNS_KEY_SERVICE is the service ID for the IPNS key management and publishing service
-	IPNS_KEY_SERVICE = "ipfs.ipns.key"
-
-	// Deprecated: IPNS_PUBLISHER_SERVICE is deprecated - use IPNS_KEY_SERVICE instead
-	// This is kept for backward compatibility
+	IPNS_KEY_SERVICE    = "ipfs.ipns.key"
 	IPNS_PUBLISHER_SERVICE = IPNS_KEY_SERVICE
 )
 
-// IPNSNodeAccess provides access to IPFS node components needed for IPNS operations
 type IPNSNodeAccess interface {
 	GetPublisher() IPNSPublisher
 	GetKeystore() keystore.Keystore
@@ -32,67 +27,31 @@ type IPNSNodeAccess interface {
 	GetPrivateKey() crypto.PrivKey
 }
 
-// IPNSPublisher provides an interface for IPNS publishing operations
 type IPNSPublisher interface {
 	Publish(ctx context.Context, privKey crypto.PrivKey, ipnsPath path.Path, options ...namesys.PublishOption) error
 	GetPublished(ctx context.Context, name ipns.Name, checkRouting bool) (*ipns.Record, error)
 	ListPublished(ctx context.Context) (map[ipns.Name]*ipns.Record, error)
 }
 
-// IPNSBoxoServices provides access to Boxo IPNS services
 type IPNSBoxoServices interface {
 	GetIPNSNode() IPNSNodeAccess
 }
 
-// IPNSKeyService defines the interface for IPNS key management and publishing
 type IPNSKeyService interface {
 	core.Service
 
-	// CreateKey creates a new IPNS key for the user
 	CreateKey(ctx context.Context, userID uint, name string, keyType int) (*pluginDb.IPFSIPNSKey, error)
-
-	// ImportKey imports an existing IPNS key
 	ImportKey(ctx context.Context, userID uint, name string, privateKeyBase64 string) (*pluginDb.IPFSIPNSKey, error)
-
-	// ExportKey exports a private key
 	ExportKey(ctx context.Context, userID uint, keyID uint) (string, error)
-
-	// ListKeys lists all IPNS keys for a user
 	ListKeys(ctx context.Context, userID uint) ([]pluginDb.IPFSIPNSKey, error)
-
-	// ListKeysWithFilters lists IPNS keys for a user with optional filters, sorting, and pagination
 	ListKeysWithFilters(ctx context.Context, userID uint, filters []filter.CrudFilter, sort []filter.Sort, pagination filter.Pagination) ([]*pluginDb.IPFSIPNSKey, int64, error)
-
-	// GetKeyByName retrieves a single IPNS key by name for a user
 	GetKeyByName(ctx context.Context, userID uint, name string) (*pluginDb.IPFSIPNSKey, error)
-
-	// GetKeyByID retrieves a single IPNS key by ID
 	GetKeyByID(ctx context.Context, userID uint, keyID uint) (*pluginDb.IPFSIPNSKey, error)
-
-	// DeleteKey deletes an IPNS key (soft delete)
 	DeleteKey(ctx context.Context, userID uint, keyID uint) error
-
-	// GetPrivateKey decrypts and returns the private key for a given key
 	GetPrivateKey(ctx context.Context, userID uint, keyID uint) (crypto.PrivKey, error)
-
-	// GetPrivateKeyByPeerID decrypts and returns the private key for a given peer ID
 	GetPrivateKeyByPeerID(ctx context.Context, peerID string) (crypto.PrivKey, uint, error)
-
-	// SyncToBoxoKeystore syncs all active IPNS keys from the database to the boxo keystore
-	SyncToBoxoKeystore(ctx context.Context) error
-
-	// PublishCID publishes a CID to an IPNS key using peer ID
 	PublishCID(ctx context.Context, keyID string, cidStr string, ttl time.Duration) error
-
-	// PublishWithKey publishes a CID using the provided private key
 	PublishWithKey(ctx context.Context, privKey crypto.PrivKey, cidStr string, ttl time.Duration) error
-
-	// GetPublished retrieves the latest published record for an IPNS name
 	GetPublished(ctx context.Context, keyID string, checkRouting bool) (*ipns.Record, error)
-
-	// ListPublished returns all IPNS records published by this node
 	ListPublished(ctx context.Context) (map[ipns.Name]*ipns.Record, error)
-
-	// RepublishAllKeysOnBoot force-publishes all IPNS keys with a known CID
-	RepublishAllKeysOnBoot(ctx context.Context)
 }

--- a/internal/service/ipns_key/db_keystore.go
+++ b/internal/service/ipns_key/db_keystore.go
@@ -1,0 +1,116 @@
+package ipns_key
+
+import (
+	"context"
+	"errors"
+
+	"github.com/ipfs/boxo/keystore"
+	ic "github.com/libp2p/go-libp2p/core/crypto"
+	"github.com/libp2p/go-libp2p/core/peer"
+	pluginDb "go.lumeweb.com/portal-plugin-ipfs/internal/db"
+	portalDb "go.lumeweb.com/portal/db"
+	mh "github.com/multiformats/go-multihash"
+	"go.uber.org/zap"
+	"gorm.io/gorm"
+)
+
+// DBKeystore implements keystore.Keystore backed by the ipfs_ipns_keys
+// database table. Key creation goes through IPNSKeyService.CreateKey, so Put
+// is not supported and returns an error. The republisher only calls List and
+// Get, which is all this provides.
+type DBKeystore struct {
+	db      *gorm.DB
+	decrypt func([]byte) (ic.PrivKey, error)
+	log     *zap.Logger
+}
+
+var _ keystore.Keystore = (*DBKeystore)(nil)
+
+func NewDBKeystore(db *gorm.DB, decrypt func([]byte) (ic.PrivKey, error), log *zap.Logger) *DBKeystore {
+	return &DBKeystore{db: db, decrypt: decrypt, log: log}
+}
+
+// peerIDToMultihash converts a keystore name (peer ID string) to a multihash
+// for querying the peer_id_multihash column.
+func peerIDToMultihash(name string) (mh.Multihash, error) {
+	pid, err := peer.Decode(name)
+	if err != nil {
+		return nil, keystore.ErrNoSuchKey
+	}
+	return mh.Multihash(pid), nil
+}
+
+func (d *DBKeystore) Has(name string) (bool, error) {
+	mhVal, err := peerIDToMultihash(name)
+	if err != nil {
+		return false, nil
+	}
+	var count int64
+	err = d.db.Model(&pluginDb.IPFSIPNSKey{}).
+		Where("peer_id_multihash = ? AND deleted_at IS NULL", mhVal).
+		Count(&count).Error
+	if err != nil {
+		return false, err
+	}
+	return count > 0, nil
+}
+
+func (d *DBKeystore) Put(name string, k ic.PrivKey) error {
+	return errors.New("DBKeystore does not support Put — use IPNSKeyService.CreateKey")
+}
+
+func (d *DBKeystore) Get(name string) (ic.PrivKey, error) {
+	mhVal, err := peerIDToMultihash(name)
+	if err != nil {
+		return nil, err
+	}
+	var key pluginDb.IPFSIPNSKey
+	err = d.db.Where("peer_id_multihash = ? AND deleted_at IS NULL", mhVal).First(&key).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, keystore.ErrNoSuchKey
+		}
+		return nil, err
+	}
+	privKey, err := d.decrypt(key.PrivateKeyEncrypted)
+	if err != nil {
+		return nil, err
+	}
+	if privKey == nil {
+		return nil, keystore.ErrNoSuchKey
+	}
+	return privKey, nil
+}
+
+func (d *DBKeystore) Delete(name string) error {
+	mhVal, err := peerIDToMultihash(name)
+	if err != nil {
+		return err
+	}
+	return d.db.Where("peer_id_multihash = ? AND deleted_at IS NULL", mhVal).
+		Delete(&pluginDb.IPFSIPNSKey{}).Error
+}
+
+func (d *DBKeystore) List() ([]string, error) {
+	var keys []pluginDb.IPFSIPNSKey
+	err := d.db.Where("deleted_at IS NULL").Find(&keys).Error
+	if err != nil {
+		return nil, err
+	}
+	names := make([]string, 0, len(keys))
+	for _, key := range keys {
+		names = append(names, key.PeerID().String())
+	}
+	return names, nil
+}
+
+func (d *DBKeystore) ListKeysWithCID(ctx context.Context) ([]pluginDb.IPFSIPNSKey, error) {
+	var keys []pluginDb.IPFSIPNSKey
+	err := portalDb.RetryableTransaction(ctx, d.db, func(tx *gorm.DB) *gorm.DB {
+		return tx.Where("last_published_cid != '' AND last_published_cid IS NOT NULL AND deleted_at IS NULL").Find(&keys)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return keys, nil
+}

--- a/internal/service/ipns_key/db_keystore_test.go
+++ b/internal/service/ipns_key/db_keystore_test.go
@@ -1,0 +1,158 @@
+package ipns_key
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ipfs/boxo/keystore"
+	ic "github.com/libp2p/go-libp2p/core/crypto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	pluginCore "go.lumeweb.com/portal-plugin-ipfs/core"
+	pluginConfig "go.lumeweb.com/portal-plugin-ipfs/internal/config"
+	"go.lumeweb.com/portal-plugin-ipfs/internal/db/migrations"
+	"go.lumeweb.com/portal-plugin-ipfs/internal/testing/mocks"
+	"go.lumeweb.com/portal-plugin-ipfs/internal/testing/util"
+	"go.lumeweb.com/portal/core"
+	coreTesting "go.lumeweb.com/portal/core/testing"
+	"go.uber.org/zap/zaptest"
+)
+
+var dbKeystoreTestOptions = coreTesting.CombineOptions(
+	coreTesting.WithServiceFactory(pluginCore.IPNS_KEY_SERVICE, NewIPNSKeyService),
+	coreTesting.WithMockServiceFactory(pluginCore.FILE_MANAGER_SERVICE, mocks.NewMockFileManagerService),
+	util.GetProtocolMock(),
+	coreTesting.WithProtocolConfig("ipfs", &pluginConfig.ProtocolConfig{}),
+	coreTesting.WithSQLitePluginMigrations(
+		"ipfs", migrations.GetSQLite(),
+	),
+)
+
+func TestDBKeystore_Has(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		keyService := core.GetService[pluginCore.IPNSKeyService](ctx, pluginCore.IPNS_KEY_SERVICE)
+		require.NotNil(tb, keyService)
+
+		svc := keyService.(*IPNSKeyServiceDefault)
+		ks := NewDBKeystore(svc.DB(), svc.decryptPrivateKey, zaptest.NewLogger(t))
+
+		has, err := ks.Has("nonexistent")
+		assert.NoError(tb, err)
+		assert.False(tb, has)
+
+		key, err := keyService.CreateKey(context.Background(), 1, "test-key", KeyType_Ed25519)
+		require.NoError(tb, err)
+
+		has, err = ks.Has(key.PeerID().String())
+		assert.NoError(tb, err)
+		assert.True(tb, has)
+	}, dbKeystoreTestOptions)
+}
+
+func TestDBKeystore_Get(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		keyService := core.GetService[pluginCore.IPNSKeyService](ctx, pluginCore.IPNS_KEY_SERVICE)
+		require.NotNil(tb, keyService)
+
+		svc := keyService.(*IPNSKeyServiceDefault)
+		ks := NewDBKeystore(svc.DB(), svc.decryptPrivateKey, zaptest.NewLogger(t))
+
+		_, err := ks.Get("nonexistent")
+		assert.ErrorIs(tb, err, keystore.ErrNoSuchKey)
+
+		key, err := keyService.CreateKey(context.Background(), 1, "test-key", KeyType_Ed25519)
+		require.NoError(tb, err)
+
+		privKey, err := ks.Get(key.PeerID().String())
+		assert.NoError(tb, err)
+		assert.NotNil(tb, privKey)
+	}, dbKeystoreTestOptions)
+}
+
+func TestDBKeystore_Put_Errors(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		keyService := core.GetService[pluginCore.IPNSKeyService](ctx, pluginCore.IPNS_KEY_SERVICE)
+		require.NotNil(tb, keyService)
+
+		svc := keyService.(*IPNSKeyServiceDefault)
+		ks := NewDBKeystore(svc.DB(), svc.decryptPrivateKey, zaptest.NewLogger(t))
+
+		privKey, _, err := ic.GenerateEd25519Key(nil)
+		require.NoError(tb, err)
+
+		err = ks.Put("test", privKey)
+		assert.Error(tb, err)
+		assert.Contains(tb, err.Error(), "does not support Put")
+	}, dbKeystoreTestOptions)
+}
+
+func TestDBKeystore_List(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		keyService := core.GetService[pluginCore.IPNSKeyService](ctx, pluginCore.IPNS_KEY_SERVICE)
+		require.NotNil(tb, keyService)
+
+		svc := keyService.(*IPNSKeyServiceDefault)
+		ks := NewDBKeystore(svc.DB(), svc.decryptPrivateKey, zaptest.NewLogger(t))
+
+		names, err := ks.List()
+		assert.NoError(tb, err)
+		assert.Empty(tb, names)
+
+		key1, err := keyService.CreateKey(context.Background(), 1, "list-key1", KeyType_Ed25519)
+		require.NoError(tb, err)
+		key2, err := keyService.CreateKey(context.Background(), 1, "list-key2", KeyType_Ed25519)
+		require.NoError(tb, err)
+
+		names, err = ks.List()
+		assert.NoError(tb, err)
+		assert.Len(tb, names, 2)
+		assert.Contains(tb, names, key1.PeerID().String())
+		assert.Contains(tb, names, key2.PeerID().String())
+	}, dbKeystoreTestOptions)
+}
+
+func TestDBKeystore_Delete(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		keyService := core.GetService[pluginCore.IPNSKeyService](ctx, pluginCore.IPNS_KEY_SERVICE)
+		require.NotNil(tb, keyService)
+
+		svc := keyService.(*IPNSKeyServiceDefault)
+		ks := NewDBKeystore(svc.DB(), svc.decryptPrivateKey, zaptest.NewLogger(t))
+
+		key, err := keyService.CreateKey(context.Background(), 1, "delete-key", KeyType_Ed25519)
+		require.NoError(tb, err)
+
+		has, err := ks.Has(key.PeerID().String())
+		assert.NoError(tb, err)
+		assert.True(tb, has)
+
+		err = ks.Delete(key.PeerID().String())
+		assert.NoError(tb, err)
+
+		has, err = ks.Has(key.PeerID().String())
+		assert.NoError(tb, err)
+		assert.False(tb, has)
+	}, dbKeystoreTestOptions)
+}
+
+func TestDBKeystore_ListKeysWithCID(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		keyService := core.GetService[pluginCore.IPNSKeyService](ctx, pluginCore.IPNS_KEY_SERVICE)
+		require.NotNil(tb, keyService)
+
+		svc := keyService.(*IPNSKeyServiceDefault)
+		ks := NewDBKeystore(svc.DB(), svc.decryptPrivateKey, zaptest.NewLogger(t))
+
+		keys, err := ks.ListKeysWithCID(context.Background())
+		assert.NoError(tb, err)
+		assert.Empty(tb, keys)
+
+		key, err := keyService.CreateKey(context.Background(), 1, "cid-key", KeyType_Ed25519)
+		require.NoError(tb, err)
+		_ = key
+
+		keys, err = ks.ListKeysWithCID(context.Background())
+		assert.NoError(tb, err)
+		assert.Empty(tb, keys, "Keys without LastPublishedCID should not be returned")
+	}, dbKeystoreTestOptions)
+}

--- a/internal/service/ipns_key/ipns_key.go
+++ b/internal/service/ipns_key/ipns_key.go
@@ -13,9 +13,7 @@ import (
 	"time"
 
 	mh "github.com/multiformats/go-multihash"
-	boxoRepublisher "github.com/ipfs/boxo/namesys/republisher"
 	"github.com/ipfs/boxo/ipns"
-	"github.com/ipfs/boxo/keystore"
 	"github.com/ipfs/boxo/namesys"
 	"github.com/ipfs/boxo/path"
 	"github.com/ipfs/go-cid"
@@ -47,102 +45,15 @@ const (
 // IPNSKeyServiceDefault implements the IPNS key management and publishing service
 type IPNSKeyServiceDefault struct {
 	*core.BaseComponent
-	protocol  protocol.ProtoNode
-	publisher pluginCore.IPNSPublisher
-	republisher *boxoRepublisher.Republisher
-	stopFunc  context.CancelFunc
+	protocol   protocol.ProtoNode
+	publisher  pluginCore.IPNSPublisher
+	republisher *Republisher
+	stopFunc   context.CancelFunc
+	dbKeystore *DBKeystore
 }
 
 // Ensure IPNSKeyServiceDefault implements the interface
 var _ pluginCore.IPNSKeyService = (*IPNSKeyServiceDefault)(nil)
-
-// SafeRepublisherKeystore wraps a keystore with additional validation for the republisher
-// It ensures that all keys returned to the republisher are non-nil
-type SafeRepublisherKeystore struct {
-	inner        keystore.Keystore
-	log          *core.Logger
-	getKeyByName func(name string) (ic.PrivKey, error)
-	deleteKey    func(name string) error
-}
-
-// NewSafeRepublisherKeystore creates a new safe republisher keystore wrapper
-func NewSafeRepublisherKeystore(inner keystore.Keystore, log *core.Logger) keystore.Keystore {
-	return &SafeRepublisherKeystore{
-		inner: inner,
-		log:   log,
-	}
-}
-
-// Has returns whether or not a key exists in the Keystore
-func (srk *SafeRepublisherKeystore) Has(name string) (bool, error) {
-	return srk.inner.Has(name)
-}
-
-// Put stores a key in the Keystore with nil validation
-func (srk *SafeRepublisherKeystore) Put(name string, k ic.PrivKey) error {
-	if k == nil {
-		srk.log.Error("Refusing to put nil key into republisher keystore",
-			zap.String("key_name", name),
-		)
-		return errors.New("cannot put nil key into keystore")
-	}
-	return srk.inner.Put(name, k)
-}
-
-// Get retrieves a key from the Keystore
-// Returns the key if it exists, and ErrNoSuchKey otherwise
-func (srk *SafeRepublisherKeystore) Get(name string) (ic.PrivKey, error) {
-	key, err := srk.inner.Get(name)
-	if err != nil {
-		return nil, err
-	}
-	// Defensive check: validate on retrieval to catch any edge cases
-	if key == nil {
-		srk.log.Error("Retrieved nil key from republisher keystore",
-			zap.String("key_name", name),
-		)
-		return nil, fmt.Errorf("key %s exists but is nil in keystore", name)
-	}
-	return key, nil
-}
-
-// Delete removes a key from the Keystore
-func (srk *SafeRepublisherKeystore) Delete(name string) error {
-	return srk.inner.Delete(name)
-}
-
-// List returns a list of key identifiers with validation
-func (srk *SafeRepublisherKeystore) List() ([]string, error) {
-	names, err := srk.inner.List()
-	if err != nil {
-		return nil, err
-	}
-
-	// Validate that all listed keys are non-nil and filter out corrupted entries
-	validNames := make([]string, 0, len(names))
-	for _, name := range names {
-		key, err := srk.inner.Get(name)
-		if err != nil {
-			// Key not found or error reading, skip
-			srk.log.Warn("Failed to get key during list validation",
-				zap.String("key_name", name),
-				zap.Error(err),
-			)
-			continue
-		}
-		if key == nil {
-			// Nil key found, delete it
-			_ = srk.inner.Delete(name)
-			srk.log.Warn("Removed nil key from republisher keystore during list",
-				zap.String("key_name", name),
-			)
-			continue
-		}
-		validNames = append(validNames, name)
-	}
-
-	return validNames, nil
-}
 
 // NewIPNSKeyService creates a new IPNS key service
 func NewIPNSKeyService() (core.Service, []core.ContextBuilderOption, error) {
@@ -175,23 +86,11 @@ func NewIPNSKeyService() (core.Service, []core.ContextBuilderOption, error) {
 			}
 			svc.publisher = publisher
 
-			// Initialize the republisher
 			cfg := core.GetProtocolConfig[*pluginConfig.ProtocolConfig](ctx, internal.ProtocolName)
 			err := svc.initRepublisher(node, cfg.IPNS)
 			if err != nil {
 				return fmt.Errorf("failed to initialize republisher: %w", err)
 			}
-
-			// Sync all IPNS keys to the boxo keystore during startup
-			err = svc.SyncToBoxoKeystore(ctx)
-			if err != nil {
-				svc.Logger().Error("Failed to sync IPNS keys to boxo keystore during startup",
-					zap.Error(err),
-				)
-				// Don't fail startup - log and continue
-			}
-
-			svc.RepublishAllKeysOnBoot(ctx)
 
 			return nil
 		}),
@@ -618,180 +517,6 @@ func (s *IPNSKeyServiceDefault) syncKeyToBoxoKeystore(ctx context.Context, key *
 
 // SyncToBoxoKeystore syncs all active IPNS keys from the database to the boxo keystore
 // This should be called during plugin startup and after key creation/import
-func (s *IPNSKeyServiceDefault) SyncToBoxoKeystore(ctx context.Context) error {
-	ctx, span := core.TraceMethod(ctx, "IPNSKeyServiceDefault.SyncToBoxoKeystore")
-	defer span.End()
-
-	// Get the boxo keystore from the IPFS node
-	proto := core.GetProtocol(internal.ProtocolName)
-	if proto == nil {
-		return fmt.Errorf("IPFS protocol not found")
-	}
-
-	ipnsNode, ok := proto.(pluginCore.IPNSBoxoServices)
-	if !ok {
-		return fmt.Errorf("IPFS protocol does not implement IPNSBoxoServices")
-	}
-
-	node := ipnsNode.GetIPNSNode()
-	if node == nil {
-		return fmt.Errorf("IPNS node not found")
-	}
-
-	boxoKS := node.GetKeystore()
-	if boxoKS == nil {
-		return fmt.Errorf("boxo keystore not found")
-	}
-
-	// Get all active IPNS keys from database
-	var keys []pluginDb.IPFSIPNSKey
-	err := db.RetryableComponentTransaction(s, ctx, func(tx *gorm.DB) *gorm.DB {
-		return tx.Find(&keys)
-	})
-	if err != nil {
-		s.Logger().Error("Failed to list IPNS keys for sync", zap.Error(err))
-		return fmt.Errorf("failed to list IPNS keys: %w", err)
-	}
-
-	syncedCount := 0
-	skippedCount := 0
-
-	for _, key := range keys {
-		// Use peer ID as the key name in the keystore
-		keyName := key.PeerID().String()
-
-		// Check if key already exists in keystore
-		has, err := boxoKS.Has(keyName)
-		if err != nil {
-			s.Logger().Warn("Failed to check if key exists in keystore",
-				zap.Error(err),
-				zap.Stringer("peer_id", key.PeerID()),
-			)
-			continue
-		}
-
-		if has {
-			// Key already exists in keystore, skip
-			skippedCount++
-			continue
-		}
-
-		// Decrypt the private key
-		privKey, err := s.decryptPrivateKey(key.PrivateKeyEncrypted)
-		if err != nil {
-			s.Logger().Error("Failed to decrypt private key for sync",
-				zap.Error(err),
-				zap.Uint("key_id", key.ID),
-				zap.Stringer("peer_id", key.PeerID()),
-			)
-			continue
-		}
-
-		// Validate private key is not nil before putting in keystore
-		if privKey == nil {
-			s.Logger().Error("Decrypted private key is nil, cannot sync to keystore",
-				zap.Uint("key_id", key.ID),
-				zap.Stringer("peer_id", key.PeerID()),
-			)
-			continue
-		}
-
-		// Import into boxo keystore
-		err = boxoKS.Put(keyName, privKey)
-		if err != nil {
-			s.Logger().Error("Failed to import key into boxo keystore",
-				zap.Error(err),
-				zap.Uint("key_id", key.ID),
-				zap.Stringer("peer_id", key.PeerID()),
-			)
-			continue
-		}
-
-		syncedCount++
-		s.Logger().Debug("Synced IPNS key to boxo keystore",
-			zap.Uint("key_id", key.ID),
-			zap.Stringer("peer_id", key.PeerID()),
-			zap.String("name", key.Name),
-		)
-	}
-
-	s.Logger().Info("Completed IPNS key sync to boxo keystore",
-		zap.Int("synced", syncedCount),
-		zap.Int("skipped", skippedCount),
-		zap.Int("total", len(keys)),
-	)
-
-	return nil
-}
-
-// RepublishAllKeysOnBoot force-publishes all IPNS keys that have a known CID
-// in the database. This seeds the boxo datastore with a record for each key
-// so the republisher doesn't silently skip them (errNoEntry → return nil).
-// Publishes are fire-and-forget with detached context — they must not block
-// or be canceled by the caller's context.
-func (s *IPNSKeyServiceDefault) RepublishAllKeysOnBoot(ctx context.Context) {
-	ctx, span := core.TraceMethod(ctx, "IPNSKeyServiceDefault.RepublishAllKeysOnBoot")
-	defer span.End()
-
-	var keys []pluginDb.IPFSIPNSKey
-	err := db.RetryableComponentTransaction(s, ctx, func(tx *gorm.DB) *gorm.DB {
-		return tx.Where("last_published_cid != '' AND last_published_cid IS NOT NULL").Find(&keys)
-	})
-	if err != nil {
-		s.Logger().Error("Failed to list IPNS keys for boot republish", zap.Error(err))
-		return
-	}
-
-	if len(keys) == 0 {
-		s.Logger().Info("No IPNS keys with published CID to republish on boot")
-		return
-	}
-
-	publishedCount := 0
-	failedCount := 0
-
-	for _, key := range keys {
-		privKey, err := s.decryptPrivateKey(key.PrivateKeyEncrypted)
-		if err != nil {
-			s.Logger().Error("Failed to decrypt private key for boot republish",
-				zap.Error(err),
-				zap.Uint("key_id", key.ID),
-				zap.Stringer("peer_id", key.PeerID()),
-			)
-			failedCount++
-			continue
-		}
-
-		if privKey == nil {
-			s.Logger().Error("Decrypted private key is nil, skipping boot republish",
-				zap.Uint("key_id", key.ID),
-				zap.Stringer("peer_id", key.PeerID()),
-			)
-			failedCount++
-			continue
-		}
-
-		publishCtx := core.DetachContext(ctx)
-		if err := s.PublishWithKey(publishCtx, privKey, key.LastPublishedCID, 0); err != nil {
-			s.Logger().Error("Failed to republish IPNS key on boot",
-				zap.Error(err),
-				zap.Stringer("peer_id", key.PeerID()),
-				zap.String("cid", key.LastPublishedCID),
-			)
-			failedCount++
-			continue
-		}
-
-		publishedCount++
-	}
-
-	s.Logger().Info("Completed IPNS boot republish",
-		zap.Int("published", publishedCount),
-		zap.Int("failed", failedCount),
-		zap.Int("total", len(keys)),
-	)
-}
-
 // GetPrivateKeyByPeerID decrypts and returns the private key for a given peer ID
 func (s *IPNSKeyServiceDefault) GetPrivateKeyByPeerID(ctx context.Context, peerIDStr string) (ic.PrivKey, uint, error) {
 	ctx, span := core.TraceMethod(ctx, "IPNSKeyServiceDefault.GetPrivateKeyByPeerID")
@@ -1027,42 +752,21 @@ func (s *IPNSKeyServiceDefault) initRepublisher(node pluginCore.IPNSNodeAccess, 
 		return fmt.Errorf("publisher not found")
 	}
 
-	ds := node.GetDatastore()
-	if ds == nil {
-		return fmt.Errorf("datastore not found")
-	}
-
-	ks := node.GetKeystore()
-	if ks == nil {
-		return fmt.Errorf("keystore not found")
-	}
-
-	// Wrap the keystore with SafeRepublisherKeystore to filter out nil keys
-	// This prevents the republisher from crashing on corrupted keystore entries
-	safeKS := NewSafeRepublisherKeystore(ks, s.Logger())
-
-	// Get the node's private key for the republisher's self key
-	// The vendor code always tries to republish the self key first
 	selfKey := node.GetPrivateKey()
-	if selfKey == nil {
-		return fmt.Errorf("node private key is nil")
-	}
 
-	// Create the boxo republisher with default settings
-	// Pass the node's private key as the self key to satisfy vendor code requirements
-	repub := boxoRepublisher.NewRepublisher(publisher, ds, selfKey, safeKS)
+	dbKeystore := NewDBKeystore(s.DB(), s.decryptPrivateKey, s.Logger().Logger)
+	s.dbKeystore = dbKeystore
 
-	repub.Interval = cfg.RepublishInterval
-	repub.RecordLifetime = cfg.RecordLifetime
+	repub := NewRepublisher(publisher, dbKeystore, selfKey, s.decryptPrivateKey, s.Logger().Logger)
+	repub.SetInterval(cfg.RepublishInterval)
+	repub.SetRecordLifetime(cfg.RecordLifetime)
 
 	s.republisher = repub
-
-	// Start the republisher
 	s.stopFunc = repub.Run()
 
 	s.Logger().Info("IPNS republisher started",
-		zap.Duration("interval", s.republisher.Interval),
-		zap.Duration("record_lifetime", s.republisher.RecordLifetime),
+		zap.Duration("interval", cfg.RepublishInterval),
+		zap.Duration("record_lifetime", cfg.RecordLifetime),
 	)
 
 	return nil
@@ -1087,30 +791,26 @@ func (s *IPNSKeyServiceDefault) GetRepublisherInterval() time.Duration {
 	if s.republisher == nil {
 		return 0
 	}
-	return s.republisher.Interval
+	return s.republisher.interval
 }
 
-// SetRepublisherInterval updates the republish interval
-// Note: This doesn't affect a running republisher - it would need to be restarted
 func (s *IPNSKeyServiceDefault) SetRepublisherInterval(interval time.Duration) {
 	if s.republisher != nil {
-		s.republisher.Interval = interval
+		s.republisher.SetInterval(interval)
 		s.Logger().Info("IPNS republisher interval updated", zap.Duration("interval", interval))
 	}
 }
 
-// GetRecordLifetime returns the current record lifetime
 func (s *IPNSKeyServiceDefault) GetRecordLifetime() time.Duration {
 	if s.republisher == nil {
 		return 0
 	}
-	return s.republisher.RecordLifetime
+	return s.republisher.recordLifetime
 }
 
-// SetRecordLifetime updates the record lifetime
 func (s *IPNSKeyServiceDefault) SetRecordLifetime(lifetime time.Duration) {
 	if s.republisher != nil {
-		s.republisher.RecordLifetime = lifetime
+		s.republisher.SetRecordLifetime(lifetime)
 		s.Logger().Info("IPNS record lifetime updated", zap.Duration("lifetime", lifetime))
 	}
 }

--- a/internal/service/ipns_key/ipns_key_test.go
+++ b/internal/service/ipns_key/ipns_key_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/base64"
 	"testing"
 
-	"github.com/ipfs/boxo/keystore"
 	"github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/stretchr/testify/assert"
@@ -21,7 +20,6 @@ import (
 	"go.lumeweb.com/portal/core"
 	coreTesting "go.lumeweb.com/portal/core/testing"
 	portalDb "go.lumeweb.com/portal/db"
-	"go.uber.org/zap/zaptest"
 	"gorm.io/gorm"
 )
 
@@ -579,32 +577,6 @@ func TestIPNSKeyService_GetPrivateKeyByPeerID_NotFound(t *testing.T) {
 	}, TestOptions)
 }
 
-func TestIPNSKeyService_SyncToBoxoKeystore(t *testing.T) {
-	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
-		// Arrange
-		keyService := core.GetService[pluginCore.IPNSKeyService](ctx, pluginCore.IPNS_KEY_SERVICE)
-		require.NotNil(tb, keyService)
-
-		userID := uint(1)
-
-		// Create multiple keys
-		_, err := keyService.CreateKey(context.Background(), userID, "sync-key1", KeyType_Ed25519)
-		require.NoError(tb, err)
-		_, err = keyService.CreateKey(context.Background(), userID, "sync-key2", KeyType_Ed25519)
-		require.NoError(tb, err)
-
-		// Act - Sync keys to boxo keystore
-		err = keyService.SyncToBoxoKeystore(context.Background())
-
-		// Assert
-		// The sync operation may fail if protocol doesn't implement IPNSBoxoServices
-		// This is expected in test environment
-		if err != nil {
-			assert.Contains(tb, err.Error(), "IPFS protocol does not implement IPNSBoxoServices")
-		}
-	}, TestOptions)
-}
-
 func TestIPNSKeyService_UniquePeerIDPerUser(t *testing.T) {
 	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 		// Arrange
@@ -661,77 +633,6 @@ func TestIPNSKeyService_UniquePeerID_DifferentUsers(t *testing.T) {
 	}, TestOptions)
 }
 
-// SafeRepublisherKeystore tests
-
-func TestSafeRepublisherKeystore_RejectsNilKeys(t *testing.T) {
-	inner := keystore.NewMemKeystore()
-	logger := &core.Logger{Logger: zaptest.NewLogger(t)}
-	safeKS := NewSafeRepublisherKeystore(inner, logger)
-
-	// Attempt to put a nil key
-	err := safeKS.Put("test-key", nil)
-	assert.Error(t, err, "Should reject nil key")
-	assert.Contains(t, err.Error(), "cannot put nil key")
-}
-
-func TestSafeRepublisherKeystore_AcceptsValidKeys(t *testing.T) {
-	inner := keystore.NewMemKeystore()
-	logger := &core.Logger{Logger: zaptest.NewLogger(t)}
-	safeKS := NewSafeRepublisherKeystore(inner, logger)
-
-	// Generate a valid key
-	privKey, _, err := crypto.GenerateKeyPair(crypto.Ed25519, 2048)
-	require.NoError(t, err)
-
-	// Put the valid key
-	err = safeKS.Put("valid-key", privKey)
-	assert.NoError(t, err, "Should accept valid key")
-
-	// Verify key can be retrieved
-	retrieved, err := safeKS.Get("valid-key")
-	assert.NoError(t, err)
-	assert.NotNil(t, retrieved, "Retrieved key should not be nil")
-}
-
-func TestSafeRepublisherKeystore_GetValidatesNonNil(t *testing.T) {
-	// This test verifies the defensive check in Get() catches any edge cases
-	// where nil keys might exist in the underlying keystore
-	inner := keystore.NewMemKeystore()
-	logger := &core.Logger{Logger: zaptest.NewLogger(t)}
-	safeKS := NewSafeRepublisherKeystore(inner, logger)
-
-	// Manually insert a nil key into the inner keystore (simulating corruption)
-	// We need to use the inner keystore directly to bypass the safe wrapper
-	_ = inner.Put("corrupted-key", nil)
-
-	// Attempt to retrieve the corrupted key
-	_, err := safeKS.Get("corrupted-key")
-	assert.Error(t, err, "Should return error for nil key")
-	assert.Contains(t, err.Error(), "is nil in keystore")
-}
-
-func TestSafeRepublisherKeystore_ListFiltersNilKeys(t *testing.T) {
-	inner := keystore.NewMemKeystore()
-	logger := &core.Logger{Logger: zaptest.NewLogger(t)}
-	safeKS := NewSafeRepublisherKeystore(inner, logger)
-
-	// Add a valid key
-	privKey, _, err := crypto.GenerateKeyPair(crypto.Ed25519, 2048)
-	require.NoError(t, err)
-	err = safeKS.Put("valid-key", privKey)
-	require.NoError(t, err)
-
-	// Manually insert a nil key into the inner keystore (simulating corruption)
-	_ = inner.Put("corrupted-key", nil)
-
-	// List keys - should filter out the corrupted one
-	names, err := safeKS.List()
-	assert.NoError(t, err)
-	assert.Len(t, names, 1, "Should only list the valid key")
-	assert.Contains(t, names, "valid-key", "Should contain valid key")
-	assert.NotContains(t, names, "corrupted-key", "Should not contain corrupted key")
-}
-
 func TestIPNSKeyService_PublishWithKey_UpdatesLastPublishedCID(t *testing.T) {
 	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 		keyService := core.GetService[pluginCore.IPNSKeyService](ctx, pluginCore.IPNS_KEY_SERVICE)
@@ -769,66 +670,6 @@ func TestIPNSKeyService_PublishWithKey_UpdatesLastPublishedCID(t *testing.T) {
 		updatedKey, err := keyService.GetKeyByID(context.Background(), userID, createdKey.ID)
 		require.NoError(tb, err)
 		assert.Equal(tb, testCID, updatedKey.LastPublishedCID)
-	}, TestOptions)
-}
-
-func TestIPNSKeyService_RepublishAllKeysOnBoot_NoKeysWithCID(t *testing.T) {
-	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
-		keyService := core.GetService[pluginCore.IPNSKeyService](ctx, pluginCore.IPNS_KEY_SERVICE)
-		require.NotNil(tb, keyService)
-
-		userID := uint(1)
-		_, err := keyService.CreateKey(context.Background(), userID, "no-cid-key", KeyType_Ed25519)
-		require.NoError(tb, err)
-
-		keyService.RepublishAllKeysOnBoot(context.Background())
-	}, TestOptions)
-}
-
-func TestIPNSKeyService_RepublishAllKeysOnBoot_PublishesKeysWithCID(t *testing.T) {
-	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
-		keyService := core.GetService[pluginCore.IPNSKeyService](ctx, pluginCore.IPNS_KEY_SERVICE)
-		require.NotNil(tb, keyService)
-
-		userID := uint(1)
-
-		key1, err := keyService.CreateKey(context.Background(), userID, "boot-repub1", KeyType_Ed25519)
-		require.NoError(tb, err)
-
-		key2, err := keyService.CreateKey(context.Background(), userID, "boot-repub2", KeyType_Ed25519)
-		require.NoError(tb, err)
-
-		testCID := "bafybeieffnocaq7t4w4daagvydl32igft5oziyyaebqr6vx6rb3ffq2ab4"
-
-		proto := core.GetProtocol(internal.ProtocolName)
-		ipnsAccess := proto.(pluginCore.IPNSBoxoServices)
-		mockPublisher := ipnsAccess.GetIPNSNode().GetPublisher().(*mocks.MockIPNSPublisher)
-
-		mockPublisher.EXPECT().Publish(mock.Anything, mock.Anything, mock.Anything).Return(nil).Twice()
-
-		privKey1, _, err := keyService.GetPrivateKeyByPeerID(context.Background(), key1.PeerID().String())
-		require.NoError(tb, err)
-		err = keyService.PublishWithKey(context.Background(), privKey1, testCID, 0)
-		require.NoError(tb, err)
-
-		privKey2, _, err := keyService.GetPrivateKeyByPeerID(context.Background(), key2.PeerID().String())
-		require.NoError(tb, err)
-		err = keyService.PublishWithKey(context.Background(), privKey2, testCID, 0)
-		require.NoError(tb, err)
-
-		var dbKey1, dbKey2 pluginDb.IPFSIPNSKey
-		portalDb.RetryableTransaction(context.Background(), ctx.DB(), func(tx *gorm.DB) *gorm.DB {
-			return tx.Where("id = ?", key1.ID).First(&dbKey1)
-		})
-		portalDb.RetryableTransaction(context.Background(), ctx.DB(), func(tx *gorm.DB) *gorm.DB {
-			return tx.Where("id = ?", key2.ID).First(&dbKey2)
-		})
-		require.NotEmpty(tb, dbKey1.LastPublishedCID)
-		require.NotEmpty(tb, dbKey2.LastPublishedCID)
-
-		mockPublisher.EXPECT().Publish(mock.Anything, mock.Anything, mock.Anything).Return(nil).Twice()
-
-		keyService.RepublishAllKeysOnBoot(context.Background())
 	}, TestOptions)
 }
 

--- a/internal/service/ipns_key/republisher.go
+++ b/internal/service/ipns_key/republisher.go
@@ -1,0 +1,136 @@
+package ipns_key
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/ipfs/boxo/ipns"
+	"github.com/ipfs/boxo/namesys"
+	"github.com/ipfs/boxo/path"
+	"github.com/ipfs/go-cid"
+	ic "github.com/libp2p/go-libp2p/core/crypto"
+	pluginDb "go.lumeweb.com/portal-plugin-ipfs/internal/db"
+	"go.uber.org/zap"
+)
+
+// Republisher broadcasts all IPNS keys with a known CID to the DHT on a
+// regular interval. Unlike boxo's Republisher, it does not require a separate
+// datastore — keys that exist in the database with a LastPublishedCID are
+// considered published and will be rebroadcast.
+type Republisher struct {
+	publisher      namesys.Publisher
+	keystore       *DBKeystore
+	self           ic.PrivKey
+	decrypt        func([]byte) (ic.PrivKey, error)
+	recordLifetime time.Duration
+	interval       time.Duration
+	log            *zap.Logger
+}
+
+const (
+	defaultRepublishInterval = time.Hour
+	defaultRecordLifetime    = ipns.DefaultRecordLifetime
+	initialRepublishDelay    = time.Minute
+	failureRetryInterval     = 5 * time.Minute
+)
+
+func NewRepublisher(publisher namesys.Publisher, keystore *DBKeystore, self ic.PrivKey, decrypt func([]byte) (ic.PrivKey, error), log *zap.Logger) *Republisher {
+	return &Republisher{
+		publisher:      publisher,
+		keystore:       keystore,
+		self:           self,
+		decrypt:        decrypt,
+		recordLifetime: defaultRecordLifetime,
+		interval:       defaultRepublishInterval,
+		log:            log,
+	}
+}
+
+func (r *Republisher) SetInterval(d time.Duration)       { r.interval = d }
+func (r *Republisher) SetRecordLifetime(d time.Duration) { r.recordLifetime = d }
+
+func (r *Republisher) Run() func() {
+	ctx, cancel := context.WithCancel(context.Background())
+	go r.run(ctx)
+	return func() {
+		r.log.Info("Stopping IPNS republisher")
+		cancel()
+	}
+}
+
+func (r *Republisher) run(ctx context.Context) {
+	timer := time.NewTimer(initialRepublishDelay)
+	defer timer.Stop()
+	if r.interval < initialRepublishDelay {
+		timer.Reset(r.interval)
+	}
+
+	for {
+		select {
+		case <-timer.C:
+			timer.Reset(r.interval)
+			err := r.republishAll(ctx)
+			if err != nil {
+				r.log.Error("Republisher failed", zap.Error(err))
+				if failureRetryInterval < r.interval {
+					timer.Reset(failureRetryInterval)
+				}
+			}
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func (r *Republisher) republishAll(ctx context.Context) error {
+	keys, err := r.keystore.ListKeysWithCID(ctx)
+	if err != nil {
+		return fmt.Errorf("list keys: %w", err)
+	}
+
+	published := 0
+	failed := 0
+	for _, key := range keys {
+		if err := r.republishKey(ctx, key); err != nil {
+			r.log.Error("Failed to republish IPNS key",
+				zap.Error(err),
+				zap.Stringer("peer_id", key.PeerID()),
+				zap.String("cid", key.LastPublishedCID),
+			)
+			failed++
+			continue
+		}
+		published++
+	}
+
+	r.log.Info("Republish cycle complete",
+		zap.Int("published", published),
+		zap.Int("failed", failed),
+		zap.Int("total", len(keys)),
+	)
+	return nil
+}
+
+func (r *Republisher) republishKey(ctx context.Context, key pluginDb.IPFSIPNSKey) error {
+	privKey, err := r.decrypt(key.PrivateKeyEncrypted)
+	if err != nil {
+		return fmt.Errorf("decrypt private key: %w", err)
+	}
+	if privKey == nil {
+		return fmt.Errorf("decrypted private key is nil for peer %s", key.PeerID())
+	}
+
+	targetCid, err := cid.Decode(key.LastPublishedCID)
+	if err != nil {
+		return fmt.Errorf("parse CID %s: %w", key.LastPublishedCID, err)
+	}
+
+	eol := time.Now().Add(r.recordLifetime)
+	err = r.publisher.Publish(ctx, privKey, path.FromCid(targetCid), namesys.PublishWithEOL(eol))
+	if err != nil {
+		return fmt.Errorf("publish: %w", err)
+	}
+
+	return nil
+}

--- a/internal/service/ipns_key/republisher_test.go
+++ b/internal/service/ipns_key/republisher_test.go
@@ -1,0 +1,141 @@
+package ipns_key
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ipfs/boxo/namesys"
+	"github.com/ipfs/boxo/path"
+	ic "github.com/libp2p/go-libp2p/core/crypto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	pluginCore "go.lumeweb.com/portal-plugin-ipfs/core"
+	pluginConfig "go.lumeweb.com/portal-plugin-ipfs/internal/config"
+	"go.lumeweb.com/portal-plugin-ipfs/internal/db/migrations"
+	"go.lumeweb.com/portal-plugin-ipfs/internal/testing/mocks"
+	"go.lumeweb.com/portal-plugin-ipfs/internal/testing/util"
+	"go.lumeweb.com/portal/core"
+	coreTesting "go.lumeweb.com/portal/core/testing"
+	"go.uber.org/zap/zaptest"
+)
+
+type mockPublisher struct {
+	publishFn func(ctx context.Context, sk ic.PrivKey, value path.Path, options ...namesys.PublishOption) error
+	calls     []publishCall
+	mu        sync.Mutex
+}
+
+type publishCall struct {
+	sk      ic.PrivKey
+	value   path.Path
+	options []namesys.PublishOption
+}
+
+func (m *mockPublisher) Publish(ctx context.Context, sk ic.PrivKey, value path.Path, options ...namesys.PublishOption) error {
+	m.mu.Lock()
+	m.calls = append(m.calls, publishCall{sk: sk, value: value, options: options})
+	m.mu.Unlock()
+	if m.publishFn != nil {
+		return m.publishFn(ctx, sk, value, options...)
+	}
+	return nil
+}
+
+func (m *mockPublisher) getCalls() []publishCall {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.calls
+}
+
+var republisherTestOptions = coreTesting.CombineOptions(
+	coreTesting.WithServiceFactory(pluginCore.IPNS_KEY_SERVICE, NewIPNSKeyService),
+	coreTesting.WithMockServiceFactory(pluginCore.FILE_MANAGER_SERVICE, mocks.NewMockFileManagerService),
+	util.GetProtocolMock(),
+	coreTesting.WithProtocolConfig("ipfs", &pluginConfig.ProtocolConfig{}),
+	coreTesting.WithSQLitePluginMigrations(
+		"ipfs", migrations.GetSQLite(),
+	),
+)
+
+func TestRepublisher_RepublishAll(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		keyService := core.GetService[pluginCore.IPNSKeyService](ctx, pluginCore.IPNS_KEY_SERVICE)
+		require.NotNil(tb, keyService)
+
+		svc := keyService.(*IPNSKeyServiceDefault)
+
+		pub := &mockPublisher{}
+		dbKs := NewDBKeystore(svc.DB(), svc.decryptPrivateKey, zaptest.NewLogger(t))
+		selfKey, _, _ := ic.GenerateEd25519Key(nil)
+
+		r := NewRepublisher(pub, dbKs, selfKey, svc.decryptPrivateKey, zaptest.NewLogger(t))
+
+		err := r.republishAll(context.Background())
+		assert.NoError(tb, err)
+		assert.Empty(tb, pub.getCalls(), "No keys with CID → nothing to republish")
+
+		key, err := keyService.CreateKey(context.Background(), 1, "republish-key", KeyType_Ed25519)
+		require.NoError(tb, err)
+		_ = key
+
+		err = r.republishAll(context.Background())
+		assert.NoError(tb, err)
+		assert.Empty(tb, pub.getCalls(), "Key without LastPublishedCID → nothing to republish")
+	}, republisherTestOptions)
+}
+
+func TestRepublisher_SetInterval(t *testing.T) {
+	r := &Republisher{interval: defaultRepublishInterval}
+	assert.Equal(t, defaultRepublishInterval, r.interval)
+
+	r.SetInterval(5 * time.Minute)
+	assert.Equal(t, 5*time.Minute, r.interval)
+}
+
+func TestRepublisher_SetRecordLifetime(t *testing.T) {
+	r := &Republisher{recordLifetime: defaultRecordLifetime}
+	assert.Equal(t, defaultRecordLifetime, r.recordLifetime)
+
+	r.SetRecordLifetime(24 * time.Hour)
+	assert.Equal(t, 24*time.Hour, r.recordLifetime)
+}
+
+func TestRepublisher_Run_CancelsOnStop(t *testing.T) {
+	pub := &mockPublisher{}
+	r := &Republisher{
+		publisher:      pub,
+		interval:       1 * time.Hour,
+		recordLifetime: defaultRecordLifetime,
+		log:            zaptest.NewLogger(t),
+	}
+
+	stop := r.Run()
+	time.Sleep(100 * time.Millisecond)
+	stop()
+
+	assert.Empty(t, pub.getCalls(), "Initial delay should prevent immediate republish")
+}
+
+func TestRepublisher_PublishError(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		keyService := core.GetService[pluginCore.IPNSKeyService](ctx, pluginCore.IPNS_KEY_SERVICE)
+		require.NotNil(tb, keyService)
+
+		svc := keyService.(*IPNSKeyServiceDefault)
+
+		pub := &mockPublisher{
+			publishFn: func(_ context.Context, _ ic.PrivKey, _ path.Path, _ ...namesys.PublishOption) error {
+				return assert.AnError
+			},
+		}
+		dbKs := NewDBKeystore(svc.DB(), svc.decryptPrivateKey, zaptest.NewLogger(t))
+		selfKey, _, _ := ic.GenerateEd25519Key(nil)
+
+		r := NewRepublisher(pub, dbKs, selfKey, svc.decryptPrivateKey, zaptest.NewLogger(t))
+
+		err := r.republishAll(context.Background())
+		assert.NoError(tb, err, "republishAll returns nil even when individual keys fail (logs error)")
+	}, republisherTestOptions)
+}

--- a/internal/testing/mocks/MockIPNSKeyService.go
+++ b/internal/testing/mocks/MockIPNSKeyService.go
@@ -1298,46 +1298,6 @@ func (_c *MockIPNSKeyService_PublishWithKey_Call) RunAndReturn(run func(ctx cont
 	return _c
 }
 
-// RepublishAllKeysOnBoot provides a mock function for the type MockIPNSKeyService
-func (_mock *MockIPNSKeyService) RepublishAllKeysOnBoot(ctx context.Context) {
-	_mock.Called(ctx)
-	return
-}
-
-// MockIPNSKeyService_RepublishAllKeysOnBoot_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RepublishAllKeysOnBoot'
-type MockIPNSKeyService_RepublishAllKeysOnBoot_Call struct {
-	*mock.Call
-}
-
-// RepublishAllKeysOnBoot is a helper method to define mock.On call
-//   - ctx context.Context
-func (_e *MockIPNSKeyService_Expecter) RepublishAllKeysOnBoot(ctx interface{}) *MockIPNSKeyService_RepublishAllKeysOnBoot_Call {
-	return &MockIPNSKeyService_RepublishAllKeysOnBoot_Call{Call: _e.mock.On("RepublishAllKeysOnBoot", ctx)}
-}
-
-func (_c *MockIPNSKeyService_RepublishAllKeysOnBoot_Call) Run(run func(ctx context.Context)) *MockIPNSKeyService_RepublishAllKeysOnBoot_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		run(
-			arg0,
-		)
-	})
-	return _c
-}
-
-func (_c *MockIPNSKeyService_RepublishAllKeysOnBoot_Call) Return() *MockIPNSKeyService_RepublishAllKeysOnBoot_Call {
-	_c.Call.Return()
-	return _c
-}
-
-func (_c *MockIPNSKeyService_RepublishAllKeysOnBoot_Call) RunAndReturn(run func(ctx context.Context)) *MockIPNSKeyService_RepublishAllKeysOnBoot_Call {
-	_c.Run(run)
-	return _c
-}
-
 // SetConfig provides a mock function for the type MockIPNSKeyService
 func (_mock *MockIPNSKeyService) SetConfig(cfg config.Manager) {
 	_mock.Called(cfg)
@@ -1495,56 +1455,5 @@ func (_c *MockIPNSKeyService_SetLogger_Call) Return() *MockIPNSKeyService_SetLog
 
 func (_c *MockIPNSKeyService_SetLogger_Call) RunAndReturn(run func(logger *core.Logger)) *MockIPNSKeyService_SetLogger_Call {
 	_c.Run(run)
-	return _c
-}
-
-// SyncToBoxoKeystore provides a mock function for the type MockIPNSKeyService
-func (_mock *MockIPNSKeyService) SyncToBoxoKeystore(ctx context.Context) error {
-	ret := _mock.Called(ctx)
-
-	if len(ret) == 0 {
-		panic("no return value specified for SyncToBoxoKeystore")
-	}
-
-	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context) error); ok {
-		r0 = returnFunc(ctx)
-	} else {
-		r0 = ret.Error(0)
-	}
-	return r0
-}
-
-// MockIPNSKeyService_SyncToBoxoKeystore_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SyncToBoxoKeystore'
-type MockIPNSKeyService_SyncToBoxoKeystore_Call struct {
-	*mock.Call
-}
-
-// SyncToBoxoKeystore is a helper method to define mock.On call
-//   - ctx context.Context
-func (_e *MockIPNSKeyService_Expecter) SyncToBoxoKeystore(ctx interface{}) *MockIPNSKeyService_SyncToBoxoKeystore_Call {
-	return &MockIPNSKeyService_SyncToBoxoKeystore_Call{Call: _e.mock.On("SyncToBoxoKeystore", ctx)}
-}
-
-func (_c *MockIPNSKeyService_SyncToBoxoKeystore_Call) Run(run func(ctx context.Context)) *MockIPNSKeyService_SyncToBoxoKeystore_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		run(
-			arg0,
-		)
-	})
-	return _c
-}
-
-func (_c *MockIPNSKeyService_SyncToBoxoKeystore_Call) Return(err error) *MockIPNSKeyService_SyncToBoxoKeystore_Call {
-	_c.Call.Return(err)
-	return _c
-}
-
-func (_c *MockIPNSKeyService_SyncToBoxoKeystore_Call) RunAndReturn(run func(ctx context.Context) error) *MockIPNSKeyService_SyncToBoxoKeystore_Call {
-	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
- Add DBKeystore implementing keystore.Keystore backed by ipfs\_ipns\_keys table
- Add custom Republisher that reads LastPublishedCID from DB instead of datastore
- Remove SyncToBoxoKeystore, SafeRepublisherKeystore, RepublishAllKeysOnBoot
- DB is now the single source of truth for IPNS keys
- All keys with LastPublishedCID are automatically considered published
- Add 11 new tests (6 DBKeystore + 5 Republisher)

* `develop` <!-- branch-stack -->
  - **refactor: replace boxo keystore/datastore with DB-backed IPNS key storage** :point\_left:

---

<!-- kody-pr-summary:start -->
Replace boxo keystore/datastore with a database-backed IPNS key storage and custom republisher

This PR eliminates the dependency on boxo's in-memory keystore and datastore for IPNS key management by introducing a `DBKeystore` that reads directly from the `ipfs_ipns_keys` database table, making the database the single source of truth for IPNS keys.

Key changes:
- **New `DBKeystore`**: Implements `keystore.Keystore` backed by the database, supporting `Has`, `Get`, `Delete`, and `List` operations. `Put` is intentionally unsupported (key creation goes through `IPNSKeyService.CreateKey`). Includes `ListKeysWithCID` for querying keys with a published CID.
- **New custom `Republisher`**: Replaces boxo's `republisher.Republisher`, reading keys to republish directly from the database via `ListKeysWithCID` instead of requiring a separate datastore. Includes configurable interval, record lifetime, initial delay, and failure retry logic.
- **Removed `SafeRepublisherKeystore`**: The nil-key validation wrapper is no longer needed since the DB keystore guarantees key integrity.
- **Removed `SyncToBoxoKeystore` and `RepublishAllKeysOnBoot`**: These startup synchronization steps are obsolete since the republisher now reads from the database directly, eliminating the need to sync keys into boxo's keystore or force-publish on boot.
- **Cleaned up `IPNSKeyService` interface**: Removed `SyncToBoxoKeystore` and `RepublishAllKeysOnBoot` methods and trimmed verbose doc comments.
<!-- kody-pr-summary:end -->