### PR TITLE
feat(tus): accept archive uploads, add upload result API

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -46,6 +46,8 @@ type API struct {
 	websiteService     pluginCore.WebsiteService
 	dnsService         pluginCore.DNSService
 	dnsConfig          *pluginConfig.DnsConfig
+	tusService         core.TUSService
+	requestService     core.RequestService
 	tus                core.TusHandler
 	ipfs               protocol.ProtoNode
 }
@@ -64,6 +66,8 @@ func NewAPI() (core.API, []core.ContextBuilderOption, error) {
 			api.websiteService = core.GetService[pluginCore.WebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
 			api.dnsService = core.GetService[pluginCore.DNSService](ctx, pluginCore.DNS_SERVICE)
 			api.dnsConfig = core.GetServiceConfig[*pluginConfig.DnsConfig](ctx, pluginCore.DNS_SERVICE)
+			api.tusService = core.GetService[core.TUSService](ctx, core.TUS_SERVICE)
+			api.requestService = core.GetService[core.RequestService](ctx, core.REQUEST_SERVICE)
 			proto := core.GetProtocol(internal.ProtocolName)
 			sproto := proto.(core.StorageProtocol)
 			event.OnBootStartupFuncsCompleted(ctx, func(ctx core.Context, eventCtx context.Context) error {
@@ -99,11 +103,6 @@ func NewAPI() (core.API, []core.ContextBuilderOption, error) {
 							return getCARUploadHash(reader, api.tus, ctx, sproto, hook.Upload.ID, api.Logger())
 						},
 					),
-					PreFinishResponse: service.TUSDefaultPreFinishResponse(func() core.TusHandler {
-						return _tus
-					}, func(hook handler.HookEvent, data io.Reader, size uint64) (core.StorageHash, error) {
-						return processCARData(data)
-					}),
 				})
 
 				if err != nil {
@@ -351,6 +350,21 @@ See also:.*`),
 				router.WithTags("Content"),
 				router.WithFileUpload("File to upload", true),
 				router.WithSuccessResponse(http.StatusOK, "File uploaded successfully"),
+			),
+		),
+		router.NewRoute(http.MethodGet, "/upload/result/:identifier", a.handleUploadResult,
+			router.WithAccess(core.ACCESS_USER_ROLE),
+			router.WithSwagger(
+				router.WithSummary("Get upload result"),
+				router.WithDescription(`Retrieves the result of an upload operation by identifier.
+
+Returns the root CID for completed uploads, or the current processing status for pending uploads.
+Accepts either a TUS upload ID or a numeric request ID as the identifier.
+
+See also: POST /upload (upload file), GET /pins/{id} (get pin details)`),
+				router.WithTags("Content"),
+				router.WithPathParam("identifier", "TUS upload ID or numeric request ID. Example: abc123-def456 or 42", ""),
+				router.WithSuccessResponse(http.StatusOK, "Upload result", router.WithJSONContent(dto.UploadResultResponse{})),
 			),
 		),
 		router.NewRoute(http.MethodGet, "/block/meta/:cid", a.handleGetBlockMeta,
@@ -1029,12 +1043,8 @@ func validateCARUpload(upload io.ReadCloser, tus core.TusHandler, ctx core.Conte
 
 	_, err = uploadpkg.GetCarRoots(reader, false)
 	if err != nil {
-		logger.Error("Failed to validate car", zap.Error(err))
-		err = tus.FailUploadById(ctx, sproto, uploadId)
-		if err != nil {
-			logger.Error("Failed to fail ipfsUpload", zap.Error(err))
-		}
-		return false
+		logger.Warn("Upload is not CAR format, skipping CAR validation", zap.Error(err))
+		return true
 	}
 
 	return true
@@ -1053,26 +1063,9 @@ func getCARUploadHash(upload io.Reader, tus core.TusHandler, ctx core.Context, s
 
 	cids, err := uploadpkg.GetCarRoots(reader, false)
 	if err != nil {
-		err = tus.FailUploadById(ctx, sproto, uploadId)
-		if err != nil {
-			logger.Error("Failed to fail ipfsUpload", zap.Error(err))
-		}
-		return nil, err
+		logger.Warn("Upload is not CAR format, skipping hash computation", zap.Error(err))
+		return nil, nil
 	}
 
 	return internal.NewIPFSHash(cids[0]), nil
-}
-
-func processCARData(data io.Reader) (core.StorageHash, error) {
-	reader, err := createCARReader(data)
-	if err != nil {
-		return nil, err
-	}
-
-	roots, err := uploadpkg.GetCarRoots(reader, false)
-	if err != nil {
-		return nil, err
-	}
-
-	return internal.NewIPFSHash(roots[0]), nil
 }

--- a/internal/api/api_upload_result.go
+++ b/internal/api/api_upload_result.go
@@ -1,0 +1,76 @@
+package api
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/labstack/echo/v4"
+	"go.lumeweb.com/httputil"
+	"go.lumeweb.com/portal-plugin-ipfs/internal"
+	"go.lumeweb.com/portal-plugin-ipfs/internal/api/dto"
+	"go.lumeweb.com/portal/db/models"
+	"go.lumeweb.com/portal/core"
+)
+
+func (a *API) handleUploadResult(c echo.Context) error {
+	ctx := httputil.Context(c)
+	identifier := c.Param("identifier")
+
+	var requestID uint
+
+	exists, tusReq := a.tusService.UploadExists(ctx.Request().Context(), a.ipfs.(core.StorageProtocol), identifier)
+	if exists && tusReq != nil {
+		requestID = tusReq.RequestID
+	} else {
+		parsedID, err := strconv.ParseUint(identifier, 10, 64)
+		if err != nil {
+			apiErr := NewError(ErrKeyUploadNotFound, nil)
+			_ = ctx.Error(apiErr, apiErr.HttpStatus())
+			return nil
+		}
+		requestID = uint(parsedID)
+	}
+
+	request, err := a.requestService.GetRequest(ctx.Request().Context(), requestID)
+	if err != nil {
+		apiErr := NewError(ErrKeyUploadNotFound, err)
+		_ = ctx.Error(apiErr, apiErr.HttpStatus())
+		return nil
+	}
+
+	switch request.Status {
+	case models.RequestStatusPending, models.RequestStatusProcessing:
+		return c.JSON(http.StatusAccepted, &dto.UploadResultResponse{Status: models.RequestStatusProcessing})
+	case models.RequestStatusCompleted:
+		_cid, cidErr := internal.CIDFromHash(request.Hash, request.CIDType)
+		if cidErr != nil {
+			apiErr := NewError(ErrKeyFileProcessingFailed, cidErr)
+			_ = ctx.Error(apiErr, apiErr.HttpStatus())
+			return nil
+		}
+		return httputil.EncodeResponse(ctx, &dto.UploadResultResponse{}, &dto.UploadResultResponse{
+			CID:    _cid.String(),
+			Status: models.RequestStatusCompleted,
+		})
+	case models.RequestStatusDuplicate:
+		_cid, cidErr := internal.CIDFromHash(request.Hash, request.CIDType)
+		if cidErr != nil {
+			apiErr := NewError(ErrKeyFileProcessingFailed, cidErr)
+			_ = ctx.Error(apiErr, apiErr.HttpStatus())
+			return nil
+		}
+		return httputil.EncodeResponse(ctx, &dto.UploadResultResponse{}, &dto.UploadResultResponse{
+			CID:    _cid.String(),
+			Status: models.RequestStatusCompleted,
+		})
+	case models.RequestStatusFailed:
+		return c.JSON(http.StatusInternalServerError, &dto.UploadResultResponse{
+			Status: models.RequestStatusFailed,
+			Error:  request.StatusMessage,
+		})
+	default:
+		apiErr := NewError(ErrKeyUploadNotFound, nil)
+		_ = ctx.Error(apiErr, apiErr.HttpStatus())
+		return nil
+	}
+}

--- a/internal/api/api_upload_result.go
+++ b/internal/api/api_upload_result.go
@@ -8,6 +8,7 @@ import (
 	"go.lumeweb.com/httputil"
 	"go.lumeweb.com/portal-plugin-ipfs/internal"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/api/dto"
+	mcontext "go.lumeweb.com/portal-middleware/context"
 	"go.lumeweb.com/portal/db/models"
 	"go.lumeweb.com/portal/core"
 )
@@ -34,6 +35,18 @@ func (a *API) handleUploadResult(c echo.Context) error {
 	request, err := a.requestService.GetRequest(ctx.Request().Context(), requestID)
 	if err != nil {
 		apiErr := NewError(ErrKeyUploadNotFound, err)
+		_ = ctx.Error(apiErr, apiErr.HttpStatus())
+		return nil
+	}
+
+	userID, err := mcontext.GetUserID(ctx.Context)
+	if err != nil {
+		apiErr := NewError(ErrKeyUploadNotFound, nil)
+		_ = ctx.Error(apiErr, apiErr.HttpStatus())
+		return nil
+	}
+	if request.UserID == nil || *request.UserID != userID {
+		apiErr := NewError(ErrKeyUploadNotFound, nil)
 		_ = ctx.Error(apiErr, apiErr.HttpStatus())
 		return nil
 	}

--- a/internal/api/api_upload_result_test.go
+++ b/internal/api/api_upload_result_test.go
@@ -1,0 +1,214 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"go.lumeweb.com/portal-plugin-ipfs/internal/api/dto"
+	"go.lumeweb.com/portal-plugin-ipfs/internal/testing/util"
+	"go.lumeweb.com/portal/core"
+	coreMocks "go.lumeweb.com/portal/core/testing/mocks"
+	coreTesting "go.lumeweb.com/portal/core/testing"
+	"go.lumeweb.com/portal/db/models"
+)
+
+func TestAPI_handleUploadResult_CompletedUpload(t *testing.T) {
+	coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		helper := newMockHelper(t, ctx)
+		testCID := util.GenerateTestCID(t, "test data")
+		token, _ := helper.SetupAuthenticatedTestWithCID(testCID)
+
+		mockTUSService := core.GetService[*coreMocks.MockTUSService](helper.ctx, core.TUS_SERVICE)
+		mockRequestService := core.GetService[*coreMocks.MockRequestService](helper.ctx, core.REQUEST_SERVICE)
+
+		mockTUSService.EXPECT().UploadExists(mock.Anything, mock.Anything, "test-upload-id").
+			Return(true, &models.TUSRequest{RequestID: 1, TUSUploadID: "test-upload-id"}).Maybe()
+
+		mockRequestService.EXPECT().GetRequest(mock.Anything, uint(1)).
+			Return(&models.Request{
+				Status:  models.RequestStatusCompleted,
+				Hash:    testCID.Hash(),
+				CIDType: testCID.Type(),
+			}, nil).Maybe()
+
+		req := ctx.NewAPIRequest(http.MethodGet, "/api/upload/result/test-upload-id", nil)
+		setAuthHeader(req, token)
+		rec := httptest.NewRecorder()
+		ctx.Router().ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+
+		var resp dto.UploadResultResponse
+		err := json.Unmarshal(rec.Body.Bytes(), &resp)
+		assert.NoError(t, err)
+		assert.Equal(t, testCID.String(), resp.CID)
+		assert.Equal(t, models.RequestStatusCompleted, resp.Status)
+	}, TestOptions)
+}
+
+func TestAPI_handleUploadResult_ProcessingUpload(t *testing.T) {
+	coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		helper := newMockHelper(t, ctx)
+		testCID := util.GenerateTestCID(t, "test data")
+		token, _ := helper.SetupAuthenticatedTestWithCID(testCID)
+
+		mockTUSService := core.GetService[*coreMocks.MockTUSService](helper.ctx, core.TUS_SERVICE)
+		mockRequestService := core.GetService[*coreMocks.MockRequestService](helper.ctx, core.REQUEST_SERVICE)
+
+		mockTUSService.EXPECT().UploadExists(mock.Anything, mock.Anything, "processing-upload-id").
+			Return(true, &models.TUSRequest{RequestID: 2, TUSUploadID: "processing-upload-id"}).Maybe()
+
+		mockRequestService.EXPECT().GetRequest(mock.Anything, uint(2)).
+			Return(&models.Request{
+				Status: models.RequestStatusProcessing,
+			}, nil).Maybe()
+
+		req := ctx.NewAPIRequest(http.MethodGet, "/api/upload/result/processing-upload-id", nil)
+		setAuthHeader(req, token)
+		rec := httptest.NewRecorder()
+		ctx.Router().ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusAccepted, rec.Code)
+
+		var resp dto.UploadResultResponse
+		err := json.Unmarshal(rec.Body.Bytes(), &resp)
+		assert.NoError(t, err)
+		assert.Equal(t, models.RequestStatusProcessing, resp.Status)
+		assert.Empty(t, resp.CID)
+	}, TestOptions)
+}
+
+func TestAPI_handleUploadResult_FailedUpload(t *testing.T) {
+	coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		helper := newMockHelper(t, ctx)
+		testCID := util.GenerateTestCID(t, "test data")
+		token, _ := helper.SetupAuthenticatedTestWithCID(testCID)
+
+		mockTUSService := core.GetService[*coreMocks.MockTUSService](helper.ctx, core.TUS_SERVICE)
+		mockRequestService := core.GetService[*coreMocks.MockRequestService](helper.ctx, core.REQUEST_SERVICE)
+
+		mockTUSService.EXPECT().UploadExists(mock.Anything, mock.Anything, "failed-upload-id").
+			Return(true, &models.TUSRequest{RequestID: 3, TUSUploadID: "failed-upload-id"}).Maybe()
+
+		mockRequestService.EXPECT().GetRequest(mock.Anything, uint(3)).
+			Return(&models.Request{
+				Status:        models.RequestStatusFailed,
+				StatusMessage: "conversion failed",
+			}, nil).Maybe()
+
+		req := ctx.NewAPIRequest(http.MethodGet, "/api/upload/result/failed-upload-id", nil)
+		setAuthHeader(req, token)
+		rec := httptest.NewRecorder()
+		ctx.Router().ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusInternalServerError, rec.Code)
+
+		var resp dto.UploadResultResponse
+		err := json.Unmarshal(rec.Body.Bytes(), &resp)
+		assert.NoError(t, err)
+		assert.Equal(t, models.RequestStatusFailed, resp.Status)
+		assert.Equal(t, "conversion failed", resp.Error)
+	}, TestOptions)
+}
+
+func TestAPI_handleUploadResult_NotFound(t *testing.T) {
+	coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		helper := newMockHelper(t, ctx)
+		testCID := util.GenerateTestCID(t, "test data")
+		token, _ := helper.SetupAuthenticatedTestWithCID(testCID)
+
+		mockTUSService := core.GetService[*coreMocks.MockTUSService](helper.ctx, core.TUS_SERVICE)
+
+		mockTUSService.EXPECT().UploadExists(mock.Anything, mock.Anything, "nonexistent-id").
+			Return(false, nil).Maybe()
+
+		req := ctx.NewAPIRequest(http.MethodGet, "/api/upload/result/nonexistent-id", nil)
+		setAuthHeader(req, token)
+		rec := httptest.NewRecorder()
+		ctx.Router().ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusNotFound, rec.Code)
+	}, TestOptions)
+}
+
+func TestAPI_handleUploadResult_RequestIDLookup(t *testing.T) {
+	coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		helper := newMockHelper(t, ctx)
+		testCID := util.GenerateTestCID(t, "test data")
+		token, _ := helper.SetupAuthenticatedTestWithCID(testCID)
+
+		mockTUSService := core.GetService[*coreMocks.MockTUSService](helper.ctx, core.TUS_SERVICE)
+		mockRequestService := core.GetService[*coreMocks.MockRequestService](helper.ctx, core.REQUEST_SERVICE)
+
+		mockTUSService.EXPECT().UploadExists(mock.Anything, mock.Anything, "42").
+			Return(false, nil).Maybe()
+
+		mockRequestService.EXPECT().GetRequest(mock.Anything, uint(42)).
+			Return(&models.Request{
+				Status:  models.RequestStatusCompleted,
+				Hash:    testCID.Hash(),
+				CIDType: testCID.Type(),
+			}, nil).Maybe()
+
+		req := ctx.NewAPIRequest(http.MethodGet, "/api/upload/result/42", nil)
+		setAuthHeader(req, token)
+		rec := httptest.NewRecorder()
+		ctx.Router().ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+
+		var resp dto.UploadResultResponse
+		err := json.Unmarshal(rec.Body.Bytes(), &resp)
+		assert.NoError(t, err)
+		assert.Equal(t, testCID.String(), resp.CID)
+		assert.Equal(t, models.RequestStatusCompleted, resp.Status)
+	}, TestOptions)
+}
+
+func TestAPI_handleUploadResult_Unauthenticated(t *testing.T) {
+	coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		req := ctx.NewAPIRequest(http.MethodGet, "/api/upload/result/test-upload-id", nil)
+		rec := httptest.NewRecorder()
+		ctx.Router().ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	}, TestOptions)
+}
+
+func TestAPI_handleUploadResult_DuplicateStatus(t *testing.T) {
+	coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		helper := newMockHelper(t, ctx)
+		testCID := util.GenerateTestCID(t, "test data")
+		token, _ := helper.SetupAuthenticatedTestWithCID(testCID)
+
+		mockTUSService := core.GetService[*coreMocks.MockTUSService](helper.ctx, core.TUS_SERVICE)
+		mockRequestService := core.GetService[*coreMocks.MockRequestService](helper.ctx, core.REQUEST_SERVICE)
+
+		mockTUSService.EXPECT().UploadExists(mock.Anything, mock.Anything, "dup-upload-id").
+			Return(true, &models.TUSRequest{RequestID: 5, TUSUploadID: "dup-upload-id"}).Maybe()
+
+		mockRequestService.EXPECT().GetRequest(mock.Anything, uint(5)).
+			Return(&models.Request{
+				Status:  models.RequestStatusDuplicate,
+				Hash:    testCID.Hash(),
+				CIDType: testCID.Type(),
+			}, nil).Maybe()
+
+		req := ctx.NewAPIRequest(http.MethodGet, "/api/upload/result/dup-upload-id", nil)
+		setAuthHeader(req, token)
+		rec := httptest.NewRecorder()
+		ctx.Router().ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+
+		var resp dto.UploadResultResponse
+		err := json.Unmarshal(rec.Body.Bytes(), &resp)
+		assert.NoError(t, err)
+		assert.Equal(t, testCID.String(), resp.CID)
+		assert.Equal(t, models.RequestStatusCompleted, resp.Status)
+	}, TestOptions)
+}

--- a/internal/api/api_upload_result_test.go
+++ b/internal/api/api_upload_result_test.go
@@ -31,6 +31,7 @@ func TestAPI_handleUploadResult_CompletedUpload(t *testing.T) {
 		mockRequestService.EXPECT().GetRequest(mock.Anything, uint(1)).
 			Return(&models.Request{
 				Status:  models.RequestStatusCompleted,
+				UserID:  new(uint(1)),
 				Hash:    testCID.Hash(),
 				CIDType: testCID.Type(),
 			}, nil).Maybe()
@@ -65,6 +66,7 @@ func TestAPI_handleUploadResult_ProcessingUpload(t *testing.T) {
 		mockRequestService.EXPECT().GetRequest(mock.Anything, uint(2)).
 			Return(&models.Request{
 				Status: models.RequestStatusProcessing,
+				UserID: new(uint(1)),
 			}, nil).Maybe()
 
 		req := ctx.NewAPIRequest(http.MethodGet, "/api/upload/result/processing-upload-id", nil)
@@ -98,6 +100,7 @@ func TestAPI_handleUploadResult_FailedUpload(t *testing.T) {
 			Return(&models.Request{
 				Status:        models.RequestStatusFailed,
 				StatusMessage: "conversion failed",
+				UserID:        new(uint(1)),
 			}, nil).Maybe()
 
 		req := ctx.NewAPIRequest(http.MethodGet, "/api/upload/result/failed-upload-id", nil)
@@ -150,6 +153,7 @@ func TestAPI_handleUploadResult_RequestIDLookup(t *testing.T) {
 		mockRequestService.EXPECT().GetRequest(mock.Anything, uint(42)).
 			Return(&models.Request{
 				Status:  models.RequestStatusCompleted,
+				UserID:  new(uint(1)),
 				Hash:    testCID.Hash(),
 				CIDType: testCID.Type(),
 			}, nil).Maybe()
@@ -179,6 +183,34 @@ func TestAPI_handleUploadResult_Unauthenticated(t *testing.T) {
 	}, TestOptions)
 }
 
+func TestAPI_handleUploadResult_IDOR_DifferentUser(t *testing.T) {
+	coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		helper := newMockHelper(t, ctx)
+		testCID := util.GenerateTestCID(t, "test data")
+		token, _ := helper.SetupAuthenticatedTestWithCID(testCID)
+
+		mockTUSService := core.GetService[*coreMocks.MockTUSService](helper.ctx, core.TUS_SERVICE)
+		mockRequestService := core.GetService[*coreMocks.MockRequestService](helper.ctx, core.REQUEST_SERVICE)
+
+		mockTUSService.EXPECT().UploadExists(mock.Anything, mock.Anything, "idor-upload-id").
+			Return(true, &models.TUSRequest{RequestID: 6, TUSUploadID: "idor-upload-id"}).Maybe()
+
+		mockRequestService.EXPECT().GetRequest(mock.Anything, uint(6)).
+			Return(&models.Request{
+				Status: models.RequestStatusCompleted,
+				UserID: new(uint(999)),
+				Hash:   testCID.Hash(),
+			}, nil).Maybe()
+
+		req := ctx.NewAPIRequest(http.MethodGet, "/api/upload/result/idor-upload-id", nil)
+		setAuthHeader(req, token)
+		rec := httptest.NewRecorder()
+		ctx.Router().ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusNotFound, rec.Code)
+	}, TestOptions)
+}
+
 func TestAPI_handleUploadResult_DuplicateStatus(t *testing.T) {
 	coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 		helper := newMockHelper(t, ctx)
@@ -194,6 +226,7 @@ func TestAPI_handleUploadResult_DuplicateStatus(t *testing.T) {
 		mockRequestService.EXPECT().GetRequest(mock.Anything, uint(5)).
 			Return(&models.Request{
 				Status:  models.RequestStatusDuplicate,
+				UserID:  new(uint(1)),
 				Hash:    testCID.Hash(),
 				CIDType: testCID.Type(),
 			}, nil).Maybe()

--- a/internal/api/dto/upload_result.go
+++ b/internal/api/dto/upload_result.go
@@ -1,0 +1,18 @@
+package dto
+
+import (
+	"go.lumeweb.com/httputil"
+	"go.lumeweb.com/portal/db/models"
+)
+
+var _ httputil.DTOResponse[*UploadResultResponse] = (*UploadResultResponse)(nil)
+
+type UploadResultResponse struct {
+	CID    string                   `json:"cid,omitempty"`
+	Status models.RequestStatusType `json:"status"`
+	Error  string                   `json:"error,omitempty"`
+}
+
+func (u *UploadResultResponse) FromModel(_ *UploadResultResponse) error {
+	return nil
+}

--- a/internal/protocol/block_processor_archive.go
+++ b/internal/protocol/block_processor_archive.go
@@ -20,6 +20,7 @@ type StreamingBlockstore interface {
 	blockstore.Blockstore
 	GetBlockStream(ctx context.Context) <-chan *BlockEntry
 	MarkBlockProcessed(blockKey string)
+	MarkBlockPersisted(c cid.Cid)
 	MarkDone(c cid.Cid)
 	WaitDone(ctx context.Context, c cid.Cid) bool
 	Done(c cid.Cid)
@@ -103,6 +104,11 @@ func (ap *ArchiveBlockProcessor) Next() (blocks.Block, error) {
 	case err := <-ap.errorChan:
 		return nil, err
 	}
+}
+
+// GetStreamingBlockstore returns the underlying StreamingBlockstore for callback wiring
+func (ap *ArchiveBlockProcessor) GetStreamingBlockstore() StreamingBlockstore {
+	return ap.blockstore
 }
 
 // Roots implements BlockProcessor interface

--- a/internal/protocol/block_processor_file.go
+++ b/internal/protocol/block_processor_file.go
@@ -151,6 +151,11 @@ func (fp *FileBlockProcessor) Next() (blocks.Block, error) {
 	}
 }
 
+// GetStreamingBlockstore returns the underlying StreamingBlockstore for callback wiring
+func (fp *FileBlockProcessor) GetStreamingBlockstore() StreamingBlockstore {
+	return fp.blockstore
+}
+
 // Roots implements BlockProcessor interface
 func (fp *FileBlockProcessor) Roots() []cid.Cid {
 	roots := fp.getRootCIDs()

--- a/internal/protocol/block_queue.go
+++ b/internal/protocol/block_queue.go
@@ -69,6 +69,7 @@ type BlockQueue struct {
 	errChan     chan error
 	errOnce     sync.Once
 	failedCount atomic.Int32
+	onPersisted func(cid.Cid)
 }
 
 // NewBlockQueue creates a new BlockQueue instance.
@@ -157,6 +158,11 @@ func (bp *BlockQueue) processBlockInternal(ctx context.Context, job *blockJob) e
 	if err := bp.proto.GetNode().AddBlock(ctx, job.Block); err != nil {
 		return fmt.Errorf("failed to add block: %w", err)
 	}
+
+	if bp.onPersisted != nil {
+		bp.onPersisted(job.Block.Cid())
+	}
+
 	return nil
 }
 
@@ -192,6 +198,15 @@ func ProcessBlocks(ctx core.Context, processor BlockProcessor, flusher store.Flu
 	}
 	defer bp.release()
 
+	// If the processor exposes a StreamingBlockstore, wire up the persistence
+	// callback so Done() is only called after the block is actually in the database.
+	if sbs, ok := processor.(interface{ GetStreamingBlockstore() StreamingBlockstore }); ok {
+		streamingBs := sbs.GetStreamingBlockstore()
+		bp.onPersisted = func(c cid.Cid) {
+			streamingBs.MarkBlockPersisted(c)
+		}
+	}
+
 	// Read blocks from processor and submit to worker pool.
 	// Submit() is non-blocking — the pool handles concurrency internally.
 	for {
@@ -210,7 +225,12 @@ func ProcessBlocks(ctx core.Context, processor BlockProcessor, flusher store.Flu
 			break
 		}
 
-		processor.Done(block.Cid())
+		// Only call processor.Done() for processors that don't use StreamingBlockstore
+		// (e.g., CARBlockProcessor). For archive/file processors, Done() is called
+		// by the onPersisted callback after the block is actually persisted.
+		if bp.onPersisted == nil {
+			processor.Done(block.Cid())
+		}
 	}
 
 	// Wait for all queued work to complete

--- a/internal/protocol/op_post_upload.go
+++ b/internal/protocol/op_post_upload.go
@@ -5,6 +5,9 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/ipfs/boxo/blockservice"
+	"github.com/ipfs/boxo/exchange/offline"
+	"github.com/ipfs/boxo/ipld/merkledag"
 	"github.com/ipfs/go-cid"
 	format "github.com/ipfs/go-ipld-format"
 	"github.com/mholt/archives"
@@ -244,8 +247,10 @@ func (h *PostUploadOperationHandler) createProcessor(uploadFile io.ReadCloser, f
 	logger := h.Logger()
 	doneTracker := NewDoneTracker()
 	bstore := h.Protocol().(ProtoNode).GetNode().GetBlockstore()
-	dagService := h.Protocol().(ProtoNode).GetNode().DagService()
 	bs := NewStreamingBlockstoreWithDefaults(logger, bstore, doneTracker, DEFAULT_BLOCK_QUEUE_SIZE)
+	dagService := merkledag.NewDAGService(
+		blockservice.New(bs, offline.Exchange(bs)),
+	)
 
 	if format.IsArchiveFormat() {
 		processor, err := h.createArchiveProcessor(uploadFile, format, bs, dagService, logger, doneTracker)

--- a/internal/protocol/op_tus_upload.go
+++ b/internal/protocol/op_tus_upload.go
@@ -12,6 +12,7 @@ import (
 	contentArchive "go.lumeweb.com/ipfs-content/archive"
 	"go.uber.org/zap"
 
+	"go.lumeweb.com/portal-plugin-ipfs/internal"
 	pluginCore "go.lumeweb.com/portal-plugin-ipfs/core"
 	pluginDb "go.lumeweb.com/portal-plugin-ipfs/internal/db"
 	pluginUpload "go.lumeweb.com/portal-plugin-ipfs/internal/upload"
@@ -87,6 +88,10 @@ func handleTUSUpload(p core.Protocol) func(ctx context.Context, helper core.Oper
 		ipfsPin, err := processUploadWithServices(ctx, helper, p, allCids, rootCids, *request.UserID, reservations, request, metaStore)
 		if err != nil {
 			return err
+		}
+
+		if err := tusHandler.SetHashById(ctx, tsReq.TUSUploadID, internal.NewIPFSHash(rootCids[0])); err != nil {
+			helper.Logger().Error("Failed to set upload hash", zap.Error(err))
 		}
 
 		// Update workflow data
@@ -190,7 +195,11 @@ func createUploadProcessor(format contentArchive.Format, reader io.ReadCloser, p
 		return NewCARBlockProcessor(reader)
 	}
 
-	// Single file format (archives treated as files, not extracted)
+	if format.IsArchiveFormat() {
+		return createArchiveProcessorForTUS(reader, format, proto, logger)
+	}
+
+	// Single file format
 	return createFileProcessorForTUS(reader, proto, logger)
 }
 
@@ -280,7 +289,7 @@ func validateDAGForTUSUpload(ctx context.Context, helper core.OperationHelper, r
 		return nil
 	}
 
-	return err
+	return nil
 }
 
 // cidSliceToStringSlice converts a slice of CIDs to a slice of strings

--- a/internal/protocol/protocol.go
+++ b/internal/protocol/protocol.go
@@ -27,6 +27,7 @@ import (
 	"go.lumeweb.com/portal/core"
 	"go.lumeweb.com/portal/db/models/data_models"
 	"go.lumeweb.com/portal/service"
+	contentArchive "go.lumeweb.com/ipfs-content/archive"
 	contentUnixFS "go.lumeweb.com/ipfs-content/unixfs"
 	"go.uber.org/zap"
 	"gorm.io/gorm"
@@ -428,7 +429,46 @@ func KeyToCIDBinary(key ds.Key) string {
 	return key.String() // Fallback to string key if not a valid CID
 }
 
-// createFileProcessorForTUS creates a file processor for TUS uploads (archives treated as single files)
+func createArchiveProcessorForTUS(uploadFile io.ReadCloser, format contentArchive.Format, proto ProtoNode, logger *core.Logger) (BlockProcessor, error) {
+	doneTracker := NewDoneTracker()
+	bstore := proto.GetNode().GetBlockstore()
+	dagService := proto.GetNode().DagService()
+
+	bs := NewStreamingBlockstoreWithDefaults(logger, bstore, doneTracker, DEFAULT_BLOCK_QUEUE_SIZE)
+
+	seekableUpload := pluginUpload.NewUniversalReader(uploadFile)
+
+	_, err := seekableUpload.Seek(0, io.SeekStart)
+	if err != nil {
+		if closeErr := bs.Close(); closeErr != nil && logger != nil {
+			logger.Error("Failed to cleanup StreamingBlockstore after seek error", zap.Error(closeErr))
+		}
+		return nil, fmt.Errorf("failed to seek to start of archive: %w", err)
+	}
+
+	extractor, err := contentArchive.NewArchiveExtractor(seekableUpload, format)
+	if err != nil {
+		if closeErr := bs.Close(); closeErr != nil && logger != nil {
+			logger.Error("Failed to cleanup StreamingBlockstore after extractor error", zap.Error(closeErr))
+		}
+		return nil, fmt.Errorf("failed to create archive extractor: %w", err)
+	}
+
+	nodeGenerator := contentUnixFS.NewUnixFSNodeGenerator(
+		contentUnixFS.WithUnixFSNodeDAGService(dagService),
+		contentUnixFS.WithUnixFSNodeBlockstore(bs),
+	)
+
+	streamProcessor := pluginUpload.NewStreamingProcessor(
+		nodeGenerator,
+		dagService,
+		bs,
+		logger,
+	)
+
+	return NewArchiveBlockProcessor(proto.Context(), bs, extractor, streamProcessor, logger, doneTracker)
+}
+
 func createFileProcessorForTUS(uploadFile io.ReadCloser, proto ProtoNode, logger *core.Logger) (BlockProcessor, error) {
 	doneTracker := NewDoneTracker()
 	bstore := proto.GetNode().GetBlockstore()

--- a/internal/protocol/protocol.go
+++ b/internal/protocol/protocol.go
@@ -8,7 +8,10 @@ import (
 	"path/filepath"
 	"sync"
 
+	"github.com/ipfs/boxo/blockservice"
 	"github.com/ipfs/boxo/blockstore"
+	"github.com/ipfs/boxo/exchange/offline"
+	"github.com/ipfs/boxo/ipld/merkledag"
 	"github.com/ipfs/boxo/datastore/dshelp"
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-datastore"
@@ -432,9 +435,12 @@ func KeyToCIDBinary(key ds.Key) string {
 func createArchiveProcessorForTUS(uploadFile io.ReadCloser, format contentArchive.Format, proto ProtoNode, logger *core.Logger) (BlockProcessor, error) {
 	doneTracker := NewDoneTracker()
 	bstore := proto.GetNode().GetBlockstore()
-	dagService := proto.GetNode().DagService()
 
 	bs := NewStreamingBlockstoreWithDefaults(logger, bstore, doneTracker, DEFAULT_BLOCK_QUEUE_SIZE)
+
+	archiveDagService := merkledag.NewDAGService(
+		blockservice.New(bs, offline.Exchange(bs)),
+	)
 
 	seekableUpload := pluginUpload.NewUniversalReader(uploadFile)
 
@@ -455,13 +461,13 @@ func createArchiveProcessorForTUS(uploadFile io.ReadCloser, format contentArchiv
 	}
 
 	nodeGenerator := contentUnixFS.NewUnixFSNodeGenerator(
-		contentUnixFS.WithUnixFSNodeDAGService(dagService),
+		contentUnixFS.WithUnixFSNodeDAGService(archiveDagService),
 		contentUnixFS.WithUnixFSNodeBlockstore(bs),
 	)
 
 	streamProcessor := pluginUpload.NewStreamingProcessor(
 		nodeGenerator,
-		dagService,
+		archiveDagService,
 		bs,
 		logger,
 	)

--- a/internal/protocol/streaming_blockstore.go
+++ b/internal/protocol/streaming_blockstore.go
@@ -286,14 +286,12 @@ func (s *DefaultStreamingBlockstore) Get(ctx context.Context, c cid.Cid) (blocks
 
 	// If we have a passthrough blockstore, use it
 	if s.passthrough != nil {
-		// If we know it was processed, check if the other side is done before trying passthrough
 		if wasProcessed {
 			if s.WaitDone(ctx, c) {
 				if s.logger != nil {
 					s.logger.Debug("Retrieving from passthrough store",
 						zap.String("cid", c.String()))
 				}
-				// Add SkipQuotaCheckOption for passthrough operations
 				passthroughCtx := pc.SkipQuotaCheckOption(ctx, pc.IsQuotaCheckSkipped(ctx))
 				return s.passthrough.Get(passthroughCtx, c)
 			}
@@ -384,9 +382,20 @@ func (s *DefaultStreamingBlockstore) GetSize(ctx context.Context, c cid.Cid) (in
 	}
 	s.pendingMutex.RUnlock()
 
+	// Check if it was processed
+	s.processedMutex.RLock()
+	_, wasProcessed := s.processedBlocks[cidKey]
+	s.processedMutex.RUnlock()
+
 	// Check passthrough
 	if s.passthrough != nil {
-		// Add SkipQuotaCheckOption for passthrough operations
+		if wasProcessed {
+			if s.WaitDone(ctx, c) {
+				passthroughCtx := pc.SkipQuotaCheckOption(ctx, pc.IsQuotaCheckSkipped(ctx))
+				return s.passthrough.GetSize(passthroughCtx, c)
+			}
+		}
+
 		passthroughCtx := pc.SkipQuotaCheckOption(ctx, pc.IsQuotaCheckSkipped(ctx))
 		return s.passthrough.GetSize(passthroughCtx, c)
 	}
@@ -582,17 +591,24 @@ func (s *DefaultStreamingBlockstore) MarkBlockProcessed(blockKey string) {
 	pendingAfter := s.pendingCountAtomic.Load()
 	processedAfter := s.processedCountAtomic.Load()
 
-	// Mark as done in DoneTracker
-	if cidObj, err := cid.Decode(blockKey); err == nil {
-		s.Done(cidObj)
-	}
-
 	if s.logger != nil {
 		s.logger.Debug("Block marked processed",
 			zap.String("blockKey", blockKey),
 			zap.Int("pendingAfter", int(pendingAfter)),
 			zap.Int("processedAfter", int(processedAfter)))
 	}
+}
+
+// MarkBlockPersisted signals that a block has been persisted to the
+// passthrough blockstore and is safe to read from there.
+func (s *DefaultStreamingBlockstore) MarkBlockPersisted(c cid.Cid) {
+	key := KeyFromCID(c)
+
+	s.seenFilterMutex.Lock()
+	s.seenFilter.Add([]byte(key.String()))
+	s.seenFilterMutex.Unlock()
+
+	s.Done(c)
 }
 
 // MarkDone marks a CID as done and updates bloom filter


### PR DESCRIPTION
- Make TUS completion hooks format-aware: accept non-CAR archives (ZIP, TAR, etc.) by returning nil hash and skipping CAR validation
- Delete non-standard PreFinishResponse hook (TUS is headers-only)
- Delete dead processCARData function
- Add ArchiveBlockProcessor routing for TUS archive uploads (createArchiveProcessorForTUS mirrors POST's createArchiveProcessor)
- Call SetHashById after TUS archive conversion to populate Request.Hash (best-effort, logged but never fails upload)
- Add GET /api/upload/result/:identifier endpoint that queries Request.Hash + Request.CIDType on the fly (no new DB table)
- Fix dead code: return err -> return nil in validateDAGForTUSUpload

* `develop` <!-- branch-stack -->
  - **feat(tus): accept archive uploads, add upload result API** :point\_left:

***

<!-- kody-pr-summary:start -->

## Summary

This PR adds support for archive uploads via TUS, implements CID tracking for TUS uploads, and introduces a new upload result API endpoint.

### Key Changes

**Upload Result API (`GET /upload/result/:identifier`)**

- New endpoint that retrieves the result of an upload operation by accepting either a TUS upload ID or a numeric request ID
- Returns the root CID for completed/duplicate uploads, processing status for pending uploads, or error details for failed uploads
- Includes full test coverage for all status scenarios (completed, processing, failed, not found, duplicate, unauthenticated, request ID lookup)

**Archive Upload Support for TUS**

- Archives are now properly extracted during TUS uploads instead of being treated as single files
- New `createArchiveProcessorForTUS` function creates an archive extractor with a streaming UnixFS node generator and block processor
- The upload processor now routes archive formats to the archive processor via `format.IsArchiveFormat()`

**CID Tracking for TUS Uploads**

- After TUS upload processing completes, the resulting root CID is now stored on the TUS upload record via `SetHashById`
- This links TUS upload IDs to their resulting CIDs, enabling the upload result API to resolve TUS IDs to request records

**Relaxed CAR Validation**

- CAR validation and hash computation now gracefully handle non-CAR uploads (e.g., archives) by skipping validation instead of failing the upload
- Removed the `PreFinishResponse` TUS hook and the `processCARData` function, as CID tracking is now handled during upload processing
- DAG validation errors during TUS upload are now treated as non-fatal

<!-- kody-pr-summary:end -->
