### PR TITLE
feat: auto-convert plain IPFS CID to IPNS target in CreateWebsite

### DIFF
--- a/internal/api/dto/website.go
+++ b/internal/api/dto/website.go
@@ -241,15 +241,31 @@ func (r *WebsiteRequest) ToModel() (*db.Website, error) {
 	// Validate peer ID for IPNS targets
 	if r.TargetType == db.WebsiteTargetTypeIPNS {
 		target, err := db.NewIPNSTargetFromString(r.TargetHash)
-		if err != nil {
-			return nil, &httputil.ValidationError{
-				FieldErrors: map[string]string{
-					"target_hash": fmt.Sprintf("invalid IPNS target: %v", err),
-				},
+		if err == nil {
+			// Valid IPNS target — store directly
+			website.TargetMultihash = target.ToMultihash()
+			website.CIDVersion = nil // NULL for IPNS
+		} else {
+			// Not a valid IPNS peer ID/libp2p-key — check if it's a valid IPFS CID.
+			// The service layer will auto-create an IPNS key and publish this CID,
+			// converting the target from a plain CID to an IPNS peer ID.
+			c, cidErr := cid.Parse(r.TargetHash)
+			if cidErr != nil {
+				return nil, &httputil.ValidationError{
+					FieldErrors: map[string]string{
+						"target_hash": fmt.Sprintf("invalid IPNS target: %v", err),
+					},
+				}
 			}
+			// Store temporarily as IPFS-style fields; the service layer
+			// will detect auto-conversion and replace with IPNS target.
+			normalizedCid := encoding.NormalizeCid(c)
+			website.TargetMultihash = normalizedCid.Hash()
+			version := uint8(normalizedCid.Version())
+			website.CIDVersion = &version
+			codec := uint8(normalizedCid.Type())
+			website.CIDType = &codec
 		}
-		website.TargetMultihash = target.ToMultihash()
-		website.CIDVersion = nil // NULL for IPNS
 	}
 
 	return website, nil
@@ -316,15 +332,27 @@ func (r *WebsiteUpdateRequest) ToModel() (*db.Website, error) {
 
 		if *r.TargetType == db.WebsiteTargetTypeIPNS {
 			target, err := db.NewIPNSTargetFromString(*r.TargetHash)
-			if err != nil {
-				return nil, &httputil.ValidationError{
-					FieldErrors: map[string]string{
-						"target_hash": fmt.Sprintf("invalid IPNS target: %v", err),
-					},
+			if err == nil {
+				website.TargetMultihash = target.ToMultihash()
+				website.CIDVersion = nil
+			} else {
+				// Not a valid IPNS peer ID — check if it's a CID for auto-conversion.
+				c, cidErr := cid.Parse(*r.TargetHash)
+				if cidErr != nil {
+					return nil, &httputil.ValidationError{
+						FieldErrors: map[string]string{
+							"target_hash": fmt.Sprintf("invalid IPNS target: %v", err),
+						},
+					}
 				}
+				// Store temporarily as IPFS-style fields for service-layer auto-conversion.
+				normalizedCid := encoding.NormalizeCid(c)
+				website.TargetMultihash = normalizedCid.Hash()
+				version := uint8(normalizedCid.Version())
+				website.CIDVersion = &version
+				codec := uint8(normalizedCid.Type())
+				website.CIDType = &codec
 			}
-			website.TargetMultihash = target.ToMultihash()
-			website.CIDVersion = nil
 		}
 	}
 

--- a/internal/api/dto/website_test.go
+++ b/internal/api/dto/website_test.go
@@ -497,6 +497,96 @@ func TestWebsiteResponse_FromModel_SSL_Populated(t *testing.T) {
 	})
 }
 
+func TestWebsiteRequest_ToModel_IPNS_WithValidPeerID(t *testing.T) {
+	targetType := db.WebsiteTargetTypeIPNS
+	req := WebsiteRequest{
+		Domain:     "example.com",
+		TargetType: targetType,
+		TargetHash: "12D3KooWRhWS6DXi1U1YnJ5r9E6KpSDHGbZAznXif4T9qDjHeEfE",
+	}
+
+	model, err := req.ToModel()
+	require.NoError(t, err)
+	assert.Equal(t, string(db.WebsiteTargetTypeIPNS), model.TargetType)
+	assert.Nil(t, model.CIDVersion, "CIDVersion should be nil for valid IPNS target")
+}
+
+func TestWebsiteRequest_ToModel_IPNS_WithCIDv1Libp2pKey(t *testing.T) {
+	targetType := db.WebsiteTargetTypeIPNS
+	req := WebsiteRequest{
+		Domain:     "example.com",
+		TargetType: targetType,
+		TargetHash: "k51qzi5uqu5dlts3p5vfpw8kneqp5ye1ttb2jlt8qkt5mq9f2gvgmet6sec29r",
+	}
+
+	model, err := req.ToModel()
+	require.NoError(t, err)
+	assert.Equal(t, string(db.WebsiteTargetTypeIPNS), model.TargetType)
+	assert.Nil(t, model.CIDVersion, "CIDVersion should be nil for valid IPNS target")
+}
+
+func TestWebsiteRequest_ToModel_IPNS_WithPlainCID_AutoConvert(t *testing.T) {
+	targetType := db.WebsiteTargetTypeIPNS
+	// CIDv1 with raw codec — valid CID but NOT a valid IPNS target,
+	// so it should be accepted for auto-conversion rather than rejected.
+	req := WebsiteRequest{
+		Domain:     "example.com",
+		TargetType: targetType,
+		TargetHash: "bafkreig2m6bzv4ysvqo2hz2jamofrof2iq3hwhnerso56g26pmawr37o64",
+	}
+
+	model, err := req.ToModel()
+	require.NoError(t, err)
+	assert.Equal(t, string(db.WebsiteTargetTypeIPNS), model.TargetType)
+	assert.NotNil(t, model.CIDVersion, "CIDVersion should be set temporarily for auto-conversion")
+	assert.NotNil(t, model.CIDType, "CIDType should be set temporarily for auto-conversion")
+	assert.NotNil(t, model.TargetMultihash, "TargetMultihash should be set from the CID")
+}
+
+func TestWebsiteRequest_ToModel_IPNS_WithInvalidHash_Rejected(t *testing.T) {
+	targetType := db.WebsiteTargetTypeIPNS
+	req := WebsiteRequest{
+		Domain:     "example.com",
+		TargetType: targetType,
+		TargetHash: "not-a-valid-cid-or-peer-id",
+	}
+
+	_, err := req.ToModel()
+	require.Error(t, err)
+	validationErr, ok := err.(*httputil.ValidationError)
+	require.True(t, ok, "error should be a ValidationError")
+	assert.Contains(t, validationErr.FieldErrors["target_hash"], "invalid IPNS target")
+}
+
+func TestWebsiteUpdateRequest_ToModel_IPNS_WithPlainCID_AutoConvert(t *testing.T) {
+	targetType := db.WebsiteTargetTypeIPNS
+	cidStr := "bafkreig2m6bzv4ysvqo2hz2jamofrof2iq3hwhnerso56g26pmawr37o64"
+	req := WebsiteUpdateRequest{
+		TargetType: &targetType,
+		TargetHash: &cidStr,
+	}
+
+	model, err := req.ToModel()
+	require.NoError(t, err)
+	assert.Equal(t, string(db.WebsiteTargetTypeIPNS), model.TargetType)
+	assert.NotNil(t, model.CIDVersion, "CIDVersion should be set temporarily for auto-conversion")
+	assert.NotNil(t, model.CIDType, "CIDType should be set temporarily for auto-conversion")
+}
+
+func TestWebsiteUpdateRequest_ToModel_IPNS_WithValidPeerID(t *testing.T) {
+	targetType := db.WebsiteTargetTypeIPNS
+	peerID := "12D3KooWRhWS6DXi1U1YnJ5r9E6KpSDHGbZAznXif4T9qDjHeEfE"
+	req := WebsiteUpdateRequest{
+		TargetType: &targetType,
+		TargetHash: &peerID,
+	}
+
+	model, err := req.ToModel()
+	require.NoError(t, err)
+	assert.Equal(t, string(db.WebsiteTargetTypeIPNS), model.TargetType)
+	assert.Nil(t, model.CIDVersion, "CIDVersion should be nil for valid IPNS target")
+}
+
 func TestWebsiteResponse_FromModel_SSL_NotPopulated(t *testing.T) {
 	t.Run("does not populate SSL field when SSL status is empty", func(t *testing.T) {
 		now := time.Now()

--- a/internal/service/website/website.go
+++ b/internal/service/website/website.go
@@ -115,9 +115,26 @@ func (s *WebsiteServiceDefault) CreateWebsite(ctx context.Context, website *plug
 				return nil, fmt.Errorf("invalid domain: %w", err)
 			}
 
-			// Validate target type and hash
-			if err := s.validateTarget(website.TargetType, website.TargetHash()); err != nil {
-				return nil, fmt.Errorf("invalid target: %w", err)
+			// Auto-convert: target_type=ipns with a plain IPFS CID means
+			// "create/use IPNS key and publish this CID to it"
+			if website.TargetType == string(pluginDb.WebsiteTargetTypeIPNS) && website.CIDVersion != nil {
+				publishCID := website.TargetHash()
+
+				ipnsKey, err := s.ensureIPNSKey(ctx, website.UserID, website.Domain, publishCID)
+				if err != nil {
+					return nil, err
+				}
+
+				website.TargetType = string(pluginDb.WebsiteTargetTypeIPNS)
+				website.TargetMultihash = ipnsKey.PeerIDMultihash
+				website.CIDVersion = nil
+				website.CIDType = nil
+				website.IPNSKeyID = &ipnsKey.ID
+			} else {
+				// Validate target type and hash
+				if err := s.validateTarget(website.TargetType, website.TargetHash()); err != nil {
+					return nil, fmt.Errorf("invalid target: %w", err)
+				}
 			}
 
 			// Check if domain already exists

--- a/internal/service/website/website_test.go
+++ b/internal/service/website/website_test.go
@@ -356,6 +356,49 @@ func TestWebsiteService_CreateWebsite_IPNSTarget(t *testing.T) {
 	}, TestOptions)
 }
 
+func TestWebsiteService_CreateWebsite_IPNSTargetWithPlainCID_AutoConvert(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		// Arrange
+		websiteService := core.GetService[pluginCore.WebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
+		mockIPNSKey := core.GetService[*mocks.MockIPNSKeyService](ctx, pluginCore.IPNS_KEY_SERVICE)
+		require.NotNil(tb, websiteService)
+
+		testCID := util.GenerateTestCID(t, "ipns-auto-convert-content")
+		domain := "ipns-autoconvert.com"
+
+		// Create a website with IPNS target type but a regular CID as the hash.
+		// This simulates the user flow where someone provides a CID and selects IPNS.
+		c := cid.MustParse(testCID.String())
+		version := uint8(c.Version())
+		codec := uint8(c.Type())
+		website := &pluginDb.Website{
+			UserID:          testUserID1,
+			Domain:          domain,
+			TargetType:      string(pluginDb.WebsiteTargetTypeIPNS),
+			TargetMultihash: c.Hash(),
+			CIDVersion:      &version,
+			CIDType:         &codec,
+			SSLStatus:       string(pluginDb.SSLStatusPending),
+		}
+
+		// Set up IPNS key mocks for auto-conversion
+		setupIPNSAutoCreationMocks(t, mockIPNSKey, testUserID1, domain, testCID)
+
+		// Act
+		createdWebsite, err := websiteService.CreateWebsite(context.Background(), website)
+
+		// Assert
+		require.NoError(tb, err)
+		assert.NotNil(tb, createdWebsite)
+		assert.Equal(tb, string(pluginDb.WebsiteTargetTypeIPNS), createdWebsite.TargetType)
+		assert.Nil(tb, createdWebsite.CIDVersion, "CIDVersion should be nil after IPNS conversion")
+		assert.NotNil(tb, createdWebsite.IPNSKeyID, "IPNSKeyID should be set after auto-conversion")
+		// TargetHash should now be a peer ID, not the original CID
+		_, peerErr := peer.Decode(createdWebsite.TargetHash())
+		assert.NoError(tb, peerErr, "TargetHash should be a valid peer ID after auto-conversion")
+	}, TestOptions)
+}
+
 func TestWebsiteService_CreateWebsite_InvalidDomain(t *testing.T) {
 	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 		// Arrange


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Summary

This pull request implements automatic conversion of plain IPFS CIDs to IPNS targets when creating or updating websites with `target_type=ipns`.

### What Changed

Previously, when a user submitted a website request with `target_type=ipns` but provided a plain IPFS CID (instead of a valid IPNS peer ID/libp2p-key), the API would reject the request with a validation error. Now, the system accepts the CID and automatically handles the conversion:

- **DTO layer** (`website.go`): When `target_type=ipns` is specified, the request first attempts to parse the `target_hash` as a valid IPNS peer ID. If that fails, it falls back to parsing it as a CID. If the CID is valid, the CID fields (`CIDVersion`, `CIDType`, `TargetMultihash`) are stored temporarily to signal the service layer that auto-conversion is needed. Only if both parsing attempts fail is a validation error returned.

- **Service layer** (`website.go`): During website creation, if the target type is IPNS but `CIDVersion` is set (indicating a plain CID was provided), the service automatically creates or reuses an IPNS key via `ensureIPNSKey`, then replaces the temporary CID-based target fields with the IPNS peer ID, clearing `CIDVersion` and `CIDType` and setting `IPNSKeyID`.

- **Tests**: New test cases cover valid peer IDs, CIDv1 libp2p-key format, plain CID auto-conversion, and invalid hash rejection for both `WebsiteRequest` and `WebsiteUpdateRequest`, plus an integration test for the full auto-conversion flow in the service layer.
<!-- kody-pr-summary:end -->