### PR TITLE
refactor: move DNS TXT validation from root domain to subdomain

### DIFF
--- a/internal/api/api_websites.go
+++ b/internal/api/api_websites.go
@@ -47,6 +47,13 @@ func (a *API) gatewayDomain() string {
 	return ""
 }
 
+func (a *API) verificationTokenKey() string {
+	if a.dnsConfig != nil && a.dnsConfig.VerificationTokenKey != "" {
+		return a.dnsConfig.VerificationTokenKey
+	}
+	return "lumeweb-verify"
+}
+
 func (a *API) zoneDomain(ctx context.Context, dnsZoneID *uint) string {
 	if dnsZoneID == nil || a.dnsService == nil {
 		return ""
@@ -141,6 +148,7 @@ func (a *API) createWebsite(c echo.Context) error {
 	}
 	resp.GatewayDomain = a.gatewayDomain()
 	resp.SetSubdomainInfo(a.zoneDomain(reqCtx, website.DNSZoneID))
+	resp.SetValidationRecordInfo(a.verificationTokenKey())
 	resp.EnrichActiveCID(ipnsKeyCIDResolver{svc: a.ipnsKeyService, ctx: reqCtx}, user, website)
 
 	ctx.Response().Before(func() {
@@ -197,6 +205,7 @@ func (a *API) listWebsites(c echo.Context) error {
 		}
 		responses[i].GatewayDomain = a.gatewayDomain()
 		responses[i].SetSubdomainInfo(a.zoneDomain(reqCtx, website.DNSZoneID))
+		responses[i].SetValidationRecordInfo(a.verificationTokenKey())
 		responses[i].EnrichActiveCID(ipnsKeyCIDResolver{svc: a.ipnsKeyService, ctx: reqCtx}, user, website)
 	}
 
@@ -239,6 +248,7 @@ func (a *API) getWebsite(c echo.Context) error {
 		if err := resp.FromModel(website); err == nil {
 			resp.GatewayDomain = a.gatewayDomain()
 			resp.SetSubdomainInfo(a.zoneDomain(reqCtx, website.DNSZoneID))
+			resp.SetValidationRecordInfo(a.verificationTokenKey())
 			resp.EnrichActiveCID(ipnsKeyCIDResolver{svc: a.ipnsKeyService, ctx: reqCtx}, user, website)
 			ctx.Response().Before(func() {
 				ctx.Response().Status = http.StatusGone
@@ -250,6 +260,7 @@ func (a *API) getWebsite(c echo.Context) error {
 	resp := &dto.WebsiteResponse{}
 	resp.GatewayDomain = a.gatewayDomain()
 	resp.SetSubdomainInfo(a.zoneDomain(reqCtx, website.DNSZoneID))
+	resp.SetValidationRecordInfo(a.verificationTokenKey())
 	resp.EnrichActiveCID(ipnsKeyCIDResolver{svc: a.ipnsKeyService, ctx: reqCtx}, user, website)
 	return httputil.EncodeResponse(ctx, website, resp)
 }
@@ -312,6 +323,7 @@ func (a *API) updateWebsite(c echo.Context) error {
 	}
 	resp.GatewayDomain = a.gatewayDomain()
 	resp.SetSubdomainInfo(a.zoneDomain(reqCtx, website.DNSZoneID))
+	resp.SetValidationRecordInfo(a.verificationTokenKey())
 	resp.EnrichActiveCID(ipnsKeyCIDResolver{svc: a.ipnsKeyService, ctx: reqCtx}, user, website)
 
 	return httputil.EncodeResponse(ctx, website, &resp)
@@ -408,6 +420,7 @@ func (a *API) getSSLStatus(c echo.Context) error {
 	resp := &dto.WebsiteResponse{}
 	resp.GatewayDomain = a.gatewayDomain()
 	resp.SetSubdomainInfo(a.zoneDomain(reqCtx, website.DNSZoneID))
+	resp.SetValidationRecordInfo(a.verificationTokenKey())
 	resp.EnrichActiveCID(ipnsKeyCIDResolver{svc: a.ipnsKeyService, ctx: reqCtx}, website.UserID, website)
 	return httputil.EncodeResponse(ctx, website, resp)
 }
@@ -451,6 +464,7 @@ func (a *API) updateSSLStatus(c echo.Context) error {
 	resp := &dto.WebsiteResponse{}
 	resp.GatewayDomain = a.gatewayDomain()
 	resp.SetSubdomainInfo(a.zoneDomain(reqCtx, website.DNSZoneID))
+	resp.SetValidationRecordInfo(a.verificationTokenKey())
 	resp.EnrichActiveCID(ipnsKeyCIDResolver{svc: a.ipnsKeyService, ctx: reqCtx}, website.UserID, website)
 	return httputil.EncodeResponse(ctx, website, resp)
 }

--- a/internal/api/dto/website.go
+++ b/internal/api/dto/website.go
@@ -376,7 +376,8 @@ type WebsiteResponse struct {
 	IPNSKeyID           *uint          `json:"ipns_key_id,omitempty"`  // FK to the linked IPNS key (set when DNS hosting auto-creates a key)
 	ActiveCID           string         `json:"active_cid,omitempty"`   // The currently-published IPFS content CID (distinct from target_hash when target is IPNS)
 	Status              string         `json:"status"`
-	ValidationToken     string         `json:"validation_token"`
+	ValidationToken       string     `json:"validation_token"`                      // The full TXT record value (e.g. "lumeweb-verify=abc123...")
+	ValidationRecordHost  string     `json:"validation_record_host,omitempty"`     // The DNS hostname for the TXT record (e.g. "lumeweb-verify.example.com")
 	ValidationExpiresAt *time.Time     `json:"validation_expires_at,omitempty"`
 	LastCheckedAt       *time.Time     `json:"last_checked_at,omitempty"`
 	DNSZoneID           *uint          `json:"dns_zone_id,omitempty"`
@@ -448,6 +449,11 @@ func (r *WebsiteResponse) EnrichActiveCID(resolver IPNSKeyCIDResolver, userID ui
 // If zoneDomain is empty, the website is considered a top-level website.
 func (r *WebsiteResponse) SetSubdomainInfo(zoneDomain string) {
 	r.IsSubdomain = zoneDomain != "" && zoneDomain != r.Domain
+}
+
+func (r *WebsiteResponse) SetValidationRecordInfo(tokenKey string) {
+	r.ValidationRecordHost = tokenKey + "." + r.Domain
+	r.ValidationToken = tokenKey + "=" + r.ValidationToken
 }
 
 // WebsiteValidateResponse represents a website validation response

--- a/internal/config/dns.go
+++ b/internal/config/dns.go
@@ -23,6 +23,9 @@ type DnsConfig struct {
 	// Gateway domain for ALIAS records (auto-wiring)
 	GatewayDomain string `config:"gateway_domain"`
 
+	// Verification token key used as the subdomain label for validation TXT records
+	VerificationTokenKey string `config:"verification_token_key"`
+
 	// Nameserver validation job configuration
 	NameserverValidationInterval time.Duration `config:"nameserver_validation_interval"`
 }
@@ -34,6 +37,7 @@ func (c DnsConfig) Defaults() map[string]any {
 		"PowerDNSAPIKey":                "",
 		"Nameservers":                   []string{},
 		"GatewayDomain":                 "",
+		"VerificationTokenKey":           "lumeweb-verify",
 		"NameserverValidationInterval":  5 * time.Minute,
 	}
 }

--- a/internal/config/website.go
+++ b/internal/config/website.go
@@ -1,10 +1,31 @@
 package config
 
 import (
+	"strings"
 	"time"
 
 	"go.lumeweb.com/portal/config"
 )
+
+// SanitizeDNSLabel converts a string into a valid DNS label per RFC 1035.
+// Lowercases, strips invalid chars to hyphens, trims leading/trailing hyphens,
+// truncates to 63 chars.
+func SanitizeDNSLabel(s string) string {
+	s = strings.ToLower(s)
+	var b strings.Builder
+	for _, c := range s {
+		if (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') {
+			b.WriteRune(c)
+		} else if c == '-' || c == '_' || c == ' ' {
+			b.WriteByte('-')
+		}
+	}
+	result := strings.Trim(b.String(), "-")
+	if len(result) > 63 {
+		result = result[:63]
+	}
+	return strings.TrimRight(result, "-")
+}
 
 var _ config.Defaults = (*WebsiteConfig)(nil)
 
@@ -17,8 +38,7 @@ type WebsiteConfig struct {
 	JanitorBatchSize    int           `config:"janitor_batch_size"`
 
 	// Validation configuration
-	ValidationTokenTTL   time.Duration `config:"validation_token_ttl"`
-	VerificationTokenKey string        `config:"verification_token_key"`
+	ValidationTokenTTL time.Duration `config:"validation_token_ttl"`
 
 	// Notification configuration
 	NotificationsEnabled bool   `config:"notifications_enabled"`
@@ -32,7 +52,6 @@ func (c WebsiteConfig) Defaults() map[string]any {
 		"JanitorWorkerCount": 10,
 		"JanitorBatchSize":   500,
 		"ValidationTokenTTL":   24 * time.Hour,
-		"VerificationTokenKey": "lumeweb-verify",
 		"NotificationsEnabled": true,
 		"AdminEmail":           "",
 	}

--- a/internal/service/dns/dns_service.go
+++ b/internal/service/dns/dns_service.go
@@ -96,6 +96,14 @@ func NewDNSServiceWithOptions(options ...DNSServiceOption) (core.Service, []core
 				return nil
 			}
 
+			sanitized := pluginConfig.SanitizeDNSLabel(svc.config.VerificationTokenKey)
+			if sanitized != svc.config.VerificationTokenKey {
+				svc.Logger().Warn("verification_token_key sanitized for DNS compatibility",
+					zap.String("original", svc.config.VerificationTokenKey),
+					zap.String("sanitized", sanitized))
+				svc.config.VerificationTokenKey = sanitized
+			}
+
 			// Initialize PowerDNS client from config if not provided via options
 			if serviceOpts.PowerDNSClient == nil && svc.config.Enabled {
 				if svc.config.PowerDNSAPIURL == "" || svc.config.PowerDNSAPIKey == "" {

--- a/internal/service/dns/dns_service_test.go
+++ b/internal/service/dns/dns_service_test.go
@@ -27,10 +27,11 @@ import (
 // Helper function to get DNS service config
 func getTestDnsConfig() *pluginConfig.DnsConfig {
 	return &pluginConfig.DnsConfig{
-		Enabled:        true,
-		PowerDNSAPIURL: "http://localhost:8081",
-		PowerDNSAPIKey: "test-api-key",
-		Nameservers:    []string{"ns1.localhost", "ns2.localhost"},
+		Enabled:              true,
+		PowerDNSAPIURL:       "http://localhost:8081",
+		PowerDNSAPIKey:       "test-api-key",
+		Nameservers:          []string{"ns1.localhost", "ns2.localhost"},
+		VerificationTokenKey: "lumeweb-verify",
 	}
 }
 

--- a/internal/service/dns/dns_service_zone.go
+++ b/internal/service/dns/dns_service_zone.go
@@ -363,6 +363,7 @@ func (s *DNSServiceDefault) CreateWebsiteDNSRecords(ctx context.Context, zoneID 
 	targetPath := string(buildTargetPath(targetHash, targetType))
 
 	dnslinkName := buildFullName("_dnslink", websiteDomain)
+	verifyName := buildFullName(s.config.VerificationTokenKey, websiteDomain)
 	recordName := buildFullName(websiteDomain, websiteDomain)
 
 	rrsets := []powerdns.RRSet{
@@ -379,7 +380,7 @@ func (s *DNSServiceDefault) CreateWebsiteDNSRecords(ctx context.Context, zoneID 
 			},
 		},
 		{
-			Name:       recordName,
+			Name:       verifyName,
 			Type:       "TXT",
 			Changetype: "REPLACE",
 			Ttl:        &ttl,
@@ -492,6 +493,7 @@ func (s *DNSServiceDefault) DeleteWebsiteDNSRecords(ctx context.Context, zoneID 
 	}
 
 	dnslinkName := buildFullName("_dnslink", websiteDomain)
+	verifyName := buildFullName(s.config.VerificationTokenKey, websiteDomain)
 	recordName := buildFullName(websiteDomain, websiteDomain)
 
 	rrsets := []powerdns.RRSet{
@@ -501,7 +503,7 @@ func (s *DNSServiceDefault) DeleteWebsiteDNSRecords(ctx context.Context, zoneID 
 			Changetype: "DELETE",
 		},
 		{
-			Name:       recordName,
+			Name:       verifyName,
 			Type:       "TXT",
 			Changetype: "DELETE",
 		},

--- a/internal/service/dns/nameserver_validator_job_test.go
+++ b/internal/service/dns/nameserver_validator_job_test.go
@@ -35,6 +35,7 @@ var NameserverValidatorTestOptions = coreTesting.CombineOptions(
 		PowerDNSAPIKey:               "test-api-key",
 		Nameservers:                  []string{"ns1.example.com.", "ns2.example.com."},
 		NameserverValidationInterval: 5 * time.Minute,
+		VerificationTokenKey:         "lumeweb-verify",
 	}).WithMigrations(map[core.DBType]fs.FS{
 		core.DB_TYPE_SQLITE: migrations.GetSQLite(),
 	}).BuilderOption(),

--- a/internal/service/website/validate_dns_test.go
+++ b/internal/service/website/validate_dns_test.go
@@ -43,7 +43,7 @@ func TestValidateDNS_PendingValidation_ValidDNSLinkAndToken_ReturnsValidated(t *
 				"ipfs": {{Identifier: created.TargetHash()}},
 			},
 		}, nil)
-		mockResolver.EXPECT().LookupTXT("validate-pending.com").Return([]string{
+		mockResolver.EXPECT().LookupTXT("lumeweb-verify.validate-pending.com").Return([]string{
 			fmt.Sprintf("lumeweb-verify=%s", created.ValidationToken),
 		}, nil)
 		setMockResolver(ws, mockResolver)
@@ -100,7 +100,7 @@ func TestValidateDNS_PendingValidation_MissingToken_ReturnsTokenMissing(t *testi
 				"ipfs": {{Identifier: created.TargetHash()}},
 			},
 		}, nil)
-		mockResolver.EXPECT().LookupTXT("missing-token.com").Return([]string{"some-other-txt-record=foo"}, nil)
+		mockResolver.EXPECT().LookupTXT("lumeweb-verify.missing-token.com").Return([]string{"some-other-txt-record=foo"}, nil)
 		setMockResolver(ws, mockResolver)
 
 		result, err := ws.ValidateDNS(context.Background(), testUserID1, created.ID)
@@ -297,7 +297,7 @@ func TestValidateDNS_TxTTLookupFailure_ReturnsError(t *testing.T) {
 				"ipfs": {{Identifier: created.TargetHash()}},
 			},
 		}, nil)
-		mockResolver.EXPECT().LookupTXT("txt-fail-test.com").Return(nil, fmt.Errorf("TXT lookup timeout"))
+		mockResolver.EXPECT().LookupTXT("lumeweb-verify.txt-fail-test.com").Return(nil, fmt.Errorf("TXT lookup timeout"))
 		setMockResolver(ws, mockResolver)
 
 		result, err := ws.ValidateDNS(context.Background(), testUserID1, created.ID)
@@ -350,7 +350,7 @@ func TestValidateDNS_IPNSTarget_ValidDNSLinkAndToken(t *testing.T) {
 				"ipns": {{Identifier: created.TargetHash()}},
 			},
 		}, nil)
-		mockResolver.EXPECT().LookupTXT("ipns-validate.com").Return([]string{
+		mockResolver.EXPECT().LookupTXT("lumeweb-verify.ipns-validate.com").Return([]string{
 			fmt.Sprintf("lumeweb-verify=%s", created.ValidationToken),
 		}, nil)
 		setMockResolver(ws, mockResolver)

--- a/internal/service/website/website.go
+++ b/internal/service/website/website.go
@@ -30,11 +30,18 @@ import (
 
 const sslCertValidity = 90 * 24 * time.Hour
 
+func (s *WebsiteServiceDefault) verificationTokenKey() string {
+	if s.dnsConfig != nil && s.dnsConfig.VerificationTokenKey != "" {
+		return s.dnsConfig.VerificationTokenKey
+	}
+	return "lumeweb-verify"
+}
+
 const (
-	msgTokenExpired  = "Validation token expired for %s — a new token has been generated. Please add the updated TXT record to your DNS configuration"
+	msgTokenExpired  = "Validation token expired for %s — a new token has been generated. Please add the updated TXT record at %s.%s to your DNS configuration"
 	msgDNSMissing    = "No DNS records found for %s. Please add the required TXT records to your DNS configuration"
 	msgDNSMismatch   = "DNS validation failed: missing or incorrect dnslink record (expected: %s, found: %s)"
-	msgTokenMissing  = "DNS validation failed: missing validation token for %s"
+	msgTokenMissing  = "DNS validation failed: missing validation token at %s.%s for %s"
 	msgValidated     = "DNS validation successful for %s"
 )
 
@@ -62,6 +69,7 @@ type WebsiteServiceDefault struct {
 	mailerSvc  core.MailerService
 	dnsSvc     pluginCore.DNSService
 	config     *pluginConfig.WebsiteConfig
+	dnsConfig  *pluginConfig.DnsConfig
 	resolver   DNSResolver
 }
 
@@ -81,6 +89,7 @@ func NewWebsiteService() (core.Service, []core.ContextBuilderOption, error) {
 
 			// Load configuration from service config
 			svc.config = core.GetServiceConfig[*pluginConfig.WebsiteConfig](ctx, pluginCore.WEBSITE_SERVICE)
+			svc.dnsConfig = core.GetServiceConfig[*pluginConfig.DnsConfig](ctx, pluginCore.DNS_SERVICE)
 
 			if svc.resolver == nil {
 				svc.resolver = LiveResolver{}
@@ -273,7 +282,7 @@ func (s *WebsiteServiceDefault) CreateWebsite(ctx context.Context, website *plug
 						zap.String("domain", website.Domain))
 
 					// Create DNS records for the website
-					if err := s.dnsSvc.CreateWebsiteDNSRecords(ctx, dnsZone.ID, website.Domain, website.TargetHash(), pluginDb.WebsiteTargetType(website.TargetType), fmt.Sprintf("%s=%s", s.config.VerificationTokenKey, website.ValidationToken)); err != nil {
+					if err := s.dnsSvc.CreateWebsiteDNSRecords(ctx, dnsZone.ID, website.Domain, website.TargetHash(), pluginDb.WebsiteTargetType(website.TargetType), fmt.Sprintf("%s=%s", s.verificationTokenKey(), website.ValidationToken)); err != nil {
 						s.Logger().Error("Failed to create DNS records for website",
 							zap.Error(err),
 							zap.Uint("website_id", website.ID),
@@ -762,7 +771,7 @@ func (s *WebsiteServiceDefault) handleDNSEnabledTransition(ctx context.Context, 
 		}
 
 		// Create DNS records
-		err := s.dnsSvc.CreateWebsiteDNSRecords(ctx, *website.DNSZoneID, website.Domain, website.TargetHash(), pluginDb.WebsiteTargetType(website.TargetType), fmt.Sprintf("%s=%s", s.config.VerificationTokenKey, newToken))
+		err := s.dnsSvc.CreateWebsiteDNSRecords(ctx, *website.DNSZoneID, website.Domain, website.TargetHash(), pluginDb.WebsiteTargetType(website.TargetType), fmt.Sprintf("%s=%s", s.verificationTokenKey(), newToken))
 		if err != nil {
 			return fmt.Errorf("failed to create DNS records: %w", err)
 		}
@@ -1069,7 +1078,7 @@ func (s *WebsiteServiceDefault) ValidateDNS(ctx context.Context, userID uint, we
 				}
 				return pluginCore.ValidateDNSResult{
 					Valid:   false,
-					Message: fmt.Sprintf(msgTokenExpired, website.Domain),
+					Message: fmt.Sprintf(msgTokenExpired, website.Domain, s.verificationTokenKey(), website.Domain),
 					Reason:  pluginCore.ValidationReasonTokenExpired,
 				}, nil
 			}
@@ -1128,10 +1137,10 @@ func (s *WebsiteServiceDefault) ValidateDNS(ctx context.Context, userID uint, we
 			}
 
 			if needsTokenCheck {
-				expectedTokenRecord := fmt.Sprintf("%s=%s", s.config.VerificationTokenKey, website.ValidationToken)
-				txtRecords, err := s.resolver.LookupTXT(website.Domain)
+				expectedTokenRecord := fmt.Sprintf("%s=%s", s.verificationTokenKey(), website.ValidationToken)
+				txtRecords, err := s.resolver.LookupTXT(s.verificationTokenKey() + "." + website.Domain)
 				if err != nil {
-					return pluginCore.ValidateDNSResult{}, fmt.Errorf("DNS TXT lookup failed for %s: %w", website.Domain, err)
+					return pluginCore.ValidateDNSResult{}, fmt.Errorf("DNS TXT lookup failed for %s.%s: %w", s.verificationTokenKey(), website.Domain, err)
 				}
 
 				var hasToken bool
@@ -1151,7 +1160,7 @@ func (s *WebsiteServiceDefault) ValidateDNS(ctx context.Context, userID uint, we
 						zap.String("expected_token", website.ValidationToken))
 					return pluginCore.ValidateDNSResult{
 						Valid:   false,
-						Message: fmt.Sprintf(msgTokenMissing, website.Domain),
+						Message: fmt.Sprintf(msgTokenMissing, s.verificationTokenKey(), website.Domain, website.Domain),
 						Reason:  pluginCore.ValidationReasonTokenMissing,
 					}, nil
 				}
@@ -1187,7 +1196,7 @@ func (s *WebsiteServiceDefault) regenerateExpiredToken(ctx context.Context, webs
 	}
 
 	if website.DNSZoneID != nil && s.dnsSvc != nil {
-		tokenRecord := fmt.Sprintf("%s=%s", s.config.VerificationTokenKey, newToken)
+		tokenRecord := fmt.Sprintf("%s=%s", s.verificationTokenKey(), newToken)
 		if err := s.dnsSvc.CreateWebsiteDNSRecords(ctx, *website.DNSZoneID, website.Domain, website.TargetHash(), pluginDb.WebsiteTargetType(website.TargetType), tokenRecord); err != nil {
 			s.Logger().Warn("Failed to update DNS records with new validation token",
 				zap.Error(err),

--- a/internal/service/website/website_test.go
+++ b/internal/service/website/website_test.go
@@ -164,16 +164,16 @@ var TestOptions = coreTesting.CombineOptions(
 	testopts.NewBaseMockPluginBuilder().
 		WithService(pluginCore.WEBSITE_SERVICE, NewWebsiteService).
 		WithServiceConfig(pluginCore.WEBSITE_SERVICE, &pluginConfig.WebsiteConfig{
-			NotificationsEnabled:  false,
-			AdminEmail:            "",
-			ValidationTokenTTL:    24 * time.Hour,
-			VerificationTokenKey:  "lumeweb-verify",
+			NotificationsEnabled: false,
+			AdminEmail:           "",
+			ValidationTokenTTL:   24 * time.Hour,
 		}).
 		WithMockServiceFactory(pluginCore.DNS_SERVICE, mocks.NewMockDNSService).
 		WithServiceConfig(pluginCore.DNS_SERVICE, &pluginConfig.DnsConfig{
 			Enabled:                      true,
 			Nameservers:                  []string{"ns1.localhost", "ns2.localhost"},
 			NameserverValidationInterval: 5 * time.Minute,
+			VerificationTokenKey:         "lumeweb-verify",
 		}).
 		WithMigrations(map[core.DBType]fs.FS{
 			core.DB_TYPE_SQLITE: migrations.GetSQLite(),


### PR DESCRIPTION
Move validation TXT record from apex (example.com) to VerificationTokenKey subdomain (lumeweb-verify.example.com) to avoid CNAME/TXT conflict at root. Add SanitizeDNSLabel to auto-compute valid DNS labels from config values. Add validation_record_host and compute validation_token as full key=value in API response. Remove VerificationTokenKey from WebsiteConfig (now in DnsConfig only).

---

<!-- kody-pr-summary:start -->
Move DNS TXT validation records from the root domain to a dedicated subdomain

This PR refactors DNS TXT validation so that verification tokens are stored and looked up at a subdomain (e.g., `lumeweb-verify.example.com`) instead of the root domain (`example.com`). This avoids polluting the root domain's TXT records and provides a cleaner separation of concerns.

Key changes:
- **Subdomain-based TXT records**: DNS validation TXT records are now created, queried, and deleted at `<verificationTokenKey>.<domain>` instead of at the root domain level.
- **API response enrichment**: Website responses now include a `validation_record_host` field indicating the full DNS hostname where the TXT record should be placed (e.g., `lumeweb-verify.example.com`), and the `validation_token` field now contains the complete TXT record value (e.g., `lumeweb-verify=abc123...`).
- **Configuration relocation**: The `verification_token_key` setting was moved from `WebsiteConfig` to `DnsConfig`, since it is DNS-specific. The default value remains `lumeweb-verify`.
- **DNS label sanitization**: A new `SanitizeDNSLabel` function ensures the configured verification token key conforms to RFC 1035 DNS label rules, with automatic sanitization and a warning logged at startup if the value was adjusted.
- **Updated validation messages**: Error messages for expired and missing tokens now reference the specific subdomain path where the TXT record is expected.
<!-- kody-pr-summary:end -->