### PR TITLE
fix: make IPNS publish async in website CRUD and fix validation token overwrite bug

### DIFF
--- a/internal/api/dto/website.go
+++ b/internal/api/dto/website.go
@@ -371,32 +371,44 @@ type SSLStatusInfo struct {
 type WebsiteResponse struct {
 	ID                  uint           `json:"id"`
 	Domain              string         `json:"domain"`
+	// IPFS or IPNS
 	TargetType          string         `json:"target_type"`
+	// CID (IPFS) or peer ID (IPNS)
 	TargetHash          string         `json:"target_hash"`
-	IPNSKeyID           *uint          `json:"ipns_key_id,omitempty"`  // FK to the linked IPNS key (set when DNS hosting auto-creates a key)
-	ActiveCID           string         `json:"active_cid,omitempty"`   // The currently-published IPFS content CID (distinct from target_hash when target is IPNS)
+	// FK to the linked IPNS key (set when DNS hosting auto-creates a key)
+	IPNSKeyID           *uint          `json:"ipns_key_id,omitempty"`
+	// The currently-published IPFS content CID (distinct from target_hash when target is IPNS)
+	ActiveCID           string         `json:"active_cid,omitempty"`
 	Status              string         `json:"status"`
-	ValidationToken       string     `json:"validation_token"`                      // The full TXT record value (e.g. "lumeweb-verify=abc123...")
-	ValidationRecordHost  string     `json:"validation_record_host,omitempty"`     // The DNS hostname for the TXT record (e.g. "lumeweb-verify.example.com")
+	// The full TXT record value (e.g. "lumeweb-verify=abc123...")
+	ValidationToken       string     `json:"validation_token"`
+	// The DNS hostname for the TXT record (e.g. "lumeweb-verify.example.com")
+	ValidationRecordHost  string     `json:"validation_record_host,omitempty"`
 	ValidationExpiresAt *time.Time     `json:"validation_expires_at,omitempty"`
 	LastCheckedAt       *time.Time     `json:"last_checked_at,omitempty"`
+	// FK to the DNS zone hosting this website's records
 	DNSZoneID           *uint          `json:"dns_zone_id,omitempty"`
+	// Whether DNS hosting (zone + records) is enabled for this website
 	Enabled             bool           `json:"dns_hosting_enabled"`
+	// True if domain is a subdomain of a shared DNS zone
 	IsSubdomain         bool           `json:"is_subdomain"`
+	// Gateway domain for constructing public URLs (e.g. ipfs.example.com)
 	GatewayDomain       string         `json:"gateway_domain,omitempty"`
 	Created             time.Time      `json:"created"`
 	Updated             time.Time      `json:"updated"`
-	Expired             bool            `json:"expired"` // Whether validation token has expired
+	// Whether validation token has expired
+	Expired             bool            `json:"expired"`
 	SSL                 *SSLStatusInfo  `json:"ssl,omitempty"`
+	// Set by SetValidationRecordInfo; consumed by FromModel to format ValidationToken/ValidationRecordHost
+	tokenKey            string
 }
 
 func (r *WebsiteResponse) FromModel(model *db.Website) error {
 	r.ID = model.ID
 	r.Domain = model.Domain
 	r.TargetType = model.TargetType
-	r.TargetHash = model.TargetHash() // Use helper to generate string from multihash
+	r.TargetHash = model.TargetHash() // helper generates string from multihash
 	r.Status = model.Status
-	r.ValidationToken = model.ValidationToken
 	r.ValidationExpiresAt = model.ValidationExpiresAt
 	r.LastCheckedAt = model.LastCheckedAt
 	r.DNSZoneID = model.DNSZoneID
@@ -405,6 +417,13 @@ func (r *WebsiteResponse) FromModel(model *db.Website) error {
 	r.Created = model.CreatedAt
 	r.Updated = model.UpdatedAt
 	r.Expired = model.IsExpired()
+
+	if r.tokenKey != "" && model.ValidationToken != "" {
+		r.ValidationToken = r.tokenKey + "=" + model.ValidationToken
+		r.ValidationRecordHost = r.tokenKey + "." + model.Domain
+	} else {
+		r.ValidationToken = model.ValidationToken
+	}
 
 	if model.SSLStatus != "" {
 		var lastUpdated *time.Time
@@ -452,8 +471,7 @@ func (r *WebsiteResponse) SetSubdomainInfo(zoneDomain string) {
 }
 
 func (r *WebsiteResponse) SetValidationRecordInfo(tokenKey string) {
-	r.ValidationRecordHost = tokenKey + "." + r.Domain
-	r.ValidationToken = tokenKey + "=" + r.ValidationToken
+	r.tokenKey = tokenKey
 }
 
 // WebsiteValidateResponse represents a website validation response

--- a/internal/api/dto/website_test.go
+++ b/internal/api/dto/website_test.go
@@ -643,3 +643,48 @@ func TestWebsiteResponse_FromModel_SSL_NotPopulated(t *testing.T) {
 		assert.Equal(t, now, resp.Updated)
 	})
 }
+
+func TestWebsiteResponse_SetValidationRecordInfo(t *testing.T) {
+	now := time.Now()
+
+	model := &db.Website{
+		ID:              1,
+		Domain:          "dev.pinner.xyz",
+		TargetType:      string(db.WebsiteTargetTypeIPFS),
+		Status:          string(db.WebsiteStatusActive),
+		ValidationToken: "abc123",
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+
+	t.Run("formats validation_token and validation_record_host when tokenKey is set", func(t *testing.T) {
+		resp := &WebsiteResponse{}
+		resp.SetValidationRecordInfo("lumeweb-verify")
+		err := resp.FromModel(model)
+		require.NoError(t, err)
+		assert.Equal(t, "lumeweb-verify=abc123", resp.ValidationToken)
+		assert.Equal(t, "lumeweb-verify.dev.pinner.xyz", resp.ValidationRecordHost)
+	})
+
+	t.Run("returns raw validation_token when tokenKey is not set", func(t *testing.T) {
+		resp := &WebsiteResponse{}
+		err := resp.FromModel(model)
+		require.NoError(t, err)
+		assert.Equal(t, "abc123", resp.ValidationToken)
+		assert.Empty(t, resp.ValidationRecordHost)
+	})
+
+	t.Run("formats survive EncodeResponse re-calling FromModel", func(t *testing.T) {
+		resp := &WebsiteResponse{}
+		resp.SetValidationRecordInfo("lumeweb-verify")
+		err := resp.FromModel(model)
+		require.NoError(t, err)
+		assert.Equal(t, "lumeweb-verify=abc123", resp.ValidationToken)
+		assert.Equal(t, "lumeweb-verify.dev.pinner.xyz", resp.ValidationRecordHost)
+
+		err = resp.FromModel(model)
+		require.NoError(t, err)
+		assert.Equal(t, "lumeweb-verify=abc123", resp.ValidationToken)
+		assert.Equal(t, "lumeweb-verify.dev.pinner.xyz", resp.ValidationRecordHost)
+	})
+}

--- a/internal/service/website/website.go
+++ b/internal/service/website/website.go
@@ -1363,6 +1363,15 @@ func (s *WebsiteServiceDefault) ensureIPNSKey(ctx context.Context, userID uint, 
 }
 
 func (s *WebsiteServiceDefault) publishCIDAsync(ctx context.Context, peerID, cid, domain string) {
+	defer func() {
+		if r := recover(); r != nil {
+			s.Logger().Error("Recovered from panic in publishCIDAsync",
+				zap.Any("panic", r),
+				zap.String("domain", domain),
+				zap.String("peer_id", peerID),
+				zap.String("cid", cid))
+		}
+	}()
 	if err := s.ipnsKeySvc.PublishCID(core.DetachContext(ctx), peerID, cid, 24*time.Hour); err != nil {
 		s.Logger().Error("Failed to publish CID to IPNS key (async)",
 			zap.Error(err),

--- a/internal/service/website/website.go
+++ b/internal/service/website/website.go
@@ -622,22 +622,7 @@ func (s *WebsiteServiceDefault) UpdateWebsite(ctx context.Context, userID uint, 
 						if publishHash == "" {
 							publishHash = website.TargetHash()
 						}
-
-						// Publish the new CID to the IPNS key
-						ttl := 24 * time.Hour
-						err = s.ipnsKeySvc.PublishCID(ctx, ipnsKey.PeerID().String(), publishHash, ttl)
-						if err != nil {
-							s.Logger().Error("Failed to republish new CID to IPNS key",
-								zap.Error(err),
-								zap.String("domain", website.Domain),
-								zap.String("peer_id", ipnsKey.PeerID().String()),
-								zap.String("cid", publishHash))
-						} else {
-							s.Logger().Info("Republished new CID to IPNS key",
-								zap.String("domain", website.Domain),
-								zap.String("peer_id", ipnsKey.PeerID().String()),
-								zap.String("cid", publishHash))
-						}
+						go s.publishCIDAsync(ctx, ipnsKey.PeerID().String(), publishHash, website.Domain)
 					}
 				}
 
@@ -1371,23 +1356,25 @@ func (s *WebsiteServiceDefault) ensureIPNSKey(ctx context.Context, userID uint, 
 	}
 
 	if s.ipnsKeySvc != nil && publishCID != "" {
-		ttl := 24 * time.Hour
-		err = s.ipnsKeySvc.PublishCID(ctx, ipnsKey.PeerID().String(), publishCID, ttl)
-		if err != nil {
-			s.Logger().Error("Failed to publish CID to IPNS key",
-				zap.Error(err),
-				zap.String("domain", domain),
-				zap.String("peer_id", ipnsKey.PeerID().String()),
-				zap.String("cid", publishCID))
-		} else {
-			s.Logger().Info("Published CID to IPNS key",
-				zap.String("domain", domain),
-				zap.String("peer_id", ipnsKey.PeerID().String()),
-				zap.String("cid", publishCID))
-		}
+		go s.publishCIDAsync(ctx, ipnsKey.PeerID().String(), publishCID, domain)
 	}
 
 	return ipnsKey, nil
+}
+
+func (s *WebsiteServiceDefault) publishCIDAsync(ctx context.Context, peerID, cid, domain string) {
+	if err := s.ipnsKeySvc.PublishCID(core.DetachContext(ctx), peerID, cid, 24*time.Hour); err != nil {
+		s.Logger().Error("Failed to publish CID to IPNS key (async)",
+			zap.Error(err),
+			zap.String("domain", domain),
+			zap.String("peer_id", peerID),
+			zap.String("cid", cid))
+	} else {
+		s.Logger().Info("Published CID to IPNS key (async)",
+			zap.String("domain", domain),
+			zap.String("peer_id", peerID),
+			zap.String("cid", cid))
+	}
 }
 
 // setIPNSTargetUpdates populates the updates map with IPNS target fields


### PR DESCRIPTION
Website create/update were blocking 10-20s on DHT publish. Move PublishCID calls in ensureIPNSKey and UpdateWebsite to background goroutines via publishCIDAsync helper. Uses DetachContext to decouple from HTTP request lifecycle. Hourly republisher acts as safety net for failed publishes.

Also fix EncodeResponse overwriting SetValidationRecordInfo values: FromModel re-ran inside EncodeResponse wiped the formatted validation\_token (key=token) and validation\_record\_host (key.domain). Move formatting into FromModel via tokenKey field so values survive the re-call. Explicit /api/ipns/publish and republisher remain synchronous.

- `develop` <!-- branch-stack -->
  - **fix: make IPNS publish async in website CRUD and fix validation token overwrite bug** :point\_left:

***

<!-- kody-pr-summary:start -->

This PR fixes two issues:

1. **Validation token overwrite bug**: Previously, `SetValidationRecordInfo` would format the `ValidationToken` and `ValidationRecordHost` fields, but a subsequent call to `FromModel` would overwrite the formatted token with the raw model value. The fix stores the `tokenKey` in a private field and defers formatting to `FromModel`, ensuring the formatted values survive multiple `FromModel` calls (e.g., when `EncodeResponse` re-processes the response).

2. **Async IPNS publishing**: IPNS `PublishCID` calls in `UpdateWebsite` and `ensureIPNSKey` are now executed asynchronously via a new `publishCIDAsync` helper using a detached context. This prevents IPNS publish latency from blocking website CRUD operations.

<!-- kody-pr-summary:end -->
