### PR TITLE
fix: normalize CID to v1 at IPNS publish write boundary

### DIFF
--- a/internal/service/ipns_key/ipns_key.go
+++ b/internal/service/ipns_key/ipns_key.go
@@ -24,6 +24,7 @@ import (
 	pluginDb "go.lumeweb.com/portal-plugin-ipfs/internal/db"
 	pluginConfig "go.lumeweb.com/portal-plugin-ipfs/internal/config"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/protocol"
+	"go.lumeweb.com/portal-plugin-ipfs/internal/protocol/encoding"
 	"go.lumeweb.com/portal/core"
 	"go.lumeweb.com/portal/db"
 	"go.uber.org/zap"
@@ -664,6 +665,9 @@ func (s *IPNSKeyServiceDefault) PublishWithKey(ctx context.Context, privKey ic.P
 		return fmt.Errorf("invalid CID %s: %w", cidStr, err)
 	}
 
+	// Normalize to v1 for consistent storage
+	normalizedCID := encoding.NormalizeCid(targetCid).String()
+
 	// Create an IPNS path from the CID
 	ipnsPath := path.FromCid(targetCid)
 
@@ -695,7 +699,7 @@ func (s *IPNSKeyServiceDefault) PublishWithKey(ctx context.Context, privKey ic.P
 		if findResult := tx.Where("peer_id_multihash = ?", mh.Multihash(peerID)).First(&key); findResult.Error != nil {
 			return findResult
 		}
-		key.LastPublishedCID = cidStr
+		key.LastPublishedCID = normalizedCID
 		key.LastPublishedAt = now
 		return tx.Model(&key).Select("last_published_cid", "last_published_at").Updates(&key)
 	})

--- a/internal/service/ipns_key/ipns_key.go
+++ b/internal/service/ipns_key/ipns_key.go
@@ -665,11 +665,12 @@ func (s *IPNSKeyServiceDefault) PublishWithKey(ctx context.Context, privKey ic.P
 		return fmt.Errorf("invalid CID %s: %w", cidStr, err)
 	}
 
-	// Normalize to v1 for consistent storage
-	normalizedCID := encoding.NormalizeCid(targetCid).String()
+	// Normalize to v1 for consistent storage and publishing
+	normalizedCid := encoding.NormalizeCid(targetCid)
+	normalizedCID := normalizedCid.String()
 
-	// Create an IPNS path from the CID
-	ipnsPath := path.FromCid(targetCid)
+	// Create an IPNS path from the normalized CID
+	ipnsPath := path.FromCid(normalizedCid)
 
 	// Build publish options
 	var options []namesys.PublishOption


### PR DESCRIPTION
LastPublishedCID was stored as the raw cidStr parameter from callers, which could be CIDv0 (Qm...). Website.TargetHash() reconstructs v0 when CIDVersion==0, and ExtractCIDFromPathStrict may return v0 from IPNS record paths. All three sources flow through PublishWithKey.

Normalize via encoding.NormalizeCid() in PublishWithKey before writing to DB. This fixes the root cause at the single write boundary, making response-level normalization unnecessary.

- `develop` <!-- branch-stack -->
  - **fix: normalize CID to v1 at IPNS publish write boundary** :point\_left:

***

<!-- kody-pr-summary:start -->

Normalize CID to v1 format when storing the last published CID in the database during IPNS key publication. This ensures consistent storage regardless of whether the input CID was provided in v0 or v1 format, preventing duplicate or mismatched CID representations in the `LastPublishedCID` field.

<!-- kody-pr-summary:end -->
