### PR TITLE
fix: resolve content resolution bottlenecks

### DIFF
--- a/core/website.go
+++ b/core/website.go
@@ -65,4 +65,7 @@ type WebsiteService interface {
 
 	// UpdateSSLStatus updates the SSL certificate status for a website domain
 	UpdateSSLStatus(ctx context.Context, domain string, status pluginDb.SSLStatus, sslError string, timestamp *time.Time) (*pluginDb.Website, error)
+
+	// WaitForPublishes blocks until all in-flight async publish operations complete
+	WaitForPublishes()
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -81,7 +81,7 @@ func (b BlockStore) Defaults() map[string]any {
 func (I IPFSProvider) Defaults() map[string]any {
 	return map[string]any{
 		"BatchSize": 5000,
-		"Interval":  18 * time.Hour,
+		"Interval":  4 * time.Hour,
 		"Timeout":   30 * time.Minute,
 	}
 }

--- a/internal/protocol/ipfs/node.go
+++ b/internal/protocol/ipfs/node.go
@@ -42,6 +42,7 @@ import (
 	"github.com/ipfs/boxo/namesys"
 	blocks "github.com/ipfs/go-block-format"
 	format "github.com/ipfs/go-ipld-format"
+	"github.com/avast/retry-go/v5"
 	"github.com/libp2p/go-libp2p"
 	dht "github.com/libp2p/go-libp2p-kad-dht"
 	"github.com/libp2p/go-libp2p-kad-dht/fullrt"
@@ -91,6 +92,7 @@ type IPFSNode interface {
 	AddPeer(addr peer.AddrInfo)
 	Pin(ctx context.Context, root cid.Cid, recursive bool) error
 	TriggerReprovider()
+	ProvideCID(ctx context.Context, c cid.Cid) error
 	GetPublisher() pluginCore.IPNSPublisher
 	GetKeystore() keystore.Keystore
 	GetDatastore() datastore.Datastore
@@ -101,18 +103,32 @@ type IPFSNode interface {
 	Port() int
 }
 
-// NopExchange wraps an exchange.Interface and disables NotifyNewBlocks.
-// This prevents the node from announcing new blocks to the network,
-// because we want to selectively control when blocks are announced,
-// thus we make NotifyNewBlocks a no-op.
-type NopExchange struct {
-	exchange.Interface
+// BlockReadyChecker checks if a block is ready to be announced to the network.
+// This gates bitswap NotifyNewBlocks on the Ready column in the metadata store.
+type BlockReadyChecker interface {
+	BlockExists(ctx context.Context, c cid.Cid) error
 }
 
-func (n *NopExchange) NotifyNewBlocks(ctx context.Context, blocks ...blocks.Block) error {
-	ctx, span := core.TraceMethod(ctx, "NopExchange.NotifyNewBlocks")
-	defer span.End()
+// ReadyAwareExchange wraps an exchange.Interface and gates NotifyNewBlocks
+// on the block's Ready status. Only blocks that have been confirmed as ready
+// (via the metadata store's Ready column) are forwarded to the underlying
+// exchange. This prevents announcing blocks that are still being uploaded
+// while allowing immediate bitswap announcements for confirmed blocks.
+type ReadyAwareExchange struct {
+	exchange.Interface
+	readyChecker BlockReadyChecker
+}
 
+func (r *ReadyAwareExchange) NotifyNewBlocks(ctx context.Context, blks ...blocks.Block) error {
+	var readyBlocks []blocks.Block
+	for _, b := range blks {
+		if r.readyChecker.BlockExists(ctx, b.Cid()) == nil {
+			readyBlocks = append(readyBlocks, b)
+		}
+	}
+	if len(readyBlocks) > 0 {
+		return r.Interface.NotifyNewBlocks(ctx, readyBlocks...)
+	}
 	return nil
 }
 
@@ -125,12 +141,13 @@ type NodeFactory struct {
 	datastore       datastore.Batching
 	blockstore      blockstore.Blockstore
 	peerTracker     *BlockRequestTracker
+	readyChecker    BlockReadyChecker
 	bootstrapPeers  []peer.AddrInfo
 	bootstrapMutex  sync.RWMutex
 }
 
 // NewNodeFactory creates a new node factory with the given shared components
-func NewNodeFactory(ctx core.Context, cfg *config.ProtocolConfig, rs pluginCore.ReprovideStore, ds datastore.Batching, bs blockstore.Blockstore, peerTracker *BlockRequestTracker) *NodeFactory {
+func NewNodeFactory(ctx core.Context, cfg *config.ProtocolConfig, rs pluginCore.ReprovideStore, ds datastore.Batching, bs blockstore.Blockstore, peerTracker *BlockRequestTracker, readyChecker BlockReadyChecker) *NodeFactory {
 	factory := &NodeFactory{
 		ctx:            ctx,
 		cfg:            cfg,
@@ -138,6 +155,7 @@ func NewNodeFactory(ctx core.Context, cfg *config.ProtocolConfig, rs pluginCore.
 		datastore:      ds,
 		blockstore:     bs,
 		peerTracker:    peerTracker,
+		readyChecker:   readyChecker,
 		bootstrapPeers: make([]peer.AddrInfo, 0),
 		bootstrapMutex: sync.RWMutex{},
 	}
@@ -176,7 +194,7 @@ func (f *NodeFactory) GetBootstrapPeers() []peer.AddrInfo {
 
 // CreateNode creates a new IPFS node instance using the factory's configuration
 func (f *NodeFactory) CreateNode() (*Node, error) {
-	return NewNode(f.ctx, f.cfg, f.reprovideStore, f.datastore, f.blockstore, f.peerTracker, f)
+	return NewNode(f.ctx, f.cfg, f.reprovideStore, f.datastore, f.blockstore, f.peerTracker, f.readyChecker, f)
 }
 
 // A Node is a minimal IPFS node
@@ -375,7 +393,7 @@ func (n *Node) Pin(ctx context.Context, root cid.Cid, recursive bool) error {
 }
 
 // NewNode creates a new IPFS node
-func NewNode(ctx core.Context, cfg *config.ProtocolConfig, rs pluginCore.ReprovideStore, ds datastore.Batching, bs blockstore.Blockstore, peerTracker *BlockRequestTracker, factory *NodeFactory) (*Node, error) {
+func NewNode(ctx core.Context, cfg *config.ProtocolConfig, rs pluginCore.ReprovideStore, ds datastore.Batching, bs blockstore.Blockstore, peerTracker *BlockRequestTracker, readyChecker BlockReadyChecker, factory *NodeFactory) (*Node, error) {
 	hasher := hkdf.New(sha256.New, ctx.Config().Config().Core.Identity.PrivateKey(), ctx.Config().Config().Core.NodeID.Bytes(), []byte(internal.ProtocolName))
 	derivedSeed := make([]byte, 32)
 
@@ -553,8 +571,21 @@ func NewNode(ctx core.Context, cfg *config.ProtocolConfig, rs pluginCore.Reprovi
 		if dhtErr != nil {
 			return nil, fmt.Errorf("failed to create companion DHT: %w", dhtErr)
 		}
-		if err := companion.Bootstrap(ctx); err != nil {
-			ctx.Logger().Warn("failed to bootstrap companion DHT", zap.Error(err))
+		err := retry.New(
+			retry.Attempts(5),
+			retry.Delay(5*time.Second),
+			retry.DelayType(retry.BackOffDelay),
+			retry.OnRetry(func(n uint, err error) {
+				ctx.Logger().Warn("failed to bootstrap companion DHT, retrying",
+					zap.Error(err),
+					zap.Uint("attempt", n+1))
+			}),
+		).Do(func() error {
+			return companion.Bootstrap(ctx)
+		})
+		if err != nil {
+			ctx.Logger().Error("failed to bootstrap companion DHT after retries",
+				zap.Error(err))
 		}
 		ipfsNode.companionDHT = companion
 
@@ -605,10 +636,9 @@ func NewNode(ctx core.Context, cfg *config.ProtocolConfig, rs pluginCore.Reprovi
 	bitswapNet := bsnet.NewFromIpfsHost(node)
 	_bitswap := bitswap.New(ctx, bitswapNet, routingImpl, bs, bitswapOpts...)
 
-	// Wrap the bitswap exchange with NopExchange to disable automatic block announcements
-	nopExchange := &NopExchange{_bitswap}
+	readyExchange := &ReadyAwareExchange{Interface: _bitswap, readyChecker: readyChecker}
 
-	blockServ := blockservice.New(bs, nopExchange)
+	blockServ := blockservice.New(bs, readyExchange)
 	dagService := merkledag.NewDAGService(blockServ)
 
 	for _, p := range cfg.Peers {
@@ -680,6 +710,13 @@ func NewNode(ctx core.Context, cfg *config.ProtocolConfig, rs pluginCore.Reprovi
 }
 func (n *Node) TriggerReprovider() {
 	n.reprovider.Trigger()
+}
+
+func (n *Node) ProvideCID(ctx context.Context, c cid.Cid) error {
+	if n.companionDHT != nil {
+		return n.companionDHT.Provide(ctx, c, true)
+	}
+	return n.routing.Provide(ctx, c, true)
 }
 
 func AnnouncementAddresses(announceWeb bool, domain string, hostAddrs []multiaddr.Multiaddr, configPort int) ([]multiaddr.Multiaddr, error) {

--- a/internal/protocol/ipfs/provide.go
+++ b/internal/protocol/ipfs/provide.go
@@ -242,7 +242,7 @@ func NewReprovider(provider pluginCore.Provider, store pluginCore.ReprovideStore
 		store:                store,
 		log:                  log,
 		triggerProvide:       make(chan struct{}, 1),
-		triggerDelayDuration: 30 * time.Second,
+		triggerDelayDuration: 2 * time.Second,
 		reprovideSleep:       time.Duration(0),
 		cancelTrigger:        make(chan struct{}),
 	}

--- a/internal/protocol/ipfs/provide_test.go
+++ b/internal/protocol/ipfs/provide_test.go
@@ -205,7 +205,7 @@ func TestNewReprovider(t *testing.T) {
 
 	assert.NotNil(t, reprovider)
 	assert.NotNil(t, reprovider.triggerProvide)
-	assert.Equal(t, 30*time.Second, reprovider.triggerDelayDuration)
+	assert.Equal(t, 2*time.Second, reprovider.triggerDelayDuration)
 	assert.Equal(t, time.Duration(0), reprovider.reprovideSleep)
 }
 

--- a/internal/protocol/op_publish.go
+++ b/internal/protocol/op_publish.go
@@ -3,6 +3,7 @@ package protocol
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"go.lumeweb.com/portal-plugin-ipfs/internal"
 	"go.lumeweb.com/portal/core"
@@ -26,16 +27,28 @@ func (h *PublishOperationHandler) ValidateRequest(ctx context.Context, req *mode
 }
 
 func (h *PublishOperationHandler) Execute(ctx context.Context, req *models.Request) error {
-	// Initialize progress tracker with manual mode for simple milestones
 	tracker, err := InitializeManualProgressTracker(h, req.ID, core.OpTypePublish, 10)
 	if err != nil {
 		return err
 	}
 
-	// Trigger the reprovider to announce the content
-	h.Protocol().(*Protocol).GetNode().TriggerReprovider()
+	node := h.Protocol().(*Protocol).GetNode()
 
-	// Complete
+	if len(req.Hash) > 0 {
+		c, cErr := internal.CIDFromHash(req.Hash, req.CIDType)
+		if cErr == nil {
+			go func() {
+				provideCtx, cancel := context.WithTimeout(core.DetachContext(ctx), 30*time.Second)
+				defer cancel()
+				if err := node.ProvideCID(provideCtx, c); err != nil {
+					h.Logger().Warn("direct DHT provide failed", zap.Error(err), zap.Stringer("cid", c))
+				}
+			}()
+		}
+	}
+
+	node.TriggerReprovider()
+
 	if err := tracker.SetProgress(100); err != nil {
 		h.Logger().Warn("Failed to update progress", zap.Error(err))
 	}

--- a/internal/protocol/protocol.go
+++ b/internal/protocol/protocol.go
@@ -361,7 +361,7 @@ func NewProtocol() (core.Protocol, []core.ContextBuilderOption, error) {
 				zap.String("mapped_level", level.String()))
 
 			// Create node factory for managing node lifecycle and bootstrap peers
-			proto.nodeFactory = ipfs.NewNodeFactory(ctx, cfg, ms, _ds, virtualBS, peerTracker)
+			proto.nodeFactory = ipfs.NewNodeFactory(ctx, cfg, ms, _ds, virtualBS, peerTracker, ms)
 
 			// Create initial node instance
 			proto.node, err = proto.nodeFactory.CreateNode()

--- a/internal/service/website/website.go
+++ b/internal/service/website/website.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 
 	dnslink "github.com/dnslink-std/go"
@@ -64,13 +65,14 @@ var (
 // WebsiteServiceDefault implements the WebsiteService interface
 type WebsiteServiceDefault struct {
 	*core.BaseComponent
-	pinSvc     pluginCore.IPFSPinService
-	ipnsKeySvc pluginCore.IPNSKeyService
-	mailerSvc  core.MailerService
-	dnsSvc     pluginCore.DNSService
-	config     *pluginConfig.WebsiteConfig
-	dnsConfig  *pluginConfig.DnsConfig
-	resolver   DNSResolver
+	pinSvc       pluginCore.IPFSPinService
+	ipnsKeySvc   pluginCore.IPNSKeyService
+	mailerSvc    core.MailerService
+	dnsSvc       pluginCore.DNSService
+	config       *pluginConfig.WebsiteConfig
+	dnsConfig    *pluginConfig.DnsConfig
+	resolver     DNSResolver
+	publishWg    sync.WaitGroup
 }
 
 // Ensure WebsiteServiceDefault implements the interface
@@ -622,7 +624,7 @@ func (s *WebsiteServiceDefault) UpdateWebsite(ctx context.Context, userID uint, 
 						if publishHash == "" {
 							publishHash = website.TargetHash()
 						}
-						go s.publishCIDAsync(ctx, ipnsKey.PeerID().String(), publishHash, website.Domain)
+						s.publishCIDAsync(ctx, ipnsKey.PeerID().String(), publishHash, website.Domain)
 					}
 				}
 
@@ -1356,34 +1358,42 @@ func (s *WebsiteServiceDefault) ensureIPNSKey(ctx context.Context, userID uint, 
 	}
 
 	if s.ipnsKeySvc != nil && publishCID != "" {
-		go s.publishCIDAsync(ctx, ipnsKey.PeerID().String(), publishCID, domain)
+		s.publishCIDAsync(ctx, ipnsKey.PeerID().String(), publishCID, domain)
 	}
 
 	return ipnsKey, nil
 }
 
 func (s *WebsiteServiceDefault) publishCIDAsync(ctx context.Context, peerID, cid, domain string) {
-	defer func() {
-		if r := recover(); r != nil {
-			s.Logger().Error("Recovered from panic in publishCIDAsync",
-				zap.Any("panic", r),
+	s.publishWg.Add(1)
+	go func() {
+		defer s.publishWg.Done()
+		defer func() {
+			if r := recover(); r != nil {
+				s.Logger().Error("Recovered from panic in publishCIDAsync",
+					zap.Any("panic", r),
+					zap.String("domain", domain),
+					zap.String("peer_id", peerID),
+					zap.String("cid", cid))
+			}
+		}()
+		if err := s.ipnsKeySvc.PublishCID(core.DetachContext(ctx), peerID, cid, 24*time.Hour); err != nil {
+			s.Logger().Error("Failed to publish CID to IPNS key (async)",
+				zap.Error(err),
+				zap.String("domain", domain),
+				zap.String("peer_id", peerID),
+				zap.String("cid", cid))
+		} else {
+			s.Logger().Info("Published CID to IPNS key (async)",
 				zap.String("domain", domain),
 				zap.String("peer_id", peerID),
 				zap.String("cid", cid))
 		}
 	}()
-	if err := s.ipnsKeySvc.PublishCID(core.DetachContext(ctx), peerID, cid, 24*time.Hour); err != nil {
-		s.Logger().Error("Failed to publish CID to IPNS key (async)",
-			zap.Error(err),
-			zap.String("domain", domain),
-			zap.String("peer_id", peerID),
-			zap.String("cid", cid))
-	} else {
-		s.Logger().Info("Published CID to IPNS key (async)",
-			zap.String("domain", domain),
-			zap.String("peer_id", peerID),
-			zap.String("cid", cid))
-	}
+}
+
+func (s *WebsiteServiceDefault) WaitForPublishes() {
+	s.publishWg.Wait()
 }
 
 // setIPNSTargetUpdates populates the updates map with IPNS target fields

--- a/internal/service/website/website_test.go
+++ b/internal/service/website/website_test.go
@@ -386,6 +386,7 @@ func TestWebsiteService_CreateWebsite_IPNSTargetWithPlainCID_AutoConvert(t *test
 
 		// Act
 		createdWebsite, err := websiteService.CreateWebsite(context.Background(), website)
+  websiteService.WaitForPublishes()
 
 		// Assert
 		require.NoError(tb, err)
@@ -1202,6 +1203,7 @@ func TestWebsiteService_CreateWebsite_DNSZoneCreatedWhenEnabled(t *testing.T) {
 		).Return(nil).Once()
 
 		createdWebsite, err := websiteService.CreateWebsite(context.Background(), website)
+  websiteService.WaitForPublishes()
 
 		// Assert
 		require.NoError(tb, err)
@@ -1261,6 +1263,7 @@ func TestWebsiteService_CreateWebsite_DNSRecordsCreated(t *testing.T) {
 		).Return(nil).Once()
 
 		createdWebsite, err := websiteService.CreateWebsite(context.Background(), website)
+  websiteService.WaitForPublishes()
 
 		// Assert
 		require.NoError(tb, err)
@@ -1333,6 +1336,7 @@ func TestWebsiteService_DeleteWebsite_DNSRecordsCleanedUp(t *testing.T) {
 		).Return(nil).Once()
 
 		createdWebsite, err := websiteService.CreateWebsite(context.Background(), website)
+  websiteService.WaitForPublishes()
 		require.NoError(tb, err)
 		require.NotNil(tb, createdWebsite)
 
@@ -1379,6 +1383,7 @@ func TestWebsiteService_DeleteWebsite_DNSCleanupFailureDoesNotPreventDeletion(t 
 		).Return(nil).Once()
 
 		createdWebsite, err := websiteService.CreateWebsite(context.Background(), website)
+  websiteService.WaitForPublishes()
 		require.NoError(tb, err)
 		require.NotNil(tb, createdWebsite)
 
@@ -1493,6 +1498,7 @@ func TestWebsiteService_CreateWebsite_DNSHostingEnabled_CreatesZoneAndRecords(t 
 
 		// Act
 		createdWebsite, err := websiteService.CreateWebsite(context.Background(), website)
+  websiteService.WaitForPublishes()
 
 		// Assert
 		require.NoError(tb, err)
@@ -1534,6 +1540,7 @@ func TestWebsiteService_UpdateWebsite_DNSHostingEnabled_NoDNSUpdateWhenTargetUnc
 		).Return(nil).Once()
 
 		createdWebsite, err := websiteService.CreateWebsite(context.Background(), website)
+  websiteService.WaitForPublishes()
 		require.NoError(tb, err)
 
 		// Act - Update website without changing target (should NOT update DNS records)
@@ -1580,6 +1587,7 @@ func TestWebsiteService_DeleteWebsite_DNSHostingEnabled_ZoneRemainsAfterDeletion
 		).Return(nil).Once()
 
 		createdWebsite, err := websiteService.CreateWebsite(context.Background(), website)
+  websiteService.WaitForPublishes()
 		require.NoError(tb, err)
 
 		// Mock DNS records deletion
@@ -1733,6 +1741,7 @@ func TestWebsiteService_CreateWebsite_DNSZoneCreationFailure_ContinuesWithoutDNS
 
 		// Act - Create website with DNS zone creation failure
 		createdWebsite, err := websiteService.CreateWebsite(context.Background(), website)
+  websiteService.WaitForPublishes()
 
 		// Assert - Website should still be created despite DNS failure
 		require.NoError(tb, err)
@@ -1779,6 +1788,7 @@ func TestWebsiteService_CreateWebsite_DNSRecordsCreationFailure_ContinuesWithout
 
 		// Act - Create website with DNS records creation failure
 		createdWebsite, err := websiteService.CreateWebsite(context.Background(), website)
+  websiteService.WaitForPublishes()
 
 		// Assert - Website should still be created with zone ID set
 		require.NoError(tb, err)
@@ -1841,6 +1851,7 @@ func TestWebsiteService_CreateWebsite_IPNSKeyAutoCreation_NoDuplicate(t *testing
 		website1 := createTestIPFSWebsite(testUserID1, domain, testCID.String())
 		website1.Enabled = true // Enable DNS hosting
 		createdWebsite1, err := websiteService.CreateWebsite(context.Background(), website1)
+  websiteService.WaitForPublishes()
 		require.NoError(tb, err)
 
 		// Assert - IPNS key was created
@@ -1987,6 +1998,7 @@ func TestWebsiteService_UpdateWebsite_DisableDNSHostingTransition(t *testing.T) 
 		setupDNSZoneCreationMocks(t, mockDNS, testZoneID, domain, testUserID1)
 
 		createdWebsite, err := websiteService.CreateWebsite(context.Background(), website)
+  websiteService.WaitForPublishes()
 		require.NoError(tb, err)
 		require.NotNil(tb, createdWebsite)
 		assert.True(t, createdWebsite.Enabled)
@@ -2105,6 +2117,7 @@ func TestWebsiteService_UpdateWebsite_DNSEnableToggleOffOn(t *testing.T) {
 		setupDNSZoneCreationMocks(t, mockDNS, testZoneID, domain, testUserID1)
 
 		createdWebsite, err := websiteService.CreateWebsite(context.Background(), website)
+  websiteService.WaitForPublishes()
 		require.NoError(tb, err)
 		require.NotNil(tb, createdWebsite)
 		assert.True(t, createdWebsite.Enabled)
@@ -2156,6 +2169,7 @@ func TestWebsiteService_UpdateWebsite_DisableDNSHostingDeleteZoneFails(t *testin
 		setupDNSZoneCreationMocks(t, mockDNS, testZoneID, domain, testUserID1)
 
 		createdWebsite, err := websiteService.CreateWebsite(context.Background(), website)
+  websiteService.WaitForPublishes()
 		require.NoError(tb, err)
 		require.NotNil(tb, createdWebsite)
 		assert.NotNil(t, createdWebsite.DNSZoneID)
@@ -2311,6 +2325,7 @@ func TestWebsiteService_UpdateWebsite_ConvertIPNSToIPFS_UpdatesDNSRecords(t *tes
 		).Return(nil).Once()
 
 		createdWebsite, err := websiteService.CreateWebsite(context.Background(), website)
+  websiteService.WaitForPublishes()
 		require.NoError(tb, err)
 		require.NotNil(tb, createdWebsite)
 		assert.Equal(tb, string(pluginDb.WebsiteTargetTypeIPNS), createdWebsite.TargetType)
@@ -2377,6 +2392,7 @@ func TestWebsiteService_UpdateWebsite_IPNSToIPNS_NoDNSUpdate(t *testing.T) {
 		).Return(nil).Once()
 
 		createdWebsite, err := websiteService.CreateWebsite(context.Background(), website)
+  websiteService.WaitForPublishes()
 		require.NoError(tb, err)
 		require.NotNil(tb, createdWebsite)
 
@@ -2432,6 +2448,7 @@ func TestWebsiteService_UpdateWebsite_ConvertIPFSToIPNS_UpdatesDNSRecords(t *tes
 		).Return(nil).Once()
 
 		createdWebsite, err := websiteService.CreateWebsite(context.Background(), website)
+  websiteService.WaitForPublishes()
 		require.NoError(tb, err)
 		require.NotNil(tb, createdWebsite)
 		require.NotNil(tb, createdWebsite.DNSZoneID)
@@ -2508,6 +2525,7 @@ func TestWebsiteService_UpdateWebsite_TargetTypeIPNSAlone(t *testing.T) {
 		}
 
 		updatedWebsite, err := websiteService.UpdateWebsite(context.Background(), testUserID1, createdWebsite.ID, updates)
+  websiteService.WaitForPublishes()
 
 		require.NoError(tb, err)
 		require.NotNil(tb, updatedWebsite)
@@ -2553,6 +2571,7 @@ func TestWebsiteService_UpdateWebsite_TargetTypeIPNSAlone_DNSRecordsUpdated(t *t
 		).Return(nil).Once()
 
 		updatedWebsite, err := websiteService.UpdateWebsite(context.Background(), testUserID1, createdWebsite.ID, updates)
+  websiteService.WaitForPublishes()
 
 		require.NoError(tb, err)
 		require.NotNil(tb, updatedWebsite)
@@ -2584,6 +2603,7 @@ func TestWebsiteService_UpdateWebsite_IPNSTargetTypeWithCID(t *testing.T) {
 		}
 
 		updatedWebsite, err := websiteService.UpdateWebsite(context.Background(), testUserID1, createdWebsite.ID, updates)
+  websiteService.WaitForPublishes()
 
 		require.NoError(tb, err)
 		require.NotNil(tb, updatedWebsite)
@@ -2618,6 +2638,7 @@ func TestWebsiteService_UpdateWebsite_IPNSToIPFSWithoutCID(t *testing.T) {
 		).Return(nil).Once()
 
 		createdWebsite, err := websiteService.CreateWebsite(context.Background(), website)
+  websiteService.WaitForPublishes()
 		require.NoError(tb, err)
 		assert.Equal(tb, string(pluginDb.WebsiteTargetTypeIPNS), createdWebsite.TargetType)
 

--- a/internal/testing/mocks/MockIPFSNode.go
+++ b/internal/testing/mocks/MockIPFSNode.go
@@ -1071,3 +1071,55 @@ func (_c *MockIPFSNode_TriggerReprovider_Call) RunAndReturn(run func()) *MockIPF
 	_c.Run(run)
 	return _c
 }
+
+func (_mock *MockIPFSNode) ProvideCID(ctx context.Context, c cid.Cid) error {
+	ret := _mock.Called(ctx, c)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ProvideCID")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, cid.Cid) error); ok {
+		r0 = returnFunc(ctx, c)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+type MockIPFSNode_ProvideCID_Call struct {
+	*mock.Call
+}
+
+func (_e *MockIPFSNode_Expecter) ProvideCID(ctx interface{}, c interface{}) *MockIPFSNode_ProvideCID_Call {
+	return &MockIPFSNode_ProvideCID_Call{Call: _e.mock.On("ProvideCID", ctx, c)}
+}
+
+func (_c *MockIPFSNode_ProvideCID_Call) Run(run func(ctx context.Context, c cid.Cid)) *MockIPFSNode_ProvideCID_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 cid.Cid
+		if args[1] != nil {
+			arg1 = args[1].(cid.Cid)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockIPFSNode_ProvideCID_Call) Return(err error) *MockIPFSNode_ProvideCID_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockIPFSNode_ProvideCID_Call) RunAndReturn(run func(ctx context.Context, c cid.Cid) error) *MockIPFSNode_ProvideCID_Call {
+	_c.Call.Return(run)
+	return _c
+}

--- a/internal/testing/mocks/MockWebsiteService.go
+++ b/internal/testing/mocks/MockWebsiteService.go
@@ -1199,6 +1199,39 @@ func (_c *MockWebsiteService_UpdateWebsite_Call) RunAndReturn(run func(ctx conte
 	return _c
 }
 
+// WaitForPublishes provides a mock function for the type MockWebsiteService
+func (_mock *MockWebsiteService) WaitForPublishes() {
+	_mock.Called()
+	return
+}
+
+// MockWebsiteService_WaitForPublishes_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'WaitForPublishes'
+type MockWebsiteService_WaitForPublishes_Call struct {
+	*mock.Call
+}
+
+// WaitForPublishes is a helper method to define mock.On call
+func (_e *MockWebsiteService_Expecter) WaitForPublishes() *MockWebsiteService_WaitForPublishes_Call {
+	return &MockWebsiteService_WaitForPublishes_Call{Call: _e.mock.On("WaitForPublishes")}
+}
+
+func (_c *MockWebsiteService_WaitForPublishes_Call) Run(run func()) *MockWebsiteService_WaitForPublishes_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockWebsiteService_WaitForPublishes_Call) Return() *MockWebsiteService_WaitForPublishes_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *MockWebsiteService_WaitForPublishes_Call) RunAndReturn(run func()) *MockWebsiteService_WaitForPublishes_Call {
+	_c.Run(run)
+	return _c
+}
+
 // ValidateDNS provides a mock function for the type MockWebsiteService
 func (_mock *MockWebsiteService) ValidateDNS(ctx context.Context, userID uint, websiteID uint) (core0.ValidateDNSResult, error) {
 	ret := _mock.Called(ctx, userID, websiteID)


### PR DESCRIPTION
Replace NopExchange with ReadyAwareExchange that gates bitswap NotifyNewBlocks on the Ready column, allowing immediate announcements for confirmed blocks while suppressing mid-upload blocks.

Reduce reprovider trigger delay from 30s to 2s for faster DHT announcement after pin completion. Reduce default interval from 18h to 4h for fresher provider records.

Add ProvideCID method for direct DHT announcement in PublishOperationHandler, bypassing the reprovider delay entirely. Uses companion DHT (server mode) when available, falls back to primary routing. Runs asynchronously with DetachContext to avoid blocking the workflow.

Upgrade companion DHT bootstrap failure from Warn to Error with 5 retries using avast/retry-go v5 with backoff delay. Without a bootstrapped companion DHT, this node cannot respond to inbound DHT queries in FullRT mode.

- `develop` <!-- branch-stack -->
  - **fix: resolve content resolution bottlenecks** :point\_left:

***

<!-- kody-pr-summary:start -->

This pull request resolves content resolution bottlenecks by making content discoverable on the IPFS network significantly faster and more reliably.

Key changes:

- **Replace NopExchange with ReadyAwareExchange**: Instead of completely suppressing bitswap block announcements (which prevented peers from discovering content via bitswap), blocks that are confirmed as "ready" in the metadata store are now immediately announced. Blocks still being uploaded remain suppressed until confirmed.

- **Add direct DHT provide on publish**: When content is published, the specific CID is now immediately provided to the DHT (via companion DHT if available) in a background goroutine, rather than waiting for the next reprovider cycle. This dramatically reduces the time before content is resolvable.

- **Reduce reprovider interval**: The IPFS provider interval was reduced from 18 hours to 4 hours, ensuring content is re-announced more frequently.

- **Reduce reprovider trigger delay**: The delay before the reprovider fires after being triggered was reduced from 30 seconds to 2 seconds.

- **Add retry logic for companion DHT bootstrap**: The companion DHT bootstrap now retries up to 5 times with exponential backoff instead of failing silently, improving network connectivity reliability.

<!-- kody-pr-summary:end -->
