### PR TITLE
fix: reject CIDv0 as valid IPNS target to prevent auto-conversion bypass

### DIFF
--- a/internal/api/dto/website_test.go
+++ b/internal/api/dto/website_test.go
@@ -543,6 +543,26 @@ func TestWebsiteRequest_ToModel_IPNS_WithPlainCID_AutoConvert(t *testing.T) {
 	assert.NotNil(t, model.TargetMultihash, "TargetMultihash should be set from the CID")
 }
 
+func TestWebsiteRequest_ToModel_IPNS_WithCIDv0_AutoConvert(t *testing.T) {
+	targetType := db.WebsiteTargetTypeIPNS
+	// CIDv0 (Qm...) accidentally passes peer.Decode since both use base58btc
+	// multihash encoding, but it's a content hash — should trigger auto-conversion.
+	req := WebsiteRequest{
+		Domain:     "example.com",
+		TargetType: targetType,
+		TargetHash: "QmWLqGsc1X914yZjFgqZ16uzPV69AZjrc4ioMemMhoHWee",
+	}
+
+	model, err := req.ToModel()
+	require.NoError(t, err)
+	assert.Equal(t, string(db.WebsiteTargetTypeIPNS), model.TargetType)
+	assert.NotNil(t, model.CIDVersion, "CIDVersion should be set for auto-conversion")
+	assert.NotNil(t, model.CIDType, "CIDType should be set for auto-conversion")
+	assert.NotNil(t, model.TargetMultihash, "TargetMultihash should be set from the CID")
+	// CIDv0 is normalized to v1, so CIDVersion should be 1, not 0
+	assert.Equal(t, uint8(1), *model.CIDVersion, "CIDv0 should be normalized to v1")
+}
+
 func TestWebsiteRequest_ToModel_IPNS_WithInvalidHash_Rejected(t *testing.T) {
 	targetType := db.WebsiteTargetTypeIPNS
 	req := WebsiteRequest{

--- a/internal/db/ipns_target.go
+++ b/internal/db/ipns_target.go
@@ -20,21 +20,27 @@ func NewIPNSTargetFromPeerID(pid peer.ID) (IPNSTarget, error) {
 	return IPNSTarget(mh), nil
 }
 
-// NewIPNSTargetFromString creates an IPNSTarget from a peer ID string or CIDv1 with libp2p-key codec
+// NewIPNSTargetFromString creates an IPNSTarget from a peer ID string or CIDv1 with libp2p-key codec.
+// CIDv0 strings are rejected because they accidentally pass peer.Decode (both use base58btc
+// multihash encoding), but a content hash is not a peer ID. Such CIDs should be handled
+// by the caller's auto-conversion path instead.
 func NewIPNSTargetFromString(s string) (IPNSTarget, error) {
-	// First try as peer ID string (base36)
+	// Check if it's a CID first.
+	// CIDv0 accidentally passes peer.Decode since both use base58btc multihash,
+	// but a content hash is not a peer ID — let the caller handle auto-conversion.
+	c, cidErr := cid.Decode(s)
+	if cidErr == nil {
+		if c.Version() == 1 && c.Type() == cid.Libp2pKey {
+			return IPNSTarget(c.Hash()), nil
+		}
+		// Any other CID (v0, v1 with dag-pb/raw/dag-cbor, etc.) is not a peer ID.
+		return IPNSTarget{}, fmt.Errorf("not a peer ID: CID must be libp2p-key codec for IPNS target")
+	}
+
+	// Not a CID — try as peer ID string (base36 or base58btc)
 	pid, err := peer.Decode(s)
 	if err == nil {
 		return IPNSTarget(mh.Multihash(pid)), nil
-	}
-
-	// Then try as CID (might be CIDv1 with libp2p-key)
-	c, err := cid.Decode(s)
-	if err == nil {
-		if c.Type() == cid.Libp2pKey {
-			return IPNSTarget(c.Hash()), nil
-		}
-		return IPNSTarget{}, fmt.Errorf("CID must be libp2p-key codec for IPNS target")
 	}
 
 	return IPNSTarget{}, fmt.Errorf("invalid IPNS target: %w", err)

--- a/internal/db/ipns_target_test.go
+++ b/internal/db/ipns_target_test.go
@@ -1,0 +1,50 @@
+package db
+
+import (
+	"testing"
+
+	"github.com/ipfs/go-cid"
+	mh "github.com/multiformats/go-multihash"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewIPNSTargetFromString_ValidPeerID(t *testing.T) {
+	target, err := NewIPNSTargetFromString("12D3KooWRhWS6DXi1U1YnJ5r9E6KpSDHGbZAznXif4T9qDjHeEfE")
+	require.NoError(t, err)
+	assert.NotNil(t, target)
+}
+
+func TestNewIPNSTargetFromString_CIDv1Libp2pKey(t *testing.T) {
+	target, err := NewIPNSTargetFromString("k51qzi5uqu5dlts3p5vfpw8kneqp5ye1ttb2jlt8qkt5mq9f2gvgmet6sec29r")
+	require.NoError(t, err)
+	assert.NotNil(t, target)
+}
+
+func TestNewIPNSTargetFromString_CIDv0_Rejected(t *testing.T) {
+	// CIDv0 (Qm...) accidentally passes peer.Decode since both use base58btc
+	// multihash encoding, but a content hash is not a peer ID.
+	_, err := NewIPNSTargetFromString("QmWLqGsc1X914yZjFgqZ16uzPV69AZjrc4ioMemMhoHWee")
+	require.Error(t, err, "CIDv0 should be rejected as IPNS target")
+	assert.Contains(t, err.Error(), "not a peer ID")
+}
+
+func TestNewIPNSTargetFromString_CIDv1NonLibp2pKey_Rejected(t *testing.T) {
+	hash := mustMultihash(t, "test-cidv1")
+	c := cid.NewCidV1(cid.DagProtobuf, hash)
+	_, err := NewIPNSTargetFromString(c.String())
+	require.Error(t, err, "CIDv1 with non-libp2p-key codec should be rejected")
+	assert.Contains(t, err.Error(), "not a peer ID")
+}
+
+func TestNewIPNSTargetFromString_InvalidString(t *testing.T) {
+	_, err := NewIPNSTargetFromString("not-a-valid-peer-id")
+	require.Error(t, err)
+}
+
+func mustMultihash(t *testing.T, data string) mh.Multihash {
+	t.Helper()
+	h, err := mh.Sum([]byte(data), mh.SHA2_256, -1)
+	require.NoError(t, err)
+	return h
+}

--- a/internal/service/ipns_key/republisher.go
+++ b/internal/service/ipns_key/republisher.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ipfs/go-cid"
 	ic "github.com/libp2p/go-libp2p/core/crypto"
 	pluginDb "go.lumeweb.com/portal-plugin-ipfs/internal/db"
+	"go.lumeweb.com/portal-plugin-ipfs/internal/protocol/encoding"
 	"go.uber.org/zap"
 )
 
@@ -126,8 +127,10 @@ func (r *Republisher) republishKey(ctx context.Context, key pluginDb.IPFSIPNSKey
 		return fmt.Errorf("parse CID %s: %w", key.LastPublishedCID, err)
 	}
 
+	normalizedCid := encoding.NormalizeCid(targetCid)
+
 	eol := time.Now().Add(r.recordLifetime)
-	err = r.publisher.Publish(ctx, privKey, path.FromCid(targetCid), namesys.PublishWithEOL(eol))
+	err = r.publisher.Publish(ctx, privKey, path.FromCid(normalizedCid), namesys.PublishWithEOL(eol))
 	if err != nil {
 		return fmt.Errorf("publish: %w", err)
 	}

--- a/internal/service/website/validate_target_test.go
+++ b/internal/service/website/validate_target_test.go
@@ -298,6 +298,12 @@ func TestIsValidIPNSTarget_CIDNotLibp2pKey(t *testing.T) {
 	require.False(t, isValidIPNSTarget(nonLibp2pKeyCID), "CID without libp2p-key codec should return false")
 }
 
+func TestIsValidIPNSTarget_CIDv0(t *testing.T) {
+	// CIDv0 (Qm...) accidentally passes peer.Decode since both use base58btc
+	// multihash encoding, but it's a content hash, not a peer ID.
+	require.False(t, isValidIPNSTarget("QmWLqGsc1X914yZjFgqZ16uzPV69AZjrc4ioMemMhoHWee"), "CIDv0 should not be valid IPNS target")
+}
+
 func TestIsValidIPNSTarget_MultipleValidFormats(t *testing.T) {
 	// Test all valid formats
 	validTargets := []string{

--- a/internal/service/website/website.go
+++ b/internal/service/website/website.go
@@ -1306,21 +1306,15 @@ func (s *WebsiteServiceDefault) validateDomain(domain string) error {
 // isValidIPNSTarget checks if a target hash is a valid IPNS target
 // Returns true if the peer ID or CIDv1 with libp2p-key codec is valid
 func isValidIPNSTarget(targetHash string) bool {
-	// Try peer ID decode first (IPNS uses libp2p peer IDs in base36)
-	_, err := peer.Decode(targetHash)
-	if err != nil {
-		// FALLBACK: Try CID decode (supports CIDv1 with libp2p-key codec)
-		c, err := cid.Decode(targetHash)
-		if err != nil {
-			return false
-		}
-		// Validate that CID uses libp2p-key codec (0x72) for IPNS
-		if c.Type() != cid.Libp2pKey {
-			return false
-		}
-		return true
+	// Check CID first — CIDv0 accidentally passes peer.Decode since both
+	// use base58btc multihash encoding, but a content hash is not a peer ID.
+	c, cidErr := cid.Decode(targetHash)
+	if cidErr == nil {
+		return c.Version() == 1 && c.Type() == cid.Libp2pKey
 	}
-	return true
+
+	_, err := peer.Decode(targetHash)
+	return err == nil
 }
 
 // ensureIPNSKey creates or reuses an IPNS key for a domain, and publishes the given CID to it.


### PR DESCRIPTION
CIDv0 strings (Qm...) accidentally pass peer.Decode() because both CIDv0 and peer.ID share the same base58btc multihash binary encoding. This caused NewIPNSTargetFromString and isValidIPNSTarget to accept a content hash as a valid peer ID, which:

1. Prevented the IPNS auto-conversion path from triggering (CIDVersion was set to nil instead of being set for auto-conversion)
2. Stored the CIDv0 as a fake peer ID with no actual IPNS key
3. Produced broken DNSLink records (/ipns/Qm... is meaningless)

Fix by checking cid.Decode() before peer.Decode() in both functions. Any CID that is not a v1 libp2p-key is rejected and falls through to the auto-conversion path, which normalizes to v1 and creates a proper IPNS key.

Also normalizes CID in the republisher before publishing to handle any stale CIDv0 data already in the database.

- `develop` <!-- branch-stack -->
  - **fix: reject CIDv0 as valid IPNS target to prevent auto-conversion bypass** :point\_left:

---

<!-- kody-pr-summary:start -->
## Fix: Reject CIDv0 as valid IPNS target to prevent auto-conversion bypass

CIDv0 strings (starting with "Qm...") were being incorrectly accepted as valid IPNS targets because they accidentally pass `peer.Decode` — both CIDv0 and peer IDs use base58btc multihash encoding. However, a CIDv0 is a content hash, not a peer ID, so treating it as an IPNS target is semantically wrong and bypasses the intended auto-conversion path that normalizes it to CIDv1.

### Changes

- **Reversed decode order in IPNS target validation**: CID decoding is now attempted first, before peer ID decoding. This ensures CIDv0 strings are properly identified as CIDs rather than being misinterpreted as peer IDs.
- **Explicit CIDv0 rejection**: When a valid CID is detected but it's either CIDv0 or a CIDv1 without the libp2p-key codec, it is rejected with a clear error message ("not a peer ID"). This allows the caller's auto-conversion path to handle it correctly (normalizing CIDv0 → CIDv1).
- **CID normalization in republisher**: The IPNS republisher now normalizes CIDs before publishing, ensuring CIDv0 references are converted to CIDv1.
- **Added comprehensive tests** for the new CIDv0 rejection behavior across all affected layers (`ipns_target`, `isValidIPNSTarget`, and `WebsiteRequest.ToModel` auto-conversion).
<!-- kody-pr-summary:end -->