### PR TITLE
fix: accept raw peer IDs in routing IPNS endpoint

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -955,15 +955,16 @@ See also:.*`),
 
 	routingV1Routes := router.DefineRoutes(
 		router.NewRoute(http.MethodGet, "/routing/v1/ipns/:name", routingWrapped,
+			router.WithMiddlewares(normalizeIPNSNameMiddleware),
 			router.WithSwagger(
 				router.WithSummary("Get IPNS record"),
 				router.WithDescription(`Returns the signed IPNS record for the given peer ID.
 
-Implements the IPFS Delegated Routing V1 HTTP API (IPIP-337). The response is a raw IPNS record in binary format (application/vnd.ipfs.ipns-record).
+Implements the IPFS Delegated Routing V1 HTTP API (IPIP-337). The response is a raw IPNS record in binary format (application/vnd.ipfs.ipns-record). Accepts both CIDv1 (bafzaajaiaejc...) and raw peer ID (12D3KooW...) formats.
 
 See also: https://specs.ipfs.tech/ipips/ipip-337/`),
 				router.WithTags("Routing"),
-				router.WithPathParam("name", "Peer ID of the IPNS key", ""),
+				router.WithPathParam("name", "Peer ID of the IPNS key (CIDv1 or raw peer ID format)", ""),
 				router.WithSuccessResponse(http.StatusOK, "IPNS record", router.WithContent("application/vnd.ipfs.ipns-record", "Raw IPNS record bytes")),
 			),
 		),

--- a/internal/api/api_routing_test.go
+++ b/internal/api/api_routing_test.go
@@ -62,6 +62,25 @@ func TestAPI_RoutingGetIPNS(t *testing.T) {
 			assert.Equal(t, http.StatusBadRequest, rec.Code)
 		}, TestOptions)
 	})
+
+	t.Run("raw_peer_id", func(t *testing.T) {
+		coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+			helper := newMockHelper(t, ctx)
+
+			protoMock := core.GetProtocol(internal.ProtocolName).(*protocol.MockProtoNode)
+			mockIPFSNode := protoMock.GetNode().(*mocks.MockIPFSNode)
+			mockPublisher := mockIPFSNode.GetPublisher().(*mocks.MockIPNSPublisher)
+
+			mockRecord := createMockIPNSRecord(t, TestCID)
+			mockPublisher.EXPECT().GetPublished(mock.Anything, mock.AnythingOfType("ipns.Name"), false).Return(mockRecord, nil)
+
+			rec := helper.makeRequest(http.MethodGet, fmt.Sprintf("/routing/v1/ipns/%s", TestPeerID), nil)
+
+			assert.Equal(t, http.StatusOK, rec.Code)
+			assert.Contains(t, rec.Header().Get("Content-Type"), "ipns-record")
+			assert.NotEmpty(t, rec.Body.Bytes())
+		}, TestOptions)
+	})
 }
 
 func TestAPI_RoutingFindProviders(t *testing.T) {

--- a/internal/api/routing_middleware.go
+++ b/internal/api/routing_middleware.go
@@ -1,0 +1,40 @@
+package api
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/ipfs/go-cid"
+	"github.com/labstack/echo/v4"
+	"github.com/libp2p/go-libp2p/core/peer"
+)
+
+// normalizeIPNSNameMiddleware converts a raw peer ID (e.g. 12D3KooW...)
+// in the :name path param to its CIDv1 form (e.g. bafzaajaiaejc...)
+// before the request reaches boxo's routing server. Boxo's GetIPNS
+// calls cid.Decode() which rejects raw peer IDs; this makes the
+// endpoint accept both, consistent with boxo's parsePeerID on /peers/.
+func normalizeIPNSNameMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		nameStr := c.Param("name")
+		if nameStr == "" {
+			return next(c)
+		}
+
+		if _, err := cid.Decode(nameStr); err != nil {
+			pid, pidErr := peer.Decode(nameStr)
+			if pidErr == nil {
+				cidForm := peer.ToCid(pid)
+				c.SetParamValues(cidForm.String())
+				rewriteRequestPath(c.Request(), nameStr, cidForm.String())
+			}
+		}
+
+		return next(c)
+	}
+}
+
+func rewriteRequestPath(r *http.Request, old, new string) {
+	r.URL.Path = strings.Replace(r.URL.Path, old, new, 1)
+	r.URL.RawPath = strings.Replace(r.URL.RawPath, old, new, 1)
+}


### PR DESCRIPTION
Boxo's GetIPNS handler requires CIDv1 format (bafzaajaiaejc...) in the path parameter, but users commonly pass raw peer IDs (12D3KooW\...) from CLI output. Add normalizeIPNSNameMiddleware that converts raw peer IDs to CIDv1 before the request reaches the boxo routing server, consistent with boxo's own parsePeerID logic used on the /peers/ endpoint.

- `develop` <!-- branch-stack -->
  - **fix: accept raw peer IDs in routing IPNS endpoint** :point\_left:

---

<!-- kody-pr-summary:start -->
Fix the `/routing/v1/ipns/:name` endpoint to accept raw peer IDs (e.g., `12D3KooW...`) in addition to CIDv1 format (e.g., `bafzaajaiaejc...`). Boxo's `GetIPNS` internally calls `cid.Decode()` which rejects raw peer IDs, so a new `normalizeIPNSNameMiddleware` is added that automatically converts raw peer IDs to their CIDv1 equivalent before the request reaches Boxo's routing server. The API documentation and parameter descriptions are updated to reflect that both formats are accepted, and a test case is added to verify raw peer ID requests work correctly.
<!-- kody-pr-summary:end -->