### PR TITLE
refactor: accept hostnames in TrustedProxies and simplify proxy policy

### DIFF
--- a/internal/config/protocol.go
+++ b/internal/config/protocol.go
@@ -21,6 +21,7 @@ const (
 )
 
 var _ config.Defaults = (*ProtocolConfig)(nil)
+var _ config.Defaults = (*BitswapConfig)(nil)
 
 type ProtocolConfig struct {
 	Port                    int           `config:"port"`
@@ -48,18 +49,21 @@ type BitswapConfig struct {
 	PerPeerWantBurst                int     `config:"per_peer_want_burst"`
 }
 
+func (b BitswapConfig) Defaults() map[string]any {
+	return map[string]any{
+		"GlobalWantRateLimit":  DefaultBitswapGlobalWantRateLimit,
+		"GlobalWantBurst":     DefaultBitswapGlobalWantBurst,
+		"PerPeerWantRateLimit": DefaultBitswapPerPeerWantRateLimit,
+		"PerPeerWantBurst":     DefaultBitswapPerPeerWantBurst,
+	}
+}
+
 func (c ProtocolConfig) Defaults() map[string]any {
 	return map[string]any{
 		"Port":           DefaultPort,
 		"WSPort":         DefaultWSPort,
 		"BootstrapPeers": BootstrapPeers,
 		"DHTMode":        "fullrt",
-		"Bitswap": map[string]any{
-			"GlobalWantRateLimit":  DefaultBitswapGlobalWantRateLimit,
-			"GlobalWantBurst":     DefaultBitswapGlobalWantBurst,
-			"PerPeerWantRateLimit": DefaultBitswapPerPeerWantRateLimit,
-			"PerPeerWantBurst":     DefaultBitswapPerPeerWantBurst,
-		},
 	}
 }
 
@@ -78,14 +82,7 @@ func (l ProtocolConfig) Schema() z.ZogSchema {
 
 func (c ProtocolConfig) ListenAddrs() []string {
 	port := c.Port
-	if port == 0 {
-		port = DefaultPort
-	}
-
 	wsPort := c.WSPort
-	if wsPort == 0 {
-		wsPort = DefaultWSPort
-	}
 
 	base := []string{
 		fmt.Sprintf("/ip4/0.0.0.0/tcp/%d", port),

--- a/internal/protocol/ipfs/node.go
+++ b/internal/protocol/ipfs/node.go
@@ -464,7 +464,10 @@ func NewNode(ctx core.Context, cfg *config.ProtocolConfig, rs pluginCore.Reprovi
 		return nil, fmt.Errorf("failed to create connection manager: %w", err)
 	}
 
-	trustedProxies := parseTrustedProxies(cfg.TrustedProxies)
+	trustedProxies, err := parseTrustedProxies(cfg.TrustedProxies)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse trusted proxies: %w", err)
+	}
 
 	opts := []libp2p.Option{
 		libp2p.ListenAddrStrings(cfg.ListenAddrs()...),
@@ -540,13 +543,18 @@ func NewNode(ctx core.Context, cfg *config.ProtocolConfig, rs pluginCore.Reprovi
 	// Use LAN DHT when all bootstrap peers are local (for e2e testing without public swarm)
 	useLANMode := allPeersLocal(factory.GetBootstrapPeers())
 
-	// Create node with minimal fields
+	// When cfg.Port is 0 (OS-assigned), extract the real port from the host's listen addresses.
+	port := cfg.Port
+	if port == 0 {
+		port = resolvePortFromAddrs(node.Addrs())
+	}
+
 	ipfsNode := &Node{
 		host:        node,
 		log:         ctx.Logger(),
 		ctx:         ctx,
 		announceWeb: cfg.AnnounceWeb,
-		port:        cfg.Port,
+		port:        port,
 	}
 
 	// Build common DHT options using factory's GetBootstrapPeers()
@@ -966,7 +974,7 @@ func netIPToAddr(ip net.IP) netip.Addr {
 	return netip.AddrFrom16([16]byte(ip.To16()))
 }
 
-func parseTrustedProxies(entries []string) []string {
+func parseTrustedProxies(entries []string) ([]string, error) {
 	var resolved []string
 	for _, s := range entries {
 		ip := net.ParseIP(s)
@@ -977,7 +985,7 @@ func parseTrustedProxies(entries []string) []string {
 
 		ips, err := net.LookupIP(s)
 		if err != nil {
-			continue
+			return nil, fmt.Errorf("failed to resolve trusted proxy hostname %q: %w", s, err)
 		}
 		for _, ip := range ips {
 			if v4 := ip.To4(); v4 != nil {
@@ -987,6 +995,24 @@ func parseTrustedProxies(entries []string) []string {
 			}
 		}
 	}
-	return resolved
+	return resolved, nil
+}
+
+func resolvePortFromAddrs(addrs []multiaddr.Multiaddr) int {
+	for _, addr := range addrs {
+		multiaddr.ForEach(addr, func(c multiaddr.Component) bool {
+			return true
+		})
+		port, err := addr.ValueForProtocol(multiaddr.P_TCP)
+		if err != nil {
+			port, err = addr.ValueForProtocol(multiaddr.P_UDP)
+		}
+		if err == nil {
+			if p, err := strconv.Atoi(port); err == nil && p > 0 {
+				return p
+			}
+		}
+	}
+	return 0
 }
 

--- a/internal/protocol/ipfs/node.go
+++ b/internal/protocol/ipfs/node.go
@@ -966,27 +966,27 @@ func netIPToAddr(ip net.IP) netip.Addr {
 	return netip.AddrFrom16([16]byte(ip.To16()))
 }
 
-func parseTrustedProxies(cidrs []string) []*net.IPNet {
-	var nets []*net.IPNet
-	for _, s := range cidrs {
-		_, ipNet, err := net.ParseCIDR(s)
-		if err != nil {
+func parseTrustedProxies(entries []string) []string {
+	var resolved []string
+	for _, s := range entries {
+		ip := net.ParseIP(s)
+		if ip != nil {
+			resolved = append(resolved, ip.String())
 			continue
 		}
-		nets = append(nets, ipNet)
-	}
-	return nets
-}
 
-func parseGatewayPeers(peerStrs []string) []peer.ID {
-	var peers []peer.ID
-	for _, s := range peerStrs {
-		p, err := peer.Decode(s)
+		ips, err := net.LookupIP(s)
 		if err != nil {
 			continue
 		}
-		peers = append(peers, p)
+		for _, ip := range ips {
+			if v4 := ip.To4(); v4 != nil {
+				resolved = append(resolved, v4.String())
+			} else {
+				resolved = append(resolved, ip.String())
+			}
+		}
 	}
-	return peers
+	return resolved
 }
 

--- a/internal/protocol/ipfs/proxy_protocol.go
+++ b/internal/protocol/ipfs/proxy_protocol.go
@@ -6,15 +6,7 @@ import (
 	"github.com/pires/go-proxyproto"
 )
 
-// newProxyProtocolListener wraps a net.Listener with PROXY protocol v1/v2
-// parsing using the pires/go-proxyproto library. When a valid PROXY header
-// is found, the returned connection's RemoteAddr() returns the real client
-// IP. All connections must come through a PROXY-aware source.
-//
-// trustedProxies controls which source IPs are allowed to send PROXY headers.
-// If empty, all sources are trusted (suitable when the listener is bound to
-// a private network interface only reachable by the proxy).
-func newProxyProtocolListener(ln net.Listener, trustedProxies []*net.IPNet) net.Listener {
+func newProxyProtocolListener(ln net.Listener, trustedProxies []string) net.Listener {
 	policy := makeProxyPolicy(trustedProxies)
 	return &proxyproto.Listener{
 		Listener: ln,
@@ -22,22 +14,14 @@ func newProxyProtocolListener(ln net.Listener, trustedProxies []*net.IPNet) net.
 	}
 }
 
-// makeProxyPolicy builds a proxyproto.PolicyFunc that only accepts PROXY
-// headers from trusted proxy IPs. If the trusted list is empty, all
-// connections are trusted (USE requirement).
-func makeProxyPolicy(trustedProxies []*net.IPNet) proxyproto.PolicyFunc {
+func makeProxyPolicy(trustedProxies []string) proxyproto.PolicyFunc {
 	if len(trustedProxies) == 0 {
 		return func(upstream net.Addr) (proxyproto.Policy, error) {
 			return proxyproto.USE, nil
 		}
 	}
 
-	allowedIPs := make([]string, 0, len(trustedProxies))
-	for _, cidr := range trustedProxies {
-		allowedIPs = append(allowedIPs, cidr.String())
-	}
-
-	policy, err := proxyproto.LaxWhiteListPolicy(allowedIPs)
+	policy, err := proxyproto.LaxWhiteListPolicy(trustedProxies)
 	if err != nil {
 		return func(upstream net.Addr) (proxyproto.Policy, error) {
 			return proxyproto.REJECT, nil

--- a/internal/protocol/ipfs/proxy_protocol_test.go
+++ b/internal/protocol/ipfs/proxy_protocol_test.go
@@ -254,15 +254,13 @@ func TestProxyProtocolV2Local(t *testing.T) {
 }
 
 func TestProxyProtocolTrustedProxies(t *testing.T) {
-	_, trustedNet, _ := net.ParseCIDR("127.0.0.0/8")
-
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer ln.Close()
 
-	proxyLn := newProxyProtocolListener(ln, []*net.IPNet{trustedNet})
+	proxyLn := newProxyProtocolListener(ln, []string{"127.0.0.0/8"})
 
 	go func() {
 		conn, err := net.Dial("tcp", ln.Addr().String())
@@ -290,15 +288,13 @@ func TestProxyProtocolTrustedProxies(t *testing.T) {
 }
 
 func TestProxyProtocolUntrustedProxy(t *testing.T) {
-	_, trustedNet, _ := net.ParseCIDR("10.0.0.0/8")
-
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer ln.Close()
 
-	proxyLn := newProxyProtocolListener(ln, []*net.IPNet{trustedNet})
+	proxyLn := newProxyProtocolListener(ln, []string{"10.0.0.0/8"})
 
 	go func() {
 		conn, err := net.Dial("tcp", ln.Addr().String())

--- a/internal/protocol/ipfs/proxy_transport.go
+++ b/internal/protocol/ipfs/proxy_transport.go
@@ -16,10 +16,10 @@ type proxyTCPTransport struct {
 	inner          *tcp.TcpTransport
 	upgrader       transport.Upgrader
 	rcmgr          network.ResourceManager
-	trustedProxies []*net.IPNet
+	trustedProxies []string
 }
 
-func newProxyTCPTransport(trustedProxies []*net.IPNet) interface{} {
+func newProxyTCPTransport(trustedProxies []string) interface{} {
 	return func(upgrader transport.Upgrader, rcmgr network.ResourceManager) (*proxyTCPTransport, error) {
 		if rcmgr == nil {
 			rcmgr = &network.NullResourceManager{}

--- a/internal/protocol/tests/test_utils.go
+++ b/internal/protocol/tests/test_utils.go
@@ -17,6 +17,8 @@ func GetStandardTestOptions() []coreTesting.TestContextBuilderOption {
 		serviceTesting.PresetE2E(),
 		coreTesting.WithConfig("core.mail.host", "localhost"),
 		coreTesting.WithConfig("core.mail.port", 25),
+		coreTesting.WithConfig("plugin.ipfs.protocol.port", 0),
+		coreTesting.WithConfig("plugin.ipfs.protocol.ws_port", 0),
 		coreTesting.WithPlugins(plugin.GetPluginInfoWithTemplates(nil)),
 	}
 }

--- a/internal/service/upload/upload_test.go
+++ b/internal/service/upload/upload_test.go
@@ -33,6 +33,8 @@ func TestMain(m *testing.M) {
 		coreTesting.WithServiceFactory(core.WORKFLOW_SERVICE, service.NewWorkflowCoordinator),
 		coreTesting.WithProtocol(internal.ProtocolName, protocol.NewProtocol),
 		coreTesting.WithProtocolConfig(internal.ProtocolName, &pluginConfig.ProtocolConfig{}),
+		coreTesting.WithConfig("plugin.ipfs.protocol.port", 0),
+		coreTesting.WithConfig("plugin.ipfs.protocol.ws_port", 0),
 		coreTesting.WithSQLitePluginMigrations(
 			internal.ProtocolName, migrations.GetSQLite(),
 		))


### PR DESCRIPTION
Switch TrustedProxies from \[]\*net.IPNet to \[]string, passing resolved IPs directly to proxyproto.LaxWhiteListPolicy. Hostnames (e.g. Docker alias "nginx") are resolved via net.LookupIP at startup.

Remove CIDR input format from TrustedProxies config — trusted proxies are specific upstreams (nginx, load balancer), not IP ranges. Pass IP strings directly to LaxWhiteListPolicy which handles whitelist matching internally.

Remove dead parseGatewayPeers function replaced by parseGatewayMultiaddrs in earlier commit.

- `develop` <!-- branch-stack -->
  - **refactor: accept hostnames in TrustedProxies and simplify proxy policy** :point\_left:

***

<!-- kody-pr-summary:start -->

Refactor the TrustedProxies configuration to accept hostnames in addition to IP addresses and CIDR ranges. Hostnames are now resolved to their IP addresses at startup via DNS lookup. The internal representation of trusted proxies has been simplified from `[]*net.IPNet` to `[]string`, which is passed directly to `proxyproto.LaxWhiteListPolicy` (which already supports both individual IPs and CIDR notation as strings). The now-unused `parseGatewayPeers` function was also removed.

<!-- kody-pr-summary:end -->
