### PR TITLE
fix: add missing upload response schema to swagger spec

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -350,7 +350,7 @@ Supports single file uploads with automatic content verification. The uploaded f
 See also:.*`),
 				router.WithTags("Content"),
 				router.WithFileUpload("File to upload", true),
-				router.WithSuccessResponse(http.StatusOK, "File uploaded successfully"),
+				router.WithSuccessResponse(http.StatusOK, "File uploaded successfully", router.WithJSONContent(dto.PostUploadResponse{})),
 			),
 		),
 		router.NewRoute(http.MethodGet, "/upload/result/:identifier", a.handleUploadResult,

--- a/internal/api/dto/upload.go
+++ b/internal/api/dto/upload.go
@@ -35,7 +35,7 @@ func (u *UploadRequest) GetArchiveMode() string {
 }
 
 type PostUploadResponse struct {
-	CID string `json:"cid"`
+	CID string `json:"CID"`
 }
 
 func (p *PostUploadResponse) FromModel(_ *PostUploadResponse) error {

--- a/internal/api/dto/upload.go
+++ b/internal/api/dto/upload.go
@@ -35,7 +35,7 @@ func (u *UploadRequest) GetArchiveMode() string {
 }
 
 type PostUploadResponse struct {
-	CID string
+	CID string `json:"cid"`
 }
 
 func (p *PostUploadResponse) FromModel(_ *PostUploadResponse) error {


### PR DESCRIPTION
POST /api/upload returned 200 with no content block in the OpenAPI spec, preventing Orval from generating types. Add router.WithJSONContent with dto.PostUploadResponse and add json:"cid" tag to the struct so it serializes correctly.

- `develop` <!-- branch-stack -->
  - **fix: add missing upload response schema to swagger spec** :point\_left:

***

<!-- kody-pr-summary:start -->

Fix the Swagger specification for the upload endpoint by adding the missing response schema and proper JSON tag.

- Added `PostUploadResponse` as the JSON response schema to the upload endpoint's success response in the Swagger spec, so API consumers can see the expected response structure.
- Added `json:"cid"` tag to the `CID` field in `PostUploadResponse` to ensure proper JSON serialization with the lowercase key.

<!-- kody-pr-summary:end -->
