### PR TITLE
fix(metrics): strip <no-scope> prefix from IPFS metric names

### DIFF
--- a/internal/metrics/adapter/adapter.go
+++ b/internal/metrics/adapter/adapter.go
@@ -1,6 +1,8 @@
 package adapter
 
 import (
+	"strings"
+
 	"github.com/ipfs/go-metrics-interface"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -10,6 +12,14 @@ import (
 // Call this once during plugin initialization before creating any IPFS components.
 func InjectPrometheusAdapter(reg prometheus.Registerer) error {
 	return metrics.InjectImpl(func(name, helptext string) metrics.Creator {
+		// go-metrics-interface uses context scopes to prefix metric names via
+		// CtxGetScope(ctx)+"."+name (see ctor.go:NewCtx). When no scope is set
+		// on the context, CtxGetScope returns "<no-scope>", which after
+		// dot-to-underscore conversion becomes "_no_scope__" — polluting every
+		// metric name from boxo components that don't receive a scoped context.
+		// Strip the prefix here since we can't fix boxo's internal context wiring.
+		name = strings.TrimPrefix(name, "_no_scope__")
+
 		return &prometheusCreator{
 			reg:      reg,
 			name:     name,


### PR DESCRIPTION
go-metrics-interface uses CtxGetScope(ctx)+"."+name to prefix metric names. When no scope is set, CtxGetScope returns "<no-scope>", which after dot-to-underscore conversion becomes "*no\_scope*\_" — polluting every metric name from boxo components that don't receive a scoped context. Strip the prefix since boxo's internal context wiring can't be fixed from our side.

- `develop` <!-- branch-stack -->
  - **fix(metrics): strip <no-scope> prefix from IPFS metric names** :point\_left:

---

<!-- kody-pr-summary:start -->
Strip `<no-scope>` prefix from IPFS metric names

When `go-metrics-interface` has no scope set on the context, it defaults to `<no-scope>`, which after dot-to-underscore conversion becomes `_no_scope__` and pollutes every metric name from boxo components that don't receive a scoped context. This fix strips that prefix in the Prometheus adapter since boxo's internal context wiring cannot be modified.
<!-- kody-pr-summary:end -->