### PR TITLE
feat(api): add /internal/ping healthcheck endpoint

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -894,6 +894,21 @@ See also:.*`),
 		a.Logger().Info("Gateway middleware initialized with configured secret")
 	}
 	gatewayAuthMw := pluginMw.GatewayAuth(apiConfig, a.Logger())
+	pingRoutes := router.DefineRoutes(
+		router.NewRoute(http.MethodGet, "/internal/ping", a.handlePing,
+			router.WithSwagger(
+				router.WithSummary("Health check"),
+				router.WithDescription("Returns service liveness status. Requires X-Gateway-Secret header for authentication."),
+				router.WithTags("Gateway"),
+				router.WithSuccessResponse(http.StatusOK, "Service is alive", router.WithJSONContent(dto.PingResponse{})),
+			),
+		),
+	)
+
+	if err := router.RegisterRoutes(r, accessSvc, a.Subdomain(), pingRoutes, router.WithMiddlewares(gatewayAuthMw), router.WithCors()); err != nil {
+		return fmt.Errorf("failed to register ping routes: %w", err)
+	}
+
 	gatewayRoutes := router.DefineRoutes(
 		router.NewRoute(http.MethodGet, "/internal/websites/:domain", a.getGatewayWebsite,
 			router.WithSwagger(

--- a/internal/api/api_gateway.go
+++ b/internal/api/api_gateway.go
@@ -76,3 +76,8 @@ func (a *API) getGatewayWebsiteStatus(c echo.Context) error {
 
 	return httputil.EncodeResponse(ctx, website, &dto.GatewayWebsiteStatusResponse{})
 }
+
+func (a *API) handlePing(c echo.Context) error {
+	ctx := httputil.Context(c)
+	return httputil.EncodeResponse(ctx, &dto.PingModel{Status: "ok"}, &dto.PingResponse{})
+}

--- a/internal/api/api_gateway_test.go
+++ b/internal/api/api_gateway_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	pluginCore "go.lumeweb.com/portal-plugin-ipfs/core"
+	"go.lumeweb.com/portal-plugin-ipfs/internal/api/dto"
 	pluginDb "go.lumeweb.com/portal-plugin-ipfs/internal/db"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/testing/mocks"
 	"go.lumeweb.com/portal/core"
@@ -285,7 +286,6 @@ func TestAPI_GetGatewayWebsiteStatus_NotFound(t *testing.T) {
 
 func TestAPI_GetGatewayWebsite_ServiceError(t *testing.T) {
 	coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
-		// Arrange
 		helper := newMockHelper(t, ctx)
 		domain := "error.example.com"
 		
@@ -295,11 +295,49 @@ func TestAPI_GetGatewayWebsite_ServiceError(t *testing.T) {
 		req := ctx.NewAPIRequest(http.MethodGet, "/internal/websites/"+domain, nil)
 		req.Header.Set("X-Gateway-Secret", "test-secret")
 
-		// Act
 		rec := httptest.NewRecorder()
 		ctx.Router().ServeHTTP(rec, req)
 
-		// Assert
 		assert.Equal(t, http.StatusInternalServerError, rec.Code, "Should return 500 Internal Server Error on service error")
+	}, TestOptions)
+}
+
+func TestAPI_Ping_Success(t *testing.T) {
+	coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		req := ctx.NewAPIRequest(http.MethodGet, "/internal/ping", nil)
+		req.Header.Set("X-Gateway-Secret", "test-secret")
+
+		rec := httptest.NewRecorder()
+		ctx.Router().ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+
+		var response dto.PingResponse
+		err := json.Unmarshal(rec.Body.Bytes(), &response)
+		require.NoError(t, err)
+		assert.Equal(t, "ok", response.Status)
+	}, TestOptions)
+}
+
+func TestAPI_Ping_MissingSecret(t *testing.T) {
+	coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		req := ctx.NewAPIRequest(http.MethodGet, "/internal/ping", nil)
+
+		rec := httptest.NewRecorder()
+		ctx.Router().ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	}, TestOptions)
+}
+
+func TestAPI_Ping_InvalidSecret(t *testing.T) {
+	coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		req := ctx.NewAPIRequest(http.MethodGet, "/internal/ping", nil)
+		req.Header.Set("X-Gateway-Secret", "wrong-secret")
+
+		rec := httptest.NewRecorder()
+		ctx.Router().ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusUnauthorized, rec.Code)
 	}, TestOptions)
 }

--- a/internal/api/dto/ping.go
+++ b/internal/api/dto/ping.go
@@ -1,0 +1,18 @@
+package dto
+
+import "go.lumeweb.com/httputil"
+
+var _ httputil.DTOResponse[*PingModel] = (*PingResponse)(nil)
+
+type PingResponse struct {
+	Status string `json:"status"`
+}
+
+type PingModel struct {
+	Status string
+}
+
+func (r *PingResponse) FromModel(m *PingModel) error {
+	r.Status = m.Status
+	return nil
+}


### PR DESCRIPTION
- `develop` <!-- branch-stack -->
  - **feat(api): add /internal/ping healthcheck endpoint** :point\_left:

---

<!-- kody-pr-summary:start -->
Add `/internal/ping` health check endpoint that returns service liveness status

This PR introduces a new `GET /internal/ping` endpoint that returns a simple `{"status": "ok"}` response to indicate the service is alive. The endpoint is protected by the existing gateway authentication middleware, requiring a valid `X-Gateway-Secret` header.

Changes include:
- New route registration with Swagger documentation (tagged under "Gateway")
- `handlePing` handler returning a `PingModel` with status "ok"
- New `PingResponse`/`PingModel` DTO with proper JSON serialization
- Tests covering successful ping, missing secret (401), and invalid secret (401) scenarios
<!-- kody-pr-summary:end -->