### PR TITLE
fix(api): add CORS preflight support for /pins routes

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -274,6 +274,29 @@ See also:.*`),
 				router.WithSuccessResponse(http.StatusAccepted, "Successful response"),
 			),
 		),
+		router.NewRoute(http.MethodOptions, "/pins", a.handlePinOptions,
+			router.WithSwagger(
+				router.WithSummary("Pins OPTIONS"),
+				router.WithDescription(`CORS preflight handler for pins endpoints.
+
+Handles OPTIONS requests for pins endpoints. Most CORS preflight requests are handled by middleware, this serves as a fallback.
+
+See also:.*`),
+				router.WithTags("Pinning"),
+			),
+		),
+		router.NewRoute(http.MethodOptions, "/pins/:requestid", a.handlePinOptions,
+			router.WithSwagger(
+				router.WithSummary("Pin detail OPTIONS"),
+				router.WithDescription(`CORS preflight handler for pin detail endpoints.
+
+Handles OPTIONS requests for pin detail endpoints. Most CORS preflight requests are handled by middleware, this serves as a fallback.
+
+See also:.*`),
+				router.WithTags("Pinning"),
+				router.WithPathParam("requestid", "Unique identifier for the pin operation. Example: bafkreiexample", ""),
+			),
+		),
 	)
 
 	fileManagerListProvider := queryutil.NewSchemaProvider().ForType(&dto.FileManagerListRequest{})

--- a/internal/api/api_pins.go
+++ b/internal/api/api_pins.go
@@ -232,3 +232,10 @@ func (a *API) deletePin(c echo.Context) error {
 
 	return ctx.NoContent(http.StatusAccepted)
 }
+
+// handlePinOptions is a fallback handler for OPTIONS requests to pin routes.
+// CORS middleware should handle preflight responses before this handler is reached.
+// If reached, it serves as a safety net returning 204 No Content.
+func (a *API) handlePinOptions(c echo.Context) error {
+	return c.NoContent(http.StatusNoContent)
+}

--- a/internal/api/api_pins_test.go
+++ b/internal/api/api_pins_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/google/uuid"
@@ -115,5 +116,38 @@ func TestAPI_listPins_pathIsolation(t *testing.T) {
 		// Verify API group path does NOT work (ensures route isolation)
 		rec2 := helper.makeAuthenticatedRequest(http.MethodGet, "/api/pins", token, nil)
 		assert.Equal(t, http.StatusNotFound, rec2.Code)
+	}, TestOptions)
+}
+
+func TestAPI_pins_CORS_preflight(t *testing.T) {
+	coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		helper := newMockHelper(t, ctx)
+		_, _, _, pinID := helper.SetupAuthenticatedTest()
+
+		preflightTests := []struct {
+			name string
+			path string
+		}{
+			{"pins list", "/pins"},
+			{"pin detail", fmt.Sprintf("/pins/%s", pinID.String())},
+		}
+
+		for _, tt := range preflightTests {
+			t.Run(tt.name, func(t *testing.T) {
+				req := ctx.NewAPIRequest(http.MethodOptions, tt.path, nil)
+				req.Header.Set("Origin", "https://example.com")
+				req.Header.Set("Access-Control-Request-Method", "POST")
+				// Headers must be sorted lexicographically per Fetch spec
+				req.Header.Set("Access-Control-Request-Headers", "authorization,content-type")
+
+				rec := httptest.NewRecorder()
+				ctx.Router().ServeHTTP(rec, req)
+
+				assert.Equal(t, http.StatusNoContent, rec.Code)
+				assert.NotEmpty(t, rec.Header().Get("Access-Control-Allow-Origin"))
+				assert.Contains(t, rec.Header().Get("Access-Control-Allow-Methods"), "POST")
+				assert.NotEmpty(t, rec.Header().Get("Access-Control-Allow-Headers"))
+			})
+		}
 	}, TestOptions)
 }


### PR DESCRIPTION
- `develop` <!-- branch-stack -->
  - **fix(api): add CORS preflight support for /pins routes** :point\_left:

---

<!-- kody-pr-summary:start -->
Add CORS preflight (OPTIONS) route handlers for `/pins` and `/pins/:requestid` endpoints

This PR adds explicit OPTIONS method routes for the pins API endpoints to properly handle CORS preflight requests from browsers. Without these routes, cross-origin requests to the pins endpoints would fail because the browser's preflight OPTIONS request would not receive a valid response.

Changes:
- Added `OPTIONS /pins` and `OPTIONS /pins/:requestid` routes with a fallback handler that returns `204 No Content`
- Added `handlePinOptions` handler function that serves as a safety net when CORS middleware doesn't intercept the preflight request
- Added Swagger documentation for both new OPTIONS routes under the "Pinning" tag
- Added test coverage verifying that CORS preflight requests to both endpoints return 204 with proper CORS response headers (Access-Control-Allow-Origin, Access-Control-Allow-Methods, Access-Control-Allow-Headers)
<!-- kody-pr-summary:end -->