### PR TITLE
fix: use companion DHT for reproviding instead of FullRT

### DIFF
--- a/internal/protocol/ipfs/node.go
+++ b/internal/protocol/ipfs/node.go
@@ -693,7 +693,15 @@ func NewNode(ctx core.Context, cfg *config.ProtocolConfig, rs pluginCore.Reprovi
 	var rp *Reprovider
 	var reproviderCancel context.CancelFunc
 	if hasProvider {
-		rp = NewReprovider(dhtProvider, rs, ctx.Logger().Named("reprovider"))
+		// When a companion (server-mode) DHT exists alongside FullRT, use the
+		// companion for providing. FullRT is client-only and does not reliably
+		// put provider records into the DHT network. This matches the behavior
+		// of ProvideCID which also routes through the companion when available.
+		reproviderProvider := dhtProvider
+		if ipfsNode.companionDHT != nil {
+			reproviderProvider = newBasicDHTProvider(ipfsNode.companionDHT)
+		}
+		rp = NewReprovider(reproviderProvider, rs, ctx.Logger().Named("reprovider"))
 		reproviderCtx, cancel := context.WithCancel(ctx)
 		reproviderCancel = cancel
 		go rp.Run(reproviderCtx, cfg.Provider.Interval, cfg.Provider.Timeout, cfg.Provider.BatchSize)

--- a/internal/protocol/ipfs/provide_test.go
+++ b/internal/protocol/ipfs/provide_test.go
@@ -10,8 +10,11 @@ import (
 	"go.lumeweb.com/portal-plugin-ipfs/core"
 
 	"github.com/ipfs/go-cid"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/multiformats/go-multihash"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/testing/mocks"
 	"go.uber.org/zap"
 )
@@ -529,4 +532,60 @@ func TestReprovider_performProvide_MinAnnouncement_NotAllAnnounced(t *testing.T)
 	sleepDuration := reprovider.performProvide(ctx, interval, timeout, batchSize)
 
 	assert.Less(t, time.Until(testCIDs[2].LastAnnouncement.Add(interval)), sleepDuration)
+}
+
+func TestBasicDHTProvider_ProvideMany(t *testing.T) {
+	t.Run("ready_always_true", func(t *testing.T) {
+		provider := newBasicDHTProvider(&stubContentRouting{})
+		assert.True(t, provider.Ready())
+	})
+
+	t.Run("provide_many_calls_provide_for_each_key", func(t *testing.T) {
+		c1 := cid.NewCidV1(cid.Raw, mustMultihash(t, "key1"))
+		c2 := cid.NewCidV1(cid.Raw, mustMultihash(t, "key2"))
+
+		scr := &stubContentRouting{}
+		provider := newBasicDHTProvider(scr)
+
+		keys := []multihash.Multihash{c1.Hash(), c2.Hash()}
+		err := provider.ProvideMany(context.Background(), keys)
+		assert.NoError(t, err)
+		assert.Equal(t, 2, scr.provideCount)
+	})
+
+	t.Run("provide_many_stops_on_first_error", func(t *testing.T) {
+		c1 := cid.NewCidV1(cid.Raw, mustMultihash(t, "key1"))
+		c2 := cid.NewCidV1(cid.Raw, mustMultihash(t, "key2"))
+
+		testErr := errors.New("provide failed")
+		scr := &stubContentRouting{err: testErr}
+		provider := newBasicDHTProvider(scr)
+
+		keys := []multihash.Multihash{c1.Hash(), c2.Hash()}
+		err := provider.ProvideMany(context.Background(), keys)
+		assert.ErrorIs(t, err, testErr)
+		assert.Equal(t, 1, scr.provideCount) // stopped after first error
+	})
+}
+
+// stubContentRouting is a minimal routing.ContentRouting stub for testing.
+type stubContentRouting struct {
+	provideCount int
+	err          error
+}
+
+func (s *stubContentRouting) Provide(_ context.Context, _ cid.Cid, _ bool) error {
+	s.provideCount++
+	return s.err
+}
+
+func (s *stubContentRouting) FindProvidersAsync(_ context.Context, _ cid.Cid, _ int) <-chan peer.AddrInfo {
+	return nil
+}
+
+func mustMultihash(t *testing.T, data string) multihash.Multihash {
+	t.Helper()
+	h, err := multihash.Sum([]byte(data), multihash.SHA2_256, -1)
+	require.NoError(t, err)
+	return h
 }


### PR DESCRIPTION
FullRT is a client-only DHT that does not reliably put provider records into the DHT network. The Reprovider was using the FullRT instance for ProvideMany, so CIDs were never advertised to the network. This caused check.ipfs.network to report ProviderRecordFromPeerInDHT: false.

When a companion (server-mode) DHT exists alongside FullRT, the reprovider now wraps the companion with basicDHTProvider, matching the behavior of ProvideCID which already routes through the companion.

Adds TestBasicDHTProvider\_ProvideMany covering Ready(), successful iteration, and error-stop-on-first-failure.

- `develop` <!-- branch-stack -->
  - **fix: use companion DHT for reproviding instead of FullRT** :point\_left:

---

<!-- kody-pr-summary:start -->
## Summary

Fix the IPFS reprovider to use the companion DHT (server-mode) instead of FullRT when a companion DHT is available.

FullRT operates in client-only mode and does not reliably put provider records into the DHT network. When a companion DHT exists alongside FullRT, the reprovider now routes through the companion instead, matching the existing behavior of `ProvideCID`. This ensures that content reprovisioning actually persists provider records in the DHT.

Additionally, unit tests were added for `basicDHTProvider` covering the `Ready()`, `ProvideMany` (happy path), and `ProvideMany` (error stop) behaviors.
<!-- kody-pr-summary:end -->