### PR TITLE
feat(ipfs): reprovider resilience redesign

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -46,9 +46,10 @@ type (
 
 	// IPFSProvider contains the configuration for the IPFS provider
 	IPFSProvider struct {
-		BatchSize int           `config:"batch_size"`
-		Interval  time.Duration `config:"interval"`
-		Timeout   time.Duration `config:"timeout"`
+		BatchSize     int           `config:"batch_size"`
+		Interval      time.Duration `config:"interval"`
+		Timeout       time.Duration `config:"timeout"`
+		PerCIDTimeout time.Duration `config:"per_cid_timeout"`
 	}
 
 	// IPNS configures IPNS record publishing and republishing
@@ -80,9 +81,10 @@ func (b BlockStore) Defaults() map[string]any {
 
 func (I IPFSProvider) Defaults() map[string]any {
 	return map[string]any{
-		"BatchSize": 5000,
-		"Interval":  4 * time.Hour,
-		"Timeout":   30 * time.Minute,
+		"BatchSize":     5000,
+		"Interval":      4 * time.Hour,
+		"Timeout":       30 * time.Minute,
+		"PerCIDTimeout": 10 * time.Second,
 	}
 }
 

--- a/internal/plugin/info.go
+++ b/internal/plugin/info.go
@@ -9,6 +9,7 @@ import (
 	"go.lumeweb.com/portal-plugin-ipfs/internal/db"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/db/migrations"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/protocol"
+	"go.lumeweb.com/portal-plugin-ipfs/internal/protocol/ipfs"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/service/block"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/service/dns"
 	filemanager "go.lumeweb.com/portal-plugin-ipfs/internal/service/file_manager"
@@ -28,6 +29,7 @@ func GetCollectors() []prometheus.Collector {
 	collectors = append(collectors, block.GetCollectors()...)
 	collectors = append(collectors, filemanager.GetCollectors()...)
 	collectors = append(collectors, website.GetCollectors()...)
+	collectors = append(collectors, ipfs.GetMetricsCollectors()...)
 
 	return collectors
 }

--- a/internal/protocol/ipfs/metrics.go
+++ b/internal/protocol/ipfs/metrics.go
@@ -1,0 +1,219 @@
+package ipfs
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	// Reprovider metrics
+	MetricReprovideAttempts             = "reprovide_attempts_total"
+	MetricReprovideSuccesses            = "reprovide_successes_total"
+	MetricReprovideFailures             = "reprovide_failures_total"
+	MetricReprovideCIDsTotal            = "reprovide_cids_total"
+	MetricReprovideCIDFailures          = "reprovide_cid_failures_total"
+	MetricReprovideDuration             = "reprovide_duration_seconds"
+	MetricReprovideBatchSize            = "reprovide_batch_size"
+	MetricReprovideCircuitOpen          = "reprovide_circuit_open"
+	MetricReprovideConsecutiveFailures = "reprovide_consecutive_failures"
+	MetricReprovideProviderReady        = "reprovide_provider_ready"
+
+	// DHT metrics
+	MetricCompanionDHTHealthy           = "companion_dht_healthy"
+	MetricCompanionDHTRoutingTable      = "companion_dht_routing_table_size"
+	MetricCompanionDHTBootstrapAttempts = "companion_dht_bootstrap_attempts_total"
+	MetricCompanionDHTBootstrapFailures = "companion_dht_bootstrap_failures_total"
+	MetricCompanionDHTConnectedPeers    = "companion_dht_connected_peers"
+)
+
+const (
+	subSystemReprovider = "ipfs.reprovider"
+	subSystemDHT        = "ipfs.dht"
+)
+
+const (
+	LabelResultSuccess  = "success"
+	LabelResultFailure  = "failure"
+	LabelTriggerScheduled = "scheduled"
+	LabelTriggerManual    = "manual"
+)
+
+var (
+	// Reprovider counters
+	ReprovideAttemptsTotal  *prometheus.CounterVec
+	ReprovideSuccessesTotal prometheus.Counter
+	ReprovideFailuresTotal  prometheus.Counter
+	ReprovideCIDsTotal      *prometheus.CounterVec
+	ReprovideCIDFailures    *prometheus.CounterVec
+
+	// Reprovider histograms
+	ReprovideDuration  *prometheus.HistogramVec
+	ReprovideBatchSize *prometheus.HistogramVec
+
+	// Reprovider gauges
+	ReprovideCircuitOpen          prometheus.Gauge
+	ReprovideConsecutiveFailures  prometheus.Gauge
+	ReprovideProviderReady        prometheus.Gauge
+
+	// DHT gauges
+	CompanionDHTHealthy                prometheus.Gauge
+	CompanionDHTRoutingTableSize       prometheus.Gauge
+	CompanionDHTBootstrapAttemptsTotal prometheus.Counter
+	CompanionDHTBootstrapFailuresTotal prometheus.Counter
+	CompanionDHTConnectedPeers         prometheus.Gauge
+)
+
+func init() {
+	// Counters
+	ReprovideAttemptsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: subSystemReprovider,
+			Name:      MetricReprovideAttempts,
+			Help:      "Total number of performProvide invocations",
+		},
+		[]string{"trigger"},
+	)
+
+	ReprovideSuccessesTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Subsystem: subSystemReprovider,
+			Name:      MetricReprovideSuccesses,
+			Help:      "Total number of successful reprovide cycles",
+		},
+	)
+
+	ReprovideFailuresTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Subsystem: subSystemReprovider,
+			Name:      MetricReprovideFailures,
+			Help:      "Total number of failed reprovide cycles",
+		},
+	)
+
+	ReprovideCIDsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: subSystemReprovider,
+			Name:      MetricReprovideCIDsTotal,
+			Help:      "Total CIDs processed by the reprovider",
+		},
+		[]string{"result"},
+	)
+
+	ReprovideCIDFailures = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: subSystemReprovider,
+			Name:      MetricReprovideCIDFailures,
+			Help:      "Total per-CID provide failures with error classification",
+		},
+		[]string{"error_type"},
+	)
+
+	// Histograms
+	provideDurationBuckets := []float64{0.1, 0.5, 1, 5, 10, 30, 60, 120, 300}
+	batchSizeBuckets := []float64{1, 5, 10, 25, 50, 100, 250, 500, 1000}
+
+	ReprovideDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Subsystem: subSystemReprovider,
+			Name:      MetricReprovideDuration,
+			Help:      "Wall-clock duration of performProvide in seconds",
+			Buckets:   provideDurationBuckets,
+		},
+		[]string{},
+	)
+
+	ReprovideBatchSize = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Subsystem: subSystemReprovider,
+			Name:      MetricReprovideBatchSize,
+			Help:      "Number of eligible CIDs in each reprovide batch",
+			Buckets:   batchSizeBuckets,
+		},
+		[]string{},
+	)
+
+	// Gauges
+	ReprovideCircuitOpen = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Subsystem: subSystemReprovider,
+			Name:      MetricReprovideCircuitOpen,
+			Help:      "1 when circuit breaker is open, 0 when closed",
+		},
+	)
+
+	ReprovideConsecutiveFailures = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Subsystem: subSystemReprovider,
+			Name:      MetricReprovideConsecutiveFailures,
+			Help:      "Current consecutive failure count for the reprovider",
+		},
+	)
+
+	ReprovideProviderReady = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Subsystem: subSystemReprovider,
+			Name:      MetricReprovideProviderReady,
+			Help:      "1 when the provider reports Ready, 0 otherwise",
+		},
+	)
+
+	// DHT gauges
+	CompanionDHTHealthy = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Subsystem: subSystemDHT,
+			Name:      MetricCompanionDHTHealthy,
+			Help:      "1 when companion DHT is healthy (bootstrapped), 0 otherwise",
+		},
+	)
+
+	CompanionDHTRoutingTableSize = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Subsystem: subSystemDHT,
+			Name:      MetricCompanionDHTRoutingTable,
+			Help:      "Number of entries in the companion DHT routing table",
+		},
+	)
+
+	CompanionDHTBootstrapAttemptsTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Subsystem: subSystemDHT,
+			Name:      MetricCompanionDHTBootstrapAttempts,
+			Help:      "Total companion DHT bootstrap attempts (initial + recovery retries)",
+		},
+	)
+
+	CompanionDHTBootstrapFailuresTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Subsystem: subSystemDHT,
+			Name:      MetricCompanionDHTBootstrapFailures,
+			Help:      "Total companion DHT bootstrap failures",
+		},
+	)
+
+	CompanionDHTConnectedPeers = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Subsystem: subSystemDHT,
+			Name:      MetricCompanionDHTConnectedPeers,
+			Help:      "Number of peers connected to the companion DHT host",
+		},
+	)
+}
+
+func GetMetricsCollectors() []prometheus.Collector {
+	return []prometheus.Collector{
+		ReprovideAttemptsTotal,
+		ReprovideSuccessesTotal,
+		ReprovideFailuresTotal,
+		ReprovideCIDsTotal,
+		ReprovideCIDFailures,
+		ReprovideDuration,
+		ReprovideBatchSize,
+		ReprovideCircuitOpen,
+		ReprovideConsecutiveFailures,
+		ReprovideProviderReady,
+		CompanionDHTHealthy,
+		CompanionDHTRoutingTableSize,
+		CompanionDHTBootstrapAttemptsTotal,
+		CompanionDHTBootstrapFailuresTotal,
+		CompanionDHTConnectedPeers,
+	}
+}

--- a/internal/protocol/ipfs/node.go
+++ b/internal/protocol/ipfs/node.go
@@ -615,27 +615,8 @@ func NewNode(ctx core.Context, cfg *config.ProtocolConfig, rs pluginCore.Reprovi
 				zap.Error(err))
 			// Do NOT close the companion -- it may recover if bootstrap peers come back.
 			// The reprovider's Ready() check will gate on companionDHTHealthy.
-			// Start a background recovery goroutine that keeps trying to bootstrap.
-			go func() {
-				recoverTicker := time.NewTicker(2 * time.Minute)
-				defer recoverTicker.Stop()
-				for {
-					select {
-					case <-ctx.Done():
-						return
-					case <-recoverTicker.C:
-						CompanionDHTBootstrapAttemptsTotal.Inc()
-						if err := companion.Bootstrap(ctx); err == nil {
-							ipfsNode.companionDHTHealthy.Store(true)
-							CompanionDHTHealthy.Set(1)
-							ctx.Logger().Info("companion DHT recovered via background bootstrap")
-							return
-						} else {
-							CompanionDHTBootstrapFailuresTotal.Inc()
-						}
-					}
-				}
-			}()
+			// Recovery goroutine is started after fullrt.NewFullRT succeeds to avoid
+			// use-after-close if NewFullRT fails and calls companion.Close().
 		} else {
 			ipfsNode.companionDHTHealthy.Store(true)
 			CompanionDHTHealthy.Set(1)
@@ -659,6 +640,31 @@ func NewNode(ctx core.Context, cfg *config.ProtocolConfig, rs pluginCore.Reprovi
 		routingImpl = frt
 		dhtProvider = frt
 		hasProvider = true
+
+		// Start recovery goroutine now that fullrt.NewFullRT succeeded.
+		// The companion DHT is alive for the lifetime of the node.
+		if !ipfsNode.companionDHTHealthy.Load() {
+			go func() {
+				recoverTicker := time.NewTicker(2 * time.Minute)
+				defer recoverTicker.Stop()
+				for {
+					select {
+					case <-ctx.Done():
+						return
+					case <-recoverTicker.C:
+						CompanionDHTBootstrapAttemptsTotal.Inc()
+						if err := companion.Bootstrap(ctx); err == nil {
+							ipfsNode.companionDHTHealthy.Store(true)
+							CompanionDHTHealthy.Set(1)
+							ctx.Logger().Info("companion DHT recovered via background bootstrap")
+							return
+						} else {
+							CompanionDHTBootstrapFailuresTotal.Inc()
+						}
+					}
+				}
+			}()
+		}
 	}
 
 	// Log configured bootstrap servers for debugging

--- a/internal/protocol/ipfs/node.go
+++ b/internal/protocol/ipfs/node.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/ipfs/go-cid"
@@ -204,7 +205,8 @@ type Node struct {
 	ctx              core.Context
 	host             host.Host
 	routing          DHTRouting
-	companionDHT     *dht.IpfsDHT
+	companionDHT       *dht.IpfsDHT
+	companionDHTHealthy atomic.Bool
 	reprovider       *Reprovider
 	blockService     blockservice.BlockService
 	dagService       format.DAGService
@@ -579,8 +581,9 @@ func NewNode(ctx core.Context, cfg *config.ProtocolConfig, rs pluginCore.Reprovi
 			return nil, fmt.Errorf("failed to create basic dht: %w", dhtErr)
 		}
 		routingImpl = basicDHT
-		// Wrap basic DHT to implement pluginCore.Provider
-		dhtProvider = newBasicDHTProvider(basicDHT)
+		// Wrap basic DHT to implement pluginCore.Provider.
+		// Basic mode uses the primary DHT directly; no health gating needed.
+		dhtProvider = newBasicDHTProvider(basicDHT, nil, 0)
 		hasProvider = true
 	case config.DHTModeFullRT, "":
 		// FullRT is a client-only DHT — it does not register protocol handlers
@@ -597,16 +600,45 @@ func NewNode(ctx core.Context, cfg *config.ProtocolConfig, rs pluginCore.Reprovi
 			retry.Delay(5*time.Second),
 			retry.DelayType(retry.BackOffDelay),
 			retry.OnRetry(func(n uint, err error) {
+				CompanionDHTBootstrapAttemptsTotal.Inc()
 				ctx.Logger().Warn("failed to bootstrap companion DHT, retrying",
 					zap.Error(err),
 					zap.Uint("attempt", n+1))
 			}),
 		).Do(func() error {
+			CompanionDHTBootstrapAttemptsTotal.Inc()
 			return companion.Bootstrap(ctx)
 		})
 		if err != nil {
-			ctx.Logger().Error("failed to bootstrap companion DHT after retries",
+			CompanionDHTBootstrapFailuresTotal.Inc()
+			ctx.Logger().Error("failed to bootstrap companion DHT after retries, marking unhealthy",
 				zap.Error(err))
+			// Do NOT close the companion -- it may recover if bootstrap peers come back.
+			// The reprovider's Ready() check will gate on companionDHTHealthy.
+			// Start a background recovery goroutine that keeps trying to bootstrap.
+			go func() {
+				recoverTicker := time.NewTicker(2 * time.Minute)
+				defer recoverTicker.Stop()
+				for {
+					select {
+					case <-ctx.Done():
+						return
+					case <-recoverTicker.C:
+						CompanionDHTBootstrapAttemptsTotal.Inc()
+						if err := companion.Bootstrap(ctx); err == nil {
+							ipfsNode.companionDHTHealthy.Store(true)
+							CompanionDHTHealthy.Set(1)
+							ctx.Logger().Info("companion DHT recovered via background bootstrap")
+							return
+						} else {
+							CompanionDHTBootstrapFailuresTotal.Inc()
+						}
+					}
+				}
+			}()
+		} else {
+			ipfsNode.companionDHTHealthy.Store(true)
+			CompanionDHTHealthy.Set(1)
 		}
 		ipfsNode.companionDHT = companion
 
@@ -699,12 +731,49 @@ func NewNode(ctx core.Context, cfg *config.ProtocolConfig, rs pluginCore.Reprovi
 		// of ProvideCID which also routes through the companion when available.
 		reproviderProvider := dhtProvider
 		if ipfsNode.companionDHT != nil {
-			reproviderProvider = newBasicDHTProvider(ipfsNode.companionDHT)
+			reproviderProvider = newBasicDHTProvider(ipfsNode.companionDHT, func() bool {
+				if ipfsNode.companionDHT == nil {
+					return false
+				}
+				if !ipfsNode.companionDHTHealthy.Load() {
+					return false
+				}
+				return ipfsNode.companionDHT.RoutingTable().Size() > 0
+			}, cfg.Provider.PerCIDTimeout)
 		}
 		rp = NewReprovider(reproviderProvider, rs, ctx.Logger().Named("reprovider"))
 		reproviderCtx, cancel := context.WithCancel(ctx)
 		reproviderCancel = cancel
 		go rp.Run(reproviderCtx, cfg.Provider.Interval, cfg.Provider.Timeout, cfg.Provider.BatchSize)
+
+		// Periodic DHT metrics goroutine -- updates gauges every 30 seconds
+		// to surface DHT health degradation even when the reprovider is idle.
+		go func() {
+			ticker := time.NewTicker(30 * time.Second)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case <-ticker.C:
+					if ipfsNode.companionDHT != nil {
+						CompanionDHTRoutingTableSize.Set(float64(ipfsNode.companionDHT.RoutingTable().Size()))
+
+						peerCount := 0
+						for range ipfsNode.host.Network().Conns() {
+							peerCount++
+						}
+						CompanionDHTConnectedPeers.Set(float64(peerCount))
+
+						if ipfsNode.companionDHTHealthy.Load() {
+							CompanionDHTHealthy.Set(1)
+						} else {
+							CompanionDHTHealthy.Set(0)
+						}
+					}
+				}
+			}
+		}()
 	}
 
 	// Create boxo keystore for IPNS key management

--- a/internal/protocol/ipfs/provide.go
+++ b/internal/protocol/ipfs/provide.go
@@ -2,6 +2,9 @@ package ipfs
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -16,27 +19,75 @@ import (
 	"go.uber.org/zap"
 )
 
-// basicDHTProvider is a wrapper around basic DHT that implements pluginCore.Provider
-// For basic DHT which doesn't implement ProvideMany natively, we provide it by iterating
+// basicDHTProvider is a wrapper around basic DHT that implements pluginCore.Provider.
+// For basic DHT which doesn't implement ProvideMany natively, we provide it by iterating.
 type basicDHTProvider struct {
-	dht routing.ContentRouting
+	dht           routing.ContentRouting
+	ready         func() bool
+	perCIDTimeout time.Duration
 }
 
 func (b *basicDHTProvider) Ready() bool {
+	if b.ready != nil {
+		return b.ready()
+	}
 	return true
 }
 
 func (b *basicDHTProvider) ProvideMany(ctx context.Context, keys []multihash.Multihash) error {
+	var failed int
+	var lastErr error
+
 	for _, k := range keys {
-		if err := b.dht.Provide(ctx, cid.NewCidV1(cid.Raw, k), true); err != nil {
-			return err
+		if ctx.Err() != nil {
+			return ctx.Err()
 		}
+
+		provideCtx := ctx
+		var cancel context.CancelFunc
+		if b.perCIDTimeout > 0 {
+			provideCtx, cancel = context.WithTimeout(ctx, b.perCIDTimeout)
+		}
+
+		err := b.dht.Provide(provideCtx, cid.NewCidV1(cid.Raw, k), true)
+		if cancel != nil {
+			cancel()
+		}
+
+		if err != nil {
+			failed++
+			lastErr = err
+
+			errorType := classifyProvideError(err)
+			ReprovideCIDFailures.WithLabelValues(errorType).Inc()
+			ReprovideCIDsTotal.WithLabelValues(LabelResultFailure).Inc()
+			continue
+		}
+		ReprovideCIDsTotal.WithLabelValues(LabelResultSuccess).Inc()
+	}
+
+	if failed > 0 {
+		return fmt.Errorf("provideMany: %d/%d CIDs failed, last error: %w", failed, len(keys), lastErr)
 	}
 	return nil
 }
 
-func newBasicDHTProvider(dht routing.ContentRouting) pluginCore.Provider {
-	return &basicDHTProvider{dht: dht}
+func newBasicDHTProvider(dht routing.ContentRouting, ready func() bool, perCIDTimeout time.Duration) pluginCore.Provider {
+	return &basicDHTProvider{dht: dht, ready: ready, perCIDTimeout: perCIDTimeout}
+}
+
+func classifyProvideError(err error) string {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return "timeout"
+	}
+	if errors.Is(err, context.Canceled) {
+		return "context_cancelled"
+	}
+	msg := err.Error()
+	if strings.Contains(msg, "routing") || strings.Contains(msg, "no peers") {
+		return "routing"
+	}
+	return "other"
 }
 
 // A Reprovider periodically announces CIDs to the IPFS network.
@@ -56,6 +107,10 @@ type Reprovider struct {
 
 	// cancelledFlag is an atomic flag to track cancellation state
 	cancelledFlag atomic.Bool
+
+	// Circuit breaker
+	consecutiveFailures atomic.Uint32
+	circuitOpenUntil    atomic.Int64 // unix nano timestamp
 }
 
 // Trigger triggers the reprovider loop to run immediately.
@@ -74,8 +129,10 @@ func (r *Reprovider) Run(ctx context.Context, interval, timeout time.Duration, b
 
 	for {
 		if r.provider.Ready() {
+			ReprovideProviderReady.Set(1)
 			break
 		}
+		ReprovideProviderReady.Set(0)
 		select {
 		case <-ctx.Done():
 			return
@@ -101,7 +158,7 @@ func (r *Reprovider) Run(ctx context.Context, interval, timeout time.Duration, b
 			return
 		case <-time.After(sleepDuration):
 			r.log.Debug("reprovide sleep expired")
-			nextSleep := r.performProvide(ctx, interval, timeout, batchSize)
+			nextSleep := r.performProvide(ctx, interval, timeout, batchSize, LabelTriggerScheduled)
 			r.mu.Lock()
 			r.reprovideSleep = nextSleep
 			r.mu.Unlock()
@@ -113,8 +170,6 @@ func (r *Reprovider) handleTriggers(ctx context.Context, interval, timeout time.
 	ctx, span := core.TraceMethod(ctx, "Reprovider.handleTriggers")
 	defer span.End()
 
-	// Use a channel instead of AfterFunc for cleaner cancellation
-	// When a trigger comes, we wait for the delay then check if cancelled
 	for {
 		select {
 		case <-ctx.Done():
@@ -123,7 +178,6 @@ func (r *Reprovider) handleTriggers(ctx context.Context, interval, timeout time.
 			return
 
 		case <-r.triggerProvide:
-			// Wait for delay with cancellation support
 			delayTimer := time.NewTimer(r.triggerDelayDuration)
 
 			select {
@@ -134,22 +188,19 @@ func (r *Reprovider) handleTriggers(ctx context.Context, interval, timeout time.
 				return
 
 			case <-delayTimer.C:
-				// Timer fired, but context might have been cancelled during wait
 				select {
 				case <-ctx.Done():
 					r.cancelledFlag.Store(true)
 					close(r.cancelTrigger)
 					return
 				default:
-					// Context still valid, proceed
 				}
 
-				// Double-check cancelled flag before calling performProvide
 				if r.cancelledFlag.Load() {
 					return
 				}
 
-				r.performProvide(ctx, interval, timeout, batchSize)
+				r.performProvide(ctx, interval, timeout, batchSize, LabelTriggerManual)
 			}
 
 			r.log.Debug("reprovide triggered")
@@ -157,14 +208,28 @@ func (r *Reprovider) handleTriggers(ctx context.Context, interval, timeout time.
 	}
 }
 
-func (r *Reprovider) performProvide(ctx context.Context, interval, timeout time.Duration, batchSize int) time.Duration {
+func (r *Reprovider) performProvide(ctx context.Context, interval, timeout time.Duration, batchSize int, trigger string) time.Duration {
 	ctx, span := core.TraceMethod(ctx, "Reprovider.performProvide")
 	defer span.End()
 
-	// Check cancellation flag at start of performProvide
-	// This prevents running after context is cancelled
+	ReprovideAttemptsTotal.WithLabelValues(trigger).Inc()
+
 	if r.cancelledFlag.Load() {
 		return 10 * time.Minute
+	}
+
+	// Circuit breaker: if open, skip until cooldown expires
+	if openUntil := r.circuitOpenUntil.Load(); openUntil > 0 {
+		now := time.Now().UnixNano()
+		if now < openUntil {
+			retryAfter := time.Unix(0, openUntil)
+			r.log.Debug("circuit breaker open, skipping provide",
+				zap.Time("retry_after", retryAfter))
+			return time.Until(retryAfter)
+		}
+		// Cooldown expired -- half-open state, try again
+		r.circuitOpenUntil.Store(0)
+		ReprovideCircuitOpen.Set(0)
 	}
 
 	doProvide := func(ctx context.Context, keys []multihash.Multihash) error {
@@ -178,8 +243,6 @@ func (r *Reprovider) performProvide(ctx context.Context, interval, timeout time.
 
 	reprovideSleep := 10 * time.Minute // Default sleep time if no CIDs to provide
 
-	start := time.Now()
-
 	// Check cancellation again before calling mocks to prevent race
 	if r.cancelledFlag.Load() {
 		return reprovideSleep
@@ -188,7 +251,9 @@ func (r *Reprovider) performProvide(ctx context.Context, interval, timeout time.
 	cids, err := r.store.ProvideCIDs(ctx, batchSize)
 	if err != nil {
 		r.log.Error("failed to fetch CIDs to provide", zap.Error(err))
-		return time.Minute // Return a shorter sleep time on error
+		ReprovideFailuresTotal.Inc()
+		r.recordFailure()
+		return time.Minute
 	}
 
 	if len(cids) == 0 {
@@ -215,24 +280,62 @@ func (r *Reprovider) performProvide(ctx context.Context, interval, timeout time.
 		return c.CID.Hash()
 	})
 
+	ReprovideBatchSize.WithLabelValues().Observe(float64(len(keys)))
+
+	start := time.Now()
+
 	if err := doProvide(ctx, keys); err != nil {
-		r.log.Error("failed to provide CIDs", zap.Error(err))
-		return time.Minute // Return a shorter sleep time on error
+		ReprovideDuration.WithLabelValues().Observe(time.Since(start).Seconds())
+		ReprovideFailuresTotal.Inc()
+		failures := r.recordFailure()
+		r.log.Error("failed to provide CIDs",
+			zap.Error(err),
+			zap.Uint32("consecutive_failures", failures))
+
+		if failures >= 3 {
+			cooldown := 15 * time.Minute
+			r.circuitOpenUntil.Store(time.Now().Add(cooldown).UnixNano())
+			ReprovideCircuitOpen.Set(1)
+			r.log.Error("circuit breaker opened",
+				zap.Uint32("failures", failures),
+				zap.Duration("cooldown", cooldown))
+			return cooldown
+		}
+		return time.Minute
 	}
+
+	ReprovideDuration.WithLabelValues().Observe(time.Since(start).Seconds())
 
 	if err := r.store.SetLastAnnouncement(ctx, announced, time.Now()); err != nil {
 		r.log.Error("failed to update last announcement time", zap.Error(err))
-		return time.Minute // Return a shorter sleep time on error
+		return time.Minute
 	}
 
-	r.log.Debug("provided CIDs", zap.Int("count", len(announced)), zap.Duration("elapsed", time.Since(start)))
+	ReprovideSuccessesTotal.Inc()
+	r.recordSuccess()
 
-	// If we've provided all CIDs, wait for the full interval before checking again
+	r.log.Debug("provided CIDs",
+		zap.Int("count", len(announced)),
+		zap.Duration("elapsed", time.Since(start)))
+
 	if len(announced) < len(cids) {
 		return time.Until(cids[len(announced)].LastAnnouncement.Add(interval))
 	}
 
 	return interval
+}
+
+// recordFailure increments the consecutive failure counter and returns the new value.
+func (r *Reprovider) recordFailure() uint32 {
+	v := r.consecutiveFailures.Add(1)
+	ReprovideConsecutiveFailures.Set(float64(v))
+	return v
+}
+
+// recordSuccess resets the consecutive failure counter.
+func (r *Reprovider) recordSuccess() {
+	r.consecutiveFailures.Store(0)
+	ReprovideConsecutiveFailures.Set(0)
 }
 
 // NewReprovider creates a new reprovider.

--- a/internal/protocol/ipfs/provide_test.go
+++ b/internal/protocol/ipfs/provide_test.go
@@ -43,7 +43,7 @@ func runReproviderAndWait(ctx context.Context, cancel context.CancelFunc, reprov
 
 func TestReprovider_Run(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	
+
 	interval := 1 * time.Second
 	timeout := 500 * time.Millisecond
 	batchSize := 10
@@ -66,7 +66,7 @@ func TestReprovider_Run(t *testing.T) {
 
 func TestReprovider_Run_ProviderNotReady(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	
+
 	interval := 1 * time.Second
 	timeout := 500 * time.Millisecond
 	batchSize := 10
@@ -88,7 +88,7 @@ func TestReprovider_Run_ProviderNotReady(t *testing.T) {
 
 func TestReprovider_Run_ProvideCIDsError(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	
+
 	interval := 1 * time.Second
 	timeout := 500 * time.Millisecond
 	batchSize := 10
@@ -106,7 +106,7 @@ func TestReprovider_Run_ProvideCIDsError(t *testing.T) {
 
 func TestReprovider_Run_ProvideManyError(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	
+
 	interval := 1 * time.Second
 	timeout := 500 * time.Millisecond
 	batchSize := 10
@@ -131,7 +131,7 @@ func TestReprovider_Run_ProvideManyError(t *testing.T) {
 
 func TestReprovider_Run_SetLastAnnouncementError(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	
+
 	interval := 1 * time.Second
 	timeout := 500 * time.Millisecond
 	batchSize := 10
@@ -193,7 +193,7 @@ func TestReprovider_Trigger(t *testing.T) {
 
 	// Wait for the reprovider to run once
 	time.Sleep(2 * interval)
-	
+
 	// Clean up the goroutine
 	cancel()
 	time.Sleep(100 * time.Millisecond)
@@ -236,7 +236,7 @@ func TestReprovider_performProvide_NoCIDs(t *testing.T) {
 	// Mock store returning no CIDs
 	mockStore.EXPECT().ProvideCIDs(mock.Anything, batchSize).Return([]core.PinnedCID{}, nil).Once()
 
-	sleepDuration := reprovider.performProvide(ctx, interval, timeout, batchSize)
+	sleepDuration := reprovider.performProvide(ctx, interval, timeout, batchSize, LabelTriggerScheduled)
 
 	assert.Equal(t, 10*time.Minute, sleepDuration)
 }
@@ -265,7 +265,7 @@ func TestReprovider_performProvide_ProvideCIDsError(t *testing.T) {
 	// Mock store returning error
 	mockStore.EXPECT().ProvideCIDs(mock.Anything, batchSize).Return(nil, errors.New("test error")).Once()
 
-	sleepDuration := reprovider.performProvide(ctx, interval, timeout, batchSize)
+	sleepDuration := reprovider.performProvide(ctx, interval, timeout, batchSize, LabelTriggerScheduled)
 
 	assert.Equal(t, time.Minute, sleepDuration)
 }
@@ -296,7 +296,7 @@ func TestReprovider_performProvide_WaitingForNextInterval(t *testing.T) {
 	testCIDs := []core.PinnedCID{{CID: cid.Cid{}, LastAnnouncement: futureTime}}
 	mockStore.EXPECT().ProvideCIDs(mock.Anything, batchSize).Return(testCIDs, nil).Once()
 
-	sleepDuration := reprovider.performProvide(ctx, interval, timeout, batchSize)
+	sleepDuration := reprovider.performProvide(ctx, interval, timeout, batchSize, LabelTriggerScheduled)
 
 	assert.Less(t, time.Until(futureTime), sleepDuration)
 }
@@ -335,7 +335,7 @@ func TestReprovider_performProvide_Success(t *testing.T) {
 	// Mock store SetLastAnnouncement
 	mockStore.EXPECT().SetLastAnnouncement(mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
 
-	sleepDuration := reprovider.performProvide(ctx, interval, timeout, batchSize)
+	sleepDuration := reprovider.performProvide(ctx, interval, timeout, batchSize, LabelTriggerScheduled)
 
 	assert.Equal(t, interval, sleepDuration)
 }
@@ -375,8 +375,7 @@ func TestReprovider_performProvide_Success_NotAllAnnounced(t *testing.T) {
 	// Mock store SetLastAnnouncement
 	mockStore.EXPECT().SetLastAnnouncement(mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
 
-	sleepDuration := reprovider.performProvide(ctx, interval, timeout, batchSize)
-
+	sleepDuration := reprovider.performProvide(ctx, interval, timeout, batchSize, LabelTriggerScheduled)
 	assert.Less(t, time.Until(testCIDs[2].LastAnnouncement.Add(interval)), sleepDuration)
 }
 
@@ -411,7 +410,7 @@ func TestReprovider_performProvide_ProvideManyError(t *testing.T) {
 	// Mock provider ProvideMany returning error
 	mockProvider.EXPECT().ProvideMany(mock.Anything, mock.Anything).Return(errors.New("test error")).Once()
 
-	sleepDuration := reprovider.performProvide(ctx, interval, timeout, batchSize)
+	sleepDuration := reprovider.performProvide(ctx, interval, timeout, batchSize, LabelTriggerScheduled)
 
 	assert.Equal(t, time.Minute, sleepDuration)
 }
@@ -450,7 +449,7 @@ func TestReprovider_performProvide_SetLastAnnouncementError(t *testing.T) {
 	// Mock store SetLastAnnouncement returning error
 	mockStore.EXPECT().SetLastAnnouncement(mock.Anything, mock.Anything, mock.Anything).Return(errors.New("test error")).Once()
 
-	sleepDuration := reprovider.performProvide(ctx, interval, timeout, batchSize)
+	sleepDuration := reprovider.performProvide(ctx, interval, timeout, batchSize, LabelTriggerScheduled)
 
 	assert.Equal(t, time.Minute, sleepDuration)
 }
@@ -489,7 +488,7 @@ func TestReprovider_performProvide_MinAnnouncement(t *testing.T) {
 	// Mock store SetLastAnnouncement
 	mockStore.EXPECT().SetLastAnnouncement(mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
 
-	sleepDuration := reprovider.performProvide(ctx, interval, timeout, batchSize)
+	sleepDuration := reprovider.performProvide(ctx, interval, timeout, batchSize, LabelTriggerScheduled)
 
 	assert.Equal(t, interval, sleepDuration)
 }
@@ -529,14 +528,24 @@ func TestReprovider_performProvide_MinAnnouncement_NotAllAnnounced(t *testing.T)
 	// Mock store SetLastAnnouncement
 	mockStore.EXPECT().SetLastAnnouncement(mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
 
-	sleepDuration := reprovider.performProvide(ctx, interval, timeout, batchSize)
+	sleepDuration := reprovider.performProvide(ctx, interval, timeout, batchSize, LabelTriggerScheduled)
 
 	assert.Less(t, time.Until(testCIDs[2].LastAnnouncement.Add(interval)), sleepDuration)
 }
 
 func TestBasicDHTProvider_ProvideMany(t *testing.T) {
-	t.Run("ready_always_true", func(t *testing.T) {
-		provider := newBasicDHTProvider(&stubContentRouting{})
+	t.Run("ready_returns_false_when_fn_returns_false", func(t *testing.T) {
+		provider := newBasicDHTProvider(&stubContentRouting{}, func() bool { return false }, 0)
+		assert.False(t, provider.Ready())
+	})
+
+	t.Run("ready_returns_true_when_fn_returns_true", func(t *testing.T) {
+		provider := newBasicDHTProvider(&stubContentRouting{}, func() bool { return true }, 0)
+		assert.True(t, provider.Ready())
+	})
+
+	t.Run("ready_defaults_to_true_when_fn_is_nil", func(t *testing.T) {
+		provider := newBasicDHTProvider(&stubContentRouting{}, nil, 0)
 		assert.True(t, provider.Ready())
 	})
 
@@ -545,7 +554,7 @@ func TestBasicDHTProvider_ProvideMany(t *testing.T) {
 		c2 := cid.NewCidV1(cid.Raw, mustMultihash(t, "key2"))
 
 		scr := &stubContentRouting{}
-		provider := newBasicDHTProvider(scr)
+		provider := newBasicDHTProvider(scr, nil, 0)
 
 		keys := []multihash.Multihash{c1.Hash(), c2.Hash()}
 		err := provider.ProvideMany(context.Background(), keys)
@@ -553,19 +562,95 @@ func TestBasicDHTProvider_ProvideMany(t *testing.T) {
 		assert.Equal(t, 2, scr.provideCount)
 	})
 
-	t.Run("provide_many_stops_on_first_error", func(t *testing.T) {
+	t.Run("provide_many_continues_past_errors", func(t *testing.T) {
 		c1 := cid.NewCidV1(cid.Raw, mustMultihash(t, "key1"))
 		c2 := cid.NewCidV1(cid.Raw, mustMultihash(t, "key2"))
 
 		testErr := errors.New("provide failed")
 		scr := &stubContentRouting{err: testErr}
-		provider := newBasicDHTProvider(scr)
+		provider := newBasicDHTProvider(scr, nil, 0)
 
 		keys := []multihash.Multihash{c1.Hash(), c2.Hash()}
 		err := provider.ProvideMany(context.Background(), keys)
-		assert.ErrorIs(t, err, testErr)
-		assert.Equal(t, 1, scr.provideCount) // stopped after first error
+		assert.Error(t, err)
+		assert.Equal(t, 2, scr.provideCount) // both CIDs attempted, not just the first
 	})
+}
+
+func TestReprovider_CircuitBreaker_Open(t *testing.T) {
+	ctx := context.Background()
+
+	mockProvider := mocks.NewMockProvider(t)
+	mockStore := mocks.NewMockReprovideStore(t)
+	logger, _ := zap.NewDevelopment()
+
+	reprovider := &Reprovider{
+		provider:             mockProvider,
+		store:                mockStore,
+		log:                  logger,
+		triggerProvide:       make(chan struct{}, 1),
+		triggerDelayDuration: 100 * time.Millisecond,
+		reprovideSleep:       0,
+		mu:                   sync.Mutex{},
+	}
+
+	// Set circuit breaker to open state with a future timestamp
+	futureTime := time.Now().Add(15 * time.Minute)
+	reprovider.circuitOpenUntil.Store(futureTime.UnixNano())
+	ReprovideCircuitOpen.Set(1)
+
+	sleepDuration := reprovider.performProvide(ctx, time.Second, 500*time.Millisecond, 10, LabelTriggerScheduled)
+
+	// Should return the time until the circuit opens, without calling store or provider
+	assert.InDelta(t, 15*time.Minute, sleepDuration, float64(time.Second))
+	mockProvider.AssertNotCalled(t, "ProvideMany")
+	mockStore.AssertNotCalled(t, "ProvideCIDs")
+}
+
+func TestReprovider_CircuitBreaker_OpenAfter3Failures(t *testing.T) {
+	ctx := context.Background()
+
+	mockProvider := mocks.NewMockProvider(t)
+	mockStore := mocks.NewMockReprovideStore(t)
+	logger, _ := zap.NewDevelopment()
+
+	interval := 1 * time.Second
+	timeout := 500 * time.Millisecond
+	batchSize := 10
+
+	reprovider := &Reprovider{
+		provider:             mockProvider,
+		store:                mockStore,
+		log:                  logger,
+		triggerProvide:       make(chan struct{}, 1),
+		triggerDelayDuration: 100 * time.Millisecond,
+		reprovideSleep:       0,
+		mu:                   sync.Mutex{},
+	}
+
+	testCIDs := []core.PinnedCID{
+		{CID: cid.Cid{}, LastAnnouncement: time.Now().Add(-2 * interval)},
+		{CID: cid.Cid{}, LastAnnouncement: time.Now().Add(-2 * interval)},
+	}
+
+	// Simulate 3 consecutive failures
+	for i := 0; i < 3; i++ {
+		mockStore.EXPECT().ProvideCIDs(mock.Anything, batchSize).Return(testCIDs, nil).Once()
+		mockProvider.EXPECT().ProvideMany(mock.Anything, mock.Anything).Return(errors.New("test error")).Once()
+
+		sleepDuration := reprovider.performProvide(ctx, interval, timeout, batchSize, LabelTriggerScheduled)
+
+		if i < 2 {
+			// First two failures: return time.Minute, circuit not yet open
+			assert.Equal(t, time.Minute, sleepDuration, "attempt %d", i)
+		} else {
+			// Third failure: circuit opens, return 15 minutes cooldown
+			assert.Equal(t, 15*time.Minute, sleepDuration, "attempt %d", i)
+		}
+	}
+
+	// Circuit breaker should now be open
+	assert.True(t, reprovider.circuitOpenUntil.Load() > 0)
 }
 
 // stubContentRouting is a minimal routing.ContentRouting stub for testing.

--- a/internal/service/website/validate_target_test.go
+++ b/internal/service/website/validate_target_test.go
@@ -3,12 +3,15 @@ package website
 import (
 	"testing"
 
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"go.lumeweb.com/portal/core"
 	pluginCore "go.lumeweb.com/portal-plugin-ipfs/core"
 	pluginDb "go.lumeweb.com/portal-plugin-ipfs/internal/db"
+	"go.lumeweb.com/portal-plugin-ipfs/internal/testing/mocks"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/testing/util"
 	coreTesting "go.lumeweb.com/portal/core/testing"
+	"gorm.io/gorm"
 )
 
 const (
@@ -167,105 +170,139 @@ func TestValidateTarget_IPNS_MultiplePeerIDFormats(t *testing.T) {
 	}, TestOptions)
 }
 
-func TestValidateIPNSTarget_ValidPeerID(t *testing.T) {
+func TestValidateIPFSTarget_PinnedCID(t *testing.T) {
 	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 		// Arrange
 		websiteService := core.GetService[pluginCore.WebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
 		require.NotNil(tb, websiteService)
+		svc := websiteService.(*WebsiteServiceDefault)
 
-		// Use a valid peer ID
-		peerIDString := TestPeerID1
+		mockPinSvc := core.GetService[*mocks.MockIPFSPinService](ctx, pluginCore.PIN_SERVICE)
+		require.NotNil(tb, mockPinSvc)
 
-		// Act & Assert
-		valid, err := websiteService.(*WebsiteServiceDefault).validateIPNSTarget(ctx, peerIDString)
-		require.NoError(tb, err, "Valid peer ID should pass validation")
-		require.True(tb, valid, "Valid peer ID should return true")
+		testCID := util.GenerateTestCID(t, "pinned-content")
+		testUserID := uint(1)
+
+		// Mock: pin exists and is pinned
+		mockPinSvc.EXPECT().GetPinByCIDAndUser(mock.Anything, testCID, testUserID).
+			Return(&pluginDb.IPFSPin{
+				UserID: testUserID,
+				CID:    testCID.Bytes(),
+				Status: pluginDb.PinningStatusPinned,
+			}, nil).Once()
+
+		// Act & Assert — should succeed because the CID is pinned
+		err := svc.validateIPFSTarget(ctx, testUserID, testCID.String())
+		require.NoError(tb, err, "Pinned CID should pass validation")
 	}, TestOptions)
 }
 
-func TestValidateIPNSTarget_CIDv1Libp2pKey(t *testing.T) {
+func TestValidateIPFSTarget_UnpinnedCID(t *testing.T) {
 	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 		// Arrange
 		websiteService := core.GetService[pluginCore.WebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
 		require.NotNil(tb, websiteService)
+		svc := websiteService.(*WebsiteServiceDefault)
 
-		// Use a valid CIDv1 with libp2p-key codec
-		cidv1Key := TestCIDv1Libp2pKey
+		mockPinSvc := core.GetService[*mocks.MockIPFSPinService](ctx, pluginCore.PIN_SERVICE)
+		require.NotNil(tb, mockPinSvc)
 
-		// Act & Assert
-		valid, err := websiteService.(*WebsiteServiceDefault).validateIPNSTarget(ctx, cidv1Key)
-		require.NoError(tb, err, "Valid CIDv1 with libp2p-key codec should pass validation")
-		require.True(tb, valid, "Valid CIDv1 should return true")
+		testCID := util.GenerateTestCID(t, "unpinned-content")
+		testUserID := uint(1)
+
+		// Mock: no pin record found
+		mockPinSvc.EXPECT().GetPinByCIDAndUser(mock.Anything, testCID, testUserID).
+			Return(nil, gorm.ErrRecordNotFound).Once()
+
+		// Act & Assert — should fail because the CID is not pinned
+		err := svc.validateIPFSTarget(ctx, testUserID, testCID.String())
+		require.Error(tb, err, "Unpinned CID should fail validation")
+		require.ErrorIs(tb, err, ErrCIDNotPinned)
 	}, TestOptions)
 }
 
-func TestValidateIPNSTarget_InvalidPeerID(t *testing.T) {
+func TestValidateIPFSTarget_QueuedPin(t *testing.T) {
 	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 		// Arrange
 		websiteService := core.GetService[pluginCore.WebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
 		require.NotNil(tb, websiteService)
+		svc := websiteService.(*WebsiteServiceDefault)
 
-		// Invalid peer ID string
-		invalidPeerID := "not-valid-peer-id"
+		mockPinSvc := core.GetService[*mocks.MockIPFSPinService](ctx, pluginCore.PIN_SERVICE)
+		require.NotNil(tb, mockPinSvc)
 
-		// Act & Assert
-		valid, err := websiteService.(*WebsiteServiceDefault).validateIPNSTarget(ctx, invalidPeerID)
-		require.Error(tb, err, "Invalid peer ID should fail validation")
-		require.False(tb, valid, "Invalid peer ID should return false")
+		testCID := util.GenerateTestCID(t, "queued-content")
+		testUserID := uint(1)
+
+		// Mock: pin exists but is still queued
+		mockPinSvc.EXPECT().GetPinByCIDAndUser(mock.Anything, testCID, testUserID).
+			Return(&pluginDb.IPFSPin{
+				UserID: testUserID,
+				CID:    testCID.Bytes(),
+				Status: pluginDb.PinningStatusQueued,
+			}, nil).Once()
+
+		// Act & Assert — should fail because the pin is still queued, not pinned
+		err := svc.validateIPFSTarget(ctx, testUserID, testCID.String())
+		require.Error(tb, err, "Queued (not yet pinned) CID should fail validation")
+		require.ErrorIs(tb, err, ErrCIDNotPinned)
 	}, TestOptions)
 }
 
-func TestValidateIPNSTarget_InvalidCID(t *testing.T) {
+func TestValidateIPFSTarget_InvalidCID(t *testing.T) {
 	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 		// Arrange
 		websiteService := core.GetService[pluginCore.WebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
 		require.NotNil(tb, websiteService)
+		svc := websiteService.(*WebsiteServiceDefault)
 
-		// Invalid CID format
-		invalidCID := "invalid-cid-format"
-
-		// Act & Assert
-		valid, err := websiteService.(*WebsiteServiceDefault).validateIPNSTarget(ctx, invalidCID)
-		require.Error(tb, err, "Invalid CID should fail validation")
-		require.False(tb, valid, "Invalid CID should return false")
+		// Act & Assert — invalid CID string should return an error
+		err := svc.validateIPFSTarget(ctx, 1, "not-a-valid-cid")
+		require.Error(tb, err, "Invalid CID string should fail validation")
 	}, TestOptions)
 }
 
-func TestValidateIPNSTarget_CIDNotLibp2pKey(t *testing.T) {
+func TestValidateIPNSKeyResolution_KeyExists(t *testing.T) {
 	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 		// Arrange
 		websiteService := core.GetService[pluginCore.WebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
 		require.NotNil(tb, websiteService)
+		svc := websiteService.(*WebsiteServiceDefault)
 
-		// Valid CID but not libp2p-key codec
-		nonLibp2pKeyCID := "bafkreiem6tcea4zz7g2z4w4ocjp7t3ve5s7uoixxxdh2ikvmq3retdhsy"
+		mockIPNSKeySvc := core.GetService[*mocks.MockIPNSKeyService](ctx, pluginCore.IPNS_KEY_SERVICE)
+		require.NotNil(tb, mockIPNSKeySvc)
 
-		// Act & Assert
-		valid, err := websiteService.(*WebsiteServiceDefault).validateIPNSTarget(ctx, nonLibp2pKeyCID)
-		require.Error(tb, err, "CID without libp2p-key codec should fail validation")
-		require.False(tb, valid, "CID without libp2p-key codec should return false")
+		testUserID := uint(1)
+		peerIDStr := TestPeerID1
+
+		// Mock: key exists and belongs to the user
+		mockIPNSKeySvc.EXPECT().GetPrivateKeyByPeerID(mock.Anything, peerIDStr).
+			Return(nil, testUserID, nil).Once()
+
+		// Act & Assert — should succeed because the key exists and belongs to the user
+		err := svc.validateIPNSKeyResolution(ctx, testUserID, peerIDStr)
+		require.NoError(tb, err, "Valid IPNS key belonging to the user should pass validation")
 	}, TestOptions)
 }
 
-func TestValidateIPNSTarget_MultipleValidFormats(t *testing.T) {
+func TestValidateIPNSKeyResolution_KeyNotFound(t *testing.T) {
 	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 		// Arrange
 		websiteService := core.GetService[pluginCore.WebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
 		require.NotNil(tb, websiteService)
+		svc := websiteService.(*WebsiteServiceDefault)
 
-		// Test multiple valid peer ID formats and CIDv1 libp2p-key formats
-		validTargets := []string{
-			TestPeerID1,        // ed25519 peer ID
-			TestPeerID2,        // Another valid ed25519 peer ID
-			TestCIDv1Libp2pKey, // CIDv1 libp2p-key
-		}
+		mockIPNSKeySvc := core.GetService[*mocks.MockIPNSKeyService](ctx, pluginCore.IPNS_KEY_SERVICE)
+		require.NotNil(tb, mockIPNSKeySvc)
 
-		// Act & Assert
-		for _, target := range validTargets {
-			valid, err := websiteService.(*WebsiteServiceDefault).validateIPNSTarget(ctx, target)
-			require.NoError(tb, err, "Target %s should pass validation", target)
-			require.True(tb, valid, "Target %s should return true", target)
-		}
+		// Act & Assert — should fail because no key exists for this peer ID
+		peerIDStr := TestPeerID1
+		mockIPNSKeySvc.EXPECT().GetPrivateKeyByPeerID(mock.Anything, peerIDStr).
+			Return(nil, uint(0), gorm.ErrRecordNotFound).Once()
+
+		err := svc.validateIPNSKeyResolution(ctx, 1, peerIDStr)
+		require.Error(tb, err, "Non-existent IPNS key should fail validation")
+		require.ErrorIs(tb, err, ErrIPNSKeyNotFound)
 	}, TestOptions)
 }
 

--- a/internal/service/website/website.go
+++ b/internal/service/website/website.go
@@ -60,6 +60,8 @@ var (
 	ErrInvalidIPNS   = errors.New("invalid IPNS name")
 	ErrInvalidTarget = errors.New("invalid target")
 	ErrInvalidDomain = errors.New("invalid domain")
+	ErrCIDNotPinned  = errors.New("CID is not pinned")
+	ErrIPNSKeyNotFound = errors.New("IPNS key not found")
 )
 
 // WebsiteServiceDefault implements the WebsiteService interface
@@ -499,6 +501,12 @@ func (s *WebsiteServiceDefault) UpdateWebsite(ctx context.Context, userID uint, 
 						publishCID := targetHashStr
 						var publishHash string
 
+						// Verify the CID is pinned before publishing to IPNS
+						if err := s.validateIPFSTarget(ctx, userID, publishCID); err != nil {
+							_ = tx.AddError(fmt.Errorf("CID validation failed: %w", err))
+							return tx
+						}
+
 						ipnsKey, err := s.ensureIPNSKey(ctx, website.UserID, website.Domain, publishCID)
 						if err != nil {
 							_ = tx.AddError(err)
@@ -528,6 +536,14 @@ func (s *WebsiteServiceDefault) UpdateWebsite(ctx context.Context, userID uint, 
 							return tx
 						}
 
+						// For IPNS targets, verify the key exists and belongs to the user
+						if targetType == string(pluginDb.WebsiteTargetTypeIPNS) {
+							if err := s.validateIPNSKeyResolution(ctx, userID, targetHashStr); err != nil {
+								_ = tx.AddError(fmt.Errorf("IPNS key validation failed: %w", err))
+								return tx
+							}
+						}
+
 						// Check if target hash changed
 						if targetHashStr != oldTargetHash {
 							targetHashChanged = true
@@ -541,6 +557,13 @@ func (s *WebsiteServiceDefault) UpdateWebsite(ctx context.Context, userID uint, 
 								_ = tx.AddError(fmt.Errorf("failed to decode CID: %w", err))
 								return tx
 							}
+
+							// Verify the CID is pinned before accepting the update
+							if err := s.validateIPFSTarget(ctx, userID, targetHashStr); err != nil {
+								_ = tx.AddError(fmt.Errorf("CID validation failed: %w", err))
+								return tx
+							}
+
 							normalizedCid := encoding.NormalizeCid(c)
 							updates["target_multihash"] = normalizedCid.Hash()
 							version := uint8(normalizedCid.Version())
@@ -568,6 +591,12 @@ func (s *WebsiteServiceDefault) UpdateWebsite(ctx context.Context, userID uint, 
 					if requestedType == pluginDb.WebsiteTargetTypeIPNS && oldTargetType == pluginDb.WebsiteTargetTypeIPFS {
 						// IPFS → IPNS: auto-create key, publish current CID
 						publishCID := oldTargetHash
+
+						// Verify the CID is pinned before publishing to IPNS
+						if err := s.validateIPFSTarget(ctx, userID, publishCID); err != nil {
+							_ = tx.AddError(fmt.Errorf("CID validation failed: %w", err))
+							return tx
+						}
 
 						ipnsKey, err := s.ensureIPNSKey(ctx, website.UserID, website.Domain, publishCID)
 						if err != nil {
@@ -1233,33 +1262,23 @@ func (s *WebsiteServiceDefault) CheckStatus(ctx context.Context, website *plugin
 			switch pluginDb.WebsiteTargetType(website.TargetType) {
 			case pluginDb.WebsiteTargetTypeIPFS:
 				// For IPFS targets, check if the CID is pinned
-				valid, err := s.validateIPFSTarget(ctx, website.TargetHash())
-				if err != nil {
+				if err := s.validateIPFSTarget(ctx, website.UserID, website.TargetHash()); err != nil {
 					s.Logger().Error("Failed to validate IPFS target",
 						zap.Error(err),
 						zap.String("target_hash", website.TargetHash()))
 					return pluginDb.WebsiteStatusBroken, fmt.Errorf("failed to validate IPFS target: %w", err)
 				}
-				if valid {
-					newStatus = pluginDb.WebsiteStatusActive
-				} else {
-					newStatus = pluginDb.WebsiteStatusBroken
-				}
+				newStatus = pluginDb.WebsiteStatusActive
 
 			case pluginDb.WebsiteTargetTypeIPNS:
-				// For IPNS targets, check if the key exists
-				valid, err := s.validateIPNSTarget(ctx, website.TargetHash())
-				if err != nil {
+				// For IPNS targets, check if the key exists and belongs to the owner
+				if err := s.validateIPNSKeyResolution(ctx, website.UserID, website.TargetHash()); err != nil {
 					s.Logger().Error("Failed to validate IPNS target",
 						zap.Error(err),
 						zap.String("target_hash", website.TargetHash()))
 					return pluginDb.WebsiteStatusBroken, fmt.Errorf("failed to validate IPNS target: %w", err)
 				}
-				if valid {
-					newStatus = pluginDb.WebsiteStatusActive
-				} else {
-					newStatus = pluginDb.WebsiteStatusBroken
-				}
+				newStatus = pluginDb.WebsiteStatusActive
 
 			default:
 				return pluginDb.WebsiteStatusBroken, fmt.Errorf("unknown target type: %s", website.TargetType)
@@ -1425,33 +1444,40 @@ func (s *WebsiteServiceDefault) validateTarget(targetType string, targetHash str
 	return nil
 }
 
-// validateIPFSTarget checks if an IPFS CID is pinned
-func (s *WebsiteServiceDefault) validateIPFSTarget(ctx context.Context, targetHash string) (bool, error) {
+// validateIPFSTarget checks if an IPFS CID is pinned and returns an error if not.
+func (s *WebsiteServiceDefault) validateIPFSTarget(ctx context.Context, userID uint, targetHash string) error {
 	c, err := cid.Decode(targetHash)
 	if err != nil {
-		return false, err
+		return fmt.Errorf("%w: %v", ErrInvalidCID, err)
 	}
 
-	// Check if the CID is pinned by any user
-	// For Phase 1, we'll just check if it's a valid CID
-	// In production, we would check the pin status
-	_, err = s.pinSvc.GetPinByCIDAndUser(ctx, c, 0)
-	if err != nil {
-		return false, nil // Not pinned
+	c = encoding.NormalizeCid(c)
+
+	pin, err := s.pinSvc.GetPinByCIDAndUser(ctx, c, userID)
+	if err != nil || pin == nil {
+		return ErrCIDNotPinned
 	}
 
-	return true, nil
+	if pin.Status != pluginDb.PinningStatusPinned {
+		return ErrCIDNotPinned
+	}
+
+	return nil
 }
 
-// validateIPNSTarget checks if an IPNS key exists
-func (s *WebsiteServiceDefault) validateIPNSTarget(ctx context.Context, targetHash string) (bool, error) {
-	// For Phase 1, we'll just check if the IPNS name is valid
-	// In production, we would check if the key exists in the database
-	if !isValidIPNSTarget(targetHash) {
-		return false, fmt.Errorf("invalid IPNS target")
+// validateIPNSKeyResolution checks that the IPNS key for the given peer ID
+// exists and belongs to the website owner.
+func (s *WebsiteServiceDefault) validateIPNSKeyResolution(ctx context.Context, userID uint, peerID string) error {
+	_, keyUserID, err := s.ipnsKeySvc.GetPrivateKeyByPeerID(ctx, peerID)
+	if err != nil {
+		return fmt.Errorf("%w: %v", ErrIPNSKeyNotFound, err)
 	}
 
-	return true, nil
+	if keyUserID != userID {
+		return fmt.Errorf("%w: key belongs to user %d, not %d", ErrIPNSKeyNotFound, keyUserID, userID)
+	}
+
+	return nil
 }
 
 // generateValidationToken generates a random validation token

--- a/internal/service/website/website_test.go
+++ b/internal/service/website/website_test.go
@@ -1281,6 +1281,7 @@ func TestWebsiteService_UpdateWebsite_DNSRecordsUpdatedWhenTargetChanges(t *test
 	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 		// Arrange
 		websiteService := core.GetService[pluginCore.WebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
+		mockPinSvc := core.GetService[*mocks.MockIPFSPinService](ctx, pluginCore.PIN_SERVICE)
 
 		testCID := util.GenerateTestCID(t, "test data")
 		domain := "dns-update-test.com"
@@ -1294,6 +1295,11 @@ func TestWebsiteService_UpdateWebsite_DNSRecordsUpdatedWhenTargetChanges(t *test
 
 		// Act - Update target to a new CID
 		newCID := util.GenerateTestCID(t, "new data for update")
+
+		// Mock: new CID must be pinned for validation to pass
+		mockPinSvc.EXPECT().GetPinByCIDAndUser(mock.Anything, newCID, testUserID1).
+			Return(&pluginDb.IPFSPin{UserID: testUserID1, CID: newCID.Bytes(), Status: pluginDb.PinningStatusPinned}, nil).Once()
+
 		updates := map[string]interface{}{
 			"target_hash": newCID.String(),
 		}
@@ -1922,6 +1928,12 @@ func TestWebsiteService_UpdateWebsite_ConvertIPFSToIPNS(t *testing.T) {
 		// Update to IPNS by changing target_hash to a peer ID
 		// targetType will be auto-detected as IPNS
 		testPeerID := "12D3KooWCqvCZqaG6LmG4mtoWZZwrvYB911DK8qqwE9gc25s4Hft"
+
+		// Mock: IPNS key must exist and belong to the user
+		mockIPNSKey := core.GetService[*mocks.MockIPNSKeyService](ctx, pluginCore.IPNS_KEY_SERVICE)
+		mockIPNSKey.EXPECT().GetPrivateKeyByPeerID(mock.Anything, testPeerID).
+			Return(nil, testUserID1, nil).Once()
+
 		updates := map[string]interface{}{
 			"target_hash": testPeerID,
 		}
@@ -2334,6 +2346,12 @@ func TestWebsiteService_UpdateWebsite_ConvertIPNSToIPFS_UpdatesDNSRecords(t *tes
 
 		// Act - Update from IPNS to IPFS
 		newCID := util.GenerateTestCID(t, "new ipfs content")
+
+		// Mock: new CID must be pinned for validation to pass
+		mockPinSvc := core.GetService[*mocks.MockIPFSPinService](ctx, pluginCore.PIN_SERVICE)
+		mockPinSvc.EXPECT().GetPinByCIDAndUser(mock.Anything, newCID, testUserID1).
+			Return(&pluginDb.IPFSPin{UserID: testUserID1, CID: newCID.Bytes(), Status: pluginDb.PinningStatusPinned}, nil).Once()
+
 		updates := map[string]interface{}{
 			"target_hash": newCID.String(),
 			"target_type": string(pluginDb.WebsiteTargetTypeIPFS),
@@ -2398,6 +2416,11 @@ func TestWebsiteService_UpdateWebsite_IPNSToIPNS_NoDNSUpdate(t *testing.T) {
 
 		// Act - Update to a new IPNS peer ID (staying as IPNS)
 		testPeerID := "12D3KooWCqvCZqaG6LmG4mtoWZZwrvYB911DK8qqwE9gc25s4Hft"
+
+		// Mock: IPNS key must exist and belong to the user
+		mockIPNSKey.EXPECT().GetPrivateKeyByPeerID(mock.Anything, testPeerID).
+			Return(nil, testUserID1, nil).Once()
+
 		updates := map[string]interface{}{
 			"target_hash": testPeerID,
 		}
@@ -2455,6 +2478,12 @@ func TestWebsiteService_UpdateWebsite_ConvertIPFSToIPNS_UpdatesDNSRecords(t *tes
 
 		// First, switch back to IPFS to set up the IPFS→IPNS scenario
 		newCID := util.GenerateTestCID(t, "intermediate ipfs content")
+
+		// Mock: CID must be pinned for validation to pass
+		mockPinSvc := core.GetService[*mocks.MockIPFSPinService](ctx, pluginCore.PIN_SERVICE)
+		mockPinSvc.EXPECT().GetPinByCIDAndUser(mock.Anything, newCID, testUserID1).
+			Return(&pluginDb.IPFSPin{UserID: testUserID1, CID: newCID.Bytes(), Status: pluginDb.PinningStatusPinned}, nil).Once()
+
 		ipfsUpdates := map[string]interface{}{
 			"target_hash": newCID.String(),
 			"target_type": string(pluginDb.WebsiteTargetTypeIPFS),
@@ -2476,6 +2505,11 @@ func TestWebsiteService_UpdateWebsite_ConvertIPFSToIPNS_UpdatesDNSRecords(t *tes
 
 		// Act - Update from IPFS to IPNS
 		testPeerID := "12D3KooWCqvCZqaG6LmG4mtoWZZwrvYB911DK8qqwE9gc25s4Hft"
+
+		// Mock: IPNS key must exist and belong to the user
+		mockIPNSKey.EXPECT().GetPrivateKeyByPeerID(mock.Anything, testPeerID).
+			Return(nil, testUserID1, nil).Once()
+
 		ipnsUpdates := map[string]interface{}{
 			"target_hash": testPeerID,
 		}
@@ -2520,6 +2554,11 @@ func TestWebsiteService_UpdateWebsite_TargetTypeIPNSAlone(t *testing.T) {
 
 		testIPNSKey := setupIPNSAutoCreationMocks(t, mockIPNSKey, testUserID1, domain, testCID)
 
+		// Mock: existing CID must be pinned for validation to pass
+		mockPinSvc := core.GetService[*mocks.MockIPFSPinService](ctx, pluginCore.PIN_SERVICE)
+		mockPinSvc.EXPECT().GetPinByCIDAndUser(mock.Anything, testCID, testUserID1).
+			Return(&pluginDb.IPFSPin{UserID: testUserID1, CID: testCID.Bytes(), Status: pluginDb.PinningStatusPinned}, nil).Once()
+
 		updates := map[string]interface{}{
 			"target_type": string(pluginDb.WebsiteTargetTypeIPNS),
 		}
@@ -2554,6 +2593,11 @@ func TestWebsiteService_UpdateWebsite_TargetTypeIPNSAlone_DNSRecordsUpdated(t *t
 		assert.Equal(tb, string(pluginDb.WebsiteTargetTypeIPFS), createdWebsite.TargetType)
 
 		testIPNSKey := setupIPNSAutoCreationMocks(t, mockIPNSKey, testUserID1, domain, testCID)
+
+		// Mock: existing CID must be pinned for validation to pass
+		mockPinSvc := core.GetService[*mocks.MockIPFSPinService](ctx, pluginCore.PIN_SERVICE)
+		mockPinSvc.EXPECT().GetPinByCIDAndUser(mock.Anything, testCID, testUserID1).
+			Return(&pluginDb.IPFSPin{UserID: testUserID1, CID: testCID.Bytes(), Status: pluginDb.PinningStatusPinned}, nil).Once()
 
 		updates := map[string]interface{}{
 			"target_type": string(pluginDb.WebsiteTargetTypeIPNS),
@@ -2595,6 +2639,12 @@ func TestWebsiteService_UpdateWebsite_IPNSTargetTypeWithCID(t *testing.T) {
 		assert.Equal(tb, string(pluginDb.WebsiteTargetTypeIPFS), createdWebsite.TargetType)
 
 		newCID := util.GenerateTestCID(t, "new data for ipns")
+
+		// Mock: CID must be pinned for validation to pass
+		mockPinSvc := core.GetService[*mocks.MockIPFSPinService](ctx, pluginCore.PIN_SERVICE)
+		mockPinSvc.EXPECT().GetPinByCIDAndUser(mock.Anything, newCID, testUserID1).
+			Return(&pluginDb.IPFSPin{UserID: testUserID1, CID: newCID.Bytes(), Status: pluginDb.PinningStatusPinned}, nil).Once()
+
 		testIPNSKey := setupIPNSAutoCreationMocks(t, mockIPNSKey, testUserID1, domain, newCID)
 
 		updates := map[string]interface{}{


### PR DESCRIPTION
## Summary

Redesign the IPFS reprovider for resilience against DHT failures and slow CID provides.

## Changes

- **PerCIDTimeout config** (default 10s): per-CID context cancellation prevents one slow provide from blocking the entire batch
- **basicDHTProvider**: wraps DHT provider with a ready check and perCIDTimeout; skips reprovide cycles when DHT is unhealthy
- **Per-CID ProvideMany loop**: iterates CIDs individually, continues past errors instead of aborting on first failure
- **Circuit breaker**: 3 consecutive failures opens a 15min cooldown; half-open probe on next attempt before resuming normal cycles
- **Companion DHT health tracking**: bootstrap failure marks DHT unhealthy and spawns a recovery goroutine (2min retry interval)
- **DHT metrics goroutine**: updates peer count, routing table size, and bootstrap health gauges every 30s
- **11 Prometheus metrics**: reprovider attempts/successes/failures/duration/CIDs processed+failed, circuit breaker state, DHT connected peers, routing table size, bootstrap status

## Tests

- Circuit breaker open state skips provide (returns cooldown)
- Circuit breaker opens after 3 consecutive failures
- basicDHTProvider ready function: false/true/nil-default cases
- ProvideMany continues past errors (attempts all CIDs)
- All existing provide tests updated for new signatures

* `develop` <!-- branch-stack -->
  - **feat(ipfs): reprovider resilience redesign** :point\_left:

***

<!-- kody-pr-summary:start -->

## Description

This PR redesigns the IPFS reprovider for resilience against DHT failures and strengthens website target validation.

### Reprovider Resilience

**Root cause fixed:** The companion DHT bootstrap was failing silently — it logged an error but did not return, leaving a "zombie" DHT with no routing table entries. Every subsequent `Provide()` call would hang until the context timeout expired (\~31 minutes), causing 100% reprovide failure rates.

**Key changes:**

1. **DHT health tracking and recovery** (`node.go`): Added a `companionDHTHealthy` atomic flag. On bootstrap failure, the DHT is marked unhealthy and a background goroutine retries bootstrap every 2 minutes until it succeeds. The companion DHT is no longer closed on failure since it may recover.

2. **Readiness gating** (`provide.go`): The provider's `Ready()` check now verifies DHT health (healthy flag + non-empty routing table) before allowing reprovide cycles to proceed. Previously it always returned `true`.

3. **Per-CID timeout** (`provide.go`, `config.go`): Added a configurable per-CID timeout (default 10s) so a single hanging CID no longer blocks the entire batch. `ProvideMany` now continues past individual CID failures instead of aborting on the first error.

4. **Circuit breaker** (`provide.go`): After 3 consecutive failures, the circuit breaker opens for a 15-minute cooldown, preventing the reprovider from hammering an unreachable DHT every minute.

5. **Prometheus metrics** (`metrics.go`, `info.go`): Added comprehensive observability — reprovider attempt/success/failure counts, per-CID success/failure with error classification, duration histograms, batch size, circuit breaker state, provider readiness, DHT health, routing table size, bootstrap attempts/failures, and connected peer count. A background goroutine updates DHT gauges every 30 seconds.

### Website Target Validation

**`website.go`:** Replaced placeholder validation with real ownership checks:

- `validateIPFSTarget` now verifies the CID is actually pinned by the requesting user with `Pinned` status (previously only checked CID format validity with a `userID=0` lookup)
- `validateIPNSTarget` replaced with `validateIPNSKeyResolution`, which verifies the IPNS key exists in the database and belongs to the website owner
- These validations are now enforced during `UpdateWebsite` for all target transition paths (IPFS→IPNS, IPNS→IPFS, IPFS→IPFS, IPNS→IPNS) and during `CheckStatus`

<!-- kody-pr-summary:end -->
