### PR TITLE
fix: give each histogram metric a unique name

### DIFF
--- a/internal/service/pin/metrics.go
+++ b/internal/service/pin/metrics.go
@@ -12,9 +12,16 @@ const (
 	MetricReplacePin        = "replace_pin_total"
 	MetricDeletePin         = "delete_pin_total"
 	MetricUpdatePinStatus   = "update_pin_status_total"
-	MetricValidateDAG       = "validate_dag_completion_total"
-	MetricGetPinByCID       = "get_pin_by_cid_total"
-	MetricDuration          = "duration_seconds"
+	MetricValidateDAG             = "validate_dag_completion_total"
+	MetricGetPinByCID             = "get_pin_by_cid_total"
+	MetricAddPinDuration          = "add_pin_duration_seconds"
+	MetricGetPinByRequestIDDuration = "get_pin_by_request_id_duration_seconds"
+	MetricListPinsDuration        = "list_pins_duration_seconds"
+	MetricReplacePinDuration      = "replace_pin_duration_seconds"
+	MetricDeletePinDuration       = "delete_pin_duration_seconds"
+	MetricUpdatePinStatusDuration = "update_pin_status_duration_seconds"
+	MetricValidateDAGDuration     = "validate_dag_completion_duration_seconds"
+	MetricGetPinByCIDDuration     = "get_pin_by_cid_duration_seconds"
 )
 
 const (
@@ -119,7 +126,7 @@ func init() {
 	// Histograms
 	AddPinDuration = *prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Name:      MetricDuration,
+			Name:      MetricAddPinDuration,
 			Subsystem: pluginCore.PIN_SERVICE,
 			Help:      "Duration of AddPin operations in seconds",
 			Buckets:   prometheus.DefBuckets,
@@ -129,7 +136,7 @@ func init() {
 
 	GetPinByRequestIDDuration = *prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Name:      MetricDuration,
+			Name:      MetricGetPinByRequestIDDuration,
 			Subsystem: pluginCore.PIN_SERVICE,
 			Help:      "Duration of GetPinByRequestID operations in seconds",
 			Buckets:   prometheus.DefBuckets,
@@ -139,7 +146,7 @@ func init() {
 
 	ListPinsDuration = *prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Name:      MetricDuration,
+			Name:      MetricListPinsDuration,
 			Subsystem: pluginCore.PIN_SERVICE,
 			Help:      "Duration of ListPins operations in seconds",
 			Buckets:   prometheus.DefBuckets,
@@ -149,7 +156,7 @@ func init() {
 
 	ReplacePinDuration = *prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Name:      MetricDuration,
+			Name:      MetricReplacePinDuration,
 			Subsystem: pluginCore.PIN_SERVICE,
 			Help:      "Duration of ReplacePin operations in seconds",
 			Buckets:   prometheus.DefBuckets,
@@ -159,7 +166,7 @@ func init() {
 
 	DeletePinDuration = *prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Name:      MetricDuration,
+			Name:      MetricDeletePinDuration,
 			Subsystem: pluginCore.PIN_SERVICE,
 			Help:      "Duration of DeletePin operations in seconds",
 			Buckets:   prometheus.DefBuckets,
@@ -169,7 +176,7 @@ func init() {
 
 	UpdatePinStatusDuration = *prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Name:      MetricDuration,
+			Name:      MetricUpdatePinStatusDuration,
 			Subsystem: pluginCore.PIN_SERVICE,
 			Help:      "Duration of UpdatePinStatus operations in seconds",
 			Buckets:   prometheus.DefBuckets,
@@ -179,7 +186,7 @@ func init() {
 
 	ValidateDAGDuration = *prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Name:      MetricDuration,
+			Name:      MetricValidateDAGDuration,
 			Subsystem: pluginCore.PIN_SERVICE,
 			Help:      "Duration of ValidateDAGCompletion operations in seconds",
 			Buckets:   prometheus.DefBuckets,
@@ -189,7 +196,7 @@ func init() {
 
 	GetPinByCIDDuration = *prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Name:      MetricDuration,
+			Name:      MetricGetPinByCIDDuration,
 			Subsystem: pluginCore.PIN_SERVICE,
 			Help:      "Duration of GetPinByCID operations in seconds",
 			Buckets:   prometheus.DefBuckets,

--- a/internal/service/website/metrics.go
+++ b/internal/service/website/metrics.go
@@ -12,9 +12,16 @@ const (
 	MetricListWebsites       = "list_websites_total"
 	MetricUpdateWebsite      = "update_website_total"
 	MetricDeleteWebsite      = "delete_website_total"
-	MetricValidateDNS        = "validate_dns_total"
-	MetricCheckStatus        = "check_status_total"
-	MetricDuration           = "duration_seconds"
+	MetricValidateDNS               = "validate_dns_total"
+	MetricCheckStatus               = "check_status_total"
+	MetricCreateWebsiteDuration     = "create_website_duration_seconds"
+	MetricGetWebsiteDuration        = "get_website_duration_seconds"
+	MetricGetWebsiteByDomainDuration = "get_website_by_domain_duration_seconds"
+	MetricListWebsitesDuration       = "list_websites_duration_seconds"
+	MetricUpdateWebsiteDuration     = "update_website_duration_seconds"
+	MetricDeleteWebsiteDuration     = "delete_website_duration_seconds"
+	MetricValidateDNSDuration       = "validate_dns_duration_seconds"
+	MetricCheckStatusDuration       = "check_status_duration_seconds"
 )
 
 const (
@@ -119,7 +126,7 @@ func init() {
 	// Histograms
 	CreateWebsiteDuration = *prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Name:      MetricDuration,
+			Name:      MetricCreateWebsiteDuration,
 			Subsystem: pluginCore.WEBSITE_SERVICE,
 			Help:      "Duration of CreateWebsite operations in seconds",
 			Buckets:   prometheus.DefBuckets,
@@ -129,7 +136,7 @@ func init() {
 
 	GetWebsiteDuration = *prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Name:      MetricDuration,
+			Name:      MetricGetWebsiteDuration,
 			Subsystem: pluginCore.WEBSITE_SERVICE,
 			Help:      "Duration of GetWebsite operations in seconds",
 			Buckets:   prometheus.DefBuckets,
@@ -139,7 +146,7 @@ func init() {
 
 	GetWebsiteByDomainDuration = *prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Name:      MetricDuration,
+			Name:      MetricGetWebsiteByDomainDuration,
 			Subsystem: pluginCore.WEBSITE_SERVICE,
 			Help:      "Duration of GetWebsiteByDomain operations in seconds",
 			Buckets:   prometheus.DefBuckets,
@@ -149,7 +156,7 @@ func init() {
 
 	ListWebsitesDuration = *prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Name:      MetricDuration,
+			Name:      MetricListWebsitesDuration,
 			Subsystem: pluginCore.WEBSITE_SERVICE,
 			Help:      "Duration of ListWebsites operations in seconds",
 			Buckets:   prometheus.DefBuckets,
@@ -159,7 +166,7 @@ func init() {
 
 	UpdateWebsiteDuration = *prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Name:      MetricDuration,
+			Name:      MetricUpdateWebsiteDuration,
 			Subsystem: pluginCore.WEBSITE_SERVICE,
 			Help:      "Duration of UpdateWebsite operations in seconds",
 			Buckets:   prometheus.DefBuckets,
@@ -169,7 +176,7 @@ func init() {
 
 	DeleteWebsiteDuration = *prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Name:      MetricDuration,
+			Name:      MetricDeleteWebsiteDuration,
 			Subsystem: pluginCore.WEBSITE_SERVICE,
 			Help:      "Duration of DeleteWebsite operations in seconds",
 			Buckets:   prometheus.DefBuckets,
@@ -179,7 +186,7 @@ func init() {
 
 	ValidateDNSDuration = *prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Name:      MetricDuration,
+			Name:      MetricValidateDNSDuration,
 			Subsystem: pluginCore.WEBSITE_SERVICE,
 			Help:      "Duration of ValidateDNS operations in seconds",
 			Buckets:   prometheus.DefBuckets,
@@ -189,7 +196,7 @@ func init() {
 
 	CheckStatusDuration = *prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Name:      MetricDuration,
+			Name:      MetricCheckStatusDuration,
 			Subsystem: pluginCore.WEBSITE_SERVICE,
 			Help:      "Duration of CheckStatus operations in seconds",
 			Buckets:   prometheus.DefBuckets,


### PR DESCRIPTION
All 8 histograms in pin/metrics.go and website/metrics.go used the
same Name ("duration\_seconds"), causing Prometheus to return 0
metric families for the entire plugin. Each histogram now has a
unique name (e.g. add\_pin\_duration\_seconds, create\_website\_duration\_seconds).

- `develop` <!-- branch-stack -->
  - **fix: give each histogram metric a unique name** :point\_left:

---

<!-- kody-pr-summary:start -->
## PR Description

This PR fixes duplicate Prometheus metric names in the pin and website service metrics. Previously, all histogram metrics in both services shared a single constant `MetricDuration` (`"duration_seconds"`), meaning every operation-specific histogram (e.g., AddPin, DeletePin, CreateWebsite, etc.) was registered with the same metric name. This would cause metric collisions or overwrites in Prometheus.

**Changes:**

- **Pin service (`internal/service/pin/metrics.go`)**: Replaced the shared `MetricDuration` constant with 8 unique, operation-specific metric name constants (e.g., `add_pin_duration_seconds`, `get_pin_by_cid_duration_seconds`, `delete_pin_duration_seconds`, etc.) and updated each histogram definition to use its corresponding unique name.

- **Website service (`internal/service/website/metrics.go`)**: Applied the same fix — replaced the shared `MetricDuration` constant with 8 unique metric name constants (e.g., `create_website_duration_seconds`, `validate_dns_duration_seconds`, `check_status_duration_seconds`, etc.) and updated each histogram accordingly.

- **`REPROVIDER_RESILIENCE_REDESIGN.md`**: Added a design document outlining a planned resilience redesign for the reprovider and companion DHT, including health tracking, per-CID timeouts, circuit breaker logic, and new observability metrics.
<!-- kody-pr-summary:end -->