### PR TITLE
feat(ipfs): parallelize ProvideMany with worker pool

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -50,6 +50,7 @@ type (
 		Interval      time.Duration `config:"interval"`
 		Timeout       time.Duration `config:"timeout"`
 		PerCIDTimeout time.Duration `config:"per_cid_timeout"`
+		ProvideWorkers int          `config:"provide_workers"`
 	}
 
 	// IPNS configures IPNS record publishing and republishing
@@ -81,10 +82,11 @@ func (b BlockStore) Defaults() map[string]any {
 
 func (I IPFSProvider) Defaults() map[string]any {
 	return map[string]any{
-		"BatchSize":     5000,
-		"Interval":      4 * time.Hour,
-		"Timeout":       30 * time.Minute,
-		"PerCIDTimeout": 10 * time.Second,
+		"BatchSize":      500,
+		"Interval":       4 * time.Hour,
+		"Timeout":        30 * time.Minute,
+		"PerCIDTimeout":  10 * time.Second,
+		"ProvideWorkers": 32,
 	}
 }
 

--- a/internal/protocol/ipfs/node.go
+++ b/internal/protocol/ipfs/node.go
@@ -583,7 +583,7 @@ func NewNode(ctx core.Context, cfg *config.ProtocolConfig, rs pluginCore.Reprovi
 		routingImpl = basicDHT
 		// Wrap basic DHT to implement pluginCore.Provider.
 		// Basic mode uses the primary DHT directly; no health gating needed.
-		dhtProvider = newBasicDHTProvider(basicDHT, nil, 0)
+		dhtProvider = newBasicDHTProvider(basicDHT, nil, 0, 0)
 		hasProvider = true
 	case config.DHTModeFullRT, "":
 		// FullRT is a client-only DHT — it does not register protocol handlers
@@ -745,7 +745,7 @@ func NewNode(ctx core.Context, cfg *config.ProtocolConfig, rs pluginCore.Reprovi
 					return false
 				}
 				return ipfsNode.companionDHT.RoutingTable().Size() > 0
-			}, cfg.Provider.PerCIDTimeout)
+			}, cfg.Provider.PerCIDTimeout, cfg.Provider.ProvideWorkers)
 		}
 		rp = NewReprovider(reproviderProvider, rs, ctx.Logger().Named("reprovider"))
 		reproviderCtx, cancel := context.WithCancel(ctx)

--- a/internal/protocol/ipfs/provide.go
+++ b/internal/protocol/ipfs/provide.go
@@ -12,6 +12,7 @@ import (
 	pluginCore "go.lumeweb.com/portal-plugin-ipfs/core"
 	"go.lumeweb.com/portal/core"
 
+	"github.com/avast/retry-go/v5"
 	"github.com/gammazero/workerpool"
 	"github.com/ipfs/go-cid"
 	"github.com/libp2p/go-libp2p/core/routing"
@@ -54,16 +55,29 @@ func (b *basicDHTProvider) ProvideMany(ctx context.Context, keys []multihash.Mul
 
 		k := k
 		wp.Submit(func() {
-			provideCtx := ctx
-			var cancel context.CancelFunc
-			if b.perCIDTimeout > 0 {
-				provideCtx, cancel = context.WithTimeout(ctx, b.perCIDTimeout)
-			}
+			err := retry.New(
+				retry.Attempts(3),
+				retry.Delay(1*time.Second),
+				retry.DelayType(retry.BackOffDelay),
+				retry.Context(ctx),
+				retry.RetryIf(func(err error) bool {
+					// Don't retry on timeout or cancellation — likely to fail again
+					// and just burn another per-CID timeout.
+					return !errors.Is(err, context.DeadlineExceeded) && !errors.Is(err, context.Canceled)
+				}),
+			).Do(func() error {
+				provideCtx := ctx
+				var cancel context.CancelFunc
+				if b.perCIDTimeout > 0 {
+					provideCtx, cancel = context.WithTimeout(ctx, b.perCIDTimeout)
+				}
 
-			err := b.dht.Provide(provideCtx, cid.NewCidV1(cid.Raw, k), true)
-			if cancel != nil {
-				cancel()
-			}
+				err := b.dht.Provide(provideCtx, cid.NewCidV1(cid.Raw, k), true)
+				if cancel != nil {
+					cancel()
+				}
+				return err
+			})
 
 			if err != nil {
 				failed.Add(1)

--- a/internal/protocol/ipfs/provide.go
+++ b/internal/protocol/ipfs/provide.go
@@ -44,7 +44,8 @@ func (b *basicDHTProvider) ProvideMany(ctx context.Context, keys []multihash.Mul
 	}
 
 	var failed atomic.Int64
-	var lastErr atomic.Value // stores error
+	var mu sync.Mutex
+	var lastErr error
 
 	wp := workerpool.New(workers)
 
@@ -81,7 +82,9 @@ func (b *basicDHTProvider) ProvideMany(ctx context.Context, keys []multihash.Mul
 
 			if err != nil {
 				failed.Add(1)
-				lastErr.Store(err)
+				mu.Lock()
+				lastErr = err
+				mu.Unlock()
 
 				errorType := classifyProvideError(err)
 				ReprovideCIDFailures.WithLabelValues(errorType).Inc()
@@ -96,10 +99,9 @@ func (b *basicDHTProvider) ProvideMany(ctx context.Context, keys []multihash.Mul
 
 	f := int(failed.Load())
 	if f > 0 {
-		var le error
-		if v := lastErr.Load(); v != nil {
-			le = v.(error)
-		}
+		mu.Lock()
+		le := lastErr
+		mu.Unlock()
 		return fmt.Errorf("provideMany: %d/%d CIDs failed, last error: %w", f, len(keys), le)
 	}
 	return nil

--- a/internal/protocol/ipfs/provide.go
+++ b/internal/protocol/ipfs/provide.go
@@ -12,6 +12,7 @@ import (
 	pluginCore "go.lumeweb.com/portal-plugin-ipfs/core"
 	"go.lumeweb.com/portal/core"
 
+	"github.com/gammazero/workerpool"
 	"github.com/ipfs/go-cid"
 	"github.com/libp2p/go-libp2p/core/routing"
 	"github.com/multiformats/go-multihash"
@@ -22,9 +23,10 @@ import (
 // basicDHTProvider is a wrapper around basic DHT that implements pluginCore.Provider.
 // For basic DHT which doesn't implement ProvideMany natively, we provide it by iterating.
 type basicDHTProvider struct {
-	dht           routing.ContentRouting
-	ready         func() bool
-	perCIDTimeout time.Duration
+	dht            routing.ContentRouting
+	ready          func() bool
+	perCIDTimeout  time.Duration
+	provideWorkers int
 }
 
 func (b *basicDHTProvider) Ready() bool {
@@ -35,45 +37,62 @@ func (b *basicDHTProvider) Ready() bool {
 }
 
 func (b *basicDHTProvider) ProvideMany(ctx context.Context, keys []multihash.Multihash) error {
-	var failed int
-	var lastErr error
+	workers := b.provideWorkers
+	if workers <= 0 {
+		workers = 1
+	}
+
+	var failed atomic.Int64
+	var lastErr atomic.Value // stores error
+
+	wp := workerpool.New(workers)
 
 	for _, k := range keys {
 		if ctx.Err() != nil {
-			return ctx.Err()
+			break
 		}
 
-		provideCtx := ctx
-		var cancel context.CancelFunc
-		if b.perCIDTimeout > 0 {
-			provideCtx, cancel = context.WithTimeout(ctx, b.perCIDTimeout)
-		}
+		k := k
+		wp.Submit(func() {
+			provideCtx := ctx
+			var cancel context.CancelFunc
+			if b.perCIDTimeout > 0 {
+				provideCtx, cancel = context.WithTimeout(ctx, b.perCIDTimeout)
+			}
 
-		err := b.dht.Provide(provideCtx, cid.NewCidV1(cid.Raw, k), true)
-		if cancel != nil {
-			cancel()
-		}
+			err := b.dht.Provide(provideCtx, cid.NewCidV1(cid.Raw, k), true)
+			if cancel != nil {
+				cancel()
+			}
 
-		if err != nil {
-			failed++
-			lastErr = err
+			if err != nil {
+				failed.Add(1)
+				lastErr.Store(err)
 
-			errorType := classifyProvideError(err)
-			ReprovideCIDFailures.WithLabelValues(errorType).Inc()
-			ReprovideCIDsTotal.WithLabelValues(LabelResultFailure).Inc()
-			continue
-		}
-		ReprovideCIDsTotal.WithLabelValues(LabelResultSuccess).Inc()
+				errorType := classifyProvideError(err)
+				ReprovideCIDFailures.WithLabelValues(errorType).Inc()
+				ReprovideCIDsTotal.WithLabelValues(LabelResultFailure).Inc()
+				return
+			}
+			ReprovideCIDsTotal.WithLabelValues(LabelResultSuccess).Inc()
+		})
 	}
 
-	if failed > 0 {
-		return fmt.Errorf("provideMany: %d/%d CIDs failed, last error: %w", failed, len(keys), lastErr)
+	wp.StopWait()
+
+	f := int(failed.Load())
+	if f > 0 {
+		var le error
+		if v := lastErr.Load(); v != nil {
+			le = v.(error)
+		}
+		return fmt.Errorf("provideMany: %d/%d CIDs failed, last error: %w", f, len(keys), le)
 	}
 	return nil
 }
 
-func newBasicDHTProvider(dht routing.ContentRouting, ready func() bool, perCIDTimeout time.Duration) pluginCore.Provider {
-	return &basicDHTProvider{dht: dht, ready: ready, perCIDTimeout: perCIDTimeout}
+func newBasicDHTProvider(dht routing.ContentRouting, ready func() bool, perCIDTimeout time.Duration, provideWorkers int) pluginCore.Provider {
+	return &basicDHTProvider{dht: dht, ready: ready, perCIDTimeout: perCIDTimeout, provideWorkers: provideWorkers}
 }
 
 func classifyProvideError(err error) string {
@@ -236,8 +255,6 @@ func (r *Reprovider) performProvide(ctx context.Context, interval, timeout time.
 		ctx, span := core.TraceMethod(ctx, "anonymous")
 		defer span.End()
 
-		ctx, cancel := context.WithTimeout(ctx, timeout)
-		defer cancel()
 		return r.provider.ProvideMany(ctx, keys)
 	}
 

--- a/internal/protocol/ipfs/provide_test.go
+++ b/internal/protocol/ipfs/provide_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -560,7 +561,7 @@ func TestBasicDHTProvider_ProvideMany(t *testing.T) {
 		keys := []multihash.Multihash{c1.Hash(), c2.Hash()}
 		err := provider.ProvideMany(context.Background(), keys)
 		assert.NoError(t, err)
-		assert.Equal(t, 2, scr.provideCount)
+		assert.Equal(t, 2, scr.getProvideCount())
 	})
 
 	t.Run("provide_many_continues_past_errors", func(t *testing.T) {
@@ -574,7 +575,44 @@ func TestBasicDHTProvider_ProvideMany(t *testing.T) {
 		keys := []multihash.Multihash{c1.Hash(), c2.Hash()}
 		err := provider.ProvideMany(context.Background(), keys)
 		assert.Error(t, err)
-		assert.Equal(t, 2, scr.provideCount) // both CIDs attempted, not just the first
+		// 2 CIDs × 3 attempts each (retries on non-timeout errors)
+		assert.Equal(t, 6, scr.getProvideCount())
+	})
+
+	t.Run("provide_many_retries_transient_then_succeeds", func(t *testing.T) {
+		key := mustMultihash(t, "retry-key")
+
+		var attempts atomic.Int32
+		scr := &stubContentRouting{
+			provideFn: func() error {
+				if attempts.Add(1) < 3 {
+					return errors.New("transient routing error")
+				}
+				return nil
+			},
+		}
+		provider := newBasicDHTProvider(scr, nil, 0, 0)
+
+		err := provider.ProvideMany(context.Background(), []multihash.Multihash{key})
+		assert.NoError(t, err)
+		assert.Equal(t, int32(3), attempts.Load())
+	})
+
+	t.Run("provide_many_does_not_retry_timeout", func(t *testing.T) {
+		key := mustMultihash(t, "timeout-key")
+
+		var attempts atomic.Int32
+		scr := &stubContentRouting{
+			provideFn: func() error {
+				attempts.Add(1)
+				return context.DeadlineExceeded
+			},
+		}
+		provider := newBasicDHTProvider(scr, nil, 0, 0)
+
+		err := provider.ProvideMany(context.Background(), []multihash.Multihash{key})
+		assert.Error(t, err)
+		assert.Equal(t, int32(1), attempts.Load()) // no retry on timeout
 	})
 
 	t.Run("provide_many_runs_in_parallel", func(t *testing.T) {
@@ -589,7 +627,7 @@ func TestBasicDHTProvider_ProvideMany(t *testing.T) {
 
 		err := provider.ProvideMany(context.Background(), keys)
 		assert.NoError(t, err)
-		assert.Equal(t, 100, scr.provideCount)
+		assert.Equal(t, 100, scr.getProvideCount())
 	})
 
 	t.Run("provide_many_respects_context_cancellation", func(t *testing.T) {
@@ -607,7 +645,7 @@ func TestBasicDHTProvider_ProvideMany(t *testing.T) {
 
 		_ = provider.ProvideMany(ctx, keys)
 		// With ctx already cancelled, the loop should break before submitting all tasks.
-		assert.Less(t, scr.provideCount, 50)
+		assert.Less(t, scr.getProvideCount(), 50)
 	})
 }
 
@@ -692,13 +730,23 @@ type stubContentRouting struct {
 	mu           sync.Mutex
 	provideCount int
 	err          error
+	provideFn    func() error // if set, called instead of returning err
 }
 
 func (s *stubContentRouting) Provide(_ context.Context, _ cid.Cid, _ bool) error {
 	s.mu.Lock()
 	s.provideCount++
 	s.mu.Unlock()
+	if s.provideFn != nil {
+		return s.provideFn()
+	}
 	return s.err
+}
+
+func (s *stubContentRouting) getProvideCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.provideCount
 }
 
 func (s *stubContentRouting) FindProvidersAsync(_ context.Context, _ cid.Cid, _ int) <-chan peer.AddrInfo {

--- a/internal/protocol/ipfs/provide_test.go
+++ b/internal/protocol/ipfs/provide_test.go
@@ -3,6 +3,7 @@ package ipfs
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -535,17 +536,17 @@ func TestReprovider_performProvide_MinAnnouncement_NotAllAnnounced(t *testing.T)
 
 func TestBasicDHTProvider_ProvideMany(t *testing.T) {
 	t.Run("ready_returns_false_when_fn_returns_false", func(t *testing.T) {
-		provider := newBasicDHTProvider(&stubContentRouting{}, func() bool { return false }, 0)
+		provider := newBasicDHTProvider(&stubContentRouting{}, func() bool { return false }, 0, 0)
 		assert.False(t, provider.Ready())
 	})
 
 	t.Run("ready_returns_true_when_fn_returns_true", func(t *testing.T) {
-		provider := newBasicDHTProvider(&stubContentRouting{}, func() bool { return true }, 0)
+		provider := newBasicDHTProvider(&stubContentRouting{}, func() bool { return true }, 0, 0)
 		assert.True(t, provider.Ready())
 	})
 
 	t.Run("ready_defaults_to_true_when_fn_is_nil", func(t *testing.T) {
-		provider := newBasicDHTProvider(&stubContentRouting{}, nil, 0)
+		provider := newBasicDHTProvider(&stubContentRouting{}, nil, 0, 0)
 		assert.True(t, provider.Ready())
 	})
 
@@ -554,7 +555,7 @@ func TestBasicDHTProvider_ProvideMany(t *testing.T) {
 		c2 := cid.NewCidV1(cid.Raw, mustMultihash(t, "key2"))
 
 		scr := &stubContentRouting{}
-		provider := newBasicDHTProvider(scr, nil, 0)
+		provider := newBasicDHTProvider(scr, nil, 0, 0)
 
 		keys := []multihash.Multihash{c1.Hash(), c2.Hash()}
 		err := provider.ProvideMany(context.Background(), keys)
@@ -568,12 +569,45 @@ func TestBasicDHTProvider_ProvideMany(t *testing.T) {
 
 		testErr := errors.New("provide failed")
 		scr := &stubContentRouting{err: testErr}
-		provider := newBasicDHTProvider(scr, nil, 0)
+		provider := newBasicDHTProvider(scr, nil, 0, 0)
 
 		keys := []multihash.Multihash{c1.Hash(), c2.Hash()}
 		err := provider.ProvideMany(context.Background(), keys)
 		assert.Error(t, err)
 		assert.Equal(t, 2, scr.provideCount) // both CIDs attempted, not just the first
+	})
+
+	t.Run("provide_many_runs_in_parallel", func(t *testing.T) {
+		// Generate 100 CIDs and verify they're all provided with 16 workers.
+		keys := make([]multihash.Multihash, 100)
+		for i := 0; i < 100; i++ {
+			keys[i] = mustMultihash(t, fmt.Sprintf("parallel-key-%d", i))
+		}
+
+		scr := &stubContentRouting{}
+		provider := newBasicDHTProvider(scr, nil, 0, 16)
+
+		err := provider.ProvideMany(context.Background(), keys)
+		assert.NoError(t, err)
+		assert.Equal(t, 100, scr.provideCount)
+	})
+
+	t.Run("provide_many_respects_context_cancellation", func(t *testing.T) {
+		// With 1 worker and a blocked provide, context cancel should stop dispatching.
+		keys := make([]multihash.Multihash, 50)
+		for i := 0; i < 50; i++ {
+			keys[i] = mustMultihash(t, fmt.Sprintf("cancel-key-%d", i))
+		}
+
+		scr := &stubContentRouting{}
+		provider := newBasicDHTProvider(scr, nil, 0, 1)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel() // cancel immediately
+
+		_ = provider.ProvideMany(ctx, keys)
+		// With ctx already cancelled, the loop should break before submitting all tasks.
+		assert.Less(t, scr.provideCount, 50)
 	})
 }
 
@@ -655,12 +689,15 @@ func TestReprovider_CircuitBreaker_OpenAfter3Failures(t *testing.T) {
 
 // stubContentRouting is a minimal routing.ContentRouting stub for testing.
 type stubContentRouting struct {
+	mu           sync.Mutex
 	provideCount int
 	err          error
 }
 
 func (s *stubContentRouting) Provide(_ context.Context, _ cid.Cid, _ bool) error {
+	s.mu.Lock()
 	s.provideCount++
+	s.mu.Unlock()
 	return s.err
 }
 


### PR DESCRIPTION
## Changes

- Replace serial for loop in `ProvideMany` with `gammazero/workerpool` (default 32 workers). Each worker calls `dht.Provide` with its own per-CID timeout
- Remove batch-level `context.WithTimeout` from `doProvide` — per-CID timeout is now the only bound, preventing mass cancellation of unprocessed CIDs
- Reduce default batch size from 5000 to 500
- Add `ProvideWorkers` config field (default: 32)
- Make `stubContentRouting` thread-safe for parallel test execution
- Add tests for parallel provide and context cancellation

* `develop` <!-- branch-stack -->
  - **feat(ipfs): parallelize ProvideMany with worker pool** :point\_left:

***

<!-- kody-pr-summary:start -->

## Pull Request Description

This PR parallelizes the `ProvideMany` operation in the IPFS DHT provider using a worker pool, enabling concurrent CID announcements instead of sequential processing.

### Key Changes

- **Worker pool integration**: The `ProvideMany` method now uses the `gammazero/workerpool` library to dispatch CID provide operations concurrently across a configurable number of workers, replacing the previous sequential loop.

- **New configuration option**: Added a `provide_workers` config field (default: 32) to control the degree of parallelism for DHT provide operations.

- **Thread-safety**: Error tracking (`failed` count and `lastErr`) was migrated to atomic types (`atomic.Int64`, `atomic.Value`) to safely handle concurrent writes. The test stub `stubContentRouting` was also made thread-safe with a mutex.

- **Batch size reduction**: Default `BatchSize` was reduced from 5000 to 500 CIDs per reprovider run.

- **Timeout handling**: The batch-level timeout wrapper in `performProvide` was removed, relying instead on the existing per-CID timeout for individual operation deadlines.

- **Context cancellation**: The main loop now breaks on context cancellation rather than returning immediately, allowing already-submitted tasks to complete.

- **New tests**: Added tests verifying parallel execution (100 CIDs with 16 workers) and context cancellation behavior (stopping dispatch when context is already cancelled).

<!-- kody-pr-summary:end -->
