### PR TITLE
feat: add want-block filter metrics

### DIFF
--- a/internal/protocol/ipfs/metrics.go
+++ b/internal/protocol/ipfs/metrics.go
@@ -6,16 +6,16 @@ import (
 
 const (
 	// Reprovider metrics
-	MetricReprovideAttempts             = "reprovide_attempts_total"
-	MetricReprovideSuccesses            = "reprovide_successes_total"
-	MetricReprovideFailures             = "reprovide_failures_total"
-	MetricReprovideCIDsTotal            = "reprovide_cids_total"
-	MetricReprovideCIDFailures          = "reprovide_cid_failures_total"
-	MetricReprovideDuration             = "reprovide_duration_seconds"
-	MetricReprovideBatchSize            = "reprovide_batch_size"
-	MetricReprovideCircuitOpen          = "reprovide_circuit_open"
+	MetricReprovideAttempts            = "reprovide_attempts_total"
+	MetricReprovideSuccesses           = "reprovide_successes_total"
+	MetricReprovideFailures            = "reprovide_failures_total"
+	MetricReprovideCIDsTotal           = "reprovide_cids_total"
+	MetricReprovideCIDFailures         = "reprovide_cid_failures_total"
+	MetricReprovideDuration            = "reprovide_duration_seconds"
+	MetricReprovideBatchSize           = "reprovide_batch_size"
+	MetricReprovideCircuitOpen         = "reprovide_circuit_open"
 	MetricReprovideConsecutiveFailures = "reprovide_consecutive_failures"
-	MetricReprovideProviderReady        = "reprovide_provider_ready"
+	MetricReprovideProviderReady       = "reprovide_provider_ready"
 
 	// DHT metrics
 	MetricCompanionDHTHealthy           = "companion_dht_healthy"
@@ -23,18 +23,29 @@ const (
 	MetricCompanionDHTBootstrapAttempts = "companion_dht_bootstrap_attempts_total"
 	MetricCompanionDHTBootstrapFailures = "companion_dht_bootstrap_failures_total"
 	MetricCompanionDHTConnectedPeers    = "companion_dht_connected_peers"
+
+	// WantBlockFilter metrics
+	MetricWantBlockRequests     = "want_block_requests_total"
+	MetricWantBlockGatewayPeers = "want_block_gateway_peers"
+	MetricWantBlockPeerLimiters = "want_block_peer_limiters"
 )
 
 const (
 	subSystemReprovider = "ipfs.reprovider"
 	subSystemDHT        = "ipfs.dht"
+	subSystemBitswap    = "ipfs.bitswap"
 )
 
 const (
-	LabelResultSuccess  = "success"
-	LabelResultFailure  = "failure"
+	LabelResultSuccess    = "success"
+	LabelResultFailure    = "failure"
 	LabelTriggerScheduled = "scheduled"
 	LabelTriggerManual    = "manual"
+
+	LabelWantAllowed           = "allowed"
+	LabelWantDeniedGlobalRate  = "denied_global_rate"
+	LabelWantDeniedPerPeerRate = "denied_per_peer_rate"
+	LabelWantAllowedGateway    = "allowed_gateway"
 )
 
 var (
@@ -50,9 +61,9 @@ var (
 	ReprovideBatchSize *prometheus.HistogramVec
 
 	// Reprovider gauges
-	ReprovideCircuitOpen          prometheus.Gauge
-	ReprovideConsecutiveFailures  prometheus.Gauge
-	ReprovideProviderReady        prometheus.Gauge
+	ReprovideCircuitOpen         prometheus.Gauge
+	ReprovideConsecutiveFailures prometheus.Gauge
+	ReprovideProviderReady       prometheus.Gauge
 
 	// DHT gauges
 	CompanionDHTHealthy                prometheus.Gauge
@@ -60,6 +71,11 @@ var (
 	CompanionDHTBootstrapAttemptsTotal prometheus.Counter
 	CompanionDHTBootstrapFailuresTotal prometheus.Counter
 	CompanionDHTConnectedPeers         prometheus.Gauge
+
+	// WantBlockFilter metrics
+	WantBlockRequestsTotal *prometheus.CounterVec
+	WantBlockGatewayPeers  prometheus.Gauge
+	WantBlockPeerLimiters  prometheus.Gauge
 )
 
 func init() {
@@ -196,6 +212,32 @@ func init() {
 			Help:      "Number of peers connected to the companion DHT host",
 		},
 	)
+
+	// WantBlockFilter metrics
+	WantBlockRequestsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: subSystemBitswap,
+			Name:      MetricWantBlockRequests,
+			Help:      "Total want-block requests by outcome (allowed, allowed_gateway, denied_global_rate, denied_per_peer_rate)",
+		},
+		[]string{"result"},
+	)
+
+	WantBlockGatewayPeers = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Subsystem: subSystemBitswap,
+			Name:      MetricWantBlockGatewayPeers,
+			Help:      "Number of gateway peers whitelisted in the want-block filter",
+		},
+	)
+
+	WantBlockPeerLimiters = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Subsystem: subSystemBitswap,
+			Name:      MetricWantBlockPeerLimiters,
+			Help:      "Number of active per-peer rate limiters in the want-block filter",
+		},
+	)
 }
 
 func GetMetricsCollectors() []prometheus.Collector {
@@ -215,5 +257,8 @@ func GetMetricsCollectors() []prometheus.Collector {
 		CompanionDHTBootstrapAttemptsTotal,
 		CompanionDHTBootstrapFailuresTotal,
 		CompanionDHTConnectedPeers,
+		WantBlockRequestsTotal,
+		WantBlockGatewayPeers,
+		WantBlockPeerLimiters,
 	}
 }

--- a/internal/protocol/ipfs/want_filter.go
+++ b/internal/protocol/ipfs/want_filter.go
@@ -59,7 +59,7 @@ func NewWantBlockFilter(h host.Host, cfg WantBlockFilterConfig) *WantBlockFilter
 		perPeerBurst = config.DefaultBitswapPerPeerWantBurst
 	}
 
-	return &WantBlockFilter{
+	f := &WantBlockFilter{
 		host:         h,
 		gatewayPeers: gatewayPeers,
 		limiter:      rate.NewLimiter(globalRate, globalBurst),
@@ -67,6 +67,9 @@ func NewWantBlockFilter(h host.Host, cfg WantBlockFilterConfig) *WantBlockFilter
 		perPeerRate:  perPeerRate,
 		perPeerBurst: perPeerBurst,
 	}
+	WantBlockGatewayPeers.Set(float64(len(gatewayPeers)))
+	WantBlockPeerLimiters.Set(0)
+	return f
 }
 
 // Allow is called by bitswap for each wantlist entry from a peer.
@@ -78,15 +81,23 @@ func (f *WantBlockFilter) Allow(p peer.ID, c cid.Cid) bool {
 	f.mu.RUnlock()
 
 	if isGateway {
+		WantBlockRequestsTotal.WithLabelValues(LabelWantAllowedGateway).Inc()
 		return true
 	}
 
 	if !f.limiter.Allow() {
+		WantBlockRequestsTotal.WithLabelValues(LabelWantDeniedGlobalRate).Inc()
 		return false
 	}
 
 	peerLimiter := f.getPeerLimiter(p)
-	return peerLimiter.Allow()
+	if !peerLimiter.Allow() {
+		WantBlockRequestsTotal.WithLabelValues(LabelWantDeniedPerPeerRate).Inc()
+		return false
+	}
+
+	WantBlockRequestsTotal.WithLabelValues(LabelWantAllowed).Inc()
+	return true
 }
 
 func (f *WantBlockFilter) getPeerLimiter(p peer.ID) *rate.Limiter {
@@ -108,6 +119,7 @@ func (f *WantBlockFilter) getPeerLimiter(p peer.ID) *rate.Limiter {
 
 	limiter = rate.NewLimiter(f.perPeerRate, f.perPeerBurst)
 	f.peerLimiters[p] = limiter
+	WantBlockPeerLimiters.Set(float64(len(f.peerLimiters)))
 	return limiter
 }
 
@@ -115,18 +127,21 @@ func (f *WantBlockFilter) AddGatewayPeer(p peer.ID) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.gatewayPeers[p] = struct{}{}
+	WantBlockGatewayPeers.Set(float64(len(f.gatewayPeers)))
 }
 
 func (f *WantBlockFilter) RemoveGatewayPeer(p peer.ID) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	delete(f.gatewayPeers, p)
+	WantBlockGatewayPeers.Set(float64(len(f.gatewayPeers)))
 }
 
 func (f *WantBlockFilter) RemovePeerLimiter(p peer.ID) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	delete(f.peerLimiters, p)
+	WantBlockPeerLimiters.Set(float64(len(f.peerLimiters)))
 }
 
 // PeerBlockRequestFilter returns a function compatible with


### PR DESCRIPTION
## What

Add Prometheus metrics for the bitswap want-block rate limiting layer.

## Why

The `WantBlockFilter` rate-limits bitswap want-block requests (global + per-peer), but has zero observability. Neither boxo v0.37.0 nor libp2p's `x/rate` package track want-block allow/deny events:

- **Boxo**: calls `PeerBlockRequestFilter` and silently appends denials to a local slice -- no counters exposed.
- **libp2p `x/rate`**: the connection rate limiter has no metrics at all.

Without these metrics we can't tell if rate limiting is working, how aggressive it is, or if gateway peers are being whitelisted correctly.

## Metrics added

| Metric                                   | Type    | Labels   | Description                                                                                                       |
| ---------------------------------------- | ------- | -------- | ----------------------------------------------------------------------------------------------------------------- |
| `ipfs_bitswap_want_block_requests_total` | counter | `result` | Total want-block requests by outcome (`allowed`, `allowed_gateway`, `denied_global_rate`, `denied_per_peer_rate`) |
| `ipfs_bitswap_want_block_gateway_peers`  | gauge   | -        | Whitelisted gateway peer count                                                                                    |
| `ipfs_bitswap_want_block_peer_limiters`  | gauge   | -        | Active per-peer rate limiter count                                                                                |

## Files changed

- `internal/protocol/ipfs/metrics.go` -- metric definitions, init, registration
- `internal/protocol/ipfs/want_filter.go` -- instrumented `Allow()`, `AddGatewayPeer`, `RemoveGatewayPeer`, `RemovePeerLimiter`, `getPeerLimiter`, `NewWantBlockFilter`

* `develop` <!-- branch-stack -->
  - **feat: add want-block filter metrics** :point\_left:

---

<!-- kody-pr-summary:start -->
## Pull Request Description

This PR adds Prometheus metrics to the WantBlockFilter, providing observability into bitswap want-block request filtering and rate limiting.

### Changes

**New Metrics Added:**
- **`want_block_requests_total`** (Counter) — Tracks total want-block requests categorized by outcome: `allowed`, `allowed_gateway`, `denied_global_rate`, and `denied_per_peer_rate`
- **`want_block_gateway_peers`** (Gauge) — Tracks the number of gateway peers whitelisted in the want-block filter
- **`want_block_peer_limiters`** (Gauge) — Tracks the number of active per-peer rate limiters

**Instrumentation:**
- The `Allow` method now records the outcome of each want-block request, distinguishing between requests allowed via gateway whitelist, allowed via rate limiter, denied by the global rate limit, and denied by the per-peer rate limit
- Gateway peer additions/removals and peer limiter creation/removal now update their respective gauges to reflect current state
- Initial gauge values are set at filter construction time

All new metrics are registered under the `ipfs.bitswap` subsystem and included in the metrics collectors returned by `GetMetricsCollectors()`.
<!-- kody-pr-summary:end -->