### PR TITLE
feat: add per-CID provide duration histogram

### DIFF
--- a/internal/protocol/ipfs/metrics.go
+++ b/internal/protocol/ipfs/metrics.go
@@ -12,6 +12,7 @@ const (
 	MetricReprovideCIDsTotal           = "reprovide_cids_total"
 	MetricReprovideCIDFailures         = "reprovide_cid_failures_total"
 	MetricReprovideDuration            = "reprovide_duration_seconds"
+	MetricReprovideCIDDuration         = "reprovide_cid_duration_seconds"
 	MetricReprovideBatchSize           = "reprovide_batch_size"
 	MetricReprovideCircuitOpen         = "reprovide_circuit_open"
 	MetricReprovideConsecutiveFailures = "reprovide_consecutive_failures"
@@ -46,6 +47,10 @@ const (
 	LabelWantDeniedGlobalRate  = "denied_global_rate"
 	LabelWantDeniedPerPeerRate = "denied_per_peer_rate"
 	LabelWantAllowedGateway    = "allowed_gateway"
+
+	LabelCIDResultSuccess = "success"
+	LabelCIDResultTimeout = "timeout"
+	LabelCIDResultOther   = "other"
 )
 
 var (
@@ -57,8 +62,9 @@ var (
 	ReprovideCIDFailures    *prometheus.CounterVec
 
 	// Reprovider histograms
-	ReprovideDuration  *prometheus.HistogramVec
-	ReprovideBatchSize *prometheus.HistogramVec
+	ReprovideDuration    *prometheus.HistogramVec
+	ReprovideCIDDuration *prometheus.HistogramVec
+	ReprovideBatchSize   *prometheus.HistogramVec
 
 	// Reprovider gauges
 	ReprovideCircuitOpen         prometheus.Gauge
@@ -135,6 +141,16 @@ func init() {
 			Buckets:   provideDurationBuckets,
 		},
 		[]string{},
+	)
+
+	ReprovideCIDDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Subsystem: subSystemReprovider,
+			Name:      MetricReprovideCIDDuration,
+			Help:      "Per-CID DHT Provide() call duration in seconds, by result",
+			Buckets:   provideDurationBuckets,
+		},
+		[]string{"result"},
 	)
 
 	ReprovideBatchSize = prometheus.NewHistogramVec(
@@ -248,6 +264,7 @@ func GetMetricsCollectors() []prometheus.Collector {
 		ReprovideCIDsTotal,
 		ReprovideCIDFailures,
 		ReprovideDuration,
+		ReprovideCIDDuration,
 		ReprovideBatchSize,
 		ReprovideCircuitOpen,
 		ReprovideConsecutiveFailures,

--- a/internal/protocol/ipfs/provide.go
+++ b/internal/protocol/ipfs/provide.go
@@ -62,7 +62,7 @@ func (b *basicDHTProvider) ProvideMany(ctx context.Context, keys []multihash.Mul
 				retry.DelayType(retry.BackOffDelay),
 				retry.Context(ctx),
 				retry.RetryIf(func(err error) bool {
-					// Don't retry on timeout or cancellation — likely to fail again
+					// Don't retry on timeout or cancellation: likely to fail again
 					// and just burn another per-CID timeout.
 					return !errors.Is(err, context.DeadlineExceeded) && !errors.Is(err, context.Canceled)
 				}),
@@ -73,9 +73,17 @@ func (b *basicDHTProvider) ProvideMany(ctx context.Context, keys []multihash.Mul
 					provideCtx, cancel = context.WithTimeout(ctx, b.perCIDTimeout)
 				}
 
+				cidStart := time.Now()
 				err := b.dht.Provide(provideCtx, cid.NewCidV1(cid.Raw, k), true)
+				cidElapsed := time.Since(cidStart).Seconds()
 				if cancel != nil {
 					cancel()
+				}
+
+				if err != nil {
+					ReprovideCIDDuration.WithLabelValues(classifyProvideError(err)).Observe(cidElapsed)
+				} else {
+					ReprovideCIDDuration.WithLabelValues(LabelCIDResultSuccess).Observe(cidElapsed)
 				}
 				return err
 			})


### PR DESCRIPTION
## What

Add `ipfs_reprovider_reprovide_cid_duration_seconds` histogram to track individual DHT `Provide()` call latency.

## Why

All CID reprovide failures are timeouts, but we have no visibility into how long individual `Provide()` calls take. The existing `reprovide_duration_seconds` histogram tracks the entire batch duration (all CIDs in one `ProvideMany` call), not per-CID timing.

Without per-CID duration we cannot distinguish between:

- Most CIDs completing fast (<1s) with a few timing out at 60s (slow DHT routing on specific keys)
- CIDs spread across 10-50s (DHT routing table is generally slow)
- All CIDs taking \~60s (systemic timeout issue)

## Metric added

| Metric                                           | Type      | Labels   | Buckets                              | Description                                                                    |
| ------------------------------------------------ | --------- | -------- | ------------------------------------ | ------------------------------------------------------------------------------ |
| `ipfs_reprovider_reprovide_cid_duration_seconds` | histogram | `result` | 0.1, 0.5, 1, 5, 10, 30, 60, 120, 300 | Per-CID DHT Provide() call duration, by result (`success`, `timeout`, `other`) |

Uses the same `classifyProvideError` function already used for the failure counter, so `result` label values match: `success`, `timeout`, `context_cancelled`, `routing`, `other`.

## Files changed

- `internal/protocol/ipfs/metrics.go` -- histogram declaration, init, registration
- `internal/protocol/ipfs/provide.go` -- timing instrumentation around `b.dht.Provide()` call

* `develop` <!-- branch-stack -->
  - **feat: add per-CID provide duration histogram** :point\_left:

---

<!-- kody-pr-summary:start -->
## Pull Request Description

This PR adds a new Prometheus histogram metric (`reprovide_cid_duration_seconds`) that tracks the duration of individual DHT `Provide()` calls per CID, labeled by result type (success, timeout, or other error).

**Changes:**

- **New metric**: `ReprovideCIDDuration` histogram with a `result` label dimension, using the existing `provideDurationBuckets` for consistent bucket boundaries.
- **Result classification labels**: Added `LabelCIDResultSuccess`, `LabelCIDResultTimeout`, and `LabelCIDResultOther` constants to categorize each provide attempt's outcome.
- **Instrumentation in `ProvideMany`**: Each individual CID provide call is now timed, and the elapsed duration is recorded in the histogram — labeled as `success` on success, or classified by error type on failure (via `classifyProvideError`).

This provides granular visibility into per-CID provide latency and failure modes, complementing the existing overall reprovide duration metric.
<!-- kody-pr-summary:end -->