### PR TITLE
feat: track DHT reprovide success/failure per boot cycle

### DIFF
--- a/core/ipfs.go
+++ b/core/ipfs.go
@@ -16,11 +16,21 @@ type Provider interface {
 
 // A ReprovideStore stores CIDs that need to be periodically announced.
 type ReprovideStore interface {
-	ProvideCIDs(ctx context.Context, limit int) ([]PinnedCID, error)
+	ProvideCIDs(ctx context.Context, since time.Time, limit int) ([]PinnedCID, error)
 	SetLastAnnouncement(ctx context.Context, cids []cid.Cid, t time.Time) error
+	// CountPinned returns stats about pinned CIDs and their DHT announcement state.
+	// announced = CIDs whose last_announcement is at or after the given threshold.
+	// pending = CIDs not yet announced since the threshold (failed or never tried).
+	CountPinned(ctx context.Context, since time.Time) (PinnedCIDStats, error)
 }
 
 type PinnedCID struct {
 	CID              cid.Cid   `json:"cid"`
 	LastAnnouncement time.Time `json:"last_announcement"`
+}
+
+type PinnedCIDStats struct {
+	Total     int64 `json:"total"`
+	Announced int64 `json:"announced"`
+	Pending   int64 `json:"pending"`
 }

--- a/internal/protocol/ipfs/metrics.go
+++ b/internal/protocol/ipfs/metrics.go
@@ -18,6 +18,16 @@ const (
 	MetricReprovideConsecutiveFailures = "reprovide_consecutive_failures"
 	MetricReprovideProviderReady       = "reprovide_provider_ready"
 
+	// Boot-cycle metrics (per boot reprovide cycle)
+	MetricReprovideBootCycleAttempted = "reprovide_boot_cycle_attempted"
+	MetricReprovideBootCycleSucceeded = "reprovide_boot_cycle_succeeded"
+	MetricReprovideBootCycleFailed    = "reprovide_boot_cycle_failed"
+
+	// Global pinned-state gauges
+	MetricReprovidePinnedTotal    = "reprovide_pinned_total"
+	MetricReprovideAnnouncedTotal = "reprovide_announced_total"
+	MetricReprovidePendingTotal   = "reprovide_pending_total"
+
 	// DHT metrics
 	MetricCompanionDHTHealthy           = "companion_dht_healthy"
 	MetricCompanionDHTRoutingTable      = "companion_dht_routing_table_size"
@@ -70,6 +80,16 @@ var (
 	ReprovideCircuitOpen         prometheus.Gauge
 	ReprovideConsecutiveFailures prometheus.Gauge
 	ReprovideProviderReady       prometheus.Gauge
+
+	// Boot-cycle gauges (reset each cycle)
+	ReprovideBootCycleAttempted prometheus.Gauge
+	ReprovideBootCycleSucceeded prometheus.Gauge
+	ReprovideBootCycleFailed    prometheus.Gauge
+
+	// Global pinned-state gauges
+	ReprovidePinnedTotal    prometheus.Gauge
+	ReprovideAnnouncedTotal prometheus.Gauge
+	ReprovidePendingTotal   prometheus.Gauge
 
 	// DHT gauges
 	CompanionDHTHealthy                prometheus.Gauge
@@ -188,6 +208,56 @@ func init() {
 		},
 	)
 
+	// Boot-cycle gauges
+	ReprovideBootCycleAttempted = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Subsystem: subSystemReprovider,
+			Name:      MetricReprovideBootCycleAttempted,
+			Help:      "CIDs attempted in the current boot reprovide cycle",
+		},
+	)
+
+	ReprovideBootCycleSucceeded = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Subsystem: subSystemReprovider,
+			Name:      MetricReprovideBootCycleSucceeded,
+			Help:      "CIDs successfully provided in the current boot reprovide cycle",
+		},
+	)
+
+	ReprovideBootCycleFailed = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Subsystem: subSystemReprovider,
+			Name:      MetricReprovideBootCycleFailed,
+			Help:      "CIDs that failed in the current boot reprovide cycle and haven't succeeded on retry",
+		},
+	)
+
+	// Global pinned-state gauges
+	ReprovidePinnedTotal = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Subsystem: subSystemReprovider,
+			Name:      MetricReprovidePinnedTotal,
+			Help:      "Total ready pinned CIDs in the database",
+		},
+	)
+
+	ReprovideAnnouncedTotal = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Subsystem: subSystemReprovider,
+			Name:      MetricReprovideAnnouncedTotal,
+			Help:      "Pinned CIDs announced within the current reprovide interval",
+		},
+	)
+
+	ReprovidePendingTotal = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Subsystem: subSystemReprovider,
+			Name:      MetricReprovidePendingTotal,
+			Help:      "Pinned CIDs not yet announced in the current interval (pending or failed)",
+		},
+	)
+
 	// DHT gauges
 	CompanionDHTHealthy = prometheus.NewGauge(
 		prometheus.GaugeOpts{
@@ -269,6 +339,12 @@ func GetMetricsCollectors() []prometheus.Collector {
 		ReprovideCircuitOpen,
 		ReprovideConsecutiveFailures,
 		ReprovideProviderReady,
+		ReprovideBootCycleAttempted,
+		ReprovideBootCycleSucceeded,
+		ReprovideBootCycleFailed,
+		ReprovidePinnedTotal,
+		ReprovideAnnouncedTotal,
+		ReprovidePendingTotal,
 		CompanionDHTHealthy,
 		CompanionDHTRoutingTableSize,
 		CompanionDHTBootstrapAttemptsTotal,

--- a/internal/protocol/ipfs/provide.go
+++ b/internal/protocol/ipfs/provide.go
@@ -46,6 +46,7 @@ func (b *basicDHTProvider) ProvideMany(ctx context.Context, keys []multihash.Mul
 	var failed atomic.Int64
 	var mu sync.Mutex
 	var lastErr error
+	failedKeys := make(map[string]struct{})
 
 	wp := workerpool.New(workers)
 
@@ -92,6 +93,7 @@ func (b *basicDHTProvider) ProvideMany(ctx context.Context, keys []multihash.Mul
 				failed.Add(1)
 				mu.Lock()
 				lastErr = err
+				failedKeys[string(k)] = struct{}{}
 				mu.Unlock()
 
 				errorType := classifyProvideError(err)
@@ -109,10 +111,41 @@ func (b *basicDHTProvider) ProvideMany(ctx context.Context, keys []multihash.Mul
 	if f > 0 {
 		mu.Lock()
 		le := lastErr
+		fk := make([]multihash.Multihash, 0, len(failedKeys))
+		for ks := range failedKeys {
+			fk = append(fk, multihash.Multihash(ks))
+		}
 		mu.Unlock()
-		return fmt.Errorf("provideMany: %d/%d CIDs failed, last error: %w", f, len(keys), le)
+		return &provideManyError{
+			failed:     f,
+			total:      len(keys),
+			err:        le,
+			failedKeys: fk,
+		}
 	}
 	return nil
+}
+
+// provideManyError is returned by ProvideMany when some CIDs fail.
+// It carries the set of failed multihashes so callers can track per-CID state.
+type provideManyError struct {
+	failed     int
+	total      int
+	err        error
+	failedKeys []multihash.Multihash
+}
+
+func (e *provideManyError) Error() string {
+	return fmt.Sprintf("provideMany: %d/%d CIDs failed, last error: %v", e.failed, e.total, e.err)
+}
+
+func (e *provideManyError) Unwrap() error {
+	return e.err
+}
+
+// FailedKeys returns the multihashes that failed to provide.
+func (e *provideManyError) FailedKeys() []multihash.Multihash {
+	return e.failedKeys
 }
 
 func newBasicDHTProvider(dht routing.ContentRouting, ready func() bool, perCIDTimeout time.Duration, provideWorkers int) pluginCore.Provider {
@@ -154,6 +187,63 @@ type Reprovider struct {
 	// Circuit breaker
 	consecutiveFailures atomic.Uint32
 	circuitOpenUntil    atomic.Int64 // unix nano timestamp
+
+	// Boot-cycle tracking: tracks per-CID success/failure during the initial
+	// reprovide sweep after boot. When a CID fails then later succeeds on retry,
+	// it is removed from the failed set.
+	bootCycle bootCycle
+}
+
+type bootCycle struct {
+	mu        sync.Mutex
+	started   bool
+	attempted int64
+	succeeded int64
+	failed    map[string]struct{} // multihash string -> failed
+}
+
+func (bc *bootCycle) markAttempted(n int) {
+	bc.mu.Lock()
+	bc.attempted += int64(n)
+	bc.mu.Unlock()
+}
+
+func (bc *bootCycle) markSucceeded(keys []multihash.Multihash) {
+	bc.mu.Lock()
+	bc.succeeded += int64(len(keys))
+	for _, k := range keys {
+		delete(bc.failed, string(k))
+	}
+	bc.mu.Unlock()
+}
+
+func (bc *bootCycle) markFailed(keys []multihash.Multihash) {
+	bc.mu.Lock()
+	for _, k := range keys {
+		bc.failed[string(k)] = struct{}{}
+	}
+	bc.mu.Unlock()
+}
+
+func (bc *bootCycle) reset() {
+	bc.mu.Lock()
+	bc.attempted = 0
+	bc.succeeded = 0
+	bc.failed = make(map[string]struct{})
+	bc.started = true
+	bc.mu.Unlock()
+}
+
+func (bc *bootCycle) snapshot() (attempted, succeeded, failedCount int64) {
+	bc.mu.Lock()
+	defer bc.mu.Unlock()
+	return bc.attempted, bc.succeeded, int64(len(bc.failed))
+}
+
+func (bc *bootCycle) isStarted() bool {
+	bc.mu.Lock()
+	defer bc.mu.Unlock()
+	return bc.started
 }
 
 // Trigger triggers the reprovider loop to run immediately.
@@ -257,6 +347,25 @@ func (r *Reprovider) performProvide(ctx context.Context, interval time.Duration,
 
 	ReprovideAttemptsTotal.WithLabelValues(trigger).Inc()
 
+	// Start boot cycle on first performProvide after boot
+	if !r.bootCycle.isStarted() {
+		r.bootCycle.reset()
+		ReprovideBootCycleAttempted.Set(0)
+		ReprovideBootCycleSucceeded.Set(0)
+		ReprovideBootCycleFailed.Set(0)
+		r.log.Info("starting boot reprovide cycle")
+	}
+
+	// Update global pinned-state gauges
+	since := time.Now().Add(-interval)
+	if stats, err := r.store.CountPinned(ctx, since); err != nil {
+		r.log.Warn("failed to count pinned CIDs", zap.Error(err))
+	} else {
+		ReprovidePinnedTotal.Set(float64(stats.Total))
+		ReprovideAnnouncedTotal.Set(float64(stats.Announced))
+		ReprovidePendingTotal.Set(float64(stats.Pending))
+	}
+
 	if r.cancelledFlag.Load() {
 		return 10 * time.Minute
 	}
@@ -289,7 +398,10 @@ func (r *Reprovider) performProvide(ctx context.Context, interval time.Duration,
 		return reprovideSleep
 	}
 
-	cids, err := r.store.ProvideCIDs(ctx, batchSize)
+	// Only fetch CIDs whose last_announcement is older than the interval.
+	// This avoids re-broadcasting CIDs that are already fresh in the DHT.
+	cutoff := time.Now().Add(-interval)
+	cids, err := r.store.ProvideCIDs(ctx, cutoff, batchSize)
 	if err != nil {
 		r.log.Error("failed to fetch CIDs to provide", zap.Error(err))
 		ReprovideFailuresTotal.Inc()
@@ -299,29 +411,28 @@ func (r *Reprovider) performProvide(ctx context.Context, interval time.Duration,
 
 	if len(cids) == 0 {
 		r.log.Debug("no CIDs to provide")
+		// Boot cycle complete: all CIDs have been processed
+		attempted, succeeded, failedCount := r.bootCycle.snapshot()
+		if attempted > 0 {
+			r.log.Info("boot reprovide cycle complete",
+				zap.Int64("attempted", attempted),
+				zap.Int64("succeeded", succeeded),
+				zap.Int64("failed", failedCount))
+		}
 		return reprovideSleep
 	}
 
-	rem := time.Until(cids[0].LastAnnouncement.Add(interval))
-	if rem > 0 {
-		r.log.Debug("waiting for next provide interval")
-		return rem
-	}
-
-	buffer := interval / 10
-	minAnnouncement := time.Now().Add(-(interval - buffer))
-	eligibleCIDs := lo.Filter(cids, func(c pluginCore.PinnedCID, _ int) bool {
-		return !c.LastAnnouncement.After(minAnnouncement)
-	})
-
-	announced := lo.Map(eligibleCIDs, func(c pluginCore.PinnedCID, _ int) cid.Cid {
+	announced := lo.Map(cids, func(c pluginCore.PinnedCID, _ int) cid.Cid {
 		return c.CID
 	})
-	keys := lo.Map(eligibleCIDs, func(c pluginCore.PinnedCID, _ int) multihash.Multihash {
+	keys := lo.Map(cids, func(c pluginCore.PinnedCID, _ int) multihash.Multihash {
 		return c.CID.Hash()
 	})
 
 	ReprovideBatchSize.WithLabelValues().Observe(float64(len(keys)))
+
+	// Track boot-cycle attempted
+	r.bootCycle.markAttempted(len(keys))
 
 	start := time.Now()
 
@@ -332,6 +443,23 @@ func (r *Reprovider) performProvide(ctx context.Context, interval time.Duration,
 		r.log.Error("failed to provide CIDs",
 			zap.Error(err),
 			zap.Uint32("consecutive_failures", failures))
+
+		// Track per-CID failures in boot cycle
+		var failedKeys []multihash.Multihash
+		var pme *provideManyError
+		if errors.As(err, &pme) {
+			failedKeys = pme.FailedKeys()
+		} else {
+			// Unknown error: mark all attempted keys as failed
+			failedKeys = keys
+		}
+		r.bootCycle.markFailed(failedKeys)
+
+		// Update boot-cycle gauges
+		attempted, succeeded, failedCount := r.bootCycle.snapshot()
+		ReprovideBootCycleAttempted.Set(float64(attempted))
+		ReprovideBootCycleSucceeded.Set(float64(succeeded))
+		ReprovideBootCycleFailed.Set(float64(failedCount))
 
 		if failures >= 3 {
 			cooldown := 15 * time.Minute
@@ -347,6 +475,13 @@ func (r *Reprovider) performProvide(ctx context.Context, interval time.Duration,
 
 	ReprovideDuration.WithLabelValues().Observe(time.Since(start).Seconds())
 
+	// Track boot-cycle succeeded: remove from failed set if previously failed
+	r.bootCycle.markSucceeded(keys)
+	attempted, succeeded, failedCount := r.bootCycle.snapshot()
+	ReprovideBootCycleAttempted.Set(float64(attempted))
+	ReprovideBootCycleSucceeded.Set(float64(succeeded))
+	ReprovideBootCycleFailed.Set(float64(failedCount))
+
 	if err := r.store.SetLastAnnouncement(ctx, announced, time.Now()); err != nil {
 		r.log.Error("failed to update last announcement time", zap.Error(err))
 		return time.Minute
@@ -358,10 +493,6 @@ func (r *Reprovider) performProvide(ctx context.Context, interval time.Duration,
 	r.log.Debug("provided CIDs",
 		zap.Int("count", len(announced)),
 		zap.Duration("elapsed", time.Since(start)))
-
-	if len(announced) < len(cids) {
-		return time.Until(cids[len(announced)].LastAnnouncement.Add(interval))
-	}
 
 	return interval
 }

--- a/internal/protocol/ipfs/provide_test.go
+++ b/internal/protocol/ipfs/provide_test.go
@@ -58,7 +58,8 @@ func TestReprovider_Run(t *testing.T) {
 		{CID: cid.Cid{}, LastAnnouncement: time.Now().Add(-2 * interval)},
 		{CID: cid.Cid{}, LastAnnouncement: time.Now().Add(-2 * interval)},
 	}
-	mockStore.EXPECT().ProvideCIDs(mock.Anything, batchSize).Return(testCIDs, nil).Maybe()
+	mockStore.EXPECT().CountPinned(mock.Anything, mock.Anything).Return(core.PinnedCIDStats{}, nil).Maybe()
+	mockStore.EXPECT().ProvideCIDs(mock.Anything, mock.Anything, batchSize).Return(testCIDs, nil).Maybe()
 	mockProvider.EXPECT().ProvideMany(mock.Anything, mock.Anything).Return(nil).Maybe()
 	mockStore.EXPECT().SetLastAnnouncement(mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
 
@@ -78,7 +79,8 @@ func TestReprovider_Run_ProviderNotReady(t *testing.T) {
 	mockProvider.EXPECT().Ready().Return(true)
 
 	// Mock store calls that happen after provider becomes ready
-	mockStore.EXPECT().ProvideCIDs(mock.Anything, batchSize).Return([]core.PinnedCID{}, nil).Maybe()
+	mockStore.EXPECT().CountPinned(mock.Anything, mock.Anything).Return(core.PinnedCIDStats{}, nil).Maybe()
+	mockStore.EXPECT().ProvideCIDs(mock.Anything, mock.Anything, batchSize).Return([]core.PinnedCID{}, nil).Maybe()
 	mockProvider.EXPECT().ProvideMany(mock.Anything, mock.Anything).Return(nil).Maybe()
 	mockStore.EXPECT().SetLastAnnouncement(mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
 
@@ -98,7 +100,8 @@ func TestReprovider_Run_ProvideCIDsError(t *testing.T) {
 	mockProvider.EXPECT().Ready().Return(true)
 
 	// Mock store returning error
-	mockStore.EXPECT().ProvideCIDs(mock.Anything, batchSize).Return(nil, errors.New("test error")).Once()
+	mockStore.EXPECT().CountPinned(mock.Anything, mock.Anything).Return(core.PinnedCIDStats{}, nil).Maybe()
+	mockStore.EXPECT().ProvideCIDs(mock.Anything, mock.Anything, batchSize).Return(nil, errors.New("test error")).Once()
 
 	runReproviderAndWait(ctx, cancel, reprovider, interval, batchSize, 2*interval)
 }
@@ -119,7 +122,8 @@ func TestReprovider_Run_ProvideManyError(t *testing.T) {
 		{CID: cid.Cid{}, LastAnnouncement: time.Now().Add(-2 * interval)},
 		{CID: cid.Cid{}, LastAnnouncement: time.Now().Add(-2 * interval)},
 	}
-	mockStore.EXPECT().ProvideCIDs(mock.Anything, batchSize).Return(testCIDs, nil).Once()
+	mockStore.EXPECT().CountPinned(mock.Anything, mock.Anything).Return(core.PinnedCIDStats{}, nil).Maybe()
+	mockStore.EXPECT().ProvideCIDs(mock.Anything, mock.Anything, batchSize).Return(testCIDs, nil).Once()
 
 	// Mock provider ProvideMany returning error
 	mockProvider.EXPECT().ProvideMany(mock.Anything, mock.Anything).Return(errors.New("test error")).Once()
@@ -143,7 +147,8 @@ func TestReprovider_Run_SetLastAnnouncementError(t *testing.T) {
 		{CID: cid.Cid{}, LastAnnouncement: time.Now().Add(-2 * interval)},
 		{CID: cid.Cid{}, LastAnnouncement: time.Now().Add(-2 * interval)},
 	}
-	mockStore.EXPECT().ProvideCIDs(mock.Anything, batchSize).Return(testCIDs, nil).Once()
+	mockStore.EXPECT().CountPinned(mock.Anything, mock.Anything).Return(core.PinnedCIDStats{}, nil).Maybe()
+	mockStore.EXPECT().ProvideCIDs(mock.Anything, mock.Anything, batchSize).Return(testCIDs, nil).Once()
 
 	// Mock provider ProvideMany
 	mockProvider.EXPECT().ProvideMany(mock.Anything, mock.Anything).Return(nil).Once()
@@ -174,7 +179,8 @@ func TestReprovider_Trigger(t *testing.T) {
 		{CID: cid.Cid{}, LastAnnouncement: time.Now().Add(-2 * interval)},
 		{CID: cid.Cid{}, LastAnnouncement: time.Now().Add(-2 * interval)},
 	}
-	mockStore.EXPECT().ProvideCIDs(mock.Anything, batchSize).Return(testCIDs, nil).Maybe()
+	mockStore.EXPECT().CountPinned(mock.Anything, mock.Anything).Return(core.PinnedCIDStats{}, nil).Maybe()
+	mockStore.EXPECT().ProvideCIDs(mock.Anything, mock.Anything, batchSize).Return(testCIDs, nil).Maybe()
 
 	// Mock provider ProvideMany
 	mockProvider.EXPECT().ProvideMany(mock.Anything, mock.Anything).Return(nil).Maybe()
@@ -229,7 +235,8 @@ func TestReprovider_performProvide_NoCIDs(t *testing.T) {
 	}
 
 	// Mock store returning no CIDs
-	mockStore.EXPECT().ProvideCIDs(mock.Anything, batchSize).Return([]core.PinnedCID{}, nil).Once()
+	mockStore.EXPECT().CountPinned(mock.Anything, mock.Anything).Return(core.PinnedCIDStats{}, nil).Maybe()
+	mockStore.EXPECT().ProvideCIDs(mock.Anything, mock.Anything, batchSize).Return([]core.PinnedCID{}, nil).Once()
 
 	sleepDuration := reprovider.performProvide(ctx, interval, batchSize, LabelTriggerScheduled)
 
@@ -257,14 +264,15 @@ func TestReprovider_performProvide_ProvideCIDsError(t *testing.T) {
 	}
 
 	// Mock store returning error
-	mockStore.EXPECT().ProvideCIDs(mock.Anything, batchSize).Return(nil, errors.New("test error")).Once()
+	mockStore.EXPECT().CountPinned(mock.Anything, mock.Anything).Return(core.PinnedCIDStats{}, nil).Maybe()
+	mockStore.EXPECT().ProvideCIDs(mock.Anything, mock.Anything, batchSize).Return(nil, errors.New("test error")).Once()
 
 	sleepDuration := reprovider.performProvide(ctx, interval, batchSize, LabelTriggerScheduled)
 
 	assert.Equal(t, time.Minute, sleepDuration)
 }
 
-func TestReprovider_performProvide_WaitingForNextInterval(t *testing.T) {
+func TestReprovider_performProvide_ProvideManyError(t *testing.T) {
 	ctx := context.Background()
 
 	mockProvider := mocks.NewMockProvider(t)
@@ -284,14 +292,20 @@ func TestReprovider_performProvide_WaitingForNextInterval(t *testing.T) {
 		mu:                   sync.Mutex{},
 	}
 
-	// Mock store returning CIDs with future LastAnnouncement
-	futureTime := time.Now().Add(2 * interval)
-	testCIDs := []core.PinnedCID{{CID: cid.Cid{}, LastAnnouncement: futureTime}}
-	mockStore.EXPECT().ProvideCIDs(mock.Anything, batchSize).Return(testCIDs, nil).Once()
+	// Mock store returning CIDs
+	testCIDs := []core.PinnedCID{
+		{CID: cid.Cid{}, LastAnnouncement: time.Now().Add(-2 * interval)},
+		{CID: cid.Cid{}, LastAnnouncement: time.Now().Add(-2 * interval)},
+	}
+	mockStore.EXPECT().CountPinned(mock.Anything, mock.Anything).Return(core.PinnedCIDStats{}, nil).Maybe()
+	mockStore.EXPECT().ProvideCIDs(mock.Anything, mock.Anything, batchSize).Return(testCIDs, nil).Once()
+
+	// Mock provider ProvideMany returning error
+	mockProvider.EXPECT().ProvideMany(mock.Anything, mock.Anything).Return(errors.New("test error")).Once()
 
 	sleepDuration := reprovider.performProvide(ctx, interval, batchSize, LabelTriggerScheduled)
 
-	assert.Less(t, time.Until(futureTime), sleepDuration)
+	assert.Equal(t, time.Minute, sleepDuration)
 }
 
 func TestReprovider_performProvide_Success(t *testing.T) {
@@ -319,7 +333,8 @@ func TestReprovider_performProvide_Success(t *testing.T) {
 		{CID: cid.Cid{}, LastAnnouncement: time.Now().Add(-2 * interval)},
 		{CID: cid.Cid{}, LastAnnouncement: time.Now().Add(-2 * interval)},
 	}
-	mockStore.EXPECT().ProvideCIDs(mock.Anything, batchSize).Return(testCIDs, nil).Once()
+	mockStore.EXPECT().CountPinned(mock.Anything, mock.Anything).Return(core.PinnedCIDStats{}, nil).Maybe()
+	mockStore.EXPECT().ProvideCIDs(mock.Anything, mock.Anything, batchSize).Return(testCIDs, nil).Once()
 
 	// Mock provider ProvideMany
 	mockProvider.EXPECT().ProvideMany(mock.Anything, mock.Anything).Return(nil).Once()
@@ -358,7 +373,8 @@ func TestReprovider_performProvide_Success_NotAllAnnounced(t *testing.T) {
 		{CID: cid.Cid{}, LastAnnouncement: time.Now().Add(-2 * interval)},
 		{CID: cid.Cid{}, LastAnnouncement: time.Now().Add(2 * interval)}, // Future announcement
 	}
-	mockStore.EXPECT().ProvideCIDs(mock.Anything, batchSize).Return(testCIDs, nil).Once()
+	mockStore.EXPECT().CountPinned(mock.Anything, mock.Anything).Return(core.PinnedCIDStats{}, nil).Maybe()
+	mockStore.EXPECT().ProvideCIDs(mock.Anything, mock.Anything, batchSize).Return(testCIDs, nil).Once()
 
 	// Mock provider ProvideMany
 	mockProvider.EXPECT().ProvideMany(mock.Anything, mock.Anything).Return(nil).Once()
@@ -367,42 +383,7 @@ func TestReprovider_performProvide_Success_NotAllAnnounced(t *testing.T) {
 	mockStore.EXPECT().SetLastAnnouncement(mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
 
 	sleepDuration := reprovider.performProvide(ctx, interval, batchSize, LabelTriggerScheduled)
-	assert.Less(t, time.Until(testCIDs[2].LastAnnouncement.Add(interval)), sleepDuration)
-}
-
-func TestReprovider_performProvide_ProvideManyError(t *testing.T) {
-	ctx := context.Background()
-
-	mockProvider := mocks.NewMockProvider(t)
-	mockStore := mocks.NewMockReprovideStore(t)
-	logger, _ := zap.NewDevelopment()
-
-	interval := 1 * time.Second
-	batchSize := 10
-
-	reprovider := &Reprovider{
-		provider:             mockProvider,
-		store:                mockStore,
-		log:                  logger,
-		triggerProvide:       make(chan struct{}, 1),
-		triggerDelayDuration: 100 * time.Millisecond,
-		reprovideSleep:       0,
-		mu:                   sync.Mutex{},
-	}
-
-	// Mock store returning CIDs
-	testCIDs := []core.PinnedCID{
-		{CID: cid.Cid{}, LastAnnouncement: time.Now().Add(-2 * interval)},
-		{CID: cid.Cid{}, LastAnnouncement: time.Now().Add(-2 * interval)},
-	}
-	mockStore.EXPECT().ProvideCIDs(mock.Anything, batchSize).Return(testCIDs, nil).Once()
-
-	// Mock provider ProvideMany returning error
-	mockProvider.EXPECT().ProvideMany(mock.Anything, mock.Anything).Return(errors.New("test error")).Once()
-
-	sleepDuration := reprovider.performProvide(ctx, interval, batchSize, LabelTriggerScheduled)
-
-	assert.Equal(t, time.Minute, sleepDuration)
+	assert.Equal(t, interval, sleepDuration)
 }
 
 func TestReprovider_performProvide_SetLastAnnouncementError(t *testing.T) {
@@ -430,7 +411,8 @@ func TestReprovider_performProvide_SetLastAnnouncementError(t *testing.T) {
 		{CID: cid.Cid{}, LastAnnouncement: time.Now().Add(-2 * interval)},
 		{CID: cid.Cid{}, LastAnnouncement: time.Now().Add(-2 * interval)},
 	}
-	mockStore.EXPECT().ProvideCIDs(mock.Anything, batchSize).Return(testCIDs, nil).Once()
+	mockStore.EXPECT().CountPinned(mock.Anything, mock.Anything).Return(core.PinnedCIDStats{}, nil).Maybe()
+	mockStore.EXPECT().ProvideCIDs(mock.Anything, mock.Anything, batchSize).Return(testCIDs, nil).Once()
 
 	// Mock provider ProvideMany
 	mockProvider.EXPECT().ProvideMany(mock.Anything, mock.Anything).Return(nil).Once()
@@ -468,7 +450,8 @@ func TestReprovider_performProvide_MinAnnouncement(t *testing.T) {
 		{CID: cid.Cid{}, LastAnnouncement: time.Now().Add(-2 * interval)},
 		{CID: cid.Cid{}, LastAnnouncement: time.Now().Add(-2 * interval)},
 	}
-	mockStore.EXPECT().ProvideCIDs(mock.Anything, batchSize).Return(testCIDs, nil).Once()
+	mockStore.EXPECT().CountPinned(mock.Anything, mock.Anything).Return(core.PinnedCIDStats{}, nil).Maybe()
+	mockStore.EXPECT().ProvideCIDs(mock.Anything, mock.Anything, batchSize).Return(testCIDs, nil).Once()
 
 	// Mock provider ProvideMany
 	mockProvider.EXPECT().ProvideMany(mock.Anything, mock.Anything).Return(nil).Once()
@@ -481,7 +464,7 @@ func TestReprovider_performProvide_MinAnnouncement(t *testing.T) {
 	assert.Equal(t, interval, sleepDuration)
 }
 
-func TestReprovider_performProvide_MinAnnouncement_NotAllAnnounced(t *testing.T) {
+func TestReprovider_performProvide_AllCIDsProvided(t *testing.T) {
 	ctx := context.Background()
 
 	mockProvider := mocks.NewMockProvider(t)
@@ -501,13 +484,14 @@ func TestReprovider_performProvide_MinAnnouncement_NotAllAnnounced(t *testing.T)
 		mu:                   sync.Mutex{},
 	}
 
-	// Mock store returning CIDs
+	// Mock store returning CIDs - all stale, all should be provided
 	testCIDs := []core.PinnedCID{
 		{CID: cid.Cid{}, LastAnnouncement: time.Now().Add(-2 * interval)},
 		{CID: cid.Cid{}, LastAnnouncement: time.Now().Add(-2 * interval)},
-		{CID: cid.Cid{}, LastAnnouncement: time.Now().Add(2 * interval)}, // Future announcement
+		{CID: cid.Cid{}, LastAnnouncement: time.Now().Add(-2 * interval)},
 	}
-	mockStore.EXPECT().ProvideCIDs(mock.Anything, batchSize).Return(testCIDs, nil).Once()
+	mockStore.EXPECT().CountPinned(mock.Anything, mock.Anything).Return(core.PinnedCIDStats{}, nil).Maybe()
+	mockStore.EXPECT().ProvideCIDs(mock.Anything, mock.Anything, batchSize).Return(testCIDs, nil).Once()
 
 	// Mock provider ProvideMany
 	mockProvider.EXPECT().ProvideMany(mock.Anything, mock.Anything).Return(nil).Once()
@@ -517,7 +501,7 @@ func TestReprovider_performProvide_MinAnnouncement_NotAllAnnounced(t *testing.T)
 
 	sleepDuration := reprovider.performProvide(ctx, interval, batchSize, LabelTriggerScheduled)
 
-	assert.Less(t, time.Until(testCIDs[2].LastAnnouncement.Add(interval)), sleepDuration)
+	assert.Equal(t, interval, sleepDuration)
 }
 
 func TestBasicDHTProvider_ProvideMany(t *testing.T) {
@@ -656,6 +640,8 @@ func TestReprovider_CircuitBreaker_Open(t *testing.T) {
 	reprovider.circuitOpenUntil.Store(futureTime.UnixNano())
 	ReprovideCircuitOpen.Set(1)
 
+	mockStore.EXPECT().CountPinned(mock.Anything, mock.Anything).Return(core.PinnedCIDStats{}, nil).Maybe()
+
 	sleepDuration := reprovider.performProvide(ctx, time.Second, 10, LabelTriggerScheduled)
 
 	// Should return the time until the circuit opens, without calling store or provider
@@ -691,7 +677,8 @@ func TestReprovider_CircuitBreaker_OpenAfter3Failures(t *testing.T) {
 
 	// Simulate 3 consecutive failures
 	for i := 0; i < 3; i++ {
-		mockStore.EXPECT().ProvideCIDs(mock.Anything, batchSize).Return(testCIDs, nil).Once()
+		mockStore.EXPECT().CountPinned(mock.Anything, mock.Anything).Return(core.PinnedCIDStats{}, nil).Maybe()
+		mockStore.EXPECT().ProvideCIDs(mock.Anything, mock.Anything, batchSize).Return(testCIDs, nil).Once()
 		mockProvider.EXPECT().ProvideMany(mock.Anything, mock.Anything).Return(errors.New("test error")).Once()
 
 		sleepDuration := reprovider.performProvide(ctx, interval, batchSize, LabelTriggerScheduled)
@@ -742,4 +729,115 @@ func mustMultihash(t *testing.T, data string) multihash.Multihash {
 	h, err := multihash.Sum([]byte(data), multihash.SHA2_256, -1)
 	require.NoError(t, err)
 	return h
+}
+
+func TestReprovider_BootCycle_FailThenSucceed(t *testing.T) {
+	ctx := context.Background()
+
+	mockProvider := mocks.NewMockProvider(t)
+	mockStore := mocks.NewMockReprovideStore(t)
+	logger, _ := zap.NewDevelopment()
+
+	interval := 1 * time.Second
+	batchSize := 10
+
+	reprovider := &Reprovider{
+		provider:             mockProvider,
+		store:                mockStore,
+		log:                  logger,
+		triggerProvide:       make(chan struct{}, 1),
+		triggerDelayDuration: 100 * time.Millisecond,
+		reprovideSleep:       0,
+		mu:                   sync.Mutex{},
+	}
+
+	c1 := cid.NewCidV1(cid.Raw, mustMultihash(t, "boot-fail-key1"))
+	c2 := cid.NewCidV1(cid.Raw, mustMultihash(t, "boot-fail-key2"))
+
+	testCIDs := []core.PinnedCID{
+		{CID: c1, LastAnnouncement: time.Now().Add(-2 * interval)},
+		{CID: c2, LastAnnouncement: time.Now().Add(-2 * interval)},
+	}
+
+	// First attempt: both CIDs fail
+	mockStore.EXPECT().CountPinned(mock.Anything, mock.Anything).Return(core.PinnedCIDStats{Total: 2, Pending: 2}, nil).Once()
+	mockStore.EXPECT().ProvideCIDs(mock.Anything, mock.Anything, batchSize).Return(testCIDs, nil).Once()
+	mockProvider.EXPECT().ProvideMany(mock.Anything, mock.Anything).Return(errors.New("dht error")).Once()
+
+	reprovider.performProvide(ctx, interval, batchSize, LabelTriggerScheduled)
+
+	// Verify boot-cycle gauges: 2 attempted, 0 succeeded, 2 failed
+	attempted, succeeded, failedCount := reprovider.bootCycle.snapshot()
+	assert.Equal(t, int64(2), attempted)
+	assert.Equal(t, int64(0), succeeded)
+	assert.Equal(t, int64(2), failedCount)
+
+	// Second attempt: both CIDs succeed (retry)
+	mockStore.EXPECT().CountPinned(mock.Anything, mock.Anything).Return(core.PinnedCIDStats{Total: 2, Announced: 2}, nil).Once()
+	mockStore.EXPECT().ProvideCIDs(mock.Anything, mock.Anything, batchSize).Return(testCIDs, nil).Once()
+	mockProvider.EXPECT().ProvideMany(mock.Anything, mock.Anything).Return(nil).Once()
+	mockStore.EXPECT().SetLastAnnouncement(mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
+
+	reprovider.performProvide(ctx, interval, batchSize, LabelTriggerScheduled)
+
+	// Verify: 4 attempted (cumulative), 2 succeeded, 0 failed (removed from failed set)
+	attempted, succeeded, failedCount = reprovider.bootCycle.snapshot()
+	assert.Equal(t, int64(4), attempted)
+	assert.Equal(t, int64(2), succeeded)
+	assert.Equal(t, int64(0), failedCount, "failed CIDs should be removed after successful retry")
+}
+
+func TestReprovider_BootCycle_PartialFailure(t *testing.T) {
+	ctx := context.Background()
+
+	mockProvider := mocks.NewMockProvider(t)
+	mockStore := mocks.NewMockReprovideStore(t)
+	logger, _ := zap.NewDevelopment()
+
+	interval := 1 * time.Second
+	batchSize := 10
+
+	reprovider := &Reprovider{
+		provider:             mockProvider,
+		store:                mockStore,
+		log:                  logger,
+		triggerProvide:       make(chan struct{}, 1),
+		triggerDelayDuration: 100 * time.Millisecond,
+		reprovideSleep:       0,
+		mu:                   sync.Mutex{},
+	}
+
+	c1 := cid.NewCidV1(cid.Raw, mustMultihash(t, "partial-key1"))
+	c2 := cid.NewCidV1(cid.Raw, mustMultihash(t, "partial-key2"))
+
+	testCIDs := []core.PinnedCID{
+		{CID: c1, LastAnnouncement: time.Now().Add(-2 * interval)},
+		{CID: c2, LastAnnouncement: time.Now().Add(-2 * interval)},
+	}
+
+	// Simulate partial failure: provideManyError with 1 failed key
+	failedKey := c1.Hash()
+	pme := &provideManyError{
+		failed:     1,
+		total:      2,
+		err:        errors.New("timeout"),
+		failedKeys: []multihash.Multihash{failedKey},
+	}
+
+	mockStore.EXPECT().CountPinned(mock.Anything, mock.Anything).Return(core.PinnedCIDStats{Total: 2, Pending: 2}, nil).Once()
+	mockStore.EXPECT().ProvideCIDs(mock.Anything, mock.Anything, batchSize).Return(testCIDs, nil).Once()
+	mockProvider.EXPECT().ProvideMany(mock.Anything, mock.Anything).Return(pme).Once()
+
+	reprovider.performProvide(ctx, interval, batchSize, LabelTriggerScheduled)
+
+	// 2 attempted, 0 succeeded (whole batch failed), 2 in failed set
+	// (provideManyError only reports 1 specific failure, but the whole batch is marked failed
+	// because we don't know which succeeded individually)
+	attempted, succeeded, failedCount := reprovider.bootCycle.snapshot()
+	assert.Equal(t, int64(2), attempted)
+	assert.Equal(t, int64(0), succeeded)
+	// Both keys are in failed set: c1 from FailedKeys, c2 from the markFailed(all keys when batch fails)
+	// Actually: provideManyError returns failedKeys=[c1], so only c1 is marked failed.
+	// Wait -- the code does errors.As check, and if it IS provideManyError, it marks only FailedKeys.
+	assert.Equal(t, int64(1), failedCount, "only the specific failed CID should be tracked")
 }

--- a/internal/protocol/store/metadata.go
+++ b/internal/protocol/store/metadata.go
@@ -562,13 +562,14 @@ WHERE b.ready = true
 	return siblings, nil
 }
 
-func (s *MetadataStoreDefault) ProvideCIDs(ctx context.Context, limit int) (cids []pluginCore.PinnedCID, err error) {
+func (s *MetadataStoreDefault) ProvideCIDs(ctx context.Context, since time.Time, limit int) (cids []pluginCore.PinnedCID, err error) {
 	ctx, span := core.TraceMethod(ctx, "MetadataStoreDefault.ProvideCIDs")
 	defer core.EndSpanWithErr(span, err)
 
 	var _blocks []pluginDb.IPFSBlock
 	if err = db.RetryableTransaction(ctx, s.db, func(tx *gorm.DB) *gorm.DB {
-		return tx.Where("ready = ?", true).Order("last_announcement ASC").Limit(limit).Find(&_blocks)
+		return tx.Where("ready = ? AND (last_announcement IS NULL OR last_announcement < ?)", true, since).
+			Order("last_announcement ASC").Limit(limit).Find(&_blocks)
 	}); err != nil {
 		return nil, fmt.Errorf("failed to query: %w", err)
 	}
@@ -591,6 +592,26 @@ func (s *MetadataStoreDefault) ProvideCIDs(ctx context.Context, limit int) (cids
 		})
 	}
 	return cids, nil
+}
+
+func (s *MetadataStoreDefault) CountPinned(ctx context.Context, since time.Time) (stats pluginCore.PinnedCIDStats, err error) {
+	ctx, span := core.TraceMethod(ctx, "MetadataStoreDefault.CountPinned")
+	defer core.EndSpanWithErr(span, err)
+
+	if err = db.RetryableTransaction(ctx, s.db, func(tx *gorm.DB) *gorm.DB {
+		return tx.Model(&pluginDb.IPFSBlock{}).Where("ready = ?", true).Count(&stats.Total)
+	}); err != nil {
+		return stats, fmt.Errorf("failed to count pinned: %w", err)
+	}
+
+	if err = db.RetryableTransaction(ctx, s.db, func(tx *gorm.DB) *gorm.DB {
+		return tx.Model(&pluginDb.IPFSBlock{}).Where("ready = ? AND last_announcement >= ?", true, since).Count(&stats.Announced)
+	}); err != nil {
+		return stats, fmt.Errorf("failed to count announced: %w", err)
+	}
+
+	stats.Pending = stats.Total - stats.Announced
+	return stats, nil
 }
 
 func (s *MetadataStoreDefault) SetLastAnnouncement(ctx context.Context, cids []cid.Cid, t time.Time) error {

--- a/internal/protocol/store/tests/metadata_test.go
+++ b/internal/protocol/store/tests/metadata_test.go
@@ -176,7 +176,7 @@ func TestMetadataStore_ProvideCIDs(t *testing.T) {
 		require.NoError(tb, err)
 
 		// Act
-		cids, err := metadataStore.ProvideCIDs(context.Background(), 2)
+		cids, err := metadataStore.ProvideCIDs(context.Background(), time.Now(), 2)
 
 		// Assert
 		require.NoError(tb, err)
@@ -357,7 +357,7 @@ func TestMetadataStore_ReaddLinkedBlockAfterDeletion(t *testing.T) {
 	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 		// Arrange
 		metadataStore := store.NewMetadataStore(ctx, core.GetProtocol(internal.ProtocolName).(protocol.ProtoNode))
-		
+
 		parentData := "parent data"
 		childData := "child data"
 		parentCid := generateCid(t, parentData)

--- a/internal/testing/mocks/MockReprovideStore.go
+++ b/internal/testing/mocks/MockReprovideStore.go
@@ -41,8 +41,8 @@ func (_m *MockReprovideStore) EXPECT() *MockReprovideStore_Expecter {
 }
 
 // ProvideCIDs provides a mock function for the type MockReprovideStore
-func (_mock *MockReprovideStore) ProvideCIDs(ctx context.Context, limit int) ([]core.PinnedCID, error) {
-	ret := _mock.Called(ctx, limit)
+func (_mock *MockReprovideStore) ProvideCIDs(ctx context.Context, since time.Time, limit int) ([]core.PinnedCID, error) {
+	ret := _mock.Called(ctx, since, limit)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ProvideCIDs")
@@ -50,18 +50,18 @@ func (_mock *MockReprovideStore) ProvideCIDs(ctx context.Context, limit int) ([]
 
 	var r0 []core.PinnedCID
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, int) ([]core.PinnedCID, error)); ok {
-		return returnFunc(ctx, limit)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, time.Time, int) ([]core.PinnedCID, error)); ok {
+		return returnFunc(ctx, since, limit)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, int) []core.PinnedCID); ok {
-		r0 = returnFunc(ctx, limit)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, time.Time, int) []core.PinnedCID); ok {
+		r0 = returnFunc(ctx, since, limit)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]core.PinnedCID)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, int) error); ok {
-		r1 = returnFunc(ctx, limit)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, time.Time, int) error); ok {
+		r1 = returnFunc(ctx, since, limit)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -75,24 +75,30 @@ type MockReprovideStore_ProvideCIDs_Call struct {
 
 // ProvideCIDs is a helper method to define mock.On call
 //   - ctx context.Context
+//   - since time.Time
 //   - limit int
-func (_e *MockReprovideStore_Expecter) ProvideCIDs(ctx interface{}, limit interface{}) *MockReprovideStore_ProvideCIDs_Call {
-	return &MockReprovideStore_ProvideCIDs_Call{Call: _e.mock.On("ProvideCIDs", ctx, limit)}
+func (_e *MockReprovideStore_Expecter) ProvideCIDs(ctx interface{}, since interface{}, limit interface{}) *MockReprovideStore_ProvideCIDs_Call {
+	return &MockReprovideStore_ProvideCIDs_Call{Call: _e.mock.On("ProvideCIDs", ctx, since, limit)}
 }
 
-func (_c *MockReprovideStore_ProvideCIDs_Call) Run(run func(ctx context.Context, limit int)) *MockReprovideStore_ProvideCIDs_Call {
+func (_c *MockReprovideStore_ProvideCIDs_Call) Run(run func(ctx context.Context, since time.Time, limit int)) *MockReprovideStore_ProvideCIDs_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
 			arg0 = args[0].(context.Context)
 		}
-		var arg1 int
+		var arg1 time.Time
 		if args[1] != nil {
-			arg1 = args[1].(int)
+			arg1 = args[1].(time.Time)
+		}
+		var arg2 int
+		if args[2] != nil {
+			arg2 = args[2].(int)
 		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -103,7 +109,7 @@ func (_c *MockReprovideStore_ProvideCIDs_Call) Return(pinnedCIDs []core.PinnedCI
 	return _c
 }
 
-func (_c *MockReprovideStore_ProvideCIDs_Call) RunAndReturn(run func(ctx context.Context, limit int) ([]core.PinnedCID, error)) *MockReprovideStore_ProvideCIDs_Call {
+func (_c *MockReprovideStore_ProvideCIDs_Call) RunAndReturn(run func(ctx context.Context, since time.Time, limit int) ([]core.PinnedCID, error)) *MockReprovideStore_ProvideCIDs_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -167,6 +173,72 @@ func (_c *MockReprovideStore_SetLastAnnouncement_Call) Return(err error) *MockRe
 }
 
 func (_c *MockReprovideStore_SetLastAnnouncement_Call) RunAndReturn(run func(ctx context.Context, cids []cid.Cid, t time.Time) error) *MockReprovideStore_SetLastAnnouncement_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// CountPinned provides a mock function for the type MockReprovideStore
+func (_mock *MockReprovideStore) CountPinned(ctx context.Context, since time.Time) (core.PinnedCIDStats, error) {
+	ret := _mock.Called(ctx, since)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CountPinned")
+	}
+
+	var r0 core.PinnedCIDStats
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, time.Time) (core.PinnedCIDStats, error)); ok {
+		return returnFunc(ctx, since)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, time.Time) core.PinnedCIDStats); ok {
+		r0 = returnFunc(ctx, since)
+	} else {
+		r0 = ret.Get(0).(core.PinnedCIDStats)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, time.Time) error); ok {
+		r1 = returnFunc(ctx, since)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockReprovideStore_CountPinned_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CountPinned'
+type MockReprovideStore_CountPinned_Call struct {
+	*mock.Call
+}
+
+// CountPinned is a helper method to define mock.On call
+//   - ctx context.Context
+//   - since time.Time
+func (_e *MockReprovideStore_Expecter) CountPinned(ctx interface{}, since interface{}) *MockReprovideStore_CountPinned_Call {
+	return &MockReprovideStore_CountPinned_Call{Call: _e.mock.On("CountPinned", ctx, since)}
+}
+
+func (_c *MockReprovideStore_CountPinned_Call) Run(run func(ctx context.Context, since time.Time)) *MockReprovideStore_CountPinned_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 time.Time
+		if args[1] != nil {
+			arg1 = args[1].(time.Time)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockReprovideStore_CountPinned_Call) Return(pinnedCIDStats core.PinnedCIDStats, err error) *MockReprovideStore_CountPinned_Call {
+	_c.Call.Return(pinnedCIDStats, err)
+	return _c
+}
+
+func (_c *MockReprovideStore_CountPinned_Call) RunAndReturn(run func(ctx context.Context, since time.Time) (core.PinnedCIDStats, error)) *MockReprovideStore_CountPinned_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
## Summary

- Add boot-cycle tracking gauges (attempted/succeeded/failed) to the reprovider, with per-CID failure tracking that removes CIDs from the failed set when they succeed on retry
- Push staleness filter into `ProvideCIDs` SQL query via a `since time.Time` parameter, so only CIDs with stale `last_announcement` are fetched instead of all ready CIDs
- Add global gauges for total pinned, announced, and pending CIDs via `CountPinned`

## Test Plan

- [x] `go build ./...` passes
- [x] `go test ./internal/protocol/ipfs/` passes (all TestReprovider tests)
- [x] `go test ./internal/protocol/store/tests/` passes (TestMetadataStore\_ProvideCIDs)
- [x] `gofmt` and `go vet` clean on modified files

* `develop` <!-- branch-stack -->
  - **feat: track DHT reprovide success/failure per boot cycle** :point\_left:

---

<!-- kody-pr-summary:start -->
## Pull Request Description

This PR adds tracking of DHT reprovide success and failure on a per-boot-cycle basis, along with global pinned-state metrics for monitoring reprovide progress.

### Key Changes

**Boot Cycle Tracking**
- Introduces a `bootCycle` tracker that monitors per-CID outcomes during the initial reprovide sweep after the node boots. It tracks how many CIDs were attempted, succeeded, and failed, and removes CIDs from the failed set when they succeed on a subsequent retry.

**New Prometheus Metrics**
- **Boot-cycle gauges** (reset each cycle): `reprovide_boot_cycle_attempted`, `reprovide_boot_cycle_succeeded`, `reprovide_boot_cycle_failed` — track progress of the initial reprovide sweep.
- **Global pinned-state gauges**: `reprovide_pinned_total`, `reprovide_announced_total`, `reprovide_pending_total` — provide visibility into how many pinned CIDs have been announced within the current reprovide interval versus how many remain pending.

**Per-CID Failure Tracking**
- `ProvideMany` now returns a structured `provideManyError` that carries the specific multihashes that failed, rather than a plain error string. This allows the reprovider to track which individual CIDs failed and reconcile them when they succeed on retry.

**Optimized CID Selection**
- `ProvideCIDs` now accepts a `since` timestamp and only returns CIDs whose `last_announcement` is older than the interval (or NULL), avoiding unnecessary re-broadcast of CIDs already fresh in the DHT. The previous client-side filtering and remaining-time calculation logic has been removed in favor of this database-level filter.

**Pinned CID Statistics**
- Adds a `CountPinned` method to the `ReprovideStore` interface that returns counts of total, announced, and pending pinned CIDs, used to populate the global gauges each cycle.
<!-- kody-pr-summary:end -->