### PR TITLE
fix: mark partially-succeeded CIDs as announced on batch failure

### DIFF
--- a/internal/protocol/ipfs/provide.go
+++ b/internal/protocol/ipfs/provide.go
@@ -440,11 +440,8 @@ func (r *Reprovider) performProvide(ctx context.Context, interval time.Duration,
 		ReprovideDuration.WithLabelValues().Observe(time.Since(start).Seconds())
 		ReprovideFailuresTotal.Inc()
 		failures := r.recordFailure()
-		r.log.Error("failed to provide CIDs",
-			zap.Error(err),
-			zap.Uint32("consecutive_failures", failures))
 
-		// Track per-CID failures in boot cycle
+		// Extract per-CID failure info
 		var failedKeys []multihash.Multihash
 		var pme *provideManyError
 		if errors.As(err, &pme) {
@@ -453,12 +450,47 @@ func (r *Reprovider) performProvide(ctx context.Context, interval time.Duration,
 			// Unknown error: mark all attempted keys as failed
 			failedKeys = keys
 		}
+
+		// Mark successfully-provided CIDs even on partial failure.
+		// Without this, CIDs that succeeded are never marked as announced,
+		// causing the reprovider to re-broadcast them on every cycle.
+		failedSet := make(map[string]struct{}, len(failedKeys))
+		for _, fk := range failedKeys {
+			failedSet[string(fk)] = struct{}{}
+		}
+		succeededCIDs := lo.Filter(announced, func(c cid.Cid, _ int) bool {
+			_, failed := failedSet[string(c.Hash())]
+			return !failed
+		})
+		if len(succeededCIDs) > 0 {
+			if err := r.store.SetLastAnnouncement(ctx, succeededCIDs, time.Now()); err != nil {
+				r.log.Warn("failed to update last announcement for partial success",
+					zap.Int("count", len(succeededCIDs)),
+					zap.Error(err))
+			}
+		}
+
+		r.log.Error("failed to provide CIDs",
+			zap.Error(err),
+			zap.Int("succeeded", len(succeededCIDs)),
+			zap.Int("failed", len(failedKeys)),
+			zap.Uint32("consecutive_failures", failures))
+
+		// Track per-CID failures in boot cycle
 		r.bootCycle.markFailed(failedKeys)
+		// Track per-CID successes in boot cycle (remove from failed set)
+		succeededKeys := lo.Filter(keys, func(k multihash.Multihash, _ int) bool {
+			_, failed := failedSet[string(k)]
+			return !failed
+		})
+		if len(succeededKeys) > 0 {
+			r.bootCycle.markSucceeded(succeededKeys)
+		}
 
 		// Update boot-cycle gauges
-		attempted, succeeded, failedCount := r.bootCycle.snapshot()
+		attempted, succeededCount, failedCount := r.bootCycle.snapshot()
 		ReprovideBootCycleAttempted.Set(float64(attempted))
-		ReprovideBootCycleSucceeded.Set(float64(succeeded))
+		ReprovideBootCycleSucceeded.Set(float64(succeededCount))
 		ReprovideBootCycleFailed.Set(float64(failedCount))
 
 		if failures >= 3 {

--- a/internal/protocol/ipfs/provide_test.go
+++ b/internal/protocol/ipfs/provide_test.go
@@ -815,7 +815,7 @@ func TestReprovider_BootCycle_PartialFailure(t *testing.T) {
 		{CID: c2, LastAnnouncement: time.Now().Add(-2 * interval)},
 	}
 
-	// Simulate partial failure: provideManyError with 1 failed key
+	// Simulate partial failure: provideManyError with 1 failed key (c1), 1 succeeded (c2)
 	failedKey := c1.Hash()
 	pme := &provideManyError{
 		failed:     1,
@@ -827,17 +827,112 @@ func TestReprovider_BootCycle_PartialFailure(t *testing.T) {
 	mockStore.EXPECT().CountPinned(mock.Anything, mock.Anything).Return(core.PinnedCIDStats{Total: 2, Pending: 2}, nil).Once()
 	mockStore.EXPECT().ProvideCIDs(mock.Anything, mock.Anything, batchSize).Return(testCIDs, nil).Once()
 	mockProvider.EXPECT().ProvideMany(mock.Anything, mock.Anything).Return(pme).Once()
+	// SetLastAnnouncement should be called for c2 (the succeeded CID)
+	mockStore.EXPECT().SetLastAnnouncement(mock.Anything, mock.MatchedBy(func(cids []cid.Cid) bool {
+		return len(cids) == 1 && cids[0].Equals(c2)
+	}), mock.Anything).Return(nil).Once()
 
 	reprovider.performProvide(ctx, interval, batchSize, LabelTriggerScheduled)
 
-	// 2 attempted, 0 succeeded (whole batch failed), 2 in failed set
-	// (provideManyError only reports 1 specific failure, but the whole batch is marked failed
-	// because we don't know which succeeded individually)
+	// 2 attempted, 1 succeeded (c2 marked as succeeded, removed from failed set), 1 failed (c1)
 	attempted, succeeded, failedCount := reprovider.bootCycle.snapshot()
 	assert.Equal(t, int64(2), attempted)
-	assert.Equal(t, int64(0), succeeded)
-	// Both keys are in failed set: c1 from FailedKeys, c2 from the markFailed(all keys when batch fails)
-	// Actually: provideManyError returns failedKeys=[c1], so only c1 is marked failed.
-	// Wait -- the code does errors.As check, and if it IS provideManyError, it marks only FailedKeys.
-	assert.Equal(t, int64(1), failedCount, "only the specific failed CID should be tracked")
+	assert.Equal(t, int64(1), succeeded)
+	assert.Equal(t, int64(1), failedCount, "only the failed CID should remain in the failed set")
+}
+
+func TestReprovider_performProvide_PartialFailure_AllFail(t *testing.T) {
+	ctx := context.Background()
+
+	mockProvider := mocks.NewMockProvider(t)
+	mockStore := mocks.NewMockReprovideStore(t)
+	logger, _ := zap.NewDevelopment()
+
+	interval := 1 * time.Second
+	batchSize := 10
+
+	reprovider := &Reprovider{
+		provider:             mockProvider,
+		store:                mockStore,
+		log:                  logger,
+		triggerProvide:       make(chan struct{}, 1),
+		triggerDelayDuration: 100 * time.Millisecond,
+		reprovideSleep:       0,
+		mu:                   sync.Mutex{},
+	}
+
+	c1 := cid.NewCidV1(cid.Raw, mustMultihash(t, "allfail-key1"))
+	c2 := cid.NewCidV1(cid.Raw, mustMultihash(t, "allfail-key2"))
+
+	testCIDs := []core.PinnedCID{
+		{CID: c1, LastAnnouncement: time.Now().Add(-2 * interval)},
+		{CID: c2, LastAnnouncement: time.Now().Add(-2 * interval)},
+	}
+
+	// All keys fail
+	pme := &provideManyError{
+		failed:     2,
+		total:      2,
+		err:        errors.New("timeout"),
+		failedKeys: []multihash.Multihash{c1.Hash(), c2.Hash()},
+	}
+
+	mockStore.EXPECT().CountPinned(mock.Anything, mock.Anything).Return(core.PinnedCIDStats{}, nil).Maybe()
+	mockStore.EXPECT().ProvideCIDs(mock.Anything, mock.Anything, batchSize).Return(testCIDs, nil).Once()
+	mockProvider.EXPECT().ProvideMany(mock.Anything, mock.Anything).Return(pme).Once()
+	// SetLastAnnouncement should NOT be called (no successes)
+	mockStore.AssertNotCalled(t, "SetLastAnnouncement")
+
+	sleepDuration := reprovider.performProvide(ctx, interval, batchSize, LabelTriggerScheduled)
+
+	assert.Equal(t, time.Minute, sleepDuration)
+	mockStore.AssertNotCalled(t, "SetLastAnnouncement")
+}
+
+func TestReprovider_performProvide_PartialFailure_SetLastAnnouncementError(t *testing.T) {
+	ctx := context.Background()
+
+	mockProvider := mocks.NewMockProvider(t)
+	mockStore := mocks.NewMockReprovideStore(t)
+	logger, _ := zap.NewDevelopment()
+
+	interval := 1 * time.Second
+	batchSize := 10
+
+	reprovider := &Reprovider{
+		provider:             mockProvider,
+		store:                mockStore,
+		log:                  logger,
+		triggerProvide:       make(chan struct{}, 1),
+		triggerDelayDuration: 100 * time.Millisecond,
+		reprovideSleep:       0,
+		mu:                   sync.Mutex{},
+	}
+
+	c1 := cid.NewCidV1(cid.Raw, mustMultihash(t, "pme-err-key1"))
+	c2 := cid.NewCidV1(cid.Raw, mustMultihash(t, "pme-err-key2"))
+
+	testCIDs := []core.PinnedCID{
+		{CID: c1, LastAnnouncement: time.Now().Add(-2 * interval)},
+		{CID: c2, LastAnnouncement: time.Now().Add(-2 * interval)},
+	}
+
+	// 1 of 2 fails
+	pme := &provideManyError{
+		failed:     1,
+		total:      2,
+		err:        errors.New("timeout"),
+		failedKeys: []multihash.Multihash{c1.Hash()},
+	}
+
+	mockStore.EXPECT().CountPinned(mock.Anything, mock.Anything).Return(core.PinnedCIDStats{}, nil).Maybe()
+	mockStore.EXPECT().ProvideCIDs(mock.Anything, mock.Anything, batchSize).Return(testCIDs, nil).Once()
+	mockProvider.EXPECT().ProvideMany(mock.Anything, mock.Anything).Return(pme).Once()
+	// SetLastAnnouncement fails (e.g. DB error) — should not block error handling
+	mockStore.EXPECT().SetLastAnnouncement(mock.Anything, mock.Anything, mock.Anything).Return(errors.New("db error")).Once()
+
+	sleepDuration := reprovider.performProvide(ctx, interval, batchSize, LabelTriggerScheduled)
+
+	// Should still return time.Minute (failure path), not crash
+	assert.Equal(t, time.Minute, sleepDuration)
 }


### PR DESCRIPTION
- `develop` <!-- branch-stack -->
  - **fix: mark partially-succeeded CIDs as announced on batch failure** :point\_left:

---

<!-- kody-pr-summary:start -->
## Description

This PR fixes an issue where CIDs that were successfully provided during a partial batch failure were never marked as announced, causing them to be re-broadcast on every reprovide cycle.

### Problem

When `ProvideMany` returned a `provideManyError` indicating that some CIDs in the batch failed, the entire batch was treated as failed. Successfully provided CIDs were not recorded via `SetLastAnnouncement`, meaning the reprovider would needlessly re-announce them on every subsequent cycle.

### Changes

- **Partial success tracking**: On batch failure, the code now identifies which CIDs succeeded (those not in the failed keys set) and calls `SetLastAnnouncement` to mark them as announced, preventing unnecessary re-broadcasts.
- **Boot cycle accuracy**: Successfully provided CIDs are now marked as succeeded in the boot cycle (via `markSucceeded`), correcting the `ReprovideBootCycleSucceeded` metric which previously showed 0 even when some CIDs succeeded.
- **Improved logging**: The error log now includes `succeeded` and `failed` counts for better observability.
- **Resilience**: If `SetLastAnnouncement` fails (e.g., due to a database error), it logs a warning without blocking the rest of the error handling flow.

### Tests

- Updated `TestReprovider_BootCycle_PartialFailure` to assert that the succeeded CID is properly tracked (1 succeeded, 1 failed).
- Added `TestReprovider_performProvide_PartialFailure_AllFail` to verify `SetLastAnnouncement` is not called when all CIDs fail.
- Added `TestReprovider_performProvide_PartialFailure_SetLastAnnouncementError` to verify the error path remains stable when `SetLastAnnouncement` itself fails.
<!-- kody-pr-summary:end -->