### PR TITLE
feat: route reprovides through FullRT.ProvideMany for keyspace batching

### DIFF
--- a/internal/protocol/ipfs/metrics.go
+++ b/internal/protocol/ipfs/metrics.go
@@ -34,6 +34,8 @@ const (
 	MetricCompanionDHTBootstrapAttempts = "companion_dht_bootstrap_attempts_total"
 	MetricCompanionDHTBootstrapFailures = "companion_dht_bootstrap_failures_total"
 	MetricCompanionDHTConnectedPeers    = "companion_dht_connected_peers"
+	MetricFullRTReady                   = "fullrt_ready"
+	MetricFullRTRoutingTableSize        = "fullrt_routing_table_size"
 
 	// WantBlockFilter metrics
 	MetricWantBlockRequests     = "want_block_requests_total"
@@ -97,6 +99,10 @@ var (
 	CompanionDHTBootstrapAttemptsTotal prometheus.Counter
 	CompanionDHTBootstrapFailuresTotal prometheus.Counter
 	CompanionDHTConnectedPeers         prometheus.Gauge
+
+	// FullRT gauges
+	FullRTReady            prometheus.Gauge
+	FullRTRoutingTableSize prometheus.Gauge
 
 	// WantBlockFilter metrics
 	WantBlockRequestsTotal *prometheus.CounterVec
@@ -299,6 +305,23 @@ func init() {
 		},
 	)
 
+	// FullRT gauges
+	FullRTReady = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Subsystem: subSystemDHT,
+			Name:      MetricFullRTReady,
+			Help:      "1 when FullRT reports Ready (initial crawl complete), 0 otherwise",
+		},
+	)
+
+	FullRTRoutingTableSize = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Subsystem: subSystemDHT,
+			Name:      MetricFullRTRoutingTableSize,
+			Help:      "Number of peers in FullRT's cached routing table",
+		},
+	)
+
 	// WantBlockFilter metrics
 	WantBlockRequestsTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
@@ -350,6 +373,8 @@ func GetMetricsCollectors() []prometheus.Collector {
 		CompanionDHTBootstrapAttemptsTotal,
 		CompanionDHTBootstrapFailuresTotal,
 		CompanionDHTConnectedPeers,
+		FullRTReady,
+		FullRTRoutingTableSize,
 		WantBlockRequestsTotal,
 		WantBlockGatewayPeers,
 		WantBlockPeerLimiters,

--- a/internal/protocol/ipfs/node.go
+++ b/internal/protocol/ipfs/node.go
@@ -204,10 +204,11 @@ type Node struct {
 	log              *core.Logger
 	ctx              core.Context
 	host             host.Host
-	routing          DHTRouting
-	companionDHT       *dht.IpfsDHT
+	routing             DHTRouting
+	companionDHT        *dht.IpfsDHT
 	companionDHTHealthy atomic.Bool
-	reprovider       *Reprovider
+	fullRT              *fullrt.FullRT
+	reprovider          *Reprovider
 	blockService     blockservice.BlockService
 	dagService       format.DAGService
 	bitswap          *bitswap.Bitswap
@@ -586,11 +587,16 @@ func NewNode(ctx core.Context, cfg *config.ProtocolConfig, rs pluginCore.Reprovi
 		dhtProvider = newBasicDHTProvider(basicDHT, nil, 0, 0)
 		hasProvider = true
 	case config.DHTModeFullRT, "":
-		// FullRT is a client-only DHT — it does not register protocol handlers
-		// and cannot respond to inbound DHT queries. Per its own docs, a
-		// companion IpfsDHT in server mode must be run alongside it so that
-		// other peers (including the website gateway) can query this node
-		// for IPNS records and content routing.
+		// FullRT is an accelerated DHT client that crawls the full network
+		// periodically and caches all DHT peers locally. GetClosestPeers is a
+		// local trie lookup (microseconds) instead of an iterative network
+		// query (~10s). ProvideMany groups keys by keyspace region and sends
+		// bulk ADD_PROVIDER messages over shared connections.
+		//
+		// FullRT does not register protocol handlers — it cannot respond to
+		// inbound DHT queries (FIND_NODE, GET_PROVIDER, PUT_VALUE). A
+		// companion IpfsDHT in server mode runs alongside it to handle
+		// inbound queries and keep this node's multiaddrs discoverable.
 		companion, dhtErr := dht.New(ctx, node, dhtOpts...)
 		if dhtErr != nil {
 			return nil, fmt.Errorf("failed to create companion DHT: %w", dhtErr)
@@ -639,6 +645,7 @@ func NewNode(ctx core.Context, cfg *config.ProtocolConfig, rs pluginCore.Reprovi
 		}
 		routingImpl = frt
 		dhtProvider = frt
+		ipfsNode.fullRT = frt
 		hasProvider = true
 
 		// Start recovery goroutine now that fullrt.NewFullRT succeeded.
@@ -731,12 +738,21 @@ func NewNode(ctx core.Context, cfg *config.ProtocolConfig, rs pluginCore.Reprovi
 	var rp *Reprovider
 	var reproviderCancel context.CancelFunc
 	if hasProvider {
-		// When a companion (server-mode) DHT exists alongside FullRT, use the
-		// companion for providing. FullRT is client-only and does not reliably
-		// put provider records into the DHT network. This matches the behavior
-		// of ProvideCID which also routes through the companion when available.
-		reproviderProvider := dhtProvider
-		if ipfsNode.companionDHT != nil {
+		// When FullRT is active, delegate provides to FullRT.ProvideMany.
+		// FullRT caches all DHT peers and does keyspace-region batching
+		// internally (local GetClosestPeers + bulk ADD_PROVIDER per peer),
+		// eliminating the per-CID GCP bottleneck of the basic DHT.
+		// The companion stays for inbound DHT server duties and IPNS writes.
+		var reproviderProvider pluginCore.Provider
+		if ipfsNode.fullRT != nil {
+			reproviderProvider = newFullrtProvider(ipfsNode.fullRT, func() bool {
+				return ipfsNode.fullRT.Ready()
+			})
+		} else {
+			reproviderProvider = dhtProvider
+		}
+		if ipfsNode.companionDHT != nil && ipfsNode.fullRT == nil {
+			// Basic DHT mode with companion: gate on companion health
 			reproviderProvider = newBasicDHTProvider(ipfsNode.companionDHT, func() bool {
 				if ipfsNode.companionDHT == nil {
 					return false
@@ -762,22 +778,30 @@ func NewNode(ctx core.Context, cfg *config.ProtocolConfig, rs pluginCore.Reprovi
 				case <-ctx.Done():
 					return
 				case <-ticker.C:
-					if ipfsNode.companionDHT != nil {
-						CompanionDHTRoutingTableSize.Set(float64(ipfsNode.companionDHT.RoutingTable().Size()))
+						if ipfsNode.companionDHT != nil {
+							CompanionDHTRoutingTableSize.Set(float64(ipfsNode.companionDHT.RoutingTable().Size()))
 
-						peerCount := 0
-						for range ipfsNode.host.Network().Conns() {
-							peerCount++
-						}
-						CompanionDHTConnectedPeers.Set(float64(peerCount))
+							peerCount := 0
+							for range ipfsNode.host.Network().Conns() {
+								peerCount++
+							}
+							CompanionDHTConnectedPeers.Set(float64(peerCount))
 
-						if ipfsNode.companionDHTHealthy.Load() {
-							CompanionDHTHealthy.Set(1)
-						} else {
-							CompanionDHTHealthy.Set(0)
+							if ipfsNode.companionDHTHealthy.Load() {
+								CompanionDHTHealthy.Set(1)
+							} else {
+								CompanionDHTHealthy.Set(0)
+							}
 						}
-					}
-				}
+						if ipfsNode.fullRT != nil {
+							if ipfsNode.fullRT.Ready() {
+								FullRTReady.Set(1)
+							} else {
+								FullRTReady.Set(0)
+							}
+							FullRTRoutingTableSize.Set(float64(len(ipfsNode.fullRT.Stat())))
+						}
+						}
 			}
 		}()
 	}
@@ -836,6 +860,9 @@ func (n *Node) TriggerReprovider() {
 }
 
 func (n *Node) ProvideCID(ctx context.Context, c cid.Cid) error {
+	if n.fullRT != nil {
+		return n.fullRT.Provide(ctx, c, true)
+	}
 	if n.companionDHT != nil {
 		return n.companionDHT.Provide(ctx, c, true)
 	}

--- a/internal/protocol/ipfs/provide.go
+++ b/internal/protocol/ipfs/provide.go
@@ -21,6 +21,59 @@ import (
 	"go.uber.org/zap"
 )
 
+// provideManyProvider is the minimal interface we need from a DHT that natively
+// implements batched ProvideMany (e.g. FullRT). Using an interface here keeps
+// provide.go free of fullrt imports.
+type provideManyProvider interface {
+	ProvideMany(ctx context.Context, keys []multihash.Multihash) error
+}
+
+// fullrtProvider delegates to FullRT.ProvideMany, which does keyspace-region
+// batching internally: one GetClosestPeers lookup per key (local trie, no
+// network round-trips), then groups keys by target peer so each peer receives
+// multiple ADD_PROVIDER messages over a single connection. This eliminates the
+// per-CID GCP bottleneck that basicDHTProvider has.
+type fullrtProvider struct {
+	dht   provideManyProvider
+	ready func() bool
+}
+
+func (f *fullrtProvider) Ready() bool {
+	if f.ready != nil {
+		return f.ready()
+	}
+	return true
+}
+
+func (f *fullrtProvider) ProvideMany(ctx context.Context, keys []multihash.Multihash) error {
+	start := time.Now()
+
+	err := f.dht.ProvideMany(ctx, keys)
+
+	elapsed := time.Since(start).Seconds()
+	if err != nil {
+		ReprovideCIDDuration.WithLabelValues(classifyProvideError(err)).Observe(elapsed)
+		// FullRT.ProvideMany returns a single error, not per-CID. Treat all
+		// keys as failed so the reprovider can retry them next cycle.
+		ReprovideCIDsTotal.WithLabelValues(LabelResultFailure).Add(float64(len(keys)))
+		ReprovideCIDFailures.WithLabelValues(classifyProvideError(err)).Add(float64(len(keys)))
+		return &provideManyError{
+			failed:     len(keys),
+			total:      len(keys),
+			err:        err,
+			failedKeys: keys,
+		}
+	}
+
+	ReprovideCIDDuration.WithLabelValues(LabelCIDResultSuccess).Observe(elapsed)
+	ReprovideCIDsTotal.WithLabelValues(LabelResultSuccess).Add(float64(len(keys)))
+	return nil
+}
+
+func newFullrtProvider(dht provideManyProvider, ready func() bool) pluginCore.Provider {
+	return &fullrtProvider{dht: dht, ready: ready}
+}
+
 // basicDHTProvider is a wrapper around basic DHT that implements pluginCore.Provider.
 // For basic DHT which doesn't implement ProvideMany natively, we provide it by iterating.
 type basicDHTProvider struct {

--- a/internal/protocol/ipfs/provide_test.go
+++ b/internal/protocol/ipfs/provide_test.go
@@ -618,6 +618,132 @@ func TestBasicDHTProvider_ProvideMany(t *testing.T) {
 	})
 }
 
+// stubProvideMany is a minimal provideManyProvider stub for testing fullrtProvider.
+type stubProvideMany struct {
+	mu       sync.Mutex
+	calls    int
+	keys     []multihash.Multihash
+	err      error
+	provideFn func(keys []multihash.Multihash) error
+}
+
+func (s *stubProvideMany) ProvideMany(_ context.Context, keys []multihash.Multihash) error {
+	s.mu.Lock()
+	s.calls++
+	s.keys = keys
+	fn := s.provideFn
+	s.mu.Unlock()
+	if fn != nil {
+		return fn(keys)
+	}
+	return s.err
+}
+
+func (s *stubProvideMany) getCalls() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.calls
+}
+
+func TestFullrtProvider_ProvideMany(t *testing.T) {
+	t.Run("ready_returns_false_when_fn_returns_false", func(t *testing.T) {
+		provider := newFullrtProvider(&stubProvideMany{}, func() bool { return false })
+		assert.False(t, provider.Ready())
+	})
+
+	t.Run("ready_returns_true_when_fn_returns_true", func(t *testing.T) {
+		provider := newFullrtProvider(&stubProvideMany{}, func() bool { return true })
+		assert.True(t, provider.Ready())
+	})
+
+	t.Run("ready_defaults_to_true_when_fn_is_nil", func(t *testing.T) {
+		provider := newFullrtProvider(&stubProvideMany{}, nil)
+		assert.True(t, provider.Ready())
+	})
+
+	t.Run("provide_many_delegates_all_keys", func(t *testing.T) {
+		c1 := cid.NewCidV1(cid.Raw, mustMultihash(t, "frt-key1"))
+		c2 := cid.NewCidV1(cid.Raw, mustMultihash(t, "frt-key2"))
+
+		stub := &stubProvideMany{}
+		provider := newFullrtProvider(stub, nil)
+
+		keys := []multihash.Multihash{c1.Hash(), c2.Hash()}
+		err := provider.ProvideMany(context.Background(), keys)
+		assert.NoError(t, err)
+		assert.Equal(t, 1, stub.getCalls())
+		assert.Equal(t, keys, stub.keys)
+	})
+
+	t.Run("provide_many_returns_provideManyError_on_failure", func(t *testing.T) {
+		c1 := cid.NewCidV1(cid.Raw, mustMultihash(t, "frt-err1"))
+		c2 := cid.NewCidV1(cid.Raw, mustMultihash(t, "frt-err2"))
+
+		testErr := errors.New("fullrtbulk send failed")
+		stub := &stubProvideMany{err: testErr}
+		provider := newFullrtProvider(stub, nil)
+
+		keys := []multihash.Multihash{c1.Hash(), c2.Hash()}
+		err := provider.ProvideMany(context.Background(), keys)
+
+		require.Error(t, err)
+
+		var pme *provideManyError
+		require.ErrorAs(t, err, &pme)
+		assert.Equal(t, 2, pme.failed)
+		assert.Equal(t, 2, pme.total)
+		assert.Equal(t, testErr, pme.err)
+		assert.Equal(t, keys, pme.failedKeys)
+	})
+
+	t.Run("provide_many_returns_all_keys_as_failed_on_error", func(t *testing.T) {
+		c1 := cid.NewCidV1(cid.Raw, mustMultihash(t, "frt-fail1"))
+		c2 := cid.NewCidV1(cid.Raw, mustMultihash(t, "frt-fail2"))
+		c3 := cid.NewCidV1(cid.Raw, mustMultihash(t, "frt-fail3"))
+
+		stub := &stubProvideMany{err: errors.New("network error")}
+		provider := newFullrtProvider(stub, nil)
+
+		keys := []multihash.Multihash{c1.Hash(), c2.Hash(), c3.Hash()}
+		err := provider.ProvideMany(context.Background(), keys)
+
+		var pme *provideManyError
+		require.ErrorAs(t, err, &pme)
+		// All 3 keys should be in failedKeys for retry
+		assert.Equal(t, 3, len(pme.failedKeys))
+	})
+
+	t.Run("provide_many_with_empty_keys_returns_nil", func(t *testing.T) {
+		stub := &stubProvideMany{}
+		provider := newFullrtProvider(stub, nil)
+
+		err := provider.ProvideMany(context.Background(), []multihash.Multihash{})
+		assert.NoError(t, err)
+		assert.Equal(t, 1, stub.getCalls())
+	})
+
+	t.Run("provide_many_respects_context_cancellation", func(t *testing.T) {
+		key := mustMultihash(t, "frt-cancel-key")
+
+		stub := &stubProvideMany{
+			provideFn: func(_ []multihash.Multihash) error {
+				return context.Canceled
+			},
+		}
+		provider := newFullrtProvider(stub, nil)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		err := provider.ProvideMany(ctx, []multihash.Multihash{key})
+		require.Error(t, err)
+
+		var pme *provideManyError
+		require.ErrorAs(t, err, &pme)
+		assert.Equal(t, 1, pme.failed)
+	})
+}
+
 func TestReprovider_CircuitBreaker_Open(t *testing.T) {
 	ctx := context.Background()
 


### PR DESCRIPTION
## Problem

The reprovider routes all provides through the companion basic DHT, which does a full iterative `GetClosestPeers` (GCP) network query per CID (\~10s each, 20-30 connections). At scale this caps throughput at \~2.5 CIDs/min, meaning \~4,000 pending CIDs take \~27 hours to clear — dangerously close to the 48h provider record expiration window.

## Root cause

PR #670 routed provides to the companion basic DHT because `check.ipfs.network` reported missing provider records. The diagnosis was that "FullRT is client-only and does not reliably put provider records." However, source analysis confirms FullRT **can** send ADD\_PROVIDER RPCs — it just cannot respond to *inbound* DHT queries. The companion DHT was the right fix for inbound connectivity, but routing all *outbound* provides through it introduced the GCP bottleneck.

## Fix

Route reprovides through `FullRT.ProvideMany` instead of the companion basic DHT. FullRT:

- Caches all \~10k DHT peers locally — `GetClosestPeers` is a trie lookup (microseconds, no network round-trips)
- Groups keys by keyspace region and sends bulk ADD\_PROVIDER messages over shared connections (`bulkMessageSend`)
- Eliminates the per-CID GCP round-trip entirely

The companion basic DHT stays for:

- Inbound DHT server queries (FIND\_NODE, GET\_PROVIDER, PUT\_VALUE)
- IPNS PutValue operations
- Node discoverability (keeping this node in k-buckets)

## Changes

- **`provide.go`**: `fullrtProvider` wrapper delegating to `FullRT.ProvideMany` with metrics + `provideManyError` on failure
- **`node.go`**: Wire `fullrtProvider` when FullRT active; route `ProvideCID` through FullRT; fix incorrect comments
- **`metrics.go`**: `ipfs_dht_fullrt_ready` + `ipfs_dht_fullrt_routing_table_size` gauges
- **`provide_test.go`**: 7 test cases for fullrtProvider (ready gating, delegation, error handling, context cancellation)

## Expected impact

\~4,000 pending CIDs should clear in minutes instead of \~27 hours. FullRT eliminates the per-CID GCP bottleneck (\~10s each) and batches ADD\_PROVIDER messages by keyspace region.

- `develop` <!-- branch-stack -->
  - **feat: route reprovides through FullRT.ProvideMany for keyspace batching** :point\_left:

---

<!-- kody-pr-summary:start -->
## Pull Request Description

This PR routes DHT reprovides through `FullRT.ProvideMany` when FullRT mode is active, enabling keyspace-region batching that significantly improves reprovider throughput.

### Key Changes

**Reprovider routing through FullRT:**
- When FullRT is active, the reprovider now delegates to `FullRT.ProvideMany` instead of the companion DHT. FullRT performs local trie lookups for `GetClosestPeers` (microseconds vs. ~10s network round-trips) and groups keys by target peer, sending bulk `ADD_PROVIDER` messages over shared connections. This eliminates the per-CID GCP bottleneck of the basic DHT provider.
- The companion DHT remains in use for inbound DHT server duties (FIND_NODE, GET_PROVIDER, PUT_VALUE) and IPNS writes, but no longer handles providing when FullRT is available.
- In basic DHT mode (no FullRT), the existing companion-health-gated providing behavior is preserved.

**Ad-hoc CID providing:**
- `ProvideCID` now routes through `FullRT.Provide` when available, falling back to the companion DHT as before.

**New `fullrtProvider` implementation:**
- A new `fullrtProvider` type wraps FullRT's native `ProvideMany`, implementing the `pluginCore.Provider` interface. On error, it returns a `provideManyError` containing all submitted keys so the reprovider can retry them in the next cycle.

**New observability metrics:**
- `fullrt_ready` — reports 1 when FullRT's initial crawl is complete, 0 otherwise.
- `fullrt_routing_table_size` — reports the number of peers in FullRT's cached routing table.

**Tests:**
- Added comprehensive unit tests for `fullrtProvider` covering `Ready()` behavior, `ProvideMany` delegation, error handling with `provideManyError`, empty key sets, and context cancellation.
<!-- kody-pr-summary:end -->