### PR TITLE
fix: reprovider timestamp race causing CIDs to never count as announced

### DIFF
--- a/internal/protocol/ipfs/provide.go
+++ b/internal/protocol/ipfs/provide.go
@@ -409,8 +409,14 @@ func (r *Reprovider) performProvide(ctx context.Context, interval time.Duration,
 		r.log.Info("starting boot reprovide cycle")
 	}
 
-	// Update global pinned-state gauges
-	since := time.Now().Add(-interval)
+	// Update global pinned-state gauges.
+	// Use a buffer slightly larger than the interval to avoid a timestamp
+	// precision race: SetLastAnnouncement sets last_announcement = T at the
+	// end of the previous cycle, and the next cycle's since = now - interval
+	// is computed a few milliseconds later, making since > T. Without the
+	// buffer, CIDs announced in the previous cycle fall just outside the
+	// window and are counted as pending (and re-provided) every time.
+	since := time.Now().Add(-interval - time.Minute)
 	if stats, err := r.store.CountPinned(ctx, since); err != nil {
 		r.log.Warn("failed to count pinned CIDs", zap.Error(err))
 	} else {
@@ -452,8 +458,9 @@ func (r *Reprovider) performProvide(ctx context.Context, interval time.Duration,
 	}
 
 	// Only fetch CIDs whose last_announcement is older than the interval.
-	// This avoids re-broadcasting CIDs that are already fresh in the DHT.
-	cutoff := time.Now().Add(-interval)
+	// Use the same buffer as CountPinned to avoid re-broadcasting CIDs that
+	// were announced in the previous cycle.
+	cutoff := time.Now().Add(-interval - time.Minute)
 	cids, err := r.store.ProvideCIDs(ctx, cutoff, batchSize)
 	if err != nil {
 		r.log.Error("failed to fetch CIDs to provide", zap.Error(err))


### PR DESCRIPTION
## Problem

`announced_total` stuck at 0 and `pending_total` stuck at 5,289 despite 10 successful batches (5,000 CIDs provided via FullRT.ProvideMany). The same CIDs were being re-provided every cycle.

## Root Cause

Timestamp precision race between `SetLastAnnouncement` and `CountPinned`/`ProvideCIDs`:

1. End of cycle N: `SetLastAnnouncement(ctx, cids, time.Now())` sets `last_announcement = T`
2. `performProvide` returns `interval` (4h), reprovider sleeps 4h
3. Start of cycle N+1: `since = time.Now().Add(-4h)` = `T + epsilon` (epsilon = ms between step 1 and 3)
4. `CountPinned` counts `last_announcement >= since` → `T >= T + epsilon` → **false**
5. `ProvideCIDs` fetches `last_announcement < cutoff` → `T < T + epsilon` → **true** — same CIDs re-fetched

Every cycle, the same CIDs get provided successfully, `SetLastAnnouncement` updates the DB, but the next cycle's `since`/`cutoff` is computed a few ms too late, so those CIDs always fall outside the "announced" window.

## Fix

Add 1-minute buffer to both `since` (CountPinned) and `cutoff` (ProvideCIDs):

```go
since := time.Now().Add(-interval - time.Minute)
cutoff := time.Now().Add(-interval - time.Minute)
```

This makes the window slightly wider than the interval, so CIDs announced in the previous cycle fall inside the "announced" window and are skipped by `ProvideCIDs`.

- `develop` <!-- branch-stack -->
  - **fix: reprovider timestamp race causing CIDs to never count as announced** :point\_left:

---

<!-- kody-pr-summary:start -->
This pull request fixes a timestamp race condition in the IPFS reprovider logic that caused CIDs to never be counted as announced, resulting in them being unnecessarily re-provided every cycle.

The issue occurred because the time window calculation (`now - interval`) was computed a few milliseconds after the previous cycle's announcement timestamp was set. This slight timing difference caused CIDs announced at the end of the previous cycle to fall just outside the query window, making them appear as pending.

To resolve this, a 1-minute buffer has been added to the interval calculation for both `CountPinned` and `ProvideCIDs` operations. This ensures CIDs announced in the previous cycle are correctly recognized as fresh and prevents redundant re-broadcasting.
<!-- kody-pr-summary:end -->