### PR TITLE
fix: drain pending CID backlog on full batch instead of sleeping full interval

### DIFF
--- a/internal/protocol/ipfs/provide.go
+++ b/internal/protocol/ipfs/provide.go
@@ -586,6 +586,13 @@ func (r *Reprovider) performProvide(ctx context.Context, interval time.Duration,
 		zap.Int("count", len(announced)),
 		zap.Duration("elapsed", time.Since(start)))
 
+	// If the batch was full, there are likely more pending CIDs.
+	// Return a short sleep to drain the backlog quickly instead of waiting
+	// the full interval between batches.
+	if len(cids) >= batchSize {
+		return time.Minute
+	}
+
 	return interval
 }
 


### PR DESCRIPTION
- `develop` <!-- branch-stack -->
  - **fix: drain pending CID backlog on full batch instead of sleeping full interval** :point\_left:

---

<!-- kody-pr-summary:start -->
## Pull Request Description

This PR optimizes the IPFS reprovider's batch processing behavior when there is a backlog of pending CIDs to announce.

**Problem**: When the reprovider processes a full batch of CIDs, it would wait the full configured interval before processing the next batch, even if more CIDs were still pending. This caused a slow drain of any accumulated backlog.

**Fix**: After processing a batch, if the batch was full (indicating more CIDs are likely waiting), the reprovider now returns a short 1-minute sleep instead of the full interval. This allows the system to quickly drain pending CID backlogs. If the batch was not full, the normal interval is used as before.

**Impact**: Improves throughput and reduces latency for CID announcement when there is a backlog of content to provide to the IPFS network.
<!-- kody-pr-summary:end -->