### PR TITLE
refactor: simplify reprovider with NewDHTProvider facade

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -50,6 +50,16 @@ type (
 		Interval       time.Duration `config:"interval"`
 		PerCIDTimeout  time.Duration `config:"per_cid_timeout"`
 		ProvideWorkers int           `config:"provide_workers"`
+		// TriggerDelay is the debounce delay before processing a manual trigger.
+		TriggerDelay   time.Duration `config:"trigger_delay"`
+		// NotReadySleep is how long to wait when the DHT provider is not ready.
+		NotReadySleep  time.Duration `config:"not_ready_sleep"`
+		// EmptySleep is how long to wait when there are no CIDs to provide.
+		EmptySleep     time.Duration `config:"empty_sleep"`
+		// ErrorSleep is how long to wait after a provide error.
+		ErrorSleep     time.Duration `config:"error_sleep"`
+		// BacklogSleep is how long to wait between batches while draining a backlog.
+		BacklogSleep   time.Duration `config:"backlog_sleep"`
 	}
 
 	// IPNS configures IPNS record publishing and republishing
@@ -85,6 +95,11 @@ func (I IPFSProvider) Defaults() map[string]any {
 		"Interval":       4 * time.Hour,
 		"PerCIDTimeout":  15 * time.Second,
 		"ProvideWorkers": 32,
+		"TriggerDelay":   2 * time.Second,
+		"NotReadySleep":  30 * time.Second,
+		"EmptySleep":     10 * time.Minute,
+		"ErrorSleep":     time.Minute,
+		"BacklogSleep":   time.Minute,
 	}
 }
 

--- a/internal/protocol/ipfs/metrics.go
+++ b/internal/protocol/ipfs/metrics.go
@@ -14,14 +14,7 @@ const (
 	MetricReprovideDuration            = "reprovide_duration_seconds"
 	MetricReprovideCIDDuration         = "reprovide_cid_duration_seconds"
 	MetricReprovideBatchSize           = "reprovide_batch_size"
-	MetricReprovideCircuitOpen         = "reprovide_circuit_open"
-	MetricReprovideConsecutiveFailures = "reprovide_consecutive_failures"
 	MetricReprovideProviderReady       = "reprovide_provider_ready"
-
-	// Boot-cycle metrics (per boot reprovide cycle)
-	MetricReprovideBootCycleAttempted = "reprovide_boot_cycle_attempted"
-	MetricReprovideBootCycleSucceeded = "reprovide_boot_cycle_succeeded"
-	MetricReprovideBootCycleFailed    = "reprovide_boot_cycle_failed"
 
 	// Global pinned-state gauges
 	MetricReprovidePinnedTotal    = "reprovide_pinned_total"
@@ -79,14 +72,7 @@ var (
 	ReprovideBatchSize   *prometheus.HistogramVec
 
 	// Reprovider gauges
-	ReprovideCircuitOpen         prometheus.Gauge
-	ReprovideConsecutiveFailures prometheus.Gauge
 	ReprovideProviderReady       prometheus.Gauge
-
-	// Boot-cycle gauges (reset each cycle)
-	ReprovideBootCycleAttempted prometheus.Gauge
-	ReprovideBootCycleSucceeded prometheus.Gauge
-	ReprovideBootCycleFailed    prometheus.Gauge
 
 	// Global pinned-state gauges
 	ReprovidePinnedTotal    prometheus.Gauge
@@ -189,53 +175,11 @@ func init() {
 		[]string{},
 	)
 
-	// Gauges
-	ReprovideCircuitOpen = prometheus.NewGauge(
-		prometheus.GaugeOpts{
-			Subsystem: subSystemReprovider,
-			Name:      MetricReprovideCircuitOpen,
-			Help:      "1 when circuit breaker is open, 0 when closed",
-		},
-	)
-
-	ReprovideConsecutiveFailures = prometheus.NewGauge(
-		prometheus.GaugeOpts{
-			Subsystem: subSystemReprovider,
-			Name:      MetricReprovideConsecutiveFailures,
-			Help:      "Current consecutive failure count for the reprovider",
-		},
-	)
-
 	ReprovideProviderReady = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Subsystem: subSystemReprovider,
 			Name:      MetricReprovideProviderReady,
 			Help:      "1 when the provider reports Ready, 0 otherwise",
-		},
-	)
-
-	// Boot-cycle gauges
-	ReprovideBootCycleAttempted = prometheus.NewGauge(
-		prometheus.GaugeOpts{
-			Subsystem: subSystemReprovider,
-			Name:      MetricReprovideBootCycleAttempted,
-			Help:      "CIDs attempted in the current boot reprovide cycle",
-		},
-	)
-
-	ReprovideBootCycleSucceeded = prometheus.NewGauge(
-		prometheus.GaugeOpts{
-			Subsystem: subSystemReprovider,
-			Name:      MetricReprovideBootCycleSucceeded,
-			Help:      "CIDs successfully provided in the current boot reprovide cycle",
-		},
-	)
-
-	ReprovideBootCycleFailed = prometheus.NewGauge(
-		prometheus.GaugeOpts{
-			Subsystem: subSystemReprovider,
-			Name:      MetricReprovideBootCycleFailed,
-			Help:      "CIDs that failed in the current boot reprovide cycle and haven't succeeded on retry",
 		},
 	)
 
@@ -359,12 +303,7 @@ func GetMetricsCollectors() []prometheus.Collector {
 		ReprovideDuration,
 		ReprovideCIDDuration,
 		ReprovideBatchSize,
-		ReprovideCircuitOpen,
-		ReprovideConsecutiveFailures,
 		ReprovideProviderReady,
-		ReprovideBootCycleAttempted,
-		ReprovideBootCycleSucceeded,
-		ReprovideBootCycleFailed,
 		ReprovidePinnedTotal,
 		ReprovideAnnouncedTotal,
 		ReprovidePendingTotal,

--- a/internal/protocol/ipfs/node.go
+++ b/internal/protocol/ipfs/node.go
@@ -539,7 +539,6 @@ func NewNode(ctx core.Context, cfg *config.ProtocolConfig, rs pluginCore.Reprovi
 	}
 
 	var routingImpl DHTRouting
-	var dhtProvider pluginCore.Provider
 	var hasProvider bool
 
 	// Detect if we should use LAN DHT mode
@@ -582,9 +581,6 @@ func NewNode(ctx core.Context, cfg *config.ProtocolConfig, rs pluginCore.Reprovi
 			return nil, fmt.Errorf("failed to create basic dht: %w", dhtErr)
 		}
 		routingImpl = basicDHT
-		// Wrap basic DHT to implement pluginCore.Provider.
-		// Basic mode uses the primary DHT directly; no health gating needed.
-		dhtProvider = newBasicDHTProvider(basicDHT, nil, 0, 0)
 		hasProvider = true
 	case config.DHTModeFullRT, "":
 		// FullRT is an accelerated DHT client that crawls the full network
@@ -644,7 +640,6 @@ func NewNode(ctx core.Context, cfg *config.ProtocolConfig, rs pluginCore.Reprovi
 			return nil, fmt.Errorf("failed to create fullrt: %w", dhtErr)
 		}
 		routingImpl = frt
-		dhtProvider = frt
 		ipfsNode.fullRT = frt
 		hasProvider = true
 
@@ -738,35 +733,35 @@ func NewNode(ctx core.Context, cfg *config.ProtocolConfig, rs pluginCore.Reprovi
 	var rp *Reprovider
 	var reproviderCancel context.CancelFunc
 	if hasProvider {
-		// When FullRT is active, delegate provides to FullRT.ProvideMany.
-		// FullRT caches all DHT peers and does keyspace-region batching
-		// internally (local GetClosestPeers + bulk ADD_PROVIDER per peer),
-		// eliminating the per-CID GCP bottleneck of the basic DHT.
-		// The companion stays for inbound DHT server duties and IPNS writes.
-		var reproviderProvider pluginCore.Provider
+		// NewDHTProvider abstracts the fullrt vs basic DHT choice:
+		// - FullRT mode: delegates to FullRT.ProvideMany (keyspace-region batching)
+		// - Basic mode: iterates with per-CID timeout over the primary DHT
+		// - FullRT mode without fullRT ready: falls back to companion DHT
+		// The ready function gates on FullRT readiness or companion health.
+		var dhtForProvide routing.ContentRouting
+		var readyFn func() bool
+
 		if ipfsNode.fullRT != nil {
-			reproviderProvider = newFullrtProvider(ipfsNode.fullRT, func() bool {
-				return ipfsNode.fullRT.Ready()
-			})
-		} else {
-			reproviderProvider = dhtProvider
-		}
-		if ipfsNode.companionDHT != nil && ipfsNode.fullRT == nil {
-			// Basic DHT mode with companion: gate on companion health
-			reproviderProvider = newBasicDHTProvider(ipfsNode.companionDHT, func() bool {
-				if ipfsNode.companionDHT == nil {
-					return false
-				}
+			readyFn = func() bool { return ipfsNode.fullRT.Ready() }
+		} else if ipfsNode.companionDHT != nil {
+			dhtForProvide = ipfsNode.companionDHT
+			readyFn = func() bool {
 				if !ipfsNode.companionDHTHealthy.Load() {
 					return false
 				}
 				return ipfsNode.companionDHT.RoutingTable().Size() > 0
-			}, cfg.Provider.PerCIDTimeout, cfg.Provider.ProvideWorkers)
+			}
+		} else {
+			// Basic mode: use the primary DHT directly, no health gating
+			dhtForProvide = routingImpl
+			readyFn = nil
 		}
-		rp = NewReprovider(reproviderProvider, rs, ctx.Logger().Named("reprovider"))
+
+		reproviderProvider := NewDHTProvider(ipfsNode.fullRT, dhtForProvide, readyFn, cfg.Provider)
+		rp = NewReprovider(reproviderProvider, rs, ctx.Logger().Named("reprovider"), cfg.Provider)
 		reproviderCtx, cancel := context.WithCancel(ctx)
 		reproviderCancel = cancel
-		go rp.Run(reproviderCtx, cfg.Provider.Interval, cfg.Provider.BatchSize)
+		go rp.Run(reproviderCtx)
 
 		// Periodic DHT metrics goroutine -- updates gauges every 30 seconds
 		// to surface DHT health degradation even when the reprovider is idle.

--- a/internal/protocol/ipfs/provide.go
+++ b/internal/protocol/ipfs/provide.go
@@ -5,12 +5,14 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/ipfs/go-cid"
 	"github.com/libp2p/go-libp2p/core/routing"
 	"github.com/multiformats/go-multihash"
 	"github.com/samber/lo"
+	"golang.org/x/sync/errgroup"
 	"go.uber.org/zap"
 
 	pluginCore "go.lumeweb.com/portal-plugin-ipfs/core"
@@ -75,9 +77,10 @@ func newFullrtProvider(dht provideManyProvider, ready func() bool) pluginCore.Pr
 // natively. It iterates over keys with a per-CID timeout. Used in basic DHT
 // mode (mainly for testing) and as a fallback when FullRT is unavailable.
 type basicDHTProvider struct {
-	dht           routing.ContentRouting
-	ready         func() bool
-	perCIDTimeout time.Duration
+	dht            routing.ContentRouting
+	ready          func() bool
+	perCIDTimeout  time.Duration
+	provideWorkers int
 }
 
 func (b *basicDHTProvider) Ready() bool {
@@ -88,36 +91,55 @@ func (b *basicDHTProvider) Ready() bool {
 }
 
 func (b *basicDHTProvider) ProvideMany(ctx context.Context, keys []multihash.Multihash) error {
-	var failed []multihash.Multihash
+	var (
+		mu     sync.Mutex
+		failed []multihash.Multihash
+	)
+
+	workers := b.provideWorkers
+	if workers <= 0 {
+		workers = len(keys)
+	}
+
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(workers)
 
 	for _, k := range keys {
-		if ctx.Err() != nil {
+		if gctx.Err() != nil {
 			break
 		}
 
-		provideCtx := ctx
-		var cancel context.CancelFunc
-		if b.perCIDTimeout > 0 {
-			provideCtx, cancel = context.WithTimeout(ctx, b.perCIDTimeout)
-		}
+		k := k
+		g.Go(func() error {
+			provideCtx := gctx
+			var cancel context.CancelFunc
+			if b.perCIDTimeout > 0 {
+				provideCtx, cancel = context.WithTimeout(gctx, b.perCIDTimeout)
+			}
 
-		cidStart := time.Now()
-		err := b.dht.Provide(provideCtx, cid.NewCidV1(cid.Raw, k), true)
-		cidElapsed := time.Since(cidStart).Seconds()
-		if cancel != nil {
-			cancel()
-		}
+			cidStart := time.Now()
+			err := b.dht.Provide(provideCtx, cid.NewCidV1(cid.Raw, k), true)
+			cidElapsed := time.Since(cidStart).Seconds()
+			if cancel != nil {
+				cancel()
+			}
 
-		if err != nil {
-			ReprovideCIDDuration.WithLabelValues(classifyProvideError(err)).Observe(cidElapsed)
-			ReprovideCIDFailures.WithLabelValues(classifyProvideError(err)).Inc()
-			ReprovideCIDsTotal.WithLabelValues(LabelResultFailure).Inc()
-			failed = append(failed, k)
-		} else {
-			ReprovideCIDDuration.WithLabelValues(LabelCIDResultSuccess).Observe(cidElapsed)
-			ReprovideCIDsTotal.WithLabelValues(LabelResultSuccess).Inc()
-		}
+			if err != nil {
+				ReprovideCIDDuration.WithLabelValues(classifyProvideError(err)).Observe(cidElapsed)
+				ReprovideCIDFailures.WithLabelValues(classifyProvideError(err)).Inc()
+				ReprovideCIDsTotal.WithLabelValues(LabelResultFailure).Inc()
+				mu.Lock()
+				failed = append(failed, k)
+				mu.Unlock()
+			} else {
+				ReprovideCIDDuration.WithLabelValues(LabelCIDResultSuccess).Observe(cidElapsed)
+				ReprovideCIDsTotal.WithLabelValues(LabelResultSuccess).Inc()
+			}
+			return nil
+		})
 	}
+
+	_ = g.Wait()
 
 	if len(failed) > 0 {
 		return &provideManyError{
@@ -127,11 +149,12 @@ func (b *basicDHTProvider) ProvideMany(ctx context.Context, keys []multihash.Mul
 			failedKeys: failed,
 		}
 	}
+
 	return nil
 }
 
-func newBasicDHTProvider(dht routing.ContentRouting, ready func() bool, perCIDTimeout time.Duration) pluginCore.Provider {
-	return &basicDHTProvider{dht: dht, ready: ready, perCIDTimeout: perCIDTimeout}
+func newBasicDHTProvider(dht routing.ContentRouting, ready func() bool, perCIDTimeout time.Duration, provideWorkers int) pluginCore.Provider {
+	return &basicDHTProvider{dht: dht, ready: ready, perCIDTimeout: perCIDTimeout, provideWorkers: provideWorkers}
 }
 
 // NewDHTProvider is the facade factory for DHT providers. It abstracts the
@@ -148,7 +171,7 @@ func NewDHTProvider(fullrt provideManyProvider, dht routing.ContentRouting, read
 	if fullrt != nil {
 		return newFullrtProvider(fullrt, ready)
 	}
-	return newBasicDHTProvider(dht, ready, cfg.PerCIDTimeout)
+	return newBasicDHTProvider(dht, ready, cfg.PerCIDTimeout, cfg.ProvideWorkers)
 }
 
 // provideManyError is returned by ProvideMany when some CIDs fail.

--- a/internal/protocol/ipfs/provide.go
+++ b/internal/protocol/ipfs/provide.go
@@ -5,20 +5,17 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"sync"
-	"sync/atomic"
 	"time"
 
-	pluginCore "go.lumeweb.com/portal-plugin-ipfs/core"
-	"go.lumeweb.com/portal/core"
-
-	"github.com/avast/retry-go/v5"
-	"github.com/gammazero/workerpool"
 	"github.com/ipfs/go-cid"
 	"github.com/libp2p/go-libp2p/core/routing"
 	"github.com/multiformats/go-multihash"
 	"github.com/samber/lo"
 	"go.uber.org/zap"
+
+	pluginCore "go.lumeweb.com/portal-plugin-ipfs/core"
+	"go.lumeweb.com/portal-plugin-ipfs/internal/config"
+	"go.lumeweb.com/portal/core"
 )
 
 // provideManyProvider is the minimal interface we need from a DHT that natively
@@ -74,13 +71,13 @@ func newFullrtProvider(dht provideManyProvider, ready func() bool) pluginCore.Pr
 	return &fullrtProvider{dht: dht, ready: ready}
 }
 
-// basicDHTProvider is a wrapper around basic DHT that implements pluginCore.Provider.
-// For basic DHT which doesn't implement ProvideMany natively, we provide it by iterating.
+// basicDHTProvider wraps a basic DHT that doesn't implement ProvideMany
+// natively. It iterates over keys with a per-CID timeout. Used in basic DHT
+// mode (mainly for testing) and as a fallback when FullRT is unavailable.
 type basicDHTProvider struct {
-	dht            routing.ContentRouting
-	ready          func() bool
-	perCIDTimeout  time.Duration
-	provideWorkers int
+	dht           routing.ContentRouting
+	ready         func() bool
+	perCIDTimeout time.Duration
 }
 
 func (b *basicDHTProvider) Ready() bool {
@@ -91,92 +88,67 @@ func (b *basicDHTProvider) Ready() bool {
 }
 
 func (b *basicDHTProvider) ProvideMany(ctx context.Context, keys []multihash.Multihash) error {
-	workers := b.provideWorkers
-	if workers <= 0 {
-		workers = 1
-	}
-
-	var failed atomic.Int64
-	var mu sync.Mutex
-	var lastErr error
-	failedKeys := make(map[string]struct{})
-
-	wp := workerpool.New(workers)
+	var failed []multihash.Multihash
 
 	for _, k := range keys {
 		if ctx.Err() != nil {
 			break
 		}
 
-		k := k
-		wp.Submit(func() {
-			err := retry.New(
-				retry.Attempts(3),
-				retry.Delay(1*time.Second),
-				retry.DelayType(retry.BackOffDelay),
-				retry.Context(ctx),
-				retry.RetryIf(func(err error) bool {
-					// Don't retry on timeout or cancellation: likely to fail again
-					// and just burn another per-CID timeout.
-					return !errors.Is(err, context.DeadlineExceeded) && !errors.Is(err, context.Canceled)
-				}),
-			).Do(func() error {
-				provideCtx := ctx
-				var cancel context.CancelFunc
-				if b.perCIDTimeout > 0 {
-					provideCtx, cancel = context.WithTimeout(ctx, b.perCIDTimeout)
-				}
+		provideCtx := ctx
+		var cancel context.CancelFunc
+		if b.perCIDTimeout > 0 {
+			provideCtx, cancel = context.WithTimeout(ctx, b.perCIDTimeout)
+		}
 
-				cidStart := time.Now()
-				err := b.dht.Provide(provideCtx, cid.NewCidV1(cid.Raw, k), true)
-				cidElapsed := time.Since(cidStart).Seconds()
-				if cancel != nil {
-					cancel()
-				}
+		cidStart := time.Now()
+		err := b.dht.Provide(provideCtx, cid.NewCidV1(cid.Raw, k), true)
+		cidElapsed := time.Since(cidStart).Seconds()
+		if cancel != nil {
+			cancel()
+		}
 
-				if err != nil {
-					ReprovideCIDDuration.WithLabelValues(classifyProvideError(err)).Observe(cidElapsed)
-				} else {
-					ReprovideCIDDuration.WithLabelValues(LabelCIDResultSuccess).Observe(cidElapsed)
-				}
-				return err
-			})
-
-			if err != nil {
-				failed.Add(1)
-				mu.Lock()
-				lastErr = err
-				failedKeys[string(k)] = struct{}{}
-				mu.Unlock()
-
-				errorType := classifyProvideError(err)
-				ReprovideCIDFailures.WithLabelValues(errorType).Inc()
-				ReprovideCIDsTotal.WithLabelValues(LabelResultFailure).Inc()
-				return
-			}
+		if err != nil {
+			ReprovideCIDDuration.WithLabelValues(classifyProvideError(err)).Observe(cidElapsed)
+			ReprovideCIDFailures.WithLabelValues(classifyProvideError(err)).Inc()
+			ReprovideCIDsTotal.WithLabelValues(LabelResultFailure).Inc()
+			failed = append(failed, k)
+		} else {
+			ReprovideCIDDuration.WithLabelValues(LabelCIDResultSuccess).Observe(cidElapsed)
 			ReprovideCIDsTotal.WithLabelValues(LabelResultSuccess).Inc()
-		})
+		}
 	}
 
-	wp.StopWait()
-
-	f := int(failed.Load())
-	if f > 0 {
-		mu.Lock()
-		le := lastErr
-		fk := make([]multihash.Multihash, 0, len(failedKeys))
-		for ks := range failedKeys {
-			fk = append(fk, multihash.Multihash(ks))
-		}
-		mu.Unlock()
+	if len(failed) > 0 {
 		return &provideManyError{
-			failed:     f,
+			failed:     len(failed),
 			total:      len(keys),
-			err:        le,
-			failedKeys: fk,
+			err:        errors.New("provide failed for some CIDs"),
+			failedKeys: failed,
 		}
 	}
 	return nil
+}
+
+func newBasicDHTProvider(dht routing.ContentRouting, ready func() bool, perCIDTimeout time.Duration) pluginCore.Provider {
+	return &basicDHTProvider{dht: dht, ready: ready, perCIDTimeout: perCIDTimeout}
+}
+
+// NewDHTProvider is the facade factory for DHT providers. It abstracts the
+// fullrt vs basic DHT choice behind a single call so node.go never branches
+// on DHT mode.
+//
+// When fullrt is non-nil, it delegates to FullRT.ProvideMany (keyspace-region
+// batching, local GetClosestPeers, bulk ADD_PROVIDER per peer).
+//
+// When fullrt is nil, it uses basicDHTProvider with the provided DHT (the
+// primary DHT in basic mode, or the companion DHT in fullrt mode without
+// fullRT available). The ready function gates health if needed.
+func NewDHTProvider(fullrt provideManyProvider, dht routing.ContentRouting, ready func() bool, cfg config.IPFSProvider) pluginCore.Provider {
+	if fullrt != nil {
+		return newFullrtProvider(fullrt, ready)
+	}
+	return newBasicDHTProvider(dht, ready, cfg.PerCIDTimeout)
 }
 
 // provideManyError is returned by ProvideMany when some CIDs fail.
@@ -201,10 +173,6 @@ func (e *provideManyError) FailedKeys() []multihash.Multihash {
 	return e.failedKeys
 }
 
-func newBasicDHTProvider(dht routing.ContentRouting, ready func() bool, perCIDTimeout time.Duration, provideWorkers int) pluginCore.Provider {
-	return &basicDHTProvider{dht: dht, ready: ready, perCIDTimeout: perCIDTimeout, provideWorkers: provideWorkers}
-}
-
 func classifyProvideError(err error) string {
 	if errors.Is(err, context.DeadlineExceeded) {
 		return "timeout"
@@ -224,82 +192,12 @@ type Reprovider struct {
 	provider pluginCore.Provider
 	store    pluginCore.ReprovideStore
 	log      *zap.Logger
+	cfg      config.IPFSProvider
 
-	triggerProvide       chan struct{}
-	triggerDelayDuration time.Duration
-
-	mu             sync.Mutex
-	reprovideSleep time.Duration
-
-	// cancelTrigger signals to stop timer callbacks
-	cancelTrigger chan struct{}
-
-	// cancelledFlag is an atomic flag to track cancellation state
-	cancelledFlag atomic.Bool
-
-	// Circuit breaker
-	consecutiveFailures atomic.Uint32
-	circuitOpenUntil    atomic.Int64 // unix nano timestamp
-
-	// Boot-cycle tracking: tracks per-CID success/failure during the initial
-	// reprovide sweep after boot. When a CID fails then later succeeds on retry,
-	// it is removed from the failed set.
-	bootCycle bootCycle
+	triggerProvide chan struct{}
 }
 
-type bootCycle struct {
-	mu        sync.Mutex
-	started   bool
-	attempted int64
-	succeeded int64
-	failed    map[string]struct{} // multihash string -> failed
-}
-
-func (bc *bootCycle) markAttempted(n int) {
-	bc.mu.Lock()
-	bc.attempted += int64(n)
-	bc.mu.Unlock()
-}
-
-func (bc *bootCycle) markSucceeded(keys []multihash.Multihash) {
-	bc.mu.Lock()
-	bc.succeeded += int64(len(keys))
-	for _, k := range keys {
-		delete(bc.failed, string(k))
-	}
-	bc.mu.Unlock()
-}
-
-func (bc *bootCycle) markFailed(keys []multihash.Multihash) {
-	bc.mu.Lock()
-	for _, k := range keys {
-		bc.failed[string(k)] = struct{}{}
-	}
-	bc.mu.Unlock()
-}
-
-func (bc *bootCycle) reset() {
-	bc.mu.Lock()
-	bc.attempted = 0
-	bc.succeeded = 0
-	bc.failed = make(map[string]struct{})
-	bc.started = true
-	bc.mu.Unlock()
-}
-
-func (bc *bootCycle) snapshot() (attempted, succeeded, failedCount int64) {
-	bc.mu.Lock()
-	defer bc.mu.Unlock()
-	return bc.attempted, bc.succeeded, int64(len(bc.failed))
-}
-
-func (bc *bootCycle) isStarted() bool {
-	bc.mu.Lock()
-	defer bc.mu.Unlock()
-	return bc.started
-}
-
-// Trigger triggers the reprovider loop to run immediately.
+// Trigger signals the reprovider loop to run immediately.
 func (r *Reprovider) Trigger() {
 	select {
 	case r.triggerProvide <- struct{}{}:
@@ -309,10 +207,11 @@ func (r *Reprovider) Trigger() {
 
 // Run starts the reprovider loop, which periodically announces CIDs that
 // have not been announced in the last interval.
-func (r *Reprovider) Run(ctx context.Context, interval time.Duration, batchSize int) {
+func (r *Reprovider) Run(ctx context.Context) {
 	ctx, span := core.TraceMethod(ctx, "Reprovider.Run")
 	defer span.End()
 
+	// Wait for the DHT provider to become ready.
 	for {
 		if r.provider.Ready() {
 			ReprovideProviderReady.Set(1)
@@ -325,89 +224,48 @@ func (r *Reprovider) Run(ctx context.Context, interval time.Duration, batchSize 
 		default:
 		}
 		r.log.Debug("provider not ready")
-		time.Sleep(30 * time.Second)
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(r.cfg.NotReadySleep):
+		}
 	}
 
-	go func() {
-		r.handleTriggers(ctx, interval, batchSize)
-	}()
+	// Initial sleep is 0 so the first provide runs immediately. This is the
+	// "boot sweep": all CIDs are stale, ProvideCIDs returns full batches, and
+	// the BacklogSleep logic in performProvide causes rapid cycling until the
+	// backlog drains, then it settles into the normal interval.
+	sleepDuration := time.Duration(0)
 
 	for {
-		r.mu.Lock()
-		sleepDuration := r.reprovideSleep
-		r.mu.Unlock()
-
 		r.log.Debug("sleeping until next reprovide time", zap.Duration("duration", sleepDuration))
 
 		select {
 		case <-ctx.Done():
 			return
 		case <-time.After(sleepDuration):
-			r.log.Debug("reprovide sleep expired")
-			nextSleep := r.performProvide(ctx, interval, batchSize, LabelTriggerScheduled)
-			r.mu.Lock()
-			r.reprovideSleep = nextSleep
-			r.mu.Unlock()
-		}
-	}
-}
-
-func (r *Reprovider) handleTriggers(ctx context.Context, interval time.Duration, batchSize int) {
-	ctx, span := core.TraceMethod(ctx, "Reprovider.handleTriggers")
-	defer span.End()
-
-	for {
-		select {
-		case <-ctx.Done():
-			r.cancelledFlag.Store(true)
-			close(r.cancelTrigger)
-			return
-
+			sleepDuration = r.performProvide(ctx, LabelTriggerScheduled)
 		case <-r.triggerProvide:
-			delayTimer := time.NewTimer(r.triggerDelayDuration)
-
+			// Debounce: wait for TriggerDelay, then provide. If another
+			// trigger arrives during the delay, the channel buffers it and
+			// the next loop iteration picks it up immediately.
+			delayTimer := time.NewTimer(r.cfg.TriggerDelay)
 			select {
 			case <-ctx.Done():
 				delayTimer.Stop()
-				r.cancelledFlag.Store(true)
-				close(r.cancelTrigger)
 				return
-
 			case <-delayTimer.C:
-				select {
-				case <-ctx.Done():
-					r.cancelledFlag.Store(true)
-					close(r.cancelTrigger)
-					return
-				default:
-				}
-
-				if r.cancelledFlag.Load() {
-					return
-				}
-
-				r.performProvide(ctx, interval, batchSize, LabelTriggerManual)
+				sleepDuration = r.performProvide(ctx, LabelTriggerManual)
 			}
-
-			r.log.Debug("reprovide triggered")
 		}
 	}
 }
 
-func (r *Reprovider) performProvide(ctx context.Context, interval time.Duration, batchSize int, trigger string) time.Duration {
+func (r *Reprovider) performProvide(ctx context.Context, trigger string) time.Duration {
 	ctx, span := core.TraceMethod(ctx, "Reprovider.performProvide")
 	defer span.End()
 
 	ReprovideAttemptsTotal.WithLabelValues(trigger).Inc()
-
-	// Start boot cycle on first performProvide after boot
-	if !r.bootCycle.isStarted() {
-		r.bootCycle.reset()
-		ReprovideBootCycleAttempted.Set(0)
-		ReprovideBootCycleSucceeded.Set(0)
-		ReprovideBootCycleFailed.Set(0)
-		r.log.Info("starting boot reprovide cycle")
-	}
 
 	// Update global pinned-state gauges.
 	// Use a buffer slightly larger than the interval to avoid a timestamp
@@ -416,7 +274,7 @@ func (r *Reprovider) performProvide(ctx context.Context, interval time.Duration,
 	// is computed a few milliseconds later, making since > T. Without the
 	// buffer, CIDs announced in the previous cycle fall just outside the
 	// window and are counted as pending (and re-provided) every time.
-	since := time.Now().Add(-interval - time.Minute)
+	since := time.Now().Add(-r.cfg.Interval - time.Minute)
 	if stats, err := r.store.CountPinned(ctx, since); err != nil {
 		r.log.Warn("failed to count pinned CIDs", zap.Error(err))
 	} else {
@@ -425,61 +283,20 @@ func (r *Reprovider) performProvide(ctx context.Context, interval time.Duration,
 		ReprovidePendingTotal.Set(float64(stats.Pending))
 	}
 
-	if r.cancelledFlag.Load() {
-		return 10 * time.Minute
-	}
-
-	// Circuit breaker: if open, skip until cooldown expires
-	if openUntil := r.circuitOpenUntil.Load(); openUntil > 0 {
-		now := time.Now().UnixNano()
-		if now < openUntil {
-			retryAfter := time.Unix(0, openUntil)
-			r.log.Debug("circuit breaker open, skipping provide",
-				zap.Time("retry_after", retryAfter))
-			return time.Until(retryAfter)
-		}
-		// Cooldown expired -- half-open state, try again
-		r.circuitOpenUntil.Store(0)
-		ReprovideCircuitOpen.Set(0)
-	}
-
-	doProvide := func(ctx context.Context, keys []multihash.Multihash) error {
-		ctx, span := core.TraceMethod(ctx, "anonymous")
-		defer span.End()
-
-		return r.provider.ProvideMany(ctx, keys)
-	}
-
-	reprovideSleep := 10 * time.Minute // Default sleep time if no CIDs to provide
-
-	// Check cancellation again before calling mocks to prevent race
-	if r.cancelledFlag.Load() {
-		return reprovideSleep
-	}
-
 	// Only fetch CIDs whose last_announcement is older than the interval.
 	// Use the same buffer as CountPinned to avoid re-broadcasting CIDs that
 	// were announced in the previous cycle.
-	cutoff := time.Now().Add(-interval - time.Minute)
-	cids, err := r.store.ProvideCIDs(ctx, cutoff, batchSize)
+	cutoff := time.Now().Add(-r.cfg.Interval - time.Minute)
+	cids, err := r.store.ProvideCIDs(ctx, cutoff, r.cfg.BatchSize)
 	if err != nil {
 		r.log.Error("failed to fetch CIDs to provide", zap.Error(err))
 		ReprovideFailuresTotal.Inc()
-		r.recordFailure()
-		return time.Minute
+		return r.cfg.ErrorSleep
 	}
 
 	if len(cids) == 0 {
 		r.log.Debug("no CIDs to provide")
-		// Boot cycle complete: all CIDs have been processed
-		attempted, succeeded, failedCount := r.bootCycle.snapshot()
-		if attempted > 0 {
-			r.log.Info("boot reprovide cycle complete",
-				zap.Int64("attempted", attempted),
-				zap.Int64("succeeded", succeeded),
-				zap.Int64("failed", failedCount))
-		}
-		return reprovideSleep
+		return r.cfg.EmptySleep
 	}
 
 	announced := lo.Map(cids, func(c pluginCore.PinnedCID, _ int) cid.Cid {
@@ -491,15 +308,11 @@ func (r *Reprovider) performProvide(ctx context.Context, interval time.Duration,
 
 	ReprovideBatchSize.WithLabelValues().Observe(float64(len(keys)))
 
-	// Track boot-cycle attempted
-	r.bootCycle.markAttempted(len(keys))
-
 	start := time.Now()
 
-	if err := doProvide(ctx, keys); err != nil {
+	if err := r.provider.ProvideMany(ctx, keys); err != nil {
 		ReprovideDuration.WithLabelValues().Observe(time.Since(start).Seconds())
 		ReprovideFailuresTotal.Inc()
-		failures := r.recordFailure()
 
 		// Extract per-CID failure info
 		var failedKeys []multihash.Multihash
@@ -533,54 +346,19 @@ func (r *Reprovider) performProvide(ctx context.Context, interval time.Duration,
 		r.log.Error("failed to provide CIDs",
 			zap.Error(err),
 			zap.Int("succeeded", len(succeededCIDs)),
-			zap.Int("failed", len(failedKeys)),
-			zap.Uint32("consecutive_failures", failures))
+			zap.Int("failed", len(failedKeys)))
 
-		// Track per-CID failures in boot cycle
-		r.bootCycle.markFailed(failedKeys)
-		// Track per-CID successes in boot cycle (remove from failed set)
-		succeededKeys := lo.Filter(keys, func(k multihash.Multihash, _ int) bool {
-			_, failed := failedSet[string(k)]
-			return !failed
-		})
-		if len(succeededKeys) > 0 {
-			r.bootCycle.markSucceeded(succeededKeys)
-		}
-
-		// Update boot-cycle gauges
-		attempted, succeededCount, failedCount := r.bootCycle.snapshot()
-		ReprovideBootCycleAttempted.Set(float64(attempted))
-		ReprovideBootCycleSucceeded.Set(float64(succeededCount))
-		ReprovideBootCycleFailed.Set(float64(failedCount))
-
-		if failures >= 3 {
-			cooldown := 15 * time.Minute
-			r.circuitOpenUntil.Store(time.Now().Add(cooldown).UnixNano())
-			ReprovideCircuitOpen.Set(1)
-			r.log.Error("circuit breaker opened",
-				zap.Uint32("failures", failures),
-				zap.Duration("cooldown", cooldown))
-			return cooldown
-		}
-		return time.Minute
+		return r.cfg.ErrorSleep
 	}
 
 	ReprovideDuration.WithLabelValues().Observe(time.Since(start).Seconds())
 
-	// Track boot-cycle succeeded: remove from failed set if previously failed
-	r.bootCycle.markSucceeded(keys)
-	attempted, succeeded, failedCount := r.bootCycle.snapshot()
-	ReprovideBootCycleAttempted.Set(float64(attempted))
-	ReprovideBootCycleSucceeded.Set(float64(succeeded))
-	ReprovideBootCycleFailed.Set(float64(failedCount))
-
 	if err := r.store.SetLastAnnouncement(ctx, announced, time.Now()); err != nil {
 		r.log.Error("failed to update last announcement time", zap.Error(err))
-		return time.Minute
+		return r.cfg.ErrorSleep
 	}
 
 	ReprovideSuccessesTotal.Inc()
-	r.recordSuccess()
 
 	r.log.Debug("provided CIDs",
 		zap.Int("count", len(announced)),
@@ -589,35 +367,20 @@ func (r *Reprovider) performProvide(ctx context.Context, interval time.Duration,
 	// If the batch was full, there are likely more pending CIDs.
 	// Return a short sleep to drain the backlog quickly instead of waiting
 	// the full interval between batches.
-	if len(cids) >= batchSize {
-		return time.Minute
+	if len(cids) >= r.cfg.BatchSize {
+		return r.cfg.BacklogSleep
 	}
 
-	return interval
-}
-
-// recordFailure increments the consecutive failure counter and returns the new value.
-func (r *Reprovider) recordFailure() uint32 {
-	v := r.consecutiveFailures.Add(1)
-	ReprovideConsecutiveFailures.Set(float64(v))
-	return v
-}
-
-// recordSuccess resets the consecutive failure counter.
-func (r *Reprovider) recordSuccess() {
-	r.consecutiveFailures.Store(0)
-	ReprovideConsecutiveFailures.Set(0)
+	return r.cfg.Interval
 }
 
 // NewReprovider creates a new reprovider.
-func NewReprovider(provider pluginCore.Provider, store pluginCore.ReprovideStore, log *zap.Logger) *Reprovider {
+func NewReprovider(provider pluginCore.Provider, store pluginCore.ReprovideStore, log *zap.Logger, cfg config.IPFSProvider) *Reprovider {
 	return &Reprovider{
-		provider:             provider,
-		store:                store,
-		log:                  log,
-		triggerProvide:       make(chan struct{}, 1),
-		triggerDelayDuration: 2 * time.Second,
-		reprovideSleep:       time.Duration(0),
-		cancelTrigger:        make(chan struct{}),
+		provider:       provider,
+		store:          store,
+		log:            log,
+		cfg:            cfg,
+		triggerProvide: make(chan struct{}, 1),
 	}
 }

--- a/internal/protocol/ipfs/provide_test.go
+++ b/internal/protocol/ipfs/provide_test.go
@@ -5,11 +5,11 @@ import (
 	"errors"
 	"fmt"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
 	"go.lumeweb.com/portal-plugin-ipfs/core"
+	"go.lumeweb.com/portal-plugin-ipfs/internal/config"
 
 	"github.com/ipfs/go-cid"
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -26,16 +26,27 @@ func newTestReprovider(t *testing.T) (*Reprovider, *mocks.MockProvider, *mocks.M
 	mockStore := mocks.NewMockReprovideStore(t)
 	logger, _ := zap.NewDevelopment()
 
-	return NewReprovider(mockProvider, mockStore, logger), mockProvider, mockStore
+	cfg := config.IPFSProvider{
+		BatchSize:     10,
+		Interval:      1 * time.Second,
+		PerCIDTimeout: 0,
+		TriggerDelay:  100 * time.Millisecond,
+		NotReadySleep: 50 * time.Millisecond,
+		EmptySleep:    10 * time.Minute,
+		ErrorSleep:    time.Minute,
+		BacklogSleep:  time.Minute,
+	}
+
+	return NewReprovider(mockProvider, mockStore, logger, cfg), mockProvider, mockStore
 }
 
 // runReproviderAndWait runs the reprovider in a goroutine and waits for it to complete
-func runReproviderAndWait(ctx context.Context, cancel context.CancelFunc, reprovider *Reprovider, interval time.Duration, batchSize int, waitDuration time.Duration) {
+func runReproviderAndWait(ctx context.Context, cancel context.CancelFunc, reprovider *Reprovider, waitDuration time.Duration) {
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		reprovider.Run(ctx, interval, batchSize)
+		reprovider.Run(ctx)
 	}()
 
 	time.Sleep(waitDuration)
@@ -46,31 +57,25 @@ func runReproviderAndWait(ctx context.Context, cancel context.CancelFunc, reprov
 func TestReprovider_Run(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 
-	interval := 1 * time.Second
-	batchSize := 10
-
 	reprovider, mockProvider, mockStore := newTestReprovider(t)
 
 	// Mock provider ready
 	mockProvider.EXPECT().Ready().Return(true)
 
 	testCIDs := []core.PinnedCID{
-		{CID: cid.Cid{}, LastAnnouncement: time.Now().Add(-2 * interval)},
-		{CID: cid.Cid{}, LastAnnouncement: time.Now().Add(-2 * interval)},
+		{CID: cid.Cid{}, LastAnnouncement: time.Now().Add(-2 * time.Second)},
+		{CID: cid.Cid{}, LastAnnouncement: time.Now().Add(-2 * time.Second)},
 	}
 	mockStore.EXPECT().CountPinned(mock.Anything, mock.Anything).Return(core.PinnedCIDStats{}, nil).Maybe()
-	mockStore.EXPECT().ProvideCIDs(mock.Anything, mock.Anything, batchSize).Return(testCIDs, nil).Maybe()
+	mockStore.EXPECT().ProvideCIDs(mock.Anything, mock.Anything, 10).Return(testCIDs, nil).Maybe()
 	mockProvider.EXPECT().ProvideMany(mock.Anything, mock.Anything).Return(nil).Maybe()
 	mockStore.EXPECT().SetLastAnnouncement(mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
 
-	runReproviderAndWait(ctx, cancel, reprovider, interval, batchSize, 2*interval)
+	runReproviderAndWait(ctx, cancel, reprovider, 2*time.Second)
 }
 
 func TestReprovider_Run_ProviderNotReady(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-
-	interval := 1 * time.Second
-	batchSize := 10
 
 	reprovider, mockProvider, mockStore := newTestReprovider(t)
 
@@ -80,19 +85,16 @@ func TestReprovider_Run_ProviderNotReady(t *testing.T) {
 
 	// Mock store calls that happen after provider becomes ready
 	mockStore.EXPECT().CountPinned(mock.Anything, mock.Anything).Return(core.PinnedCIDStats{}, nil).Maybe()
-	mockStore.EXPECT().ProvideCIDs(mock.Anything, mock.Anything, batchSize).Return([]core.PinnedCID{}, nil).Maybe()
+	mockStore.EXPECT().ProvideCIDs(mock.Anything, mock.Anything, 10).Return([]core.PinnedCID{}, nil).Maybe()
 	mockProvider.EXPECT().ProvideMany(mock.Anything, mock.Anything).Return(nil).Maybe()
 	mockStore.EXPECT().SetLastAnnouncement(mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
 
-	// Wait longer to account for the 30-second sleep in the Run function
-	runReproviderAndWait(ctx, cancel, reprovider, interval, batchSize, 2*interval+30*time.Second)
+	// NotReadySleep is 50ms in test config, so 1s is enough
+	runReproviderAndWait(ctx, cancel, reprovider, 2*time.Second)
 }
 
 func TestReprovider_Run_ProvideCIDsError(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-
-	interval := 1 * time.Second
-	batchSize := 10
 
 	reprovider, mockProvider, mockStore := newTestReprovider(t)
 
@@ -101,17 +103,14 @@ func TestReprovider_Run_ProvideCIDsError(t *testing.T) {
 
 	// Mock store returning error
 	mockStore.EXPECT().CountPinned(mock.Anything, mock.Anything).Return(core.PinnedCIDStats{}, nil).Maybe()
-	mockStore.EXPECT().ProvideCIDs(mock.Anything, mock.Anything, batchSize).Return(nil, errors.New("test error")).Once()
+	mockStore.EXPECT().ProvideCIDs(mock.Anything, mock.Anything, 10).Return(nil, errors.New("test error")).Once()
 
-	runReproviderAndWait(ctx, cancel, reprovider, interval, batchSize, 2*interval)
+	runReproviderAndWait(ctx, cancel, reprovider, 2*time.Second)
 }
 
 func TestReprovider_Run_ProvideManyError(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 
-	interval := 1 * time.Second
-	batchSize := 10
-
 	reprovider, mockProvider, mockStore := newTestReprovider(t)
 
 	// Mock provider ready
@@ -119,24 +118,21 @@ func TestReprovider_Run_ProvideManyError(t *testing.T) {
 
 	// Mock store returning CIDs
 	testCIDs := []core.PinnedCID{
-		{CID: cid.Cid{}, LastAnnouncement: time.Now().Add(-2 * interval)},
-		{CID: cid.Cid{}, LastAnnouncement: time.Now().Add(-2 * interval)},
+		{CID: cid.Cid{}, LastAnnouncement: time.Now().Add(-2 * time.Second)},
+		{CID: cid.Cid{}, LastAnnouncement: time.Now().Add(-2 * time.Second)},
 	}
 	mockStore.EXPECT().CountPinned(mock.Anything, mock.Anything).Return(core.PinnedCIDStats{}, nil).Maybe()
-	mockStore.EXPECT().ProvideCIDs(mock.Anything, mock.Anything, batchSize).Return(testCIDs, nil).Once()
+	mockStore.EXPECT().ProvideCIDs(mock.Anything, mock.Anything, 10).Return(testCIDs, nil).Once()
 
 	// Mock provider ProvideMany returning error
 	mockProvider.EXPECT().ProvideMany(mock.Anything, mock.Anything).Return(errors.New("test error")).Once()
 
-	runReproviderAndWait(ctx, cancel, reprovider, interval, batchSize, 2*interval)
+	runReproviderAndWait(ctx, cancel, reprovider, 2*time.Second)
 }
 
 func TestReprovider_Run_SetLastAnnouncementError(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 
-	interval := 1 * time.Second
-	batchSize := 10
-
 	reprovider, mockProvider, mockStore := newTestReprovider(t)
 
 	// Mock provider ready
@@ -144,11 +140,11 @@ func TestReprovider_Run_SetLastAnnouncementError(t *testing.T) {
 
 	// Mock store returning CIDs
 	testCIDs := []core.PinnedCID{
-		{CID: cid.Cid{}, LastAnnouncement: time.Now().Add(-2 * interval)},
-		{CID: cid.Cid{}, LastAnnouncement: time.Now().Add(-2 * interval)},
+		{CID: cid.Cid{}, LastAnnouncement: time.Now().Add(-2 * time.Second)},
+		{CID: cid.Cid{}, LastAnnouncement: time.Now().Add(-2 * time.Second)},
 	}
 	mockStore.EXPECT().CountPinned(mock.Anything, mock.Anything).Return(core.PinnedCIDStats{}, nil).Maybe()
-	mockStore.EXPECT().ProvideCIDs(mock.Anything, mock.Anything, batchSize).Return(testCIDs, nil).Once()
+	mockStore.EXPECT().ProvideCIDs(mock.Anything, mock.Anything, 10).Return(testCIDs, nil).Once()
 
 	// Mock provider ProvideMany
 	mockProvider.EXPECT().ProvideMany(mock.Anything, mock.Anything).Return(nil).Once()
@@ -156,7 +152,7 @@ func TestReprovider_Run_SetLastAnnouncementError(t *testing.T) {
 	// Mock store SetLastAnnouncement returning error
 	mockStore.EXPECT().SetLastAnnouncement(mock.Anything, mock.Anything, mock.Anything).Return(errors.New("test error")).Once()
 
-	runReproviderAndWait(ctx, cancel, reprovider, interval, batchSize, 2*interval)
+	runReproviderAndWait(ctx, cancel, reprovider, 2*time.Second)
 }
 
 func TestReprovider_Trigger(t *testing.T) {
@@ -166,21 +162,28 @@ func TestReprovider_Trigger(t *testing.T) {
 	mockStore := mocks.NewMockReprovideStore(t)
 	logger, _ := zap.NewDevelopment()
 
-	interval := 1 * time.Second
-	batchSize := 10
+	cfg := config.IPFSProvider{
+		BatchSize:     10,
+		Interval:      1 * time.Second,
+		TriggerDelay:  100 * time.Millisecond,
+		NotReadySleep: 50 * time.Millisecond,
+		EmptySleep:    10 * time.Minute,
+		ErrorSleep:    time.Minute,
+		BacklogSleep:  time.Minute,
+	}
 
-	reprovider := NewReprovider(mockProvider, mockStore, logger)
+	reprovider := NewReprovider(mockProvider, mockStore, logger, cfg)
 
 	// Mock provider ready
 	mockProvider.EXPECT().Ready().Return(true)
 
 	// Mock store returning CIDs
 	testCIDs := []core.PinnedCID{
-		{CID: cid.Cid{}, LastAnnouncement: time.Now().Add(-2 * interval)},
-		{CID: cid.Cid{}, LastAnnouncement: time.Now().Add(-2 * interval)},
+		{CID: cid.Cid{}, LastAnnouncement: time.Now().Add(-2 * time.Second)},
+		{CID: cid.Cid{}, LastAnnouncement: time.Now().Add(-2 * time.Second)},
 	}
 	mockStore.EXPECT().CountPinned(mock.Anything, mock.Anything).Return(core.PinnedCIDStats{}, nil).Maybe()
-	mockStore.EXPECT().ProvideCIDs(mock.Anything, mock.Anything, batchSize).Return(testCIDs, nil).Maybe()
+	mockStore.EXPECT().ProvideCIDs(mock.Anything, mock.Anything, 10).Return(testCIDs, nil).Maybe()
 
 	// Mock provider ProvideMany
 	mockProvider.EXPECT().ProvideMany(mock.Anything, mock.Anything).Return(nil).Maybe()
@@ -188,13 +191,13 @@ func TestReprovider_Trigger(t *testing.T) {
 	// Mock store SetLastAnnouncement
 	mockStore.EXPECT().SetLastAnnouncement(mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
 
-	go reprovider.Run(ctx, interval, batchSize)
+	go reprovider.Run(ctx)
 
 	// Trigger the reprovider
 	reprovider.Trigger()
 
 	// Wait for the reprovider to run once
-	time.Sleep(2 * interval)
+	time.Sleep(2 * time.Second)
 
 	// Clean up the goroutine
 	cancel()
@@ -206,12 +209,33 @@ func TestNewReprovider(t *testing.T) {
 	mockStore := mocks.NewMockReprovideStore(t)
 	logger, _ := zap.NewDevelopment()
 
-	reprovider := NewReprovider(mockProvider, mockStore, logger)
+	cfg := config.IPFSProvider{
+		BatchSize:     500,
+		Interval:      4 * time.Hour,
+		TriggerDelay:  2 * time.Second,
+		NotReadySleep: 30 * time.Second,
+		EmptySleep:    10 * time.Minute,
+		ErrorSleep:    time.Minute,
+		BacklogSleep:  time.Minute,
+	}
+
+	reprovider := NewReprovider(mockProvider, mockStore, logger, cfg)
 
 	assert.NotNil(t, reprovider)
 	assert.NotNil(t, reprovider.triggerProvide)
-	assert.Equal(t, 2*time.Second, reprovider.triggerDelayDuration)
-	assert.Equal(t, time.Duration(0), reprovider.reprovideSleep)
+	assert.Equal(t, cfg, reprovider.cfg)
+}
+
+func newTestReproviderCfg(interval time.Duration, batchSize int) config.IPFSProvider {
+	return config.IPFSProvider{
+		BatchSize:     batchSize,
+		Interval:      interval,
+		TriggerDelay:  100 * time.Millisecond,
+		NotReadySleep: 50 * time.Millisecond,
+		EmptySleep:    10 * time.Minute,
+		ErrorSleep:    time.Minute,
+		BacklogSleep:  time.Minute,
+	}
 }
 
 func TestReprovider_performProvide_NoCIDs(t *testing.T) {
@@ -221,24 +245,21 @@ func TestReprovider_performProvide_NoCIDs(t *testing.T) {
 	mockStore := mocks.NewMockReprovideStore(t)
 	logger, _ := zap.NewDevelopment()
 
-	interval := 1 * time.Second
-	batchSize := 10
+	cfg := newTestReproviderCfg(1*time.Second, 10)
 
 	reprovider := &Reprovider{
-		provider:             mockProvider,
-		store:                mockStore,
-		log:                  logger,
-		triggerProvide:       make(chan struct{}, 1),
-		triggerDelayDuration: 100 * time.Millisecond,
-		reprovideSleep:       0,
-		mu:                   sync.Mutex{},
+		provider:       mockProvider,
+		store:          mockStore,
+		log:            logger,
+		cfg:            cfg,
+		triggerProvide: make(chan struct{}, 1),
 	}
 
 	// Mock store returning no CIDs
 	mockStore.EXPECT().CountPinned(mock.Anything, mock.Anything).Return(core.PinnedCIDStats{}, nil).Maybe()
-	mockStore.EXPECT().ProvideCIDs(mock.Anything, mock.Anything, batchSize).Return([]core.PinnedCID{}, nil).Once()
+	mockStore.EXPECT().ProvideCIDs(mock.Anything, mock.Anything, 10).Return([]core.PinnedCID{}, nil).Once()
 
-	sleepDuration := reprovider.performProvide(ctx, interval, batchSize, LabelTriggerScheduled)
+	sleepDuration := reprovider.performProvide(ctx, LabelTriggerScheduled)
 
 	assert.Equal(t, 10*time.Minute, sleepDuration)
 }
@@ -250,24 +271,21 @@ func TestReprovider_performProvide_ProvideCIDsError(t *testing.T) {
 	mockStore := mocks.NewMockReprovideStore(t)
 	logger, _ := zap.NewDevelopment()
 
-	interval := 1 * time.Second
-	batchSize := 10
+	cfg := newTestReproviderCfg(1*time.Second, 10)
 
 	reprovider := &Reprovider{
-		provider:             mockProvider,
-		store:                mockStore,
-		log:                  logger,
-		triggerProvide:       make(chan struct{}, 1),
-		triggerDelayDuration: 100 * time.Millisecond,
-		reprovideSleep:       0,
-		mu:                   sync.Mutex{},
+		provider:       mockProvider,
+		store:          mockStore,
+		log:            logger,
+		cfg:            cfg,
+		triggerProvide: make(chan struct{}, 1),
 	}
 
 	// Mock store returning error
 	mockStore.EXPECT().CountPinned(mock.Anything, mock.Anything).Return(core.PinnedCIDStats{}, nil).Maybe()
-	mockStore.EXPECT().ProvideCIDs(mock.Anything, mock.Anything, batchSize).Return(nil, errors.New("test error")).Once()
+	mockStore.EXPECT().ProvideCIDs(mock.Anything, mock.Anything, 10).Return(nil, errors.New("test error")).Once()
 
-	sleepDuration := reprovider.performProvide(ctx, interval, batchSize, LabelTriggerScheduled)
+	sleepDuration := reprovider.performProvide(ctx, LabelTriggerScheduled)
 
 	assert.Equal(t, time.Minute, sleepDuration)
 }
@@ -279,31 +297,28 @@ func TestReprovider_performProvide_ProvideManyError(t *testing.T) {
 	mockStore := mocks.NewMockReprovideStore(t)
 	logger, _ := zap.NewDevelopment()
 
-	interval := 1 * time.Second
-	batchSize := 10
+	cfg := newTestReproviderCfg(1*time.Second, 10)
 
 	reprovider := &Reprovider{
-		provider:             mockProvider,
-		store:                mockStore,
-		log:                  logger,
-		triggerProvide:       make(chan struct{}, 1),
-		triggerDelayDuration: 100 * time.Millisecond,
-		reprovideSleep:       0,
-		mu:                   sync.Mutex{},
+		provider:       mockProvider,
+		store:          mockStore,
+		log:            logger,
+		cfg:            cfg,
+		triggerProvide: make(chan struct{}, 1),
 	}
 
 	// Mock store returning CIDs
 	testCIDs := []core.PinnedCID{
-		{CID: cid.Cid{}, LastAnnouncement: time.Now().Add(-2 * interval)},
-		{CID: cid.Cid{}, LastAnnouncement: time.Now().Add(-2 * interval)},
+		{CID: cid.Cid{}, LastAnnouncement: time.Now().Add(-2 * time.Second)},
+		{CID: cid.Cid{}, LastAnnouncement: time.Now().Add(-2 * time.Second)},
 	}
 	mockStore.EXPECT().CountPinned(mock.Anything, mock.Anything).Return(core.PinnedCIDStats{}, nil).Maybe()
-	mockStore.EXPECT().ProvideCIDs(mock.Anything, mock.Anything, batchSize).Return(testCIDs, nil).Once()
+	mockStore.EXPECT().ProvideCIDs(mock.Anything, mock.Anything, 10).Return(testCIDs, nil).Once()
 
 	// Mock provider ProvideMany returning error
 	mockProvider.EXPECT().ProvideMany(mock.Anything, mock.Anything).Return(errors.New("test error")).Once()
 
-	sleepDuration := reprovider.performProvide(ctx, interval, batchSize, LabelTriggerScheduled)
+	sleepDuration := reprovider.performProvide(ctx, LabelTriggerScheduled)
 
 	assert.Equal(t, time.Minute, sleepDuration)
 }
@@ -315,26 +330,23 @@ func TestReprovider_performProvide_Success(t *testing.T) {
 	mockStore := mocks.NewMockReprovideStore(t)
 	logger, _ := zap.NewDevelopment()
 
-	interval := 1 * time.Second
-	batchSize := 10
+	cfg := newTestReproviderCfg(1*time.Second, 10)
 
 	reprovider := &Reprovider{
-		provider:             mockProvider,
-		store:                mockStore,
-		log:                  logger,
-		triggerProvide:       make(chan struct{}, 1),
-		triggerDelayDuration: 100 * time.Millisecond,
-		reprovideSleep:       0,
-		mu:                   sync.Mutex{},
+		provider:       mockProvider,
+		store:          mockStore,
+		log:            logger,
+		cfg:            cfg,
+		triggerProvide: make(chan struct{}, 1),
 	}
 
 	// Mock store returning CIDs
 	testCIDs := []core.PinnedCID{
-		{CID: cid.Cid{}, LastAnnouncement: time.Now().Add(-2 * interval)},
-		{CID: cid.Cid{}, LastAnnouncement: time.Now().Add(-2 * interval)},
+		{CID: cid.Cid{}, LastAnnouncement: time.Now().Add(-2 * time.Second)},
+		{CID: cid.Cid{}, LastAnnouncement: time.Now().Add(-2 * time.Second)},
 	}
 	mockStore.EXPECT().CountPinned(mock.Anything, mock.Anything).Return(core.PinnedCIDStats{}, nil).Maybe()
-	mockStore.EXPECT().ProvideCIDs(mock.Anything, mock.Anything, batchSize).Return(testCIDs, nil).Once()
+	mockStore.EXPECT().ProvideCIDs(mock.Anything, mock.Anything, 10).Return(testCIDs, nil).Once()
 
 	// Mock provider ProvideMany
 	mockProvider.EXPECT().ProvideMany(mock.Anything, mock.Anything).Return(nil).Once()
@@ -342,48 +354,9 @@ func TestReprovider_performProvide_Success(t *testing.T) {
 	// Mock store SetLastAnnouncement
 	mockStore.EXPECT().SetLastAnnouncement(mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
 
-	sleepDuration := reprovider.performProvide(ctx, interval, batchSize, LabelTriggerScheduled)
+	sleepDuration := reprovider.performProvide(ctx, LabelTriggerScheduled)
 
-	assert.Equal(t, interval, sleepDuration)
-}
-
-func TestReprovider_performProvide_Success_NotAllAnnounced(t *testing.T) {
-	ctx := context.Background()
-
-	mockProvider := mocks.NewMockProvider(t)
-	mockStore := mocks.NewMockReprovideStore(t)
-	logger, _ := zap.NewDevelopment()
-
-	interval := 1 * time.Second
-	batchSize := 10
-
-	reprovider := &Reprovider{
-		provider:             mockProvider,
-		store:                mockStore,
-		log:                  logger,
-		triggerProvide:       make(chan struct{}, 1),
-		triggerDelayDuration: 100 * time.Millisecond,
-		reprovideSleep:       0,
-		mu:                   sync.Mutex{},
-	}
-
-	// Mock store returning CIDs
-	testCIDs := []core.PinnedCID{
-		{CID: cid.Cid{}, LastAnnouncement: time.Now().Add(-2 * interval)},
-		{CID: cid.Cid{}, LastAnnouncement: time.Now().Add(-2 * interval)},
-		{CID: cid.Cid{}, LastAnnouncement: time.Now().Add(2 * interval)}, // Future announcement
-	}
-	mockStore.EXPECT().CountPinned(mock.Anything, mock.Anything).Return(core.PinnedCIDStats{}, nil).Maybe()
-	mockStore.EXPECT().ProvideCIDs(mock.Anything, mock.Anything, batchSize).Return(testCIDs, nil).Once()
-
-	// Mock provider ProvideMany
-	mockProvider.EXPECT().ProvideMany(mock.Anything, mock.Anything).Return(nil).Once()
-
-	// Mock store SetLastAnnouncement
-	mockStore.EXPECT().SetLastAnnouncement(mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
-
-	sleepDuration := reprovider.performProvide(ctx, interval, batchSize, LabelTriggerScheduled)
-	assert.Equal(t, interval, sleepDuration)
+	assert.Equal(t, 1*time.Second, sleepDuration)
 }
 
 func TestReprovider_performProvide_SetLastAnnouncementError(t *testing.T) {
@@ -393,26 +366,23 @@ func TestReprovider_performProvide_SetLastAnnouncementError(t *testing.T) {
 	mockStore := mocks.NewMockReprovideStore(t)
 	logger, _ := zap.NewDevelopment()
 
-	interval := 1 * time.Second
-	batchSize := 10
+	cfg := newTestReproviderCfg(1*time.Second, 10)
 
 	reprovider := &Reprovider{
-		provider:             mockProvider,
-		store:                mockStore,
-		log:                  logger,
-		triggerProvide:       make(chan struct{}, 1),
-		triggerDelayDuration: 100 * time.Millisecond,
-		reprovideSleep:       0,
-		mu:                   sync.Mutex{},
+		provider:       mockProvider,
+		store:          mockStore,
+		log:            logger,
+		cfg:            cfg,
+		triggerProvide: make(chan struct{}, 1),
 	}
 
 	// Mock store returning CIDs
 	testCIDs := []core.PinnedCID{
-		{CID: cid.Cid{}, LastAnnouncement: time.Now().Add(-2 * interval)},
-		{CID: cid.Cid{}, LastAnnouncement: time.Now().Add(-2 * interval)},
+		{CID: cid.Cid{}, LastAnnouncement: time.Now().Add(-2 * time.Second)},
+		{CID: cid.Cid{}, LastAnnouncement: time.Now().Add(-2 * time.Second)},
 	}
 	mockStore.EXPECT().CountPinned(mock.Anything, mock.Anything).Return(core.PinnedCIDStats{}, nil).Maybe()
-	mockStore.EXPECT().ProvideCIDs(mock.Anything, mock.Anything, batchSize).Return(testCIDs, nil).Once()
+	mockStore.EXPECT().ProvideCIDs(mock.Anything, mock.Anything, 10).Return(testCIDs, nil).Once()
 
 	// Mock provider ProvideMany
 	mockProvider.EXPECT().ProvideMany(mock.Anything, mock.Anything).Return(nil).Once()
@@ -420,38 +390,36 @@ func TestReprovider_performProvide_SetLastAnnouncementError(t *testing.T) {
 	// Mock store SetLastAnnouncement returning error
 	mockStore.EXPECT().SetLastAnnouncement(mock.Anything, mock.Anything, mock.Anything).Return(errors.New("test error")).Once()
 
-	sleepDuration := reprovider.performProvide(ctx, interval, batchSize, LabelTriggerScheduled)
+	sleepDuration := reprovider.performProvide(ctx, LabelTriggerScheduled)
 
 	assert.Equal(t, time.Minute, sleepDuration)
 }
 
-func TestReprovider_performProvide_MinAnnouncement(t *testing.T) {
+func TestReprovider_performProvide_BacklogDrain(t *testing.T) {
 	ctx := context.Background()
 
 	mockProvider := mocks.NewMockProvider(t)
 	mockStore := mocks.NewMockReprovideStore(t)
 	logger, _ := zap.NewDevelopment()
 
-	interval := 1 * time.Second
-	batchSize := 10
+	cfg := newTestReproviderCfg(1*time.Second, 3)
 
 	reprovider := &Reprovider{
-		provider:             mockProvider,
-		store:                mockStore,
-		log:                  logger,
-		triggerProvide:       make(chan struct{}, 1),
-		triggerDelayDuration: 100 * time.Millisecond,
-		reprovideSleep:       0,
-		mu:                   sync.Mutex{},
+		provider:       mockProvider,
+		store:          mockStore,
+		log:            logger,
+		cfg:            cfg,
+		triggerProvide: make(chan struct{}, 1),
 	}
 
-	// Mock store returning CIDs
+	// Mock store returning full batch (3 CIDs = batch size)
 	testCIDs := []core.PinnedCID{
-		{CID: cid.Cid{}, LastAnnouncement: time.Now().Add(-2 * interval)},
-		{CID: cid.Cid{}, LastAnnouncement: time.Now().Add(-2 * interval)},
+		{CID: cid.NewCidV1(cid.Raw, mustMultihash(t, "backlog1")), LastAnnouncement: time.Now().Add(-2 * time.Second)},
+		{CID: cid.NewCidV1(cid.Raw, mustMultihash(t, "backlog2")), LastAnnouncement: time.Now().Add(-2 * time.Second)},
+		{CID: cid.NewCidV1(cid.Raw, mustMultihash(t, "backlog3")), LastAnnouncement: time.Now().Add(-2 * time.Second)},
 	}
 	mockStore.EXPECT().CountPinned(mock.Anything, mock.Anything).Return(core.PinnedCIDStats{}, nil).Maybe()
-	mockStore.EXPECT().ProvideCIDs(mock.Anything, mock.Anything, batchSize).Return(testCIDs, nil).Once()
+	mockStore.EXPECT().ProvideCIDs(mock.Anything, mock.Anything, 3).Return(testCIDs, nil).Once()
 
 	// Mock provider ProvideMany
 	mockProvider.EXPECT().ProvideMany(mock.Anything, mock.Anything).Return(nil).Once()
@@ -459,64 +427,25 @@ func TestReprovider_performProvide_MinAnnouncement(t *testing.T) {
 	// Mock store SetLastAnnouncement
 	mockStore.EXPECT().SetLastAnnouncement(mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
 
-	sleepDuration := reprovider.performProvide(ctx, interval, batchSize, LabelTriggerScheduled)
+	sleepDuration := reprovider.performProvide(ctx, LabelTriggerScheduled)
 
-	assert.Equal(t, interval, sleepDuration)
-}
-
-func TestReprovider_performProvide_AllCIDsProvided(t *testing.T) {
-	ctx := context.Background()
-
-	mockProvider := mocks.NewMockProvider(t)
-	mockStore := mocks.NewMockReprovideStore(t)
-	logger, _ := zap.NewDevelopment()
-
-	interval := 1 * time.Second
-	batchSize := 10
-
-	reprovider := &Reprovider{
-		provider:             mockProvider,
-		store:                mockStore,
-		log:                  logger,
-		triggerProvide:       make(chan struct{}, 1),
-		triggerDelayDuration: 100 * time.Millisecond,
-		reprovideSleep:       0,
-		mu:                   sync.Mutex{},
-	}
-
-	// Mock store returning CIDs - all stale, all should be provided
-	testCIDs := []core.PinnedCID{
-		{CID: cid.Cid{}, LastAnnouncement: time.Now().Add(-2 * interval)},
-		{CID: cid.Cid{}, LastAnnouncement: time.Now().Add(-2 * interval)},
-		{CID: cid.Cid{}, LastAnnouncement: time.Now().Add(-2 * interval)},
-	}
-	mockStore.EXPECT().CountPinned(mock.Anything, mock.Anything).Return(core.PinnedCIDStats{}, nil).Maybe()
-	mockStore.EXPECT().ProvideCIDs(mock.Anything, mock.Anything, batchSize).Return(testCIDs, nil).Once()
-
-	// Mock provider ProvideMany
-	mockProvider.EXPECT().ProvideMany(mock.Anything, mock.Anything).Return(nil).Once()
-
-	// Mock store SetLastAnnouncement
-	mockStore.EXPECT().SetLastAnnouncement(mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
-
-	sleepDuration := reprovider.performProvide(ctx, interval, batchSize, LabelTriggerScheduled)
-
-	assert.Equal(t, interval, sleepDuration)
+	// Full batch → BacklogSleep (1m), not Interval
+	assert.Equal(t, time.Minute, sleepDuration)
 }
 
 func TestBasicDHTProvider_ProvideMany(t *testing.T) {
 	t.Run("ready_returns_false_when_fn_returns_false", func(t *testing.T) {
-		provider := newBasicDHTProvider(&stubContentRouting{}, func() bool { return false }, 0, 0)
+		provider := newBasicDHTProvider(&stubContentRouting{}, func() bool { return false }, 0)
 		assert.False(t, provider.Ready())
 	})
 
 	t.Run("ready_returns_true_when_fn_returns_true", func(t *testing.T) {
-		provider := newBasicDHTProvider(&stubContentRouting{}, func() bool { return true }, 0, 0)
+		provider := newBasicDHTProvider(&stubContentRouting{}, func() bool { return true }, 0)
 		assert.True(t, provider.Ready())
 	})
 
 	t.Run("ready_defaults_to_true_when_fn_is_nil", func(t *testing.T) {
-		provider := newBasicDHTProvider(&stubContentRouting{}, nil, 0, 0)
+		provider := newBasicDHTProvider(&stubContentRouting{}, nil, 0)
 		assert.True(t, provider.Ready())
 	})
 
@@ -525,7 +454,7 @@ func TestBasicDHTProvider_ProvideMany(t *testing.T) {
 		c2 := cid.NewCidV1(cid.Raw, mustMultihash(t, "key2"))
 
 		scr := &stubContentRouting{}
-		provider := newBasicDHTProvider(scr, nil, 0, 0)
+		provider := newBasicDHTProvider(scr, nil, 0)
 
 		keys := []multihash.Multihash{c1.Hash(), c2.Hash()}
 		err := provider.ProvideMany(context.Background(), keys)
@@ -539,75 +468,23 @@ func TestBasicDHTProvider_ProvideMany(t *testing.T) {
 
 		testErr := errors.New("provide failed")
 		scr := &stubContentRouting{err: testErr}
-		provider := newBasicDHTProvider(scr, nil, 0, 0)
+		provider := newBasicDHTProvider(scr, nil, 0)
 
 		keys := []multihash.Multihash{c1.Hash(), c2.Hash()}
 		err := provider.ProvideMany(context.Background(), keys)
 		assert.Error(t, err)
-		// 2 CIDs × 3 attempts each (retries on non-timeout errors)
-		assert.Equal(t, 6, scr.getProvideCount())
-	})
-
-	t.Run("provide_many_retries_transient_then_succeeds", func(t *testing.T) {
-		key := mustMultihash(t, "retry-key")
-
-		var attempts atomic.Int32
-		scr := &stubContentRouting{
-			provideFn: func() error {
-				if attempts.Add(1) < 3 {
-					return errors.New("transient routing error")
-				}
-				return nil
-			},
-		}
-		provider := newBasicDHTProvider(scr, nil, 0, 0)
-
-		err := provider.ProvideMany(context.Background(), []multihash.Multihash{key})
-		assert.NoError(t, err)
-		assert.Equal(t, int32(3), attempts.Load())
-	})
-
-	t.Run("provide_many_does_not_retry_timeout", func(t *testing.T) {
-		key := mustMultihash(t, "timeout-key")
-
-		var attempts atomic.Int32
-		scr := &stubContentRouting{
-			provideFn: func() error {
-				attempts.Add(1)
-				return context.DeadlineExceeded
-			},
-		}
-		provider := newBasicDHTProvider(scr, nil, 0, 0)
-
-		err := provider.ProvideMany(context.Background(), []multihash.Multihash{key})
-		assert.Error(t, err)
-		assert.Equal(t, int32(1), attempts.Load()) // no retry on timeout
-	})
-
-	t.Run("provide_many_runs_in_parallel", func(t *testing.T) {
-		// Generate 100 CIDs and verify they're all provided with 16 workers.
-		keys := make([]multihash.Multihash, 100)
-		for i := 0; i < 100; i++ {
-			keys[i] = mustMultihash(t, fmt.Sprintf("parallel-key-%d", i))
-		}
-
-		scr := &stubContentRouting{}
-		provider := newBasicDHTProvider(scr, nil, 0, 16)
-
-		err := provider.ProvideMany(context.Background(), keys)
-		assert.NoError(t, err)
-		assert.Equal(t, 100, scr.getProvideCount())
+		// No retries: 1 call per key
+		assert.Equal(t, 2, scr.getProvideCount())
 	})
 
 	t.Run("provide_many_respects_context_cancellation", func(t *testing.T) {
-		// With 1 worker and a blocked provide, context cancel should stop dispatching.
 		keys := make([]multihash.Multihash, 50)
 		for i := 0; i < 50; i++ {
 			keys[i] = mustMultihash(t, fmt.Sprintf("cancel-key-%d", i))
 		}
 
 		scr := &stubContentRouting{}
-		provider := newBasicDHTProvider(scr, nil, 0, 1)
+		provider := newBasicDHTProvider(scr, nil, 0)
 
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel() // cancel immediately
@@ -620,10 +497,10 @@ func TestBasicDHTProvider_ProvideMany(t *testing.T) {
 
 // stubProvideMany is a minimal provideManyProvider stub for testing fullrtProvider.
 type stubProvideMany struct {
-	mu       sync.Mutex
-	calls    int
-	keys     []multihash.Multihash
-	err      error
+	mu        sync.Mutex
+	calls     int
+	keys      []multihash.Multihash
+	err       error
 	provideFn func(keys []multihash.Multihash) error
 }
 
@@ -744,82 +621,97 @@ func TestFullrtProvider_ProvideMany(t *testing.T) {
 	})
 }
 
-func TestReprovider_CircuitBreaker_Open(t *testing.T) {
+func TestReprovider_performProvide_PartialFailure_AllFail(t *testing.T) {
 	ctx := context.Background()
 
 	mockProvider := mocks.NewMockProvider(t)
 	mockStore := mocks.NewMockReprovideStore(t)
 	logger, _ := zap.NewDevelopment()
 
-	reprovider := &Reprovider{
-		provider:             mockProvider,
-		store:                mockStore,
-		log:                  logger,
-		triggerProvide:       make(chan struct{}, 1),
-		triggerDelayDuration: 100 * time.Millisecond,
-		reprovideSleep:       0,
-		mu:                   sync.Mutex{},
-	}
-
-	// Set circuit breaker to open state with a future timestamp
-	futureTime := time.Now().Add(15 * time.Minute)
-	reprovider.circuitOpenUntil.Store(futureTime.UnixNano())
-	ReprovideCircuitOpen.Set(1)
-
-	mockStore.EXPECT().CountPinned(mock.Anything, mock.Anything).Return(core.PinnedCIDStats{}, nil).Maybe()
-
-	sleepDuration := reprovider.performProvide(ctx, time.Second, 10, LabelTriggerScheduled)
-
-	// Should return the time until the circuit opens, without calling store or provider
-	assert.InDelta(t, 15*time.Minute, sleepDuration, float64(time.Second))
-	mockProvider.AssertNotCalled(t, "ProvideMany")
-	mockStore.AssertNotCalled(t, "ProvideCIDs")
-}
-
-func TestReprovider_CircuitBreaker_OpenAfter3Failures(t *testing.T) {
-	ctx := context.Background()
-
-	mockProvider := mocks.NewMockProvider(t)
-	mockStore := mocks.NewMockReprovideStore(t)
-	logger, _ := zap.NewDevelopment()
-
-	interval := 1 * time.Second
-	batchSize := 10
+	cfg := newTestReproviderCfg(1*time.Second, 10)
 
 	reprovider := &Reprovider{
-		provider:             mockProvider,
-		store:                mockStore,
-		log:                  logger,
-		triggerProvide:       make(chan struct{}, 1),
-		triggerDelayDuration: 100 * time.Millisecond,
-		reprovideSleep:       0,
-		mu:                   sync.Mutex{},
+		provider:       mockProvider,
+		store:          mockStore,
+		log:            logger,
+		cfg:            cfg,
+		triggerProvide: make(chan struct{}, 1),
 	}
+
+	c1 := cid.NewCidV1(cid.Raw, mustMultihash(t, "allfail-key1"))
+	c2 := cid.NewCidV1(cid.Raw, mustMultihash(t, "allfail-key2"))
 
 	testCIDs := []core.PinnedCID{
-		{CID: cid.Cid{}, LastAnnouncement: time.Now().Add(-2 * interval)},
-		{CID: cid.Cid{}, LastAnnouncement: time.Now().Add(-2 * interval)},
+		{CID: c1, LastAnnouncement: time.Now().Add(-2 * time.Second)},
+		{CID: c2, LastAnnouncement: time.Now().Add(-2 * time.Second)},
 	}
 
-	// Simulate 3 consecutive failures
-	for i := 0; i < 3; i++ {
-		mockStore.EXPECT().CountPinned(mock.Anything, mock.Anything).Return(core.PinnedCIDStats{}, nil).Maybe()
-		mockStore.EXPECT().ProvideCIDs(mock.Anything, mock.Anything, batchSize).Return(testCIDs, nil).Once()
-		mockProvider.EXPECT().ProvideMany(mock.Anything, mock.Anything).Return(errors.New("test error")).Once()
-
-		sleepDuration := reprovider.performProvide(ctx, interval, batchSize, LabelTriggerScheduled)
-
-		if i < 2 {
-			// First two failures: return time.Minute, circuit not yet open
-			assert.Equal(t, time.Minute, sleepDuration, "attempt %d", i)
-		} else {
-			// Third failure: circuit opens, return 15 minutes cooldown
-			assert.Equal(t, 15*time.Minute, sleepDuration, "attempt %d", i)
-		}
+	// All keys fail
+	pme := &provideManyError{
+		failed:     2,
+		total:      2,
+		err:        errors.New("timeout"),
+		failedKeys: []multihash.Multihash{c1.Hash(), c2.Hash()},
 	}
 
-	// Circuit breaker should now be open
-	assert.True(t, reprovider.circuitOpenUntil.Load() > 0)
+	mockStore.EXPECT().CountPinned(mock.Anything, mock.Anything).Return(core.PinnedCIDStats{}, nil).Maybe()
+	mockStore.EXPECT().ProvideCIDs(mock.Anything, mock.Anything, 10).Return(testCIDs, nil).Once()
+	mockProvider.EXPECT().ProvideMany(mock.Anything, mock.Anything).Return(pme).Once()
+	// SetLastAnnouncement should NOT be called (no successes)
+	mockStore.AssertNotCalled(t, "SetLastAnnouncement")
+
+	sleepDuration := reprovider.performProvide(ctx, LabelTriggerScheduled)
+
+	assert.Equal(t, time.Minute, sleepDuration)
+	mockStore.AssertNotCalled(t, "SetLastAnnouncement")
+}
+
+func TestReprovider_performProvide_PartialFailure_SetLastAnnouncementError(t *testing.T) {
+	ctx := context.Background()
+
+	mockProvider := mocks.NewMockProvider(t)
+	mockStore := mocks.NewMockReprovideStore(t)
+	logger, _ := zap.NewDevelopment()
+
+	cfg := newTestReproviderCfg(1*time.Second, 10)
+
+	reprovider := &Reprovider{
+		provider:       mockProvider,
+		store:          mockStore,
+		log:            logger,
+		cfg:            cfg,
+		triggerProvide: make(chan struct{}, 1),
+	}
+
+	c1 := cid.NewCidV1(cid.Raw, mustMultihash(t, "pme-err-key1"))
+	c2 := cid.NewCidV1(cid.Raw, mustMultihash(t, "pme-err-key2"))
+
+	testCIDs := []core.PinnedCID{
+		{CID: c1, LastAnnouncement: time.Now().Add(-2 * time.Second)},
+		{CID: c2, LastAnnouncement: time.Now().Add(-2 * time.Second)},
+	}
+
+	// 1 of 2 fails
+	pme := &provideManyError{
+		failed:     1,
+		total:      2,
+		err:        errors.New("timeout"),
+		failedKeys: []multihash.Multihash{c1.Hash()},
+	}
+
+	mockStore.EXPECT().CountPinned(mock.Anything, mock.Anything).Return(core.PinnedCIDStats{}, nil).Maybe()
+	mockStore.EXPECT().ProvideCIDs(mock.Anything, mock.Anything, 10).Return(testCIDs, nil).Once()
+	mockProvider.EXPECT().ProvideMany(mock.Anything, mock.Anything).Return(pme).Once()
+	// SetLastAnnouncement fails (e.g. DB error) — should not block error handling
+	// Called for c2 (the succeeded CID)
+	mockStore.EXPECT().SetLastAnnouncement(mock.Anything, mock.MatchedBy(func(cids []cid.Cid) bool {
+		return len(cids) == 1 && cids[0].Equals(c2)
+	}), mock.Anything).Return(errors.New("db error")).Once()
+
+	sleepDuration := reprovider.performProvide(ctx, LabelTriggerScheduled)
+
+	// Should still return ErrorSleep (failure path), not crash
+	assert.Equal(t, time.Minute, sleepDuration)
 }
 
 // stubContentRouting is a minimal routing.ContentRouting stub for testing.
@@ -857,208 +749,4 @@ func mustMultihash(t *testing.T, data string) multihash.Multihash {
 	return h
 }
 
-func TestReprovider_BootCycle_FailThenSucceed(t *testing.T) {
-	ctx := context.Background()
 
-	mockProvider := mocks.NewMockProvider(t)
-	mockStore := mocks.NewMockReprovideStore(t)
-	logger, _ := zap.NewDevelopment()
-
-	interval := 1 * time.Second
-	batchSize := 10
-
-	reprovider := &Reprovider{
-		provider:             mockProvider,
-		store:                mockStore,
-		log:                  logger,
-		triggerProvide:       make(chan struct{}, 1),
-		triggerDelayDuration: 100 * time.Millisecond,
-		reprovideSleep:       0,
-		mu:                   sync.Mutex{},
-	}
-
-	c1 := cid.NewCidV1(cid.Raw, mustMultihash(t, "boot-fail-key1"))
-	c2 := cid.NewCidV1(cid.Raw, mustMultihash(t, "boot-fail-key2"))
-
-	testCIDs := []core.PinnedCID{
-		{CID: c1, LastAnnouncement: time.Now().Add(-2 * interval)},
-		{CID: c2, LastAnnouncement: time.Now().Add(-2 * interval)},
-	}
-
-	// First attempt: both CIDs fail
-	mockStore.EXPECT().CountPinned(mock.Anything, mock.Anything).Return(core.PinnedCIDStats{Total: 2, Pending: 2}, nil).Once()
-	mockStore.EXPECT().ProvideCIDs(mock.Anything, mock.Anything, batchSize).Return(testCIDs, nil).Once()
-	mockProvider.EXPECT().ProvideMany(mock.Anything, mock.Anything).Return(errors.New("dht error")).Once()
-
-	reprovider.performProvide(ctx, interval, batchSize, LabelTriggerScheduled)
-
-	// Verify boot-cycle gauges: 2 attempted, 0 succeeded, 2 failed
-	attempted, succeeded, failedCount := reprovider.bootCycle.snapshot()
-	assert.Equal(t, int64(2), attempted)
-	assert.Equal(t, int64(0), succeeded)
-	assert.Equal(t, int64(2), failedCount)
-
-	// Second attempt: both CIDs succeed (retry)
-	mockStore.EXPECT().CountPinned(mock.Anything, mock.Anything).Return(core.PinnedCIDStats{Total: 2, Announced: 2}, nil).Once()
-	mockStore.EXPECT().ProvideCIDs(mock.Anything, mock.Anything, batchSize).Return(testCIDs, nil).Once()
-	mockProvider.EXPECT().ProvideMany(mock.Anything, mock.Anything).Return(nil).Once()
-	mockStore.EXPECT().SetLastAnnouncement(mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
-
-	reprovider.performProvide(ctx, interval, batchSize, LabelTriggerScheduled)
-
-	// Verify: 4 attempted (cumulative), 2 succeeded, 0 failed (removed from failed set)
-	attempted, succeeded, failedCount = reprovider.bootCycle.snapshot()
-	assert.Equal(t, int64(4), attempted)
-	assert.Equal(t, int64(2), succeeded)
-	assert.Equal(t, int64(0), failedCount, "failed CIDs should be removed after successful retry")
-}
-
-func TestReprovider_BootCycle_PartialFailure(t *testing.T) {
-	ctx := context.Background()
-
-	mockProvider := mocks.NewMockProvider(t)
-	mockStore := mocks.NewMockReprovideStore(t)
-	logger, _ := zap.NewDevelopment()
-
-	interval := 1 * time.Second
-	batchSize := 10
-
-	reprovider := &Reprovider{
-		provider:             mockProvider,
-		store:                mockStore,
-		log:                  logger,
-		triggerProvide:       make(chan struct{}, 1),
-		triggerDelayDuration: 100 * time.Millisecond,
-		reprovideSleep:       0,
-		mu:                   sync.Mutex{},
-	}
-
-	c1 := cid.NewCidV1(cid.Raw, mustMultihash(t, "partial-key1"))
-	c2 := cid.NewCidV1(cid.Raw, mustMultihash(t, "partial-key2"))
-
-	testCIDs := []core.PinnedCID{
-		{CID: c1, LastAnnouncement: time.Now().Add(-2 * interval)},
-		{CID: c2, LastAnnouncement: time.Now().Add(-2 * interval)},
-	}
-
-	// Simulate partial failure: provideManyError with 1 failed key (c1), 1 succeeded (c2)
-	failedKey := c1.Hash()
-	pme := &provideManyError{
-		failed:     1,
-		total:      2,
-		err:        errors.New("timeout"),
-		failedKeys: []multihash.Multihash{failedKey},
-	}
-
-	mockStore.EXPECT().CountPinned(mock.Anything, mock.Anything).Return(core.PinnedCIDStats{Total: 2, Pending: 2}, nil).Once()
-	mockStore.EXPECT().ProvideCIDs(mock.Anything, mock.Anything, batchSize).Return(testCIDs, nil).Once()
-	mockProvider.EXPECT().ProvideMany(mock.Anything, mock.Anything).Return(pme).Once()
-	// SetLastAnnouncement should be called for c2 (the succeeded CID)
-	mockStore.EXPECT().SetLastAnnouncement(mock.Anything, mock.MatchedBy(func(cids []cid.Cid) bool {
-		return len(cids) == 1 && cids[0].Equals(c2)
-	}), mock.Anything).Return(nil).Once()
-
-	reprovider.performProvide(ctx, interval, batchSize, LabelTriggerScheduled)
-
-	// 2 attempted, 1 succeeded (c2 marked as succeeded, removed from failed set), 1 failed (c1)
-	attempted, succeeded, failedCount := reprovider.bootCycle.snapshot()
-	assert.Equal(t, int64(2), attempted)
-	assert.Equal(t, int64(1), succeeded)
-	assert.Equal(t, int64(1), failedCount, "only the failed CID should remain in the failed set")
-}
-
-func TestReprovider_performProvide_PartialFailure_AllFail(t *testing.T) {
-	ctx := context.Background()
-
-	mockProvider := mocks.NewMockProvider(t)
-	mockStore := mocks.NewMockReprovideStore(t)
-	logger, _ := zap.NewDevelopment()
-
-	interval := 1 * time.Second
-	batchSize := 10
-
-	reprovider := &Reprovider{
-		provider:             mockProvider,
-		store:                mockStore,
-		log:                  logger,
-		triggerProvide:       make(chan struct{}, 1),
-		triggerDelayDuration: 100 * time.Millisecond,
-		reprovideSleep:       0,
-		mu:                   sync.Mutex{},
-	}
-
-	c1 := cid.NewCidV1(cid.Raw, mustMultihash(t, "allfail-key1"))
-	c2 := cid.NewCidV1(cid.Raw, mustMultihash(t, "allfail-key2"))
-
-	testCIDs := []core.PinnedCID{
-		{CID: c1, LastAnnouncement: time.Now().Add(-2 * interval)},
-		{CID: c2, LastAnnouncement: time.Now().Add(-2 * interval)},
-	}
-
-	// All keys fail
-	pme := &provideManyError{
-		failed:     2,
-		total:      2,
-		err:        errors.New("timeout"),
-		failedKeys: []multihash.Multihash{c1.Hash(), c2.Hash()},
-	}
-
-	mockStore.EXPECT().CountPinned(mock.Anything, mock.Anything).Return(core.PinnedCIDStats{}, nil).Maybe()
-	mockStore.EXPECT().ProvideCIDs(mock.Anything, mock.Anything, batchSize).Return(testCIDs, nil).Once()
-	mockProvider.EXPECT().ProvideMany(mock.Anything, mock.Anything).Return(pme).Once()
-	// SetLastAnnouncement should NOT be called (no successes)
-	mockStore.AssertNotCalled(t, "SetLastAnnouncement")
-
-	sleepDuration := reprovider.performProvide(ctx, interval, batchSize, LabelTriggerScheduled)
-
-	assert.Equal(t, time.Minute, sleepDuration)
-	mockStore.AssertNotCalled(t, "SetLastAnnouncement")
-}
-
-func TestReprovider_performProvide_PartialFailure_SetLastAnnouncementError(t *testing.T) {
-	ctx := context.Background()
-
-	mockProvider := mocks.NewMockProvider(t)
-	mockStore := mocks.NewMockReprovideStore(t)
-	logger, _ := zap.NewDevelopment()
-
-	interval := 1 * time.Second
-	batchSize := 10
-
-	reprovider := &Reprovider{
-		provider:             mockProvider,
-		store:                mockStore,
-		log:                  logger,
-		triggerProvide:       make(chan struct{}, 1),
-		triggerDelayDuration: 100 * time.Millisecond,
-		reprovideSleep:       0,
-		mu:                   sync.Mutex{},
-	}
-
-	c1 := cid.NewCidV1(cid.Raw, mustMultihash(t, "pme-err-key1"))
-	c2 := cid.NewCidV1(cid.Raw, mustMultihash(t, "pme-err-key2"))
-
-	testCIDs := []core.PinnedCID{
-		{CID: c1, LastAnnouncement: time.Now().Add(-2 * interval)},
-		{CID: c2, LastAnnouncement: time.Now().Add(-2 * interval)},
-	}
-
-	// 1 of 2 fails
-	pme := &provideManyError{
-		failed:     1,
-		total:      2,
-		err:        errors.New("timeout"),
-		failedKeys: []multihash.Multihash{c1.Hash()},
-	}
-
-	mockStore.EXPECT().CountPinned(mock.Anything, mock.Anything).Return(core.PinnedCIDStats{}, nil).Maybe()
-	mockStore.EXPECT().ProvideCIDs(mock.Anything, mock.Anything, batchSize).Return(testCIDs, nil).Once()
-	mockProvider.EXPECT().ProvideMany(mock.Anything, mock.Anything).Return(pme).Once()
-	// SetLastAnnouncement fails (e.g. DB error) — should not block error handling
-	mockStore.EXPECT().SetLastAnnouncement(mock.Anything, mock.Anything, mock.Anything).Return(errors.New("db error")).Once()
-
-	sleepDuration := reprovider.performProvide(ctx, interval, batchSize, LabelTriggerScheduled)
-
-	// Should still return time.Minute (failure path), not crash
-	assert.Equal(t, time.Minute, sleepDuration)
-}

--- a/internal/protocol/ipfs/provide_test.go
+++ b/internal/protocol/ipfs/provide_test.go
@@ -435,17 +435,17 @@ func TestReprovider_performProvide_BacklogDrain(t *testing.T) {
 
 func TestBasicDHTProvider_ProvideMany(t *testing.T) {
 	t.Run("ready_returns_false_when_fn_returns_false", func(t *testing.T) {
-		provider := newBasicDHTProvider(&stubContentRouting{}, func() bool { return false }, 0)
+		provider := newBasicDHTProvider(&stubContentRouting{}, func() bool { return false }, 0, 0)
 		assert.False(t, provider.Ready())
 	})
 
 	t.Run("ready_returns_true_when_fn_returns_true", func(t *testing.T) {
-		provider := newBasicDHTProvider(&stubContentRouting{}, func() bool { return true }, 0)
+		provider := newBasicDHTProvider(&stubContentRouting{}, func() bool { return true }, 0, 0)
 		assert.True(t, provider.Ready())
 	})
 
 	t.Run("ready_defaults_to_true_when_fn_is_nil", func(t *testing.T) {
-		provider := newBasicDHTProvider(&stubContentRouting{}, nil, 0)
+		provider := newBasicDHTProvider(&stubContentRouting{}, nil, 0, 0)
 		assert.True(t, provider.Ready())
 	})
 
@@ -454,7 +454,7 @@ func TestBasicDHTProvider_ProvideMany(t *testing.T) {
 		c2 := cid.NewCidV1(cid.Raw, mustMultihash(t, "key2"))
 
 		scr := &stubContentRouting{}
-		provider := newBasicDHTProvider(scr, nil, 0)
+		provider := newBasicDHTProvider(scr, nil, 0, 0)
 
 		keys := []multihash.Multihash{c1.Hash(), c2.Hash()}
 		err := provider.ProvideMany(context.Background(), keys)
@@ -468,7 +468,7 @@ func TestBasicDHTProvider_ProvideMany(t *testing.T) {
 
 		testErr := errors.New("provide failed")
 		scr := &stubContentRouting{err: testErr}
-		provider := newBasicDHTProvider(scr, nil, 0)
+		provider := newBasicDHTProvider(scr, nil, 0, 0)
 
 		keys := []multihash.Multihash{c1.Hash(), c2.Hash()}
 		err := provider.ProvideMany(context.Background(), keys)
@@ -484,7 +484,7 @@ func TestBasicDHTProvider_ProvideMany(t *testing.T) {
 		}
 
 		scr := &stubContentRouting{}
-		provider := newBasicDHTProvider(scr, nil, 0)
+		provider := newBasicDHTProvider(scr, nil, 0, 0)
 
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel() // cancel immediately

--- a/internal/service/website/website_test.go
+++ b/internal/service/website/website_test.go
@@ -2500,6 +2500,7 @@ func TestWebsiteService_UpdateWebsite_ConvertIPFSToIPNS_UpdatesDNSRecords(t *tes
 		).Return(nil).Once()
 
 		ipfsWebsite, err := websiteService.UpdateWebsite(context.Background(), testUserID1, createdWebsite.ID, ipfsUpdates)
+		websiteService.WaitForPublishes()
 		require.NoError(tb, err)
 		assert.Equal(tb, string(pluginDb.WebsiteTargetTypeIPFS), ipfsWebsite.TargetType)
 
@@ -2528,6 +2529,7 @@ func TestWebsiteService_UpdateWebsite_ConvertIPFSToIPNS_UpdatesDNSRecords(t *tes
 		).Return(nil).Once()
 
 		updatedWebsite, err := websiteService.UpdateWebsite(context.Background(), testUserID1, ipfsWebsite.ID, ipnsUpdates)
+		websiteService.WaitForPublishes()
 
 		// Assert
 		require.NoError(tb, err)


### PR DESCRIPTION
## Summary

Simplifies the reprovider by replacing the fullrt/basic if-else branching with a `NewDHTProvider` facade, and removes dead complexity (circuit breaker, boot-cycle tracking, `handleTriggers` goroutine, `retry-go`/`workerpool` deps).

## Changes

**`provide.go`** (623 → 386 lines)

- `NewDHTProvider(fullrt, dht, ready, cfg)` facade — node.go calls one factory, no branching
- `basicDHTProvider` simplified to a plain loop with per-CID timeout (no workerpool, no retry-go)
- `handleTriggers` goroutine removed — trigger handling merged into `Run` select loop
- Circuit breaker and `bootCycle` struct removed — upstream FullRT handles failures; `ErrorSleep` config backs off
- Boot-sweep behavior preserved naturally via `BacklogSleep` on full batches
- Hardcoded timing values moved to config: `TriggerDelay`, `NotReadySleep`, `EmptySleep`, `ErrorSleep`, `BacklogSleep`

**`node.go`**

- 30-line if/else reprovider wiring chain → single `NewDHTProvider(...)` call
- Removed `dhtProvider` intermediate variable

**`metrics.go`**

- Removed 5 dead metrics: `ReprovideCircuitOpen`, `ReprovideConsecutiveFailures`, `ReprovideBootCycleAttempted/Succeeded/Failed`

**`config.go`**

- Added 5 config fields with defaults replacing hardcoded values

**`provide_test.go`** (1064 → 749 lines)

- Removed 4 tests for deleted features (2 circuit breaker, 2 boot cycle)
- Removed retry/parallel tests for simplified `basicDHTProvider`
- Updated all signatures to use `cfg` struct

## Net

-937 lines, +337 lines across 5 files.

***

<!-- kody-pr-summary:start -->

## Summary

This PR simplifies the IPFS reprovider by introducing a `NewDHTProvider` facade and removing several complex resilience mechanisms in favor of a simpler, config-driven approach.

### Key Changes

**New `NewDHTProvider` facade**: Consolidates the FullRT vs basic DHT provider selection logic that was previously spread across `node.go` into a single factory function. `node.go` no longer branches on DHT mode — it determines the appropriate DHT instance and readiness function, then delegates to `NewDHTProvider`.

**Removed circuit breaker**: Eliminated the consecutive failure counter, circuit-open/cooldown state, and related metrics (`reprovide_circuit_open`, `reprovide_consecutive_failures`). The reprovider now relies on configurable error sleep durations instead.

**Removed boot cycle tracking**: Removed the `bootCycle` struct and its per-CID success/failure tracking during the initial reprovide sweep, along with associated metrics (`reprovide_boot_cycle_attempted/succeeded/failed`).

**Simplified `basicDHTProvider.ProvideMany`**: Removed the worker pool, retry logic (3 attempts with backoff), and parallel execution. Provides now run sequentially with a per-CID timeout.

**Configurable sleep durations**: All hardcoded sleep values (not-ready wait, empty batch, error recovery, backlog drain, trigger debounce) are now configurable via `IPFSProvider` config with sensible defaults.

**Unified `Run` loop**: Merged the separate `handleTriggers` goroutine into the main `Run` loop, eliminating the mutex, cancellation flags, and trigger channel plumbing. The `Run` and `performProvide` methods no longer accept `interval` and `batchSize` parameters — they read from the injected config.

### Impact

The reprovider is significantly simpler with fewer moving parts, at the cost of removing automatic retry-on-failure and circuit breaker protection. Failed CIDs will naturally be retried on the next scheduled cycle since their `last_announcement` timestamp won't be updated. The initial boot sweep behavior is preserved through the zero-initial-sleep plus backlog drain logic.

<!-- kody-pr-summary:end -->

- `develop` <!-- branch-stack -->
  - **refactor: simplify reprovider with NewDHTProvider facade** :point\_left:
