### PR TITLE
feat(ipfs): add want-block filter observability

### DIFF
--- a/internal/protocol/ipfs/metrics.go
+++ b/internal/protocol/ipfs/metrics.go
@@ -6,15 +6,15 @@ import (
 
 const (
 	// Reprovider metrics
-	MetricReprovideAttempts            = "reprovide_attempts_total"
-	MetricReprovideSuccesses           = "reprovide_successes_total"
-	MetricReprovideFailures            = "reprovide_failures_total"
-	MetricReprovideCIDsTotal           = "reprovide_cids_total"
-	MetricReprovideCIDFailures         = "reprovide_cid_failures_total"
-	MetricReprovideDuration            = "reprovide_duration_seconds"
-	MetricReprovideCIDDuration         = "reprovide_cid_duration_seconds"
-	MetricReprovideBatchSize           = "reprovide_batch_size"
-	MetricReprovideProviderReady       = "reprovide_provider_ready"
+	MetricReprovideAttempts      = "reprovide_attempts_total"
+	MetricReprovideSuccesses     = "reprovide_successes_total"
+	MetricReprovideFailures      = "reprovide_failures_total"
+	MetricReprovideCIDsTotal     = "reprovide_cids_total"
+	MetricReprovideCIDFailures   = "reprovide_cid_failures_total"
+	MetricReprovideDuration      = "reprovide_duration_seconds"
+	MetricReprovideCIDDuration   = "reprovide_cid_duration_seconds"
+	MetricReprovideBatchSize     = "reprovide_batch_size"
+	MetricReprovideProviderReady = "reprovide_provider_ready"
 
 	// Global pinned-state gauges
 	MetricReprovidePinnedTotal    = "reprovide_pinned_total"
@@ -31,9 +31,10 @@ const (
 	MetricFullRTRoutingTableSize        = "fullrt_routing_table_size"
 
 	// WantBlockFilter metrics
-	MetricWantBlockRequests     = "want_block_requests_total"
-	MetricWantBlockGatewayPeers = "want_block_gateway_peers"
-	MetricWantBlockPeerLimiters = "want_block_peer_limiters"
+	MetricWantBlockRequests       = "want_block_requests_total"
+	MetricWantBlockGatewayPeers   = "want_block_gateway_peers"
+	MetricWantBlockPeerLimiters   = "want_block_peer_limiters"
+	MetricWantBlockTopDeniedPeers = "want_block_top_denied_peers"
 )
 
 const (
@@ -52,6 +53,7 @@ const (
 	LabelWantDeniedGlobalRate  = "denied_global_rate"
 	LabelWantDeniedPerPeerRate = "denied_per_peer_rate"
 	LabelWantAllowedGateway    = "allowed_gateway"
+	LabelWantAllowedSelf       = "allowed_self"
 
 	LabelCIDResultSuccess = "success"
 	LabelCIDResultTimeout = "timeout"
@@ -72,7 +74,7 @@ var (
 	ReprovideBatchSize   *prometheus.HistogramVec
 
 	// Reprovider gauges
-	ReprovideProviderReady       prometheus.Gauge
+	ReprovideProviderReady prometheus.Gauge
 
 	// Global pinned-state gauges
 	ReprovidePinnedTotal    prometheus.Gauge
@@ -271,7 +273,7 @@ func init() {
 		prometheus.CounterOpts{
 			Subsystem: subSystemBitswap,
 			Name:      MetricWantBlockRequests,
-			Help:      "Total want-block requests by outcome (allowed, allowed_gateway, denied_global_rate, denied_per_peer_rate)",
+			Help:      "Total want-block requests by outcome (allowed, allowed_gateway, allowed_self, denied_global_rate, denied_per_peer_rate)",
 		},
 		[]string{"result"},
 	)

--- a/internal/protocol/ipfs/node.go
+++ b/internal/protocol/ipfs/node.go
@@ -32,9 +32,10 @@ import (
 	"golang.org/x/crypto/hkdf"
 	"golang.org/x/time/rate"
 
+	"github.com/avast/retry-go/v5"
 	"github.com/ipfs/boxo/bitswap"
-	tracerpkg "github.com/ipfs/boxo/bitswap/tracer"
 	"github.com/ipfs/boxo/bitswap/network/bsnet"
+	tracerpkg "github.com/ipfs/boxo/bitswap/tracer"
 	"github.com/ipfs/boxo/blockservice"
 	"github.com/ipfs/boxo/blockstore"
 	"github.com/ipfs/boxo/exchange"
@@ -44,23 +45,22 @@ import (
 	"github.com/ipfs/boxo/namesys"
 	blocks "github.com/ipfs/go-block-format"
 	format "github.com/ipfs/go-ipld-format"
-	"github.com/avast/retry-go/v5"
 	"github.com/libp2p/go-libp2p"
 	dht "github.com/libp2p/go-libp2p-kad-dht"
 	"github.com/libp2p/go-libp2p-kad-dht/fullrt"
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	pubsubrouter "github.com/libp2p/go-libp2p-pubsub-router"
 	libp2pCoreConnmgr "github.com/libp2p/go-libp2p/core/connmgr"
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/peerstore"
-	pubsub "github.com/libp2p/go-libp2p-pubsub"
-	pubsubrouter "github.com/libp2p/go-libp2p-pubsub-router"
+	rcmgr "github.com/libp2p/go-libp2p/p2p/host/resource-manager"
+	"github.com/libp2p/go-libp2p/p2p/net/connmgr"
 	quic "github.com/libp2p/go-libp2p/p2p/transport/quic"
 	webrtc "github.com/libp2p/go-libp2p/p2p/transport/webrtc"
 	ws "github.com/libp2p/go-libp2p/p2p/transport/websocket"
 	webtransport "github.com/libp2p/go-libp2p/p2p/transport/webtransport"
-	rcmgr "github.com/libp2p/go-libp2p/p2p/host/resource-manager"
-	"github.com/libp2p/go-libp2p/p2p/net/connmgr"
 	libp2pRate "github.com/libp2p/go-libp2p/x/rate"
 )
 
@@ -77,7 +77,6 @@ type DHTRouting interface {
 	routing.ContentRouting
 	routing.PeerRouting
 }
-
 
 // IPFSNode defines the interface for IPFS node operations
 type IPFSNode interface {
@@ -137,30 +136,35 @@ func (r *ReadyAwareExchange) NotifyNewBlocks(ctx context.Context, blks ...blocks
 // NodeFactory manages the creation and recreation of IPFS nodes
 // It stores shared components that persist across node restarts
 type NodeFactory struct {
-	ctx             core.Context
-	cfg             *config.ProtocolConfig
-	reprovideStore  pluginCore.ReprovideStore
-	datastore       datastore.Batching
-	blockstore      blockstore.Blockstore
-	peerTracker     *BlockRequestTracker
-	readyChecker    BlockReadyChecker
-	bootstrapPeers  []peer.AddrInfo
-	bootstrapMutex  sync.RWMutex
+	ctx            core.Context
+	cfg            *config.ProtocolConfig
+	reprovideStore pluginCore.ReprovideStore
+	datastore      datastore.Batching
+	blockstore     blockstore.Blockstore
+	peerTracker    *BlockRequestTracker
+	readyChecker   BlockReadyChecker
+	bootstrapPeers []peer.AddrInfo
+	bootstrapMutex sync.RWMutex
+
+	deniedPeersCollector *topNDeniedPeersCollector
 }
 
 // NewNodeFactory creates a new node factory with the given shared components
 func NewNodeFactory(ctx core.Context, cfg *config.ProtocolConfig, rs pluginCore.ReprovideStore, ds datastore.Batching, bs blockstore.Blockstore, peerTracker *BlockRequestTracker, readyChecker BlockReadyChecker) *NodeFactory {
 	factory := &NodeFactory{
-		ctx:            ctx,
-		cfg:            cfg,
-		reprovideStore: rs,
-		datastore:      ds,
-		blockstore:     bs,
-		peerTracker:    peerTracker,
-		readyChecker:   readyChecker,
-		bootstrapPeers: make([]peer.AddrInfo, 0),
-		bootstrapMutex: sync.RWMutex{},
+		ctx:                  ctx,
+		cfg:                  cfg,
+		reprovideStore:       rs,
+		datastore:            ds,
+		blockstore:           bs,
+		peerTracker:          peerTracker,
+		readyChecker:         readyChecker,
+		bootstrapPeers:       make([]peer.AddrInfo, 0),
+		bootstrapMutex:       sync.RWMutex{},
+		deniedPeersCollector: newTopNDeniedPeersCollector(10),
 	}
+
+	core.PluginMetricsRegistry(internal.ProtocolName).MustRegister(factory.deniedPeersCollector)
 
 	// Add initial bootstrap peers from config
 	for _, bp := range cfg.BootstrapPeers {
@@ -188,7 +192,7 @@ func (f *NodeFactory) ClearBootstrapPeers() {
 func (f *NodeFactory) GetBootstrapPeers() []peer.AddrInfo {
 	f.bootstrapMutex.RLock()
 	defer f.bootstrapMutex.RUnlock()
-	
+
 	peers := make([]peer.AddrInfo, len(f.bootstrapPeers))
 	copy(peers, f.bootstrapPeers)
 	return peers
@@ -201,25 +205,25 @@ func (f *NodeFactory) CreateNode() (*Node, error) {
 
 // A Node is a minimal IPFS node
 type Node struct {
-	log              *core.Logger
-	ctx              core.Context
-	host             host.Host
+	log                 *core.Logger
+	ctx                 core.Context
+	host                host.Host
 	routing             DHTRouting
 	companionDHT        *dht.IpfsDHT
 	companionDHTHealthy atomic.Bool
 	fullRT              *fullrt.FullRT
 	reprovider          *Reprovider
-	blockService     blockservice.BlockService
-	dagService       format.DAGService
-	bitswap          *bitswap.Bitswap
-	reproviderCancel context.CancelFunc
-	datastore        datastore.Datastore
-	keystore         keystore.Keystore
-	publisher        *namesys.IPNSPublisher
-	pubsub           *pubsub.PubSub
-	pubsubValueStore *pubsubrouter.PubsubValueStore
-	announceWeb      bool
-	port             int
+	blockService        blockservice.BlockService
+	dagService          format.DAGService
+	bitswap             *bitswap.Bitswap
+	reproviderCancel    context.CancelFunc
+	datastore           datastore.Datastore
+	keystore            keystore.Keystore
+	publisher           *namesys.IPNSPublisher
+	pubsub              *pubsub.PubSub
+	pubsubValueStore    *pubsubrouter.PubsubValueStore
+	announceWeb         bool
+	port                int
 }
 
 // Close closes the node
@@ -490,47 +494,47 @@ func NewNode(ctx core.Context, cfg *config.ProtocolConfig, rs pluginCore.Reprovi
 	}
 
 	opts = append(opts, libp2p.AddrsFactory(func(addrs []multiaddr.Multiaddr) []multiaddr.Multiaddr {
-			ctx.Logger().Debug("ipfs AddrsFactory invoked",
-				zap.Int("host_addr_count", len(addrs)),
-				zap.Int("config_port", cfg.Port),
-				zap.Strings("host_addrs", lo.Map(lo.Filter(addrs, func(a multiaddr.Multiaddr, _ int) bool { return a != nil }), func(a multiaddr.Multiaddr, _ int) string {
-					return a.String()
-				})),
-			)
-			var domain string
-			if cfg.AnnounceWeb {
-				httpSvc := core.GetService[core.HTTPService](ctx, core.HTTP_SERVICE)
-				if httpSvc != nil {
-					domain = httpSvc.APISubdomain(internal.ProtocolName, false)
-				}
+		ctx.Logger().Debug("ipfs AddrsFactory invoked",
+			zap.Int("host_addr_count", len(addrs)),
+			zap.Int("config_port", cfg.Port),
+			zap.Strings("host_addrs", lo.Map(lo.Filter(addrs, func(a multiaddr.Multiaddr, _ int) bool { return a != nil }), func(a multiaddr.Multiaddr, _ int) string {
+				return a.String()
+			})),
+		)
+		var domain string
+		if cfg.AnnounceWeb {
+			httpSvc := core.GetService[core.HTTPService](ctx, core.HTTP_SERVICE)
+			if httpSvc != nil {
+				domain = httpSvc.APISubdomain(internal.ProtocolName, false)
 			}
-			announceAddresses, err := AnnouncementAddresses(cfg.AnnounceWeb, domain, addrs, cfg.Port)
-			ctx.Logger().Debug("ipfs announcement addresses resolved",
-				zap.Bool("announce_web", cfg.AnnounceWeb),
-				zap.String("domain", domain),
-				zap.Int("config_port", cfg.Port),
-				zap.Int("announce_addr_count", len(announceAddresses)),
-				zap.Strings("announce_addrs", lo.Map(announceAddresses, func(a multiaddr.Multiaddr, _ int) string {
-					return a.String()
-				})),
-				zap.Error(err),
-			)
-			if err != nil {
-				ctx.Logger().Error("failed to get announcement addresses", zap.Error(err))
-				return lo.Filter(addrs, func(addr multiaddr.Multiaddr, _ int) bool {
-					return addr != nil
-				})
-			}
-
-			if len(announceAddresses) == 0 {
-				return lo.Filter(addrs, func(addr multiaddr.Multiaddr, _ int) bool {
-					return addr != nil
-				})
-			}
-
-			return lo.Filter(announceAddresses, func(addr multiaddr.Multiaddr, _ int) bool {
+		}
+		announceAddresses, err := AnnouncementAddresses(cfg.AnnounceWeb, domain, addrs, cfg.Port)
+		ctx.Logger().Debug("ipfs announcement addresses resolved",
+			zap.Bool("announce_web", cfg.AnnounceWeb),
+			zap.String("domain", domain),
+			zap.Int("config_port", cfg.Port),
+			zap.Int("announce_addr_count", len(announceAddresses)),
+			zap.Strings("announce_addrs", lo.Map(announceAddresses, func(a multiaddr.Multiaddr, _ int) string {
+				return a.String()
+			})),
+			zap.Error(err),
+		)
+		if err != nil {
+			ctx.Logger().Error("failed to get announcement addresses", zap.Error(err))
+			return lo.Filter(addrs, func(addr multiaddr.Multiaddr, _ int) bool {
 				return addr != nil
 			})
+		}
+
+		if len(announceAddresses) == 0 {
+			return lo.Filter(addrs, func(addr multiaddr.Multiaddr, _ int) bool {
+				return addr != nil
+			})
+		}
+
+		return lo.Filter(announceAddresses, func(addr multiaddr.Multiaddr, _ int) bool {
+			return addr != nil
+		})
 	}))
 
 	node, err := libp2p.New(opts...)
@@ -698,11 +702,14 @@ func NewNode(ctx core.Context, cfg *config.ProtocolConfig, rs pluginCore.Reprovi
 
 	if cfg.Bitswap.GlobalWantRateLimit > 0 || len(gatewayPeerIDs) > 0 {
 		wantFilter := NewWantBlockFilter(node, WantBlockFilterConfig{
-			GatewayPeers: gatewayPeerIDs,
-			GlobalRate:   rate.Limit(cfg.Bitswap.GlobalWantRateLimit),
-			GlobalBurst:  cfg.Bitswap.GlobalWantBurst,
-			PerPeerRate:  rate.Limit(cfg.Bitswap.PerPeerWantRateLimit),
-			PerPeerBurst: cfg.Bitswap.PerPeerWantBurst,
+			SelfPeer:             node.ID(),
+			Logger:               ctx.Logger().Named("wantblock_filter"),
+			GatewayPeers:         gatewayPeerIDs,
+			GlobalRate:           rate.Limit(cfg.Bitswap.GlobalWantRateLimit),
+			GlobalBurst:          cfg.Bitswap.GlobalWantBurst,
+			PerPeerRate:          rate.Limit(cfg.Bitswap.PerPeerWantRateLimit),
+			PerPeerBurst:         cfg.Bitswap.PerPeerWantBurst,
+			DeniedPeersCollector: factory.deniedPeersCollector,
 		})
 		bitswapOpts = append(bitswapOpts, bitswap.WithPeerBlockRequestFilter(wantFilter.PeerBlockRequestFilter()))
 
@@ -773,30 +780,30 @@ func NewNode(ctx core.Context, cfg *config.ProtocolConfig, rs pluginCore.Reprovi
 				case <-ctx.Done():
 					return
 				case <-ticker.C:
-						if ipfsNode.companionDHT != nil {
-							CompanionDHTRoutingTableSize.Set(float64(ipfsNode.companionDHT.RoutingTable().Size()))
+					if ipfsNode.companionDHT != nil {
+						CompanionDHTRoutingTableSize.Set(float64(ipfsNode.companionDHT.RoutingTable().Size()))
 
-							peerCount := 0
-							for range ipfsNode.host.Network().Conns() {
-								peerCount++
-							}
-							CompanionDHTConnectedPeers.Set(float64(peerCount))
+						peerCount := 0
+						for range ipfsNode.host.Network().Conns() {
+							peerCount++
+						}
+						CompanionDHTConnectedPeers.Set(float64(peerCount))
 
-							if ipfsNode.companionDHTHealthy.Load() {
-								CompanionDHTHealthy.Set(1)
-							} else {
-								CompanionDHTHealthy.Set(0)
-							}
+						if ipfsNode.companionDHTHealthy.Load() {
+							CompanionDHTHealthy.Set(1)
+						} else {
+							CompanionDHTHealthy.Set(0)
 						}
-						if ipfsNode.fullRT != nil {
-							if ipfsNode.fullRT.Ready() {
-								FullRTReady.Set(1)
-							} else {
-								FullRTReady.Set(0)
-							}
-							FullRTRoutingTableSize.Set(float64(len(ipfsNode.fullRT.Stat())))
+					}
+					if ipfsNode.fullRT != nil {
+						if ipfsNode.fullRT.Ready() {
+							FullRTReady.Set(1)
+						} else {
+							FullRTReady.Set(0)
 						}
-						}
+						FullRTRoutingTableSize.Set(float64(len(ipfsNode.fullRT.Stat())))
+					}
+				}
 			}
 		}()
 	}
@@ -1120,4 +1127,3 @@ func resolvePortFromAddrs(addrs []multiaddr.Multiaddr) int {
 	}
 	return 0
 }
-

--- a/internal/protocol/ipfs/want_block_collector.go
+++ b/internal/protocol/ipfs/want_block_collector.go
@@ -1,0 +1,102 @@
+package ipfs
+
+import (
+	"sort"
+	"sync"
+	"sync/atomic"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// topNDeniedPeersCollector exposes the top N most-denied peers as a gauge
+// with a peer label. This avoids unbounded cardinality from tracking every
+// unique peer in a counter label, while still giving dashboards visibility
+// into which peers are being throttled the most.
+type topNDeniedPeersCollector struct {
+	mu     sync.RWMutex
+	counts map[string]*int64 // peer ID -> denial count (atomic)
+	topN   int
+	metric *prometheus.GaugeVec
+	label  string
+}
+
+func newTopNDeniedPeersCollector(topN int) *topNDeniedPeersCollector {
+	c := &topNDeniedPeersCollector{
+		counts: make(map[string]*int64),
+		topN:   topN,
+		metric: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Subsystem: subSystemBitswap,
+				Name:      MetricWantBlockTopDeniedPeers,
+				Help:      "Top N most-denied peers by want-block request count, refreshed on each scrape",
+			},
+			[]string{"peer"},
+		),
+		label: "peer",
+	}
+	return c
+}
+
+func (c *topNDeniedPeersCollector) increment(peerID string) {
+	c.mu.RLock()
+	counter, ok := c.counts[peerID]
+	c.mu.RUnlock()
+
+	if ok {
+		atomic.AddInt64(counter, 1)
+		return
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	counter, ok = c.counts[peerID]
+	if !ok {
+		counter = new(int64)
+		c.counts[peerID] = counter
+	}
+	atomic.AddInt64(counter, 1)
+}
+
+func (c *topNDeniedPeersCollector) RemovePeer(peerID string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.counts, peerID)
+}
+
+// Collect implements prometheus.Collector. It computes the top N most-denied
+// peers and emits them as gauge values. The gauge is reset each scrape.
+func (c *topNDeniedPeersCollector) Collect(ch chan<- prometheus.Metric) {
+	c.mu.RLock()
+	type entry struct {
+		peer  string
+		count int64
+	}
+	entries := make([]entry, 0, len(c.counts))
+	for p, ctr := range c.counts {
+		entries = append(entries, entry{p, atomic.LoadInt64(ctr)})
+	}
+	c.mu.RUnlock()
+
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].count > entries[j].count
+	})
+
+	if len(entries) > c.topN {
+		entries = entries[:c.topN]
+	}
+
+	// Reset the gauge vec so stale peers from last scrape are cleared.
+	c.metric.Reset()
+
+	for _, e := range entries {
+		c.metric.WithLabelValues(e.peer).Set(float64(e.count))
+	}
+
+	c.metric.Collect(ch)
+}
+
+// Describe implements prometheus.Collector.
+func (c *topNDeniedPeersCollector) Describe(ch chan<- *prometheus.Desc) {
+	c.metric.Describe(ch)
+}

--- a/internal/protocol/ipfs/want_filter.go
+++ b/internal/protocol/ipfs/want_filter.go
@@ -7,31 +7,38 @@ import (
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/config"
+	"go.uber.org/zap"
 	"golang.org/x/time/rate"
 )
 
 // WantBlockFilter implements bitswap.PeerBlockRequestFilter with gateway
 // peer whitelisting and per-peer rate limiting. Gateway peers (identified
-// by peer ID extracted from multiaddrs) get unlimited access. All other
-// peers are rate-limited to prevent want-block overload from aggressive
-// DHT peers.
+// by peer ID extracted from multiaddrs) and the local node's own peer ID
+// get unlimited access. All other peers are rate-limited to prevent
+// want-block overload from aggressive DHT peers.
 type WantBlockFilter struct {
 	mu           sync.RWMutex
 	host         host.Host
+	selfPeer     peer.ID
+	log          *zap.Logger
 	gatewayPeers map[peer.ID]struct{}
 	limiter      *rate.Limiter
 	peerLimiters map[peer.ID]*rate.Limiter
 	perPeerRate  rate.Limit
 	perPeerBurst int
+	deniedPeers  *topNDeniedPeersCollector
 }
 
 // WantBlockFilterConfig holds the configuration for creating a WantBlockFilter.
 type WantBlockFilterConfig struct {
-	GatewayPeers []peer.ID
-	GlobalRate   rate.Limit
-	GlobalBurst  int
-	PerPeerRate  rate.Limit
-	PerPeerBurst int
+	SelfPeer             peer.ID
+	Logger               *zap.Logger
+	GatewayPeers         []peer.ID
+	GlobalRate           rate.Limit
+	GlobalBurst          int
+	PerPeerRate          rate.Limit
+	PerPeerBurst         int
+	DeniedPeersCollector *topNDeniedPeersCollector
 }
 
 // NewWantBlockFilter creates a new WantBlockFilter with the given configuration.
@@ -59,13 +66,26 @@ func NewWantBlockFilter(h host.Host, cfg WantBlockFilterConfig) *WantBlockFilter
 		perPeerBurst = config.DefaultBitswapPerPeerWantBurst
 	}
 
+	logger := cfg.Logger
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+
+	deniedPeers := cfg.DeniedPeersCollector
+	if deniedPeers == nil {
+		deniedPeers = newTopNDeniedPeersCollector(10)
+	}
+
 	f := &WantBlockFilter{
 		host:         h,
+		selfPeer:     cfg.SelfPeer,
+		log:          logger.Named("wantblock_filter"),
 		gatewayPeers: gatewayPeers,
 		limiter:      rate.NewLimiter(globalRate, globalBurst),
 		peerLimiters: make(map[peer.ID]*rate.Limiter),
 		perPeerRate:  perPeerRate,
 		perPeerBurst: perPeerBurst,
+		deniedPeers:  deniedPeers,
 	}
 	WantBlockGatewayPeers.Set(float64(len(gatewayPeers)))
 	WantBlockPeerLimiters.Set(0)
@@ -74,8 +94,15 @@ func NewWantBlockFilter(h host.Host, cfg WantBlockFilterConfig) *WantBlockFilter
 
 // Allow is called by bitswap for each wantlist entry from a peer.
 // It returns true if the request should be fulfilled.
-// Gateway peers always pass. Other peers are subject to global and per-peer rate limits.
+// Gateway peers and the local node always pass. Other peers are subject
+// to global and per-peer rate limits.
 func (f *WantBlockFilter) Allow(p peer.ID, c cid.Cid) bool {
+	// Self peer — always allow without question.
+	if p == f.selfPeer {
+		WantBlockRequestsTotal.WithLabelValues(LabelWantAllowedSelf).Inc()
+		return true
+	}
+
 	f.mu.RLock()
 	_, isGateway := f.gatewayPeers[p]
 	f.mu.RUnlock()
@@ -87,12 +114,22 @@ func (f *WantBlockFilter) Allow(p peer.ID, c cid.Cid) bool {
 
 	if !f.limiter.Allow() {
 		WantBlockRequestsTotal.WithLabelValues(LabelWantDeniedGlobalRate).Inc()
+		f.deniedPeers.increment(p.String())
+		f.log.Debug("want-block denied by global rate limit",
+			zap.Stringer("peer", p),
+			zap.Stringer("cid", c),
+		)
 		return false
 	}
 
 	peerLimiter := f.getPeerLimiter(p)
 	if !peerLimiter.Allow() {
 		WantBlockRequestsTotal.WithLabelValues(LabelWantDeniedPerPeerRate).Inc()
+		f.deniedPeers.increment(p.String())
+		f.log.Debug("want-block denied by per-peer rate limit",
+			zap.Stringer("peer", p),
+			zap.Stringer("cid", c),
+		)
 		return false
 	}
 
@@ -142,6 +179,7 @@ func (f *WantBlockFilter) RemovePeerLimiter(p peer.ID) {
 	defer f.mu.Unlock()
 	delete(f.peerLimiters, p)
 	WantBlockPeerLimiters.Set(float64(len(f.peerLimiters)))
+	f.deniedPeers.RemovePeer(p.String())
 }
 
 // PeerBlockRequestFilter returns a function compatible with

--- a/internal/protocol/ipfs/want_filter_test.go
+++ b/internal/protocol/ipfs/want_filter_test.go
@@ -5,16 +5,23 @@ import (
 
 	"github.com/ipfs/go-cid"
 	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 )
+
+func newTestCollector() *topNDeniedPeersCollector {
+	return newTopNDeniedPeersCollector(10)
+}
 
 func TestWantBlockFilterGatewayPeer(t *testing.T) {
 	gatewayPeer := peer.ID("gateway-peer")
 	filter := NewWantBlockFilter(nil, WantBlockFilterConfig{
-		GatewayPeers: []peer.ID{gatewayPeer},
-		GlobalRate:   10,
-		GlobalBurst:  10,
-		PerPeerRate:  1,
-		PerPeerBurst: 1,
+		GatewayPeers:         []peer.ID{gatewayPeer},
+		GlobalRate:           10,
+		GlobalBurst:          10,
+		PerPeerRate:          1,
+		PerPeerBurst:         1,
+		DeniedPeersCollector: newTestCollector(),
 	})
 
 	// Gateway peer should always be allowed, even after rate limit is exhausted
@@ -25,13 +32,33 @@ func TestWantBlockFilterGatewayPeer(t *testing.T) {
 	}
 }
 
+func TestWantBlockFilterSelfPeer(t *testing.T) {
+	selfPeer := peer.ID("self-peer")
+	filter := NewWantBlockFilter(nil, WantBlockFilterConfig{
+		SelfPeer:             selfPeer,
+		GlobalRate:           1,
+		GlobalBurst:          1,
+		PerPeerRate:          1,
+		PerPeerBurst:         1,
+		DeniedPeersCollector: newTestCollector(),
+	})
+
+	// Self peer should always be allowed, even after rate limits are exhausted
+	for i := 0; i < 100; i++ {
+		if !filter.Allow(selfPeer, cid.Undef) {
+			t.Fatalf("self peer should always be allowed, failed at iteration %d", i)
+		}
+	}
+}
+
 func TestWantBlockFilterRateLimiting(t *testing.T) {
 	filter := NewWantBlockFilter(nil, WantBlockFilterConfig{
-		GatewayPeers: nil,
-		GlobalRate:   100,
-		GlobalBurst:  5,
-		PerPeerRate:  1,
-		PerPeerBurst: 3,
+		GatewayPeers:         nil,
+		GlobalRate:           100,
+		GlobalBurst:          5,
+		PerPeerRate:          1,
+		PerPeerBurst:         3,
+		DeniedPeersCollector: newTestCollector(),
 	})
 
 	normalPeer := peer.ID("normal-peer")
@@ -51,11 +78,12 @@ func TestWantBlockFilterRateLimiting(t *testing.T) {
 
 func TestWantBlockFilterAddRemoveGateway(t *testing.T) {
 	filter := NewWantBlockFilter(nil, WantBlockFilterConfig{
-		GatewayPeers: nil,
-		GlobalRate:   10,
-		GlobalBurst:  10,
-		PerPeerRate:  1,
-		PerPeerBurst: 1,
+		GatewayPeers:         nil,
+		GlobalRate:           10,
+		GlobalBurst:          10,
+		PerPeerRate:          1,
+		PerPeerBurst:         1,
+		DeniedPeersCollector: newTestCollector(),
 	})
 
 	p := peer.ID("new-gateway")
@@ -89,7 +117,9 @@ func TestWantBlockFilterAddRemoveGateway(t *testing.T) {
 }
 
 func TestWantBlockFilterDefaultConfig(t *testing.T) {
-	filter := NewWantBlockFilter(nil, WantBlockFilterConfig{})
+	filter := NewWantBlockFilter(nil, WantBlockFilterConfig{
+		DeniedPeersCollector: newTestCollector(),
+	})
 
 	p := peer.ID("some-peer")
 
@@ -101,10 +131,11 @@ func TestWantBlockFilterDefaultConfig(t *testing.T) {
 
 func TestWantBlockFilterPerPeerIsolation(t *testing.T) {
 	filter := NewWantBlockFilter(nil, WantBlockFilterConfig{
-		GlobalRate:   1000,
-		GlobalBurst:  1000,
-		PerPeerRate:  1,
-		PerPeerBurst: 2,
+		GlobalRate:           1000,
+		GlobalBurst:          1000,
+		PerPeerRate:          1,
+		PerPeerBurst:         2,
+		DeniedPeersCollector: newTestCollector(),
 	})
 
 	peer1 := peer.ID("peer-1")
@@ -123,11 +154,12 @@ func TestWantBlockFilterPerPeerIsolation(t *testing.T) {
 func TestWantBlockFilterPeerBlockRequestFilterFunc(t *testing.T) {
 	gatewayPeer := peer.ID("gateway")
 	filter := NewWantBlockFilter(nil, WantBlockFilterConfig{
-		GatewayPeers: []peer.ID{gatewayPeer},
-		GlobalRate:   10,
-		GlobalBurst:  10,
-		PerPeerRate:  1,
-		PerPeerBurst: 1,
+		GatewayPeers:         []peer.ID{gatewayPeer},
+		GlobalRate:           10,
+		GlobalBurst:          10,
+		PerPeerRate:          1,
+		PerPeerBurst:         1,
+		DeniedPeersCollector: newTestCollector(),
 	})
 
 	fn := filter.PeerBlockRequestFilter()
@@ -135,5 +167,77 @@ func TestWantBlockFilterPeerBlockRequestFilterFunc(t *testing.T) {
 	// Gateway peer should always pass
 	if !fn(gatewayPeer, cid.Undef) {
 		t.Error("gateway peer should pass via PeerBlockRequestFilter func")
+	}
+}
+
+func TestWantBlockFilterNilLogger(t *testing.T) {
+	// Should not panic when no logger is provided
+	filter := NewWantBlockFilter(nil, WantBlockFilterConfig{
+		GlobalRate:           10,
+		GlobalBurst:          1,
+		PerPeerRate:          1,
+		PerPeerBurst:         1,
+		DeniedPeersCollector: newTestCollector(),
+	})
+
+	p := peer.ID("test-peer")
+
+	// Exhaust rate limit to trigger denied log path
+	filter.Allow(p, cid.Undef)
+	// This should not panic even with nil logger
+	filter.Allow(p, cid.Undef)
+}
+
+func TestWantBlockFilterTopDeniedPeers(t *testing.T) {
+	collector := newTopNDeniedPeersCollector(3)
+	filter := NewWantBlockFilter(nil, WantBlockFilterConfig{
+		GlobalRate:           100,
+		GlobalBurst:          100,
+		PerPeerRate:          1,
+		PerPeerBurst:         1,
+		DeniedPeersCollector: collector,
+	})
+
+	// Peer A — denied 10 times
+	peerA := peer.ID("peer-A")
+	for i := 0; i < 11; i++ {
+		filter.Allow(peerA, cid.Undef) // 1 allowed, 10 denied
+	}
+
+	// Peer B — denied 5 times
+	peerB := peer.ID("peer-B")
+	for i := 0; i < 6; i++ {
+		filter.Allow(peerB, cid.Undef) // 1 allowed, 5 denied
+	}
+
+	// Peer C — denied 3 times
+	peerC := peer.ID("peer-C")
+	for i := 0; i < 4; i++ {
+		filter.Allow(peerC, cid.Undef) // 1 allowed, 3 denied
+	}
+
+	// Peer D — denied 1 time (should NOT appear in top 3)
+	peerD := peer.ID("peer-D")
+	for i := 0; i < 2; i++ {
+		filter.Allow(peerD, cid.Undef) // 1 allowed, 1 denied
+	}
+
+	// Collect metrics
+	ch := make(chan prometheus.Metric, 10)
+	collector.Collect(ch)
+	close(ch)
+
+	count := 0
+	for m := range ch {
+		dto := &dto.Metric{}
+		if err := m.Write(dto); err != nil {
+			t.Fatal(err)
+		}
+		count++
+	}
+
+	// Verify we have at most 3 metrics (top N)
+	if count > 3 {
+		t.Errorf("expected at most 3 top denied peers, got %d", count)
 	}
 }


### PR DESCRIPTION
## Summary

Adds observability to the bitswap want-block filter so denied requests are
visible in metrics and logs.

- **Self-peer whitelist**: the node's own peer ID is exempt from rate
  limiting, so self-initiated fetches are never denied
- **Debug logging**: denied want-block requests log the peer ID and CID at
  debug level under the `wantblock_filter` logger
- **Top-N denied peers gauge**: a custom Prometheus collector
  (`want_block_denied_peers_top`) exposes the top 10 most-denied peers with
  a `peer` label. Cardinality is bounded at 10 series regardless of peer
  count
- New label `allowed_self` on `want_block_requests_total` to track
  self-peer exemptions

## Test Plan

- [x] `go build ./...` passes
- [x] `go vet ./internal/protocol/ipfs/` passes
- [x] 9 unit tests pass covering gateway peer, self-peer whitelist, rate
  limiting, nil-logger safety, and top-N collector cardinality bound

* `develop` <!-- branch-stack -->
  - **feat(ipfs): add want-block filter observability** :point\_left:

***

<!-- kody-pr-summary:start -->

## Pull Request Description

This PR enhances the want-block filter with improved observability capabilities, allowing better visibility into which peers are being rate-limited and how often.

### Key Changes

1. **Self-peer bypass**: The local node's own peer ID now always bypasses rate limiting on want-block requests, preventing the node from throttling itself. A new `allowed_self` outcome label tracks these requests in the `want_block_requests_total` metric.

2. **Top-N denied peers tracking**: A new Prometheus collector (`want_block_top_denied_peers`) exposes the top N most-denied peers by want-block request count. This provides dashboard visibility into which peers are being throttled the most, while avoiding unbounded label cardinality by limiting results to a configurable top N (default: 10). The gauge is reset on each scrape to clear stale entries.

3. **Debug logging**: Denied want-block requests now emit debug-level log entries including the peer ID and CID, aiding in diagnosing rate-limiting behavior.

4. **Peer cleanup**: When a peer disconnects and its per-peer limiter is removed, the peer is also removed from the denied-peers tracking map.

5. **Tests**: Added test coverage for self-peer bypass behavior, nil logger handling, and top-N denied peers collection.

<!-- kody-pr-summary:end -->
