### PR TITLE
fix(ipfs): use const metric emission in top denied peers collector

### DIFF
--- a/internal/protocol/ipfs/want_block_collector.go
+++ b/internal/protocol/ipfs/want_block_collector.go
@@ -24,7 +24,7 @@ func newTopNDeniedPeersCollector(topN int) *topNDeniedPeersCollector {
 		counts: make(map[string]*int64),
 		topN:   topN,
 		desc: prometheus.NewDesc(
-			prometheus.BuildFQName("ipfs", "bitswap", MetricWantBlockTopDeniedPeers),
+			prometheus.BuildFQName("", subSystemBitswap, MetricWantBlockTopDeniedPeers),
 			"Top N most-denied peers by want-block request count, refreshed on each scrape",
 			[]string{"peer"},
 			nil,

--- a/internal/protocol/ipfs/want_block_collector.go
+++ b/internal/protocol/ipfs/want_block_collector.go
@@ -16,23 +16,19 @@ type topNDeniedPeersCollector struct {
 	mu     sync.RWMutex
 	counts map[string]*int64 // peer ID -> denial count (atomic)
 	topN   int
-	metric *prometheus.GaugeVec
-	label  string
+	desc   *prometheus.Desc
 }
 
 func newTopNDeniedPeersCollector(topN int) *topNDeniedPeersCollector {
 	c := &topNDeniedPeersCollector{
 		counts: make(map[string]*int64),
 		topN:   topN,
-		metric: prometheus.NewGaugeVec(
-			prometheus.GaugeOpts{
-				Subsystem: subSystemBitswap,
-				Name:      MetricWantBlockTopDeniedPeers,
-				Help:      "Top N most-denied peers by want-block request count, refreshed on each scrape",
-			},
+		desc: prometheus.NewDesc(
+			prometheus.BuildFQName("ipfs", "bitswap", MetricWantBlockTopDeniedPeers),
+			"Top N most-denied peers by want-block request count, refreshed on each scrape",
 			[]string{"peer"},
+			nil,
 		),
-		label: "peer",
 	}
 	return c
 }
@@ -65,7 +61,8 @@ func (c *topNDeniedPeersCollector) RemovePeer(peerID string) {
 }
 
 // Collect implements prometheus.Collector. It computes the top N most-denied
-// peers and emits them as gauge values. The gauge is reset each scrape.
+// peers and emits them as const gauge metrics. Each scrape emits fresh
+// metrics with no shared mutable state between scrapes.
 func (c *topNDeniedPeersCollector) Collect(ch chan<- prometheus.Metric) {
 	c.mu.RLock()
 	type entry struct {
@@ -86,17 +83,12 @@ func (c *topNDeniedPeersCollector) Collect(ch chan<- prometheus.Metric) {
 		entries = entries[:c.topN]
 	}
 
-	// Reset the gauge vec so stale peers from last scrape are cleared.
-	c.metric.Reset()
-
 	for _, e := range entries {
-		c.metric.WithLabelValues(e.peer).Set(float64(e.count))
+		ch <- prometheus.MustNewConstMetric(c.desc, prometheus.GaugeValue, float64(e.count), e.peer)
 	}
-
-	c.metric.Collect(ch)
 }
 
 // Describe implements prometheus.Collector.
 func (c *topNDeniedPeersCollector) Describe(ch chan<- *prometheus.Desc) {
-	c.metric.Describe(ch)
+	ch <- c.desc
 }

--- a/internal/service/website/website_test.go
+++ b/internal/service/website/website_test.go
@@ -2430,6 +2430,7 @@ func TestWebsiteService_UpdateWebsite_IPNSToIPNS_NoDNSUpdate(t *testing.T) {
 		mockIPNSKey.EXPECT().PublishCID(mock.Anything, mock.Anything, mock.Anything, mock.AnythingOfType("time.Duration")).Return(nil).Once()
 
 		updatedWebsite, err := websiteService.UpdateWebsite(context.Background(), testUserID1, createdWebsite.ID, updates)
+		websiteService.WaitForPublishes()
 
 		// Assert
 		require.NoError(tb, err)


### PR DESCRIPTION
The `topNDeniedPeersCollector` used a `GaugeVec` with `Reset()` inside `Collect()`. This is a documented anti-pattern that causes race conditions on concurrent scrapes and silently drops metrics when the denied peers map is momentarily empty.

Replace with `prometheus.NewDesc` + `MustNewConstMetric` — the standard pattern for custom collectors. Metrics are emitted directly to the channel per scrape with no shared mutable state.

- `develop` <!-- branch-stack -->
  - **fix(ipfs): use const metric emission in top denied peers collector** :point\_left:

***

<!-- kody-pr-summary:start -->

## Pull Request Description

This PR fixes the `topNDeniedPeersCollector` in the IPFS bitswap protocol by replacing the stateful `prometheus.GaugeVec` with stateless const metric emission.

### Changes

The collector previously used a `GaugeVec` that maintained internal mutable state between scrapes. On each scrape, it had to explicitly `Reset()` the gauge to clear stale peer entries, then set new values via `WithLabelValues()`, and finally delegate to `c.metric.Collect(ch)`. This pattern introduced shared mutable state across scrapes, which could lead to stale or inconsistent metrics.

The fix replaces the `GaugeVec` with a `prometheus.Desc` and emits fresh const gauge metrics directly on each scrape using `prometheus.MustNewConstMetric()`. This eliminates the need for resetting state between scrapes and removes any shared mutable state, following the recommended Prometheus pattern for custom collectors.

### Functional Impact

- Ensures each scrape produces accurate, self-contained metrics with no risk of stale peer data leaking between scrapes
- Improves metric reliability for the "top N most-denied peers by want-block request count" metric

<!-- kody-pr-summary:end -->
