### PR TITLE
feat: add CID span attributes and fix trace context propagation

### DIFF
--- a/internal/protocol/store/blockstore.go
+++ b/internal/protocol/store/blockstore.go
@@ -11,16 +11,17 @@ import (
 	format "github.com/ipfs/go-ipld-format"
 	"github.com/multiformats/go-multicodec"
 	"github.com/multiformats/go-multihash"
+	"go.opentelemetry.io/otel/attribute"
 
-	"go.lumeweb.com/portal-plugin-ipfs/internal/protocol/ipfs"
 	pluginCore "go.lumeweb.com/portal-plugin-ipfs/core"
 	"go.lumeweb.com/portal-plugin-ipfs/internal"
+	pc "go.lumeweb.com/portal-plugin-ipfs/internal/protocol/context"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/protocol/encoding"
+	"go.lumeweb.com/portal-plugin-ipfs/internal/protocol/ipfs"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/quota"
 	"go.lumeweb.com/portal/core"
 	"go.lumeweb.com/portal/service"
 	"go.uber.org/zap"
-	pc "go.lumeweb.com/portal-plugin-ipfs/internal/protocol/context"
 )
 
 type (
@@ -31,11 +32,11 @@ type (
 
 		bucket string
 
-		metadata    pluginCore.MetadataStore
-		downloader  pluginCore.BlockDownloader
-		storage     core.StorageService
-		upload      core.UploadService
-		tracker     *ipfs.BlockRequestTracker
+		metadata   pluginCore.MetadataStore
+		downloader pluginCore.BlockDownloader
+		storage    core.StorageService
+		upload     core.UploadService
+		tracker    *ipfs.BlockRequestTracker
 
 		proto   core.StorageProtocol
 		batcher *metadataBatcher
@@ -44,7 +45,8 @@ type (
 
 // DeleteBlock removes a given block from the blockstore.
 func (bs *BlockStore) DeleteBlock(ctx context.Context, c cid.Cid) error {
-	ctx, span := core.TraceMethod(ctx, "BlockStore.DeleteBlock")
+	ctx, span := core.TraceMethod(ctx, "BlockStore.DeleteBlock",
+		core.WithAttributes(attribute.String("cid", c.String())))
 	defer span.End()
 
 	key := cidKey(c)
@@ -70,7 +72,8 @@ func (bs *BlockStore) DeleteBlock(ctx context.Context, c cid.Cid) error {
 
 // Has returns whether or not a given block is in the blockstore.
 func (bs *BlockStore) Has(ctx context.Context, c cid.Cid) (bool, error) {
-	ctx, span := core.TraceMethod(ctx, "BlockStore.Has")
+	ctx, span := core.TraceMethod(ctx, "BlockStore.Has",
+		core.WithAttributes(attribute.String("cid", c.String())))
 	defer span.End()
 
 	log := bs.log.Named("Has").With(zap.Stringer("cid", c))
@@ -95,7 +98,8 @@ func (bs *BlockStore) Has(ctx context.Context, c cid.Cid) (bool, error) {
 
 // Get returns a block by CID
 func (bs *BlockStore) Get(ctx context.Context, c cid.Cid) (blocks.Block, error) {
-	ctx, span := core.TraceMethod(ctx, "BlockStore.Get")
+	ctx, span := core.TraceMethod(ctx, "BlockStore.Get",
+		core.WithAttributes(attribute.String("cid", c.String())))
 	defer span.End()
 
 	if pc.IsVirtualReadEnabled(ctx) {
@@ -170,8 +174,8 @@ func (bs *BlockStore) Get(ctx context.Context, c cid.Cid) (blocks.Block, error) 
 						zap.Stringer("cid", c))
 				}
 			}
-			
-				// Emit download event regardless of attribution IP availability
+
+			// Emit download event regardless of attribution IP availability
 			// as long as quotas are not disabled
 			if attributionIP == "" {
 				bs.log.Debug("No attribution IP available, emitting download event without IP",
@@ -189,7 +193,8 @@ func (bs *BlockStore) Get(ctx context.Context, c cid.Cid) (blocks.Block, error) 
 
 // GetSize returns the CIDs mapped BlockSize
 func (bs *BlockStore) GetSize(ctx context.Context, c cid.Cid) (int, error) {
-	ctx, span := core.TraceMethod(ctx, "BlockStore.GetSize")
+	ctx, span := core.TraceMethod(ctx, "BlockStore.GetSize",
+		core.WithAttributes(attribute.String("cid", c.String())))
 	defer span.End()
 
 	key := cidKey(c)
@@ -220,7 +225,8 @@ func (bs *BlockStore) GetSize(ctx context.Context, c cid.Cid) (int, error) {
 
 // Put puts a given block to the underlying datastore
 func (bs *BlockStore) Put(ctx context.Context, b blocks.Block) error {
-	ctx, span := core.TraceMethod(ctx, "BlockStore.Put")
+	ctx, span := core.TraceMethod(ctx, "BlockStore.Put",
+		core.WithAttributes(attribute.String("cid", b.Cid().String())))
 	defer span.End()
 
 	key := cidKey(b.Cid())
@@ -276,7 +282,8 @@ func (bs *BlockStore) Put(ctx context.Context, b blocks.Block) error {
 // PutMany puts a slice of blocks at the same time using batching
 // capabilities of the underlying datastore whenever possible.
 func (bs *BlockStore) PutMany(ctx context.Context, blocks []blocks.Block) error {
-	ctx, span := core.TraceMethod(ctx, "BlockStore.PutMany")
+	ctx, span := core.TraceMethod(ctx, "BlockStore.PutMany",
+		core.WithAttributes(attribute.Int("block_count", len(blocks))))
 	defer span.End()
 
 	log := bs.log.Named("PutMany").With(zap.Int("blocks", len(blocks)))
@@ -383,7 +390,8 @@ func NewBlockStore(ctx core.Context, downloader pluginCore.BlockDownloader, meta
 }
 
 func blockLinks(ctx context.Context, b blocks.Block) []*format.Link {
-	ctx, span := core.TraceMethod(ctx, "blockLinks")
+	ctx, span := core.TraceMethod(ctx, "blockLinks",
+		core.WithAttributes(attribute.String("cid", b.Cid().String())))
 	defer span.End()
 
 	pn, err := encoding.DecodeBlock(ctx, b)

--- a/internal/protocol/store/downloader/downloader.go
+++ b/internal/protocol/store/downloader/downloader.go
@@ -17,6 +17,7 @@ import (
 	"go.lumeweb.com/portal-plugin-ipfs/internal"
 	pc "go.lumeweb.com/portal-plugin-ipfs/internal/protocol/context"
 	"go.lumeweb.com/portal/core"
+	"go.opentelemetry.io/otel/attribute"
 
 	blocks "github.com/ipfs/go-block-format"
 	"github.com/ipfs/go-cid"
@@ -120,7 +121,8 @@ func (h *priorityQueue) Pop() any {
 var _ heap.Interface = &priorityQueue{}
 
 func (br *blockResponse) block(ctx context.Context, c cid.Cid) (blocks.Block, error) {
-	ctx, span := core.TraceMethod(ctx, "blockResponse.block")
+	ctx, span := core.TraceMethod(ctx, "blockResponse.block",
+		core.WithAttributes(attribute.String("cid", c.String())))
 	defer span.End()
 
 	select {
@@ -142,7 +144,8 @@ func (br *blockResponse) block(ctx context.Context, c cid.Cid) (blocks.Block, er
 }
 
 func (bd *BlockDownloaderDefault) downloadBlockData(ctx context.Context, c cid.Cid, clientIP string) ([]byte, error) {
-	ctx, span := core.TraceMethod(ctx, "BlockDownloaderDefault.downloadBlockData")
+	ctx, span := core.TraceMethod(ctx, "BlockDownloaderDefault.downloadBlockData",
+		core.WithAttributes(attribute.String("cid", c.String())))
 	defer span.End()
 
 	blockBuf := bytes.NewBuffer(make([]byte, 0, 2<<20))
@@ -186,7 +189,8 @@ func (bd *BlockDownloaderDefault) downloadBlockData(ctx context.Context, c cid.C
 }
 
 func (bd *BlockDownloaderDefault) queueRelated(ctx context.Context, c cid.Cid) {
-	ctx, span := core.TraceMethod(ctx, "BlockDownloaderDefault.queueRelated")
+	ctx, span := core.TraceMethod(ctx, "BlockDownloaderDefault.queueRelated",
+		core.WithAttributes(attribute.String("cid", c.String())))
 	defer span.End()
 
 	log := bd.log.Named("queueRelated").With(zap.Stringer("cid", c))
@@ -238,14 +242,18 @@ func (bd *BlockDownloaderDefault) doDownloadTask(task *blockResponse, log *zap.L
 	start := time.Now()
 	log = log.Named("doDownloadTask").With(zap.Stringer("cid", task.cid), zap.Stringer("priority", task.priority))
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	// Use DetachContext to preserve trace context while preventing cancellation
+	// from the original request. This connects the download spans (including
+	// the renterd HTTP call) to the parent trace, making the full download
+	// chain visible in Tempo.
+	ctx, cancel := context.WithTimeout(core.DetachContext(task.ctx), time.Minute)
 	defer cancel()
 
 	buf, err := bd.downloadBlockData(ctx, task.cid, task.clientIP)
-	
+
 	task.mu.Lock()
 	defer task.mu.Unlock()
-	
+
 	if err != nil {
 		log.Error("failed to download block", zap.Error(err))
 		task.err = err
@@ -285,7 +293,8 @@ func (bd *BlockDownloaderDefault) downloadWorker(n int) {
 }
 
 func (bd *BlockDownloaderDefault) queueBlock(ctx context.Context, c cid.Cid, priority downloadPriority, clientIP string) (*blockResponse, bool) {
-	ctx, span := core.TraceMethod(ctx, "BlockDownloaderDefault.queueBlock")
+	ctx, span := core.TraceMethod(ctx, "BlockDownloaderDefault.queueBlock",
+		core.WithAttributes(attribute.String("cid", c.String())))
 	defer span.End()
 
 	resp, ok := bd.inflight[cidKey(c)]
@@ -323,7 +332,8 @@ func (bd *BlockDownloaderDefault) queueBlock(ctx context.Context, c cid.Cid, pri
 
 // Get returns a block by CID.
 func (bd *BlockDownloaderDefault) Get(ctx context.Context, c cid.Cid) (blocks.Block, error) {
-	ctx, span := core.TraceMethod(ctx, "BlockDownloaderDefault.Get")
+	ctx, span := core.TraceMethod(ctx, "BlockDownloaderDefault.Get",
+		core.WithAttributes(attribute.String("cid", c.String())))
 	defer span.End()
 
 	// Check context before doing any work

--- a/internal/protocol/store/virtual.go
+++ b/internal/protocol/store/virtual.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ipfs/go-datastore"
 	pc "go.lumeweb.com/portal-plugin-ipfs/internal/protocol/context"
 	"go.lumeweb.com/portal/core"
+	"go.opentelemetry.io/otel/attribute"
 )
 
 type MockBlockstore interface {
@@ -26,7 +27,7 @@ type Flusher interface {
 
 // VirtualBlockStore is a wrapper around a CachedBlockstore that can bypass the cache
 type VirtualBlockStore struct {
-	cachedBS  blockstore.Blockstore
+	cachedBS blockstore.Blockstore
 	directBS blockstore.Blockstore
 	flusher  Flusher
 }
@@ -55,7 +56,8 @@ func (v *VirtualBlockStore) Flush(ctx context.Context) error {
 
 // DeleteBlock removes a given block from the blockstore
 func (v *VirtualBlockStore) DeleteBlock(ctx context.Context, c cid.Cid) error {
-	ctx, span := core.TraceMethod(ctx, "VirtualBlockStore.DeleteBlock")
+	ctx, span := core.TraceMethod(ctx, "VirtualBlockStore.DeleteBlock",
+		core.WithAttributes(attribute.String("cid", c.String())))
 	defer span.End()
 
 	if pc.IsVirtualReadEnabled(ctx) {
@@ -66,7 +68,8 @@ func (v *VirtualBlockStore) DeleteBlock(ctx context.Context, c cid.Cid) error {
 
 // Has returns whether or not a given block is in the blockstore
 func (v *VirtualBlockStore) Has(ctx context.Context, c cid.Cid) (bool, error) {
-	ctx, span := core.TraceMethod(ctx, "VirtualBlockStore.Has")
+	ctx, span := core.TraceMethod(ctx, "VirtualBlockStore.Has",
+		core.WithAttributes(attribute.String("cid", c.String())))
 	defer span.End()
 
 	if pc.IsVirtualReadEnabled(ctx) {
@@ -77,7 +80,8 @@ func (v *VirtualBlockStore) Has(ctx context.Context, c cid.Cid) (bool, error) {
 
 // Get returns a block by CID
 func (v *VirtualBlockStore) Get(ctx context.Context, c cid.Cid) (blocks.Block, error) {
-	ctx, span := core.TraceMethod(ctx, "VirtualBlockStore.Get")
+	ctx, span := core.TraceMethod(ctx, "VirtualBlockStore.Get",
+		core.WithAttributes(attribute.String("cid", c.String())))
 	defer span.End()
 
 	if pc.IsVirtualReadEnabled(ctx) {
@@ -88,7 +92,8 @@ func (v *VirtualBlockStore) Get(ctx context.Context, c cid.Cid) (blocks.Block, e
 
 // GetSize returns the CIDs mapped BlockSize
 func (v *VirtualBlockStore) GetSize(ctx context.Context, c cid.Cid) (int, error) {
-	ctx, span := core.TraceMethod(ctx, "VirtualBlockStore.GetSize")
+	ctx, span := core.TraceMethod(ctx, "VirtualBlockStore.GetSize",
+		core.WithAttributes(attribute.String("cid", c.String())))
 	defer span.End()
 
 	if pc.IsVirtualReadEnabled(ctx) {
@@ -99,7 +104,8 @@ func (v *VirtualBlockStore) GetSize(ctx context.Context, c cid.Cid) (int, error)
 
 // Put puts a given block to the underlying datastore
 func (v *VirtualBlockStore) Put(ctx context.Context, b blocks.Block) error {
-	ctx, span := core.TraceMethod(ctx, "VirtualBlockStore.Put")
+	ctx, span := core.TraceMethod(ctx, "VirtualBlockStore.Put",
+		core.WithAttributes(attribute.String("cid", b.Cid().String())))
 	defer span.End()
 
 	if pc.IsVirtualReadEnabled(ctx) {
@@ -110,7 +116,8 @@ func (v *VirtualBlockStore) Put(ctx context.Context, b blocks.Block) error {
 
 // PutMany puts a slice of blocks at the same time using batching
 func (v *VirtualBlockStore) PutMany(ctx context.Context, bs []blocks.Block) error {
-	ctx, span := core.TraceMethod(ctx, "VirtualBlockStore.PutMany")
+	ctx, span := core.TraceMethod(ctx, "VirtualBlockStore.PutMany",
+		core.WithAttributes(attribute.Int("block_count", len(bs))))
 	defer span.End()
 
 	if pc.IsVirtualReadEnabled(ctx) {


### PR DESCRIPTION
- Add `cid` attribute to all VirtualBlockStore span call sites (virtual.go)
- Add `cid` attribute to all BlockStore span call sites (blockstore.go)
- Add `cid` attribute to all BlockDownloader span call sites (downloader.go)
- Add `block_count` attribute to PutMany spans
- Fix `doDownloadTask` to use `DetachContext(task.ctx)` instead of `context.Background()`

The context fix is the key change: `doDownloadTask` was creating a new `context.Background()` which disconnected the renterd HTTP calls (`RenterDefault.GetObject`) from the parent download trace. By using `DetachContext(task.ctx)`, the trace context is preserved while still preventing cancellation from the original request. This makes the full download chain visible in Tempo — from `VirtualBlockStore.Get` through `BlockDownloaderDefault.downloadBlockData` to `RenterDefault.GetObject`.

- `develop` <!-- branch-stack -->
  - **feat: add CID span attributes and fix trace context propagation** :point\_left:

---

<!-- kody-pr-summary:start -->
This PR enhances OpenTelemetry tracing across the IPFS blockstore and downloader components by adding CID (Content Identifier) span attributes to trace spans, making it easier to correlate traces with specific blocks being processed. CID attributes are now attached to spans in methods such as `Get`, `Put`, `Has`, `DeleteBlock`, `GetSize`, `PutMany`, `queueBlock`, `downloadBlockData`, and `queueRelated` across both `BlockStore`, `VirtualBlockStore`, and `BlockDownloaderDefault`.

Additionally, it fixes trace context propagation in the `doDownloadTask` method. Previously, the download task created a new context from `context.Background()`, which disconnected the download spans (including the renterd HTTP call) from the parent trace. By using `core.DetachContext`, the trace context is now preserved while still preventing cancellation from the original request, making the full download chain visible in tracing tools like Tempo.
<!-- kody-pr-summary:end -->