### PR TITLE
fix(ipfs): remove verbose AddrsFactory debug logging

### DIFF
--- a/internal/protocol/ipfs/node.go
+++ b/internal/protocol/ipfs/node.go
@@ -494,13 +494,6 @@ func NewNode(ctx core.Context, cfg *config.ProtocolConfig, rs pluginCore.Reprovi
 	}
 
 	opts = append(opts, libp2p.AddrsFactory(func(addrs []multiaddr.Multiaddr) []multiaddr.Multiaddr {
-		ctx.Logger().Debug("ipfs AddrsFactory invoked",
-			zap.Int("host_addr_count", len(addrs)),
-			zap.Int("config_port", cfg.Port),
-			zap.Strings("host_addrs", lo.Map(lo.Filter(addrs, func(a multiaddr.Multiaddr, _ int) bool { return a != nil }), func(a multiaddr.Multiaddr, _ int) string {
-				return a.String()
-			})),
-		)
 		var domain string
 		if cfg.AnnounceWeb {
 			httpSvc := core.GetService[core.HTTPService](ctx, core.HTTP_SERVICE)
@@ -509,16 +502,6 @@ func NewNode(ctx core.Context, cfg *config.ProtocolConfig, rs pluginCore.Reprovi
 			}
 		}
 		announceAddresses, err := AnnouncementAddresses(cfg.AnnounceWeb, domain, addrs, cfg.Port)
-		ctx.Logger().Debug("ipfs announcement addresses resolved",
-			zap.Bool("announce_web", cfg.AnnounceWeb),
-			zap.String("domain", domain),
-			zap.Int("config_port", cfg.Port),
-			zap.Int("announce_addr_count", len(announceAddresses)),
-			zap.Strings("announce_addrs", lo.Map(announceAddresses, func(a multiaddr.Multiaddr, _ int) string {
-				return a.String()
-			})),
-			zap.Error(err),
-		)
 		if err != nil {
 			ctx.Logger().Error("failed to get announcement addresses", zap.Error(err))
 			return lo.Filter(addrs, func(addr multiaddr.Multiaddr, _ int) bool {


### PR DESCRIPTION
## Summary

- Remove the `AddrsFactory invoked` debug log that dumps all 24+ host addresses every 5 seconds
- Remove the `announcement addresses resolved` debug log that dumps announce addresses on the same cadence
- Error path logging is preserved

* `develop` <!-- branch-stack -->
  - **fix(ipfs): remove verbose AddrsFactory debug logging** :point\_left:

---

<!-- kody-pr-summary:start -->
This PR removes verbose debug logging from the `AddrsFactory` function in the IPFS node initialization. The removed debug statements logged details about host addresses, configuration ports, announcement addresses, and related metadata each time the factory was invoked. The underlying address resolution and announcement logic remains unchanged; only the debug log output has been stripped out to reduce log noise.
<!-- kody-pr-summary:end -->