### PR TITLE
fix: propagate request context through BlockQueue for trace linking

### DIFF
--- a/internal/protocol/block_queue.go
+++ b/internal/protocol/block_queue.go
@@ -73,8 +73,10 @@ type BlockQueue struct {
 }
 
 // NewBlockQueue creates a new BlockQueue instance.
-func NewBlockQueue(coreCtx core.Context, proto ProtoNode, logger *core.Logger) *BlockQueue {
-	ctx, cancel := context.WithTimeout(coreCtx.GetContext(), 30*time.Minute)
+// requestCtx carries the trace context from the upload request so that
+// processBlock spans are children of the upload trace, not root spans.
+func NewBlockQueue(coreCtx core.Context, requestCtx context.Context, proto ProtoNode, logger *core.Logger) *BlockQueue {
+	ctx, cancel := context.WithTimeout(requestCtx, 30*time.Minute)
 
 	workers := resolveWorkerCount(coreCtx)
 
@@ -181,7 +183,9 @@ func (bp *BlockQueue) recordError(err error) {
 // ProcessBlocks processes blocks using a BlockProcessor to provide blocks
 // and BlockQueue to process them. After all blocks are processed, it flushes
 // any buffered metadata through the provided Flusher.
-func ProcessBlocks(ctx core.Context, processor BlockProcessor, flusher store.Flusher) ([]cid.Cid, []cid.Cid, error) {
+// requestCtx carries the trace context from the upload request so that
+// block processing spans chain to the upload trace.
+func ProcessBlocks(ctx core.Context, requestCtx context.Context, processor BlockProcessor, flusher store.Flusher) ([]cid.Cid, []cid.Cid, error) {
 	protoInterface := core.GetProtocol(internal.ProtocolName)
 	if protoInterface == nil {
 		return nil, nil, fmt.Errorf("protocol %s not found", internal.ProtocolName)
@@ -192,7 +196,7 @@ func ProcessBlocks(ctx core.Context, processor BlockProcessor, flusher store.Flu
 	}
 	logger := ctx.Logger()
 
-	bp := NewBlockQueue(ctx, proto, logger)
+	bp := NewBlockQueue(ctx, requestCtx, proto, logger)
 	if bp == nil {
 		return nil, nil, fmt.Errorf("failed to create block queue")
 	}

--- a/internal/protocol/op_post_upload.go
+++ b/internal/protocol/op_post_upload.go
@@ -12,18 +12,18 @@ import (
 	format "github.com/ipfs/go-ipld-format"
 	"github.com/mholt/archives"
 	"github.com/samber/lo"
+	contentArchive "go.lumeweb.com/ipfs-content/archive"
+	contentUnixFS "go.lumeweb.com/ipfs-content/unixfs"
 	pluginCore "go.lumeweb.com/portal-plugin-ipfs/core"
 	"go.lumeweb.com/portal-plugin-ipfs/internal"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/db"
-	"go.lumeweb.com/portal-plugin-ipfs/internal/upload/common"
-	pc "go.lumeweb.com/portal-plugin-ipfs/internal/protocol/context"
 	pluginErrors "go.lumeweb.com/portal-plugin-ipfs/internal/errors"
+	pc "go.lumeweb.com/portal-plugin-ipfs/internal/protocol/context"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/quota"
 	pluginUpload "go.lumeweb.com/portal-plugin-ipfs/internal/upload"
+	"go.lumeweb.com/portal-plugin-ipfs/internal/upload/common"
 	"go.lumeweb.com/portal/core"
 	"go.lumeweb.com/portal/db/models"
-	contentArchive "go.lumeweb.com/ipfs-content/archive"
-	contentUnixFS "go.lumeweb.com/ipfs-content/unixfs"
 	"go.uber.org/zap"
 )
 
@@ -138,7 +138,7 @@ func (h *PostUploadOperationHandler) Execute(ctx context.Context, req *models.Re
 		h.Logger().Warn("Failed to update progress", zap.Error(err))
 	}
 
-	allCids, rootCids, err := ProcessBlocks(h.Context(), processor, h.Protocol().(ProtoNode).GetBlockstoreFlusher())
+	allCids, rootCids, err := ProcessBlocks(h.Context(), ctx, processor, h.Protocol().(ProtoNode).GetBlockstoreFlusher())
 	if err != nil {
 		return fmt.Errorf("failed to process CIDs from upload: %w", err)
 	}

--- a/internal/protocol/op_tus_upload.go
+++ b/internal/protocol/op_tus_upload.go
@@ -7,18 +7,18 @@ import (
 
 	"github.com/ipfs/go-cid"
 	"github.com/samber/lo"
-	"go.lumeweb.com/portal/db/models"
-	"go.lumeweb.com/portal/core"
 	contentArchive "go.lumeweb.com/ipfs-content/archive"
+	"go.lumeweb.com/portal/core"
+	"go.lumeweb.com/portal/db/models"
 	"go.uber.org/zap"
 
-	"go.lumeweb.com/portal-plugin-ipfs/internal"
 	pluginCore "go.lumeweb.com/portal-plugin-ipfs/core"
+	"go.lumeweb.com/portal-plugin-ipfs/internal"
 	pluginDb "go.lumeweb.com/portal-plugin-ipfs/internal/db"
+	pc "go.lumeweb.com/portal-plugin-ipfs/internal/protocol/context"
+	"go.lumeweb.com/portal-plugin-ipfs/internal/quota"
 	pluginUpload "go.lumeweb.com/portal-plugin-ipfs/internal/upload"
 	uploadCommon "go.lumeweb.com/portal-plugin-ipfs/internal/upload/common"
-	"go.lumeweb.com/portal-plugin-ipfs/internal/quota"
-	pc "go.lumeweb.com/portal-plugin-ipfs/internal/protocol/context"
 )
 
 // handleTUSUpload is the main handler for TUS upload operations
@@ -167,7 +167,6 @@ func calculateDAGSize(ctx context.Context, format contentArchive.Format, reader 
 	return uploadCommon.GetUploadDataSize(ctx, reader, format, logger)
 }
 
-
 // validateUploadQuotas validates upload and storage quotas for the given size
 func validateUploadQuotas(coreCtx core.Context, userID uint, dagSize uint64) error {
 	if dagSize == 0 {
@@ -205,7 +204,7 @@ func createUploadProcessor(format contentArchive.Format, reader io.ReadCloser, p
 
 // processUploadAndCreateReservations processes the upload and creates block reservations
 func processUploadAndCreateReservations(ctx context.Context, helper core.OperationHelper, processor BlockProcessor, proto ProtoNode, userID uint) ([]cid.Cid, []cid.Cid, map[cid.Cid]*quota.BlockReservations, error) {
-	allCids, rootCids, err := ProcessBlocks(helper.Context(), processor, proto.GetBlockstoreFlusher())
+	allCids, rootCids, err := ProcessBlocks(helper.Context(), ctx, processor, proto.GetBlockstoreFlusher())
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to process upload: %w", err)
 	}

--- a/internal/protocol/tests/block_queue_test.go
+++ b/internal/protocol/tests/block_queue_test.go
@@ -105,7 +105,7 @@ func TestProcessCarIntegration(t *testing.T) {
 				require.NoError(t, err)
 
 				// Call the ProcessBlocks function
-				processedCIDs, _, err := protocol.ProcessBlocks(ctx, processor, proto.GetBlockstoreFlusher())
+				processedCIDs, _, err := protocol.ProcessBlocks(ctx, ctx.GetContext(), processor, proto.GetBlockstoreFlusher())
 
 				// Assert the error
 				if tc.expectError {


### PR DESCRIPTION
## Problem

`BlockQueue.processBlock` spans appeared as root traces in Tempo — disconnected from the upload request that triggered them. This made it impossible to trace the upload `\u2192` block processing pipeline end-to-end.

## Root Cause

`NewBlockQueue` derived its context from `coreCtx.GetContext()` — the portal startup context, not the request context. So when `processBlock` called `core.TraceMethod(ctx, ...)`, there was no parent trace to chain to.

## Fix

- Add `requestCtx context.Context` parameter to `NewBlockQueue` and `ProcessBlocks`
- Derive the timeout context from `requestCtx` (carrying the request trace context) instead of `coreCtx.GetContext()`
- Update both callers (`op_post_upload.go`, `op_tus_upload.go`) to pass the request `ctx`
- Update `block_queue_test.go` to pass `ctx.GetContext()`

## Result

`BlockQueue.processBlock` spans now chain to the upload request trace as children, not root spans.

## Testing

- `go build ./...` — clean
- `go vet ./internal/protocol/...` — clean
- `TestTUSUploadOperation_PinStatus` (exercises `ProcessBlocks`) — pass
- `TestProcessCarIntegration` — pre-existing failure (missing fixture files in module cache, not from this change)
- Kodos review — clean

* `develop` <!-- branch-stack -->
  - **fix: propagate request context through BlockQueue for trace linking** :point\_left:
