### PR TITLE
fix(dns): allow optional name for apex records

### DIFF
--- a/internal/api/dto/dns.go
+++ b/internal/api/dto/dns.go
@@ -148,12 +148,12 @@ type RecordRequest struct {
 
 func (r RecordRequest) Schema() *zog.StructSchema {
 	return zog.Struct(zog.Shape{
-		"Name":    zog.String().Required().Min(1).Max(255),
-		"Type":    zog.String().Required().OneOf([]string{
+		"Name":     zog.String().Optional().Max(255),
+		"Type":     zog.String().Required().OneOf([]string{
 			"A", "AAAA", "CNAME", "MX", "TXT", "NS", "SRV", "ALIAS",
 		}),
-		"Content": zog.String().Required().Min(1).Max(1024),
-		"TTL":     zog.UintLike[uint]().Optional(),
+		"Content":  zog.String().Required().Min(1).Max(1024),
+		"TTL":      zog.UintLike[uint]().Optional(),
 		"Disabled": zog.Bool().Optional(),
 	})
 }

--- a/internal/service/dns/dns_helpers.go
+++ b/internal/service/dns/dns_helpers.go
@@ -41,7 +41,12 @@ func buildFullName(name, domain string) string {
 	// Normalize both name and domain (strip trailing dots for comparison)
 	nameNoDot := strings.TrimSuffix(name, ".")
 	domainNoDot := strings.TrimSuffix(domain, ".")
-	
+
+	// If name is the zone apex shorthand (@ or empty string), return canonical domain
+	if nameNoDot == "@" || nameNoDot == "" {
+		return domainNoDot + "."
+	}
+
 	// If name is the zone apex (equals domain), return canonical domain
 	if nameNoDot == domainNoDot {
 		return domainNoDot + "."
@@ -59,7 +64,13 @@ func buildFullName(name, domain string) string {
 }
 
 // stripDomain removes the domain suffix from a full DNS name
+// Returns empty string if the name IS the domain (apex record)
 func stripDomain(name, domain string) string {
+	nameNoDot := strings.TrimSuffix(name, ".")
+	domainNoDot := strings.TrimSuffix(domain, ".")
+	if nameNoDot == domainNoDot {
+		return ""
+	}
 	if strings.HasSuffix(name, "."+domain) {
 		return strings.TrimSuffix(name, "."+domain)
 	}

--- a/internal/service/dns/dns_helpers_test.go
+++ b/internal/service/dns/dns_helpers_test.go
@@ -160,6 +160,16 @@ func TestBuildFullName_EdgeCases(t *testing.T) {
 		expected string
 	}{
 		{
+			name:     "",
+			domain:   "example.com",
+			expected: "example.com.",
+		},
+		{
+			name:     "@",
+			domain:   "example.com",
+			expected: "example.com.",
+		},
+		{
 			name:     "a",
 			domain:   "b.com",
 			expected: "a.b.com.",
@@ -219,7 +229,7 @@ func TestStripDomain(t *testing.T) {
 		{
 			name:     "example.com",
 			domain:   "example.com",
-			expected: "example.com",
+			expected: "",
 		},
 		{
 			name:     "www",

--- a/internal/service/dns/dns_service_test.go
+++ b/internal/service/dns/dns_service_test.go
@@ -807,6 +807,46 @@ func TestDNSServiceCreateRecord(t *testing.T) {
 		}, testOptions)
 	})
 
+	t.Run("success_apex_record_empty_name", func(t *testing.T) {
+		coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+			svc := core.GetService[*DNSServiceDefault](ctx, pluginCore.DNS_SERVICE)
+			require.NotNil(tb, svc)
+
+			zone, err := svc.CreateZone(ctx, "example.com.", 1)
+			require.NoError(tb, err)
+			require.NotNil(tb, zone)
+
+			record, err := svc.CreateRecord(ctx, zone.ID, "", "TXT", "v=spf1 include:_spf.example.com ~all", 3600)
+			require.NoError(tb, err)
+			require.NotNil(tb, record)
+
+			require.Equal(tb, zone.ID, record.ZoneID)
+			require.Equal(tb, "", record.Name)
+			require.Equal(tb, "TXT", record.Type)
+			require.Equal(tb, "v=spf1 include:_spf.example.com ~all", record.Content)
+		}, testOptions)
+	})
+
+	t.Run("success_apex_record_at_symbol", func(t *testing.T) {
+		coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+			svc := core.GetService[*DNSServiceDefault](ctx, pluginCore.DNS_SERVICE)
+			require.NotNil(tb, svc)
+
+			zone, err := svc.CreateZone(ctx, "example.com.", 1)
+			require.NoError(tb, err)
+			require.NotNil(tb, zone)
+
+			record, err := svc.CreateRecord(ctx, zone.ID, "@", "A", "192.0.2.1", 3600)
+			require.NoError(tb, err)
+			require.NotNil(tb, record)
+
+			require.Equal(tb, zone.ID, record.ZoneID)
+			require.Equal(tb, "", record.Name)
+			require.Equal(tb, "A", record.Type)
+			require.Equal(tb, "192.0.2.1", record.Content)
+		}, testOptions)
+	})
+
 	t.Run("zone_not_found", func(t *testing.T) {
 		coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 			svc := core.GetService[*DNSServiceDefault](ctx, pluginCore.DNS_SERVICE)


### PR DESCRIPTION
## Summary

- Make Name optional in RecordRequest DTO (remove Required/Min(1))
- Treat both @ and empty string as zone apex in buildFullName
- Normalise apex names to empty string in stripDomain
- Add tests for empty name and @ symbol apex record creation

* `develop` <!-- branch-stack -->
  - **fix(dns): allow optional name for apex records** :point\_left:

---

<!-- kody-pr-summary:start -->
This PR allows DNS records to be created at the zone apex without requiring an explicit name, supporting both empty string and `@` as apex record shorthands.

Key changes:
- Made the `Name` field optional in the record request schema, removing the previous minimum length requirement
- Updated `buildFullName` to treat `@` or empty string as the zone apex, resolving to the canonical domain name
- Updated `stripDomain` to return an empty string when the name matches the domain (apex record), ensuring consistent round-trip behavior
- Added tests covering apex record creation with both empty name and `@` symbol, and updated existing `stripDomain` test expectations
<!-- kody-pr-summary:end -->