### PR TITLE
fix(dns): check PowerDNS HTTP status codes and validate @ position

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ go.work.sum
 node_modules
 pnpm-lock.yaml
 .aider*
+.hermes/

--- a/internal/api/api_dns.go
+++ b/internal/api/api_dns.go
@@ -1,7 +1,9 @@
 package api
 
 import (
+	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/labstack/echo/v4"
@@ -322,6 +324,10 @@ func (a *API) createRecord(c echo.Context) error {
 		return nil
 	}
 
+	if err := validateRecordNameAndRespond(ctx, req.Name); err != nil {
+		return err
+	}
+
 	ttl := uint(dnsservice.DefaultTTL) // Using constant from service layer
 
 	record, err := a.dnsService.CreateRecord(reqCtx, zoneID, req.Name, req.Type, req.Content, ttl)
@@ -351,6 +357,10 @@ func (a *API) updateRecord(c echo.Context) error {
 	reqCtx := ctx.Context.Request().Context()
 	name := c.Param("name")
 	recordType := c.Param("type")
+
+	if err := validateRecordNameAndRespond(ctx, name); err != nil {
+		return err
+	}
 
 	var req dto.RecordRequest
 	_, ok := httputil.DecodeAndValidateRequest(ctx, &req)
@@ -393,6 +403,10 @@ func (a *API) deleteRecord(c echo.Context) error {
 	name := c.Param("name")
 	recordType := c.Param("type")
 
+	if err := validateRecordNameAndRespond(ctx, name); err != nil {
+		return err
+	}
+
 	err = a.dnsService.DeleteRecord(reqCtx, zoneID, name, recordType)
 	if err != nil {
 		a.Logger().Error("Failed to delete DNS record", zap.Error(err), zap.String("name", name), zap.String("type", recordType))
@@ -421,6 +435,18 @@ func (a *API) bulkRecords(c echo.Context) error {
 	var req dto.BulkRecordRequest
 	if _, ok := httputil.DecodeAndValidateRequest(ctx, &req); !ok {
 		return nil
+	}
+
+	var invalid []string
+	for _, r := range req.Records {
+		if err := validateRecordName(r.Name); err != nil {
+			invalid = append(invalid, fmt.Sprintf("%q: %v", r.Name, err))
+		}
+	}
+	if len(invalid) > 0 {
+		msg := strings.Join(invalid, "; ")
+		apiErr := NewError(ErrKeyInvalidRecordName, fmt.Errorf("%s", msg))
+		return ctx.Error(apiErr, apiErr.HttpStatus())
 	}
 
 	// For bulk operations, we'll process each record individually
@@ -479,4 +505,25 @@ func (a *API) bulkDeleteRecords(c echo.Context) error {
 	}
 
 	return c.JSON(http.StatusOK, response)
+}
+
+// validateRecordName checks that a record name is valid DNS syntax.
+// Returns an error for invalid names like "subdomain.@" where @ is misplaced.
+func validateRecordName(name string) error {
+	// @ is only valid as the sole character (apex shorthand)
+	nameNoDot := strings.TrimSuffix(name, ".")
+	if strings.Contains(nameNoDot, "@") && nameNoDot != "@" {
+		return fmt.Errorf("\"@\" must be used alone for apex records")
+	}
+	return nil
+}
+
+// validateRecordNameAndRespond validates a record name and returns a 422
+// error response if invalid. Use in API handlers that take a name param.
+func validateRecordNameAndRespond(ctx httputil.RequestContext, name string) error {
+	if err := validateRecordName(name); err != nil {
+		apiErr := NewError(ErrKeyInvalidRecordName, err)
+		return ctx.Error(apiErr, apiErr.HttpStatus())
+	}
+	return nil
 }

--- a/internal/api/errors.go
+++ b/internal/api/errors.go
@@ -46,6 +46,7 @@ const (
 	ErrKeyInvalidDomainFormat core.ErrorType = "INVALID_DOMAIN_FORMAT"
 	ErrKeyDuplicateRecord     core.ErrorType = "DUPLICATE_RECORD"
 	ErrKeyValidationFailed    core.ErrorType = "VALIDATION_FAILED"
+	ErrKeyInvalidRecordName   core.ErrorType = "INVALID_RECORD_NAME"
 
 	// Website validation error types
 	ErrKeyInvalidCID    core.ErrorType = "INVALID_CID"
@@ -80,6 +81,7 @@ func init() {
 		ErrKeyInvalidDomainFormat:   {Key: ErrKeyInvalidDomainFormat, Message: "Invalid domain format"},
 		ErrKeyDuplicateRecord:       {Key: ErrKeyDuplicateRecord, Message: "Duplicate DNS record"},
 		ErrKeyValidationFailed:      {Key: ErrKeyValidationFailed, Message: "DNS validation failed"},
+		ErrKeyInvalidRecordName:     {Key: ErrKeyInvalidRecordName, Message: "Invalid DNS record name"},
 		ErrKeyPermissionDenied:      {Key: ErrKeyPermissionDenied, Message: "Permission denied"},
 		ErrKeyInvalidCID:            {Key: ErrKeyInvalidCID, Message: "Invalid CID provided"},
 		ErrKeyInvalidTarget:         {Key: ErrKeyInvalidTarget, Message: "Invalid target hash or peer ID provided"},
@@ -106,6 +108,7 @@ func init() {
 		ErrKeyZoneNotFound:          http.StatusNotFound,
 		ErrKeyDuplicateRecord:       http.StatusConflict,
 		ErrKeyValidationFailed:      http.StatusInternalServerError,
+		ErrKeyInvalidRecordName:     http.StatusUnprocessableEntity,
 		ErrKeyInvalidRequest:        http.StatusUnprocessableEntity,
 		ErrKeyInvalidIdentifier:     http.StatusUnprocessableEntity,
 		ErrKeyInvalidCID:            http.StatusUnprocessableEntity,

--- a/internal/service/dns/dns_helpers.go
+++ b/internal/service/dns/dns_helpers.go
@@ -35,32 +35,38 @@ func (s *DNSServiceDefault) getZoneWithPowerDNS(ctx context.Context, zoneID uint
 	return zone, pdnsZone, nil
 }
 
-// buildFullName constructs the full DNS record name from a name and domain
-// Returns a canonical DNS name (with trailing dot) as required by PowerDNS API
-func buildFullName(name, domain string) string {
+// buildFullName constructs the full DNS record name from a name and domain.
+// Returns a canonical DNS name (with trailing dot) as required by PowerDNS API.
+// Returns an error if the name contains "@" in an invalid position.
+func buildFullName(name, domain string) (string, error) {
 	// Normalize both name and domain (strip trailing dots for comparison)
 	nameNoDot := strings.TrimSuffix(name, ".")
 	domainNoDot := strings.TrimSuffix(domain, ".")
 
 	// If name is the zone apex shorthand (@ or empty string), return canonical domain
 	if nameNoDot == "@" || nameNoDot == "" {
-		return domainNoDot + "."
+		return domainNoDot + ".", nil
+	}
+
+	// Reject @ used anywhere except as the sole character (invalid DNS name)
+	if strings.Contains(nameNoDot, "@") {
+		return "", fmt.Errorf("%q contains \"@\" which must be used alone for apex records", name)
 	}
 
 	// If name is the zone apex (equals domain), return canonical domain
 	if nameNoDot == domainNoDot {
-		return domainNoDot + "."
+		return domainNoDot + ".", nil
 	}
-	
+
 	// If name already contains the domain
 	if strings.HasSuffix(nameNoDot, "."+domainNoDot) {
 		// Return it canonically normalized (with trailing dot)
-		return nameNoDot + "."
+		return nameNoDot + ".", nil
 	}
-	
+
 	// Otherwise, construct the full name and canonicalize
 	fullName := nameNoDot + "." + domainNoDot
-	return fullName + "."
+	return fullName + ".", nil
 }
 
 // stripDomain removes the domain suffix from a full DNS name

--- a/internal/service/dns/dns_helpers_test.go
+++ b/internal/service/dns/dns_helpers_test.go
@@ -146,7 +146,8 @@ func TestBuildFullName_RelativeName(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := buildFullName(tt.name, tt.domain)
+			result, err := buildFullName(tt.name, tt.domain)
+			require.NoError(t, err)
 			assert.Equal(t, tt.expected, result, "buildFullName(%q, %q)", tt.name, tt.domain)
 		})
 	}
@@ -188,8 +189,28 @@ func TestBuildFullName_EdgeCases(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := buildFullName(tt.name, tt.domain)
+			result, err := buildFullName(tt.name, tt.domain)
+			require.NoError(t, err)
 			assert.Equal(t, tt.expected, result, "buildFullName(%q, %q)", tt.name, tt.domain)
+		})
+	}
+}
+
+// TestBuildFullName_InvalidAtPosition tests that @ in non-apex position returns an error
+func TestBuildFullName_InvalidAtPosition(t *testing.T) {
+	tests := []string{
+		"subdomain.@",
+		"@.subdomain",
+		"a@b",
+		"prefix@",
+		"@suffix",
+	}
+
+	for _, name := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, err := buildFullName(name, "example.com")
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "must be used alone for apex records")
 		})
 	}
 }
@@ -198,7 +219,8 @@ func TestBuildFullName_EdgeCases(t *testing.T) {
 func TestBuildFullName_CaseSensitivity(t *testing.T) {
 	name := "WWW"
 	domain := "EXAMPLE.COM"
-	result := buildFullName(name, domain)
+	result, err := buildFullName(name, domain)
+	require.NoError(t, err)
 
 	// The result should preserve the input case
 	assert.Equal(t, "WWW.EXAMPLE.COM.", result)
@@ -260,7 +282,8 @@ func TestBuildFullNameIdentity(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.relativeName, func(t *testing.T) {
-			fullName := buildFullName(tt.relativeName, tt.domainBase)
+			fullName, err := buildFullName(tt.relativeName, tt.domainBase)
+			require.NoError(t, err)
 			// stripDomain needs the full name without trailing dot to properly match
 			strippedName := stripDomain(strings.TrimSuffix(fullName, "."), tt.domainBase)
 			assert.Equal(t, tt.relativeName, strippedName,
@@ -304,7 +327,8 @@ func TestBuildFullNameRoundTrip(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			full := buildFullName(tc.name, tc.domain)
+			full, err := buildFullName(tc.name, tc.domain)
+			require.NoError(t, err)
 			// stripDomain needs the full name without trailing dot to properly match
 			relative := stripDomain(strings.TrimSuffix(full, "."), tc.domain)
 
@@ -344,7 +368,8 @@ func TestBuildFullName_AbsoluteName(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := buildFullName(tt.name, tt.domain)
+			result, err := buildFullName(tt.name, tt.domain)
+			require.NoError(t, err)
 			assert.Equal(t, tt.expected, result, "buildFullName(%q, %q)", tt.name, tt.domain)
 		})
 	}
@@ -380,7 +405,8 @@ func TestBuildFullName_ZoneApex(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := buildFullName(tt.name, tt.domain)
+			result, err := buildFullName(tt.name, tt.domain)
+			require.NoError(t, err)
 			assert.Equal(t, tt.expected, result, "buildFullName(%q, %q)", tt.name, tt.domain)
 		})
 	}
@@ -411,7 +437,8 @@ func TestBuildFullName_SubdomainLevels(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := buildFullName(tt.name, tt.domain)
+			result, err := buildFullName(tt.name, tt.domain)
+			require.NoError(t, err)
 			assert.Equal(t, tt.expected, result, "buildFullName(%q, %q)", tt.name, tt.domain)
 		})
 	}
@@ -452,7 +479,8 @@ func TestBuildFullName_DomainWithTrailingDot(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := buildFullName(tt.name, tt.domain)
+			result, err := buildFullName(tt.name, tt.domain)
+			require.NoError(t, err)
 			assert.Equal(t, tt.expected, result, "buildFullName(%q, %q)", tt.name, tt.domain)
 		})
 	}
@@ -475,7 +503,8 @@ func TestBuildFullName_CanonicalAllResults(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := buildFullName(tt.name, tt.domain)
+			result, err := buildFullName(tt.name, tt.domain)
+			require.NoError(t, err)
 			assert.True(t, strings.HasSuffix(result, "."),
 				"Result should have trailing dot: buildFullName(%q, %q) = %q", tt.name, tt.domain, result)
 		})
@@ -509,7 +538,8 @@ func TestBuildFullName_RealWorldScenarios(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := buildFullName(tt.name, tt.domain)
+			result, err := buildFullName(tt.name, tt.domain)
+			require.NoError(t, err)
 			assert.Equal(t, tt.expected, result, "buildFullName(%q, %q)", tt.name, tt.domain)
 		})
 	}

--- a/internal/service/dns/dns_service_record.go
+++ b/internal/service/dns/dns_service_record.go
@@ -63,7 +63,10 @@ func (s *DNSServiceDefault) GetRRSet(ctx context.Context, zoneID uint, name stri
 	}
 
 	// Find matching RRSet
-	fullName := buildFullName(name, zone.Domain)
+	fullName, err := buildFullName(name, zone.Domain)
+	if err != nil {
+		return nil, err
+	}
 
 	if pdnsZone.Rrsets != nil {
 		matchingRRSet, found := lo.Find(*pdnsZone.Rrsets, func(rrset powerdns.RRSet) bool {
@@ -91,7 +94,10 @@ func (s *DNSServiceDefault) CreateRecord(ctx context.Context, zoneID uint, name 
 		return nil, err
 	}
 
-	fullName := buildFullName(name, zone.Domain)
+	fullName, err := buildFullName(name, zone.Domain)
+	if err != nil {
+		return nil, fmt.Errorf("invalid record name: %w", err)
+	}
 
 	pdnsContent := formatRecordContent(recordType, content)
 
@@ -142,7 +148,10 @@ func (s *DNSServiceDefault) UpdateRecord(ctx context.Context, zoneID uint, name 
 		return nil, err
 	}
 
-	fullName := buildFullName(name, zone.Domain)
+	fullName, err := buildFullName(name, zone.Domain)
+	if err != nil {
+		return nil, fmt.Errorf("invalid record name: %w", err)
+	}
 
 	pdnsRecords := lo.Map(records, func(r string, _ int) powerdns.Record {
 		return powerdns.Record{Content: formatRecordContent(recordType, r)}
@@ -187,7 +196,10 @@ func (s *DNSServiceDefault) DeleteRecord(ctx context.Context, zoneID uint, name 
 		return err
 	}
 
-	fullName := buildFullName(name, zone.Domain)
+	fullName, err := buildFullName(name, zone.Domain)
+	if err != nil {
+		return fmt.Errorf("invalid record name: %w", err)
+	}
 
 	rrset := buildRRSet(fullName, recordType, powerdns.DELETE, nil, nil)
 
@@ -219,10 +231,14 @@ func (s *DNSServiceDefault) BulkDeleteRecords(ctx context.Context, zoneID uint, 
 	}
 
 	// Convert RecordIdentifiers to PowerDNS DELETE RRSet operations
-	rrsets := lo.Map(records, func(r apiDTO.RecordIdentifier, _ int) powerdns.RRSet {
-		fullName := buildFullName(r.Name, zone.Domain)
-		return buildRRSet(fullName, r.Type, powerdns.DELETE, nil, nil)
-	})
+	rrsets := make([]powerdns.RRSet, 0, len(records))
+	for _, r := range records {
+		fullName, err := buildFullName(r.Name, zone.Domain)
+		if err != nil {
+			return nil, fmt.Errorf("invalid record name %q: %w", r.Name, err)
+		}
+		rrsets = append(rrsets, buildRRSet(fullName, r.Type, powerdns.DELETE, nil, nil))
+	}
 
 	// If dryRun is true, return success results without actually deleting
 	if dryRun {
@@ -430,7 +446,16 @@ func (s *DNSServiceDefault) ImportZoneFile(ctx context.Context, zoneID uint, zon
 			continue
 		}
 
-		fullName := buildFullName(name, zone.Domain)
+		fullName, err := buildFullName(name, zone.Domain)
+		if err != nil {
+			response.Errors = append(response.Errors, apiDTO.ImportZoneError{
+				Name:  name,
+				Type:  recordType,
+				Error: fmt.Sprintf("Invalid record name: %v", err),
+			})
+			response.FailedCount++
+			continue
+		}
 		key := fmt.Sprintf("%s:%s", fullName, recordType)
 
 		values := entry.Values()

--- a/internal/service/dns/dns_service_test.go
+++ b/internal/service/dns/dns_service_test.go
@@ -903,11 +903,11 @@ func TestDNSServiceCreateRecord(t *testing.T) {
 			require.NoError(tb, err)
 			require.NotNil(tb, zone)
 
-			// Try to create a record - PATCH succeeds but GetRRSet fails
+			// Try to create a record - PATCH returns 500, so error is caught immediately
 			_, err = svc.CreateRecord(ctx, zone.ID, "www", "A", "192.0.2.1", 3600)
 			require.Error(tb, err)
-			// Error should be from GetRRSet failing after creation
-			require.Contains(tb, err.Error(), "RRSet not found")
+			// Error should be from UpdateZoneRRSets detecting the 500
+			require.Contains(tb, err.Error(), "PowerDNS returned status 500")
 		}, testOptionsWithError)
 	})
 

--- a/internal/service/dns/dns_service_zone.go
+++ b/internal/service/dns/dns_service_zone.go
@@ -362,9 +362,18 @@ func (s *DNSServiceDefault) CreateWebsiteDNSRecords(ctx context.Context, zoneID 
 	disabled := false
 	targetPath := string(buildTargetPath(targetHash, targetType))
 
-	dnslinkName := buildFullName("_dnslink", websiteDomain)
-	verifyName := buildFullName(s.config.VerificationTokenKey, websiteDomain)
-	recordName := buildFullName(websiteDomain, websiteDomain)
+	dnslinkName, err := buildFullName("_dnslink", websiteDomain)
+	if err != nil {
+		return fmt.Errorf("invalid dnslink name: %w", err)
+	}
+	verifyName, err := buildFullName(s.config.VerificationTokenKey, websiteDomain)
+	if err != nil {
+		return fmt.Errorf("invalid verification token key: %w", err)
+	}
+	recordName, err := buildFullName(websiteDomain, websiteDomain)
+	if err != nil {
+		return fmt.Errorf("invalid record name: %w", err)
+	}
 
 	rrsets := []powerdns.RRSet{
 		{
@@ -444,7 +453,10 @@ func (s *DNSServiceDefault) UpdateWebsiteDNSRecords(ctx context.Context, zoneID 
 	disabled := false
 	targetPath := string(buildTargetPath(targetHash, targetType))
 
-	dnslinkName := buildFullName("_dnslink", websiteDomain)
+	dnslinkName, err := buildFullName("_dnslink", websiteDomain)
+	if err != nil {
+		return fmt.Errorf("invalid dnslink name: %w", err)
+	}
 
 	rrsets := []powerdns.RRSet{
 		{
@@ -492,9 +504,18 @@ func (s *DNSServiceDefault) DeleteWebsiteDNSRecords(ctx context.Context, zoneID 
 		return fmt.Errorf("DNS hosting not enabled")
 	}
 
-	dnslinkName := buildFullName("_dnslink", websiteDomain)
-	verifyName := buildFullName(s.config.VerificationTokenKey, websiteDomain)
-	recordName := buildFullName(websiteDomain, websiteDomain)
+	dnslinkName, err := buildFullName("_dnslink", websiteDomain)
+	if err != nil {
+		return fmt.Errorf("invalid dnslink name: %w", err)
+	}
+	verifyName, err := buildFullName(s.config.VerificationTokenKey, websiteDomain)
+	if err != nil {
+		return fmt.Errorf("invalid verification token key: %w", err)
+	}
+	recordName, err := buildFullName(websiteDomain, websiteDomain)
+	if err != nil {
+		return fmt.Errorf("invalid record name: %w", err)
+	}
 
 	rrsets := []powerdns.RRSet{
 		{

--- a/internal/service/dns/powerdns_client.go
+++ b/internal/service/dns/powerdns_client.go
@@ -136,8 +136,18 @@ func (c *PowerDNSClient) UpdateZoneRRSets(ctx context.Context, zoneID string, rr
 	if err != nil {
 		return fmt.Errorf("failed to update zone: %w", err)
 	}
-	if resp != nil {
-		defer resp.Body.Close()
+	if resp == nil {
+		return fmt.Errorf("failed to update zone: nil response from PowerDNS")
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		bodyBytes, _ := io.ReadAll(resp.Body)
+		c.logger.Warn("PowerDNS returned non-success status",
+			zap.Int("status", resp.StatusCode),
+			zap.String("zone_id", zoneID),
+			zap.String("body", string(bodyBytes)))
+		return fmt.Errorf("PowerDNS returned status %d", resp.StatusCode)
 	}
 
 	c.logger.Info("Zone RRsets updated in PowerDNS",
@@ -153,8 +163,18 @@ func (c *PowerDNSClient) DeleteZone(ctx context.Context, zoneID string) error {
 	if err != nil {
 		return fmt.Errorf("failed to delete zone: %w", err)
 	}
-	if resp != nil {
-		defer resp.Body.Close()
+	if resp == nil {
+		return fmt.Errorf("failed to delete zone: nil response from PowerDNS")
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		bodyBytes, _ := io.ReadAll(resp.Body)
+		c.logger.Warn("PowerDNS returned non-success status",
+			zap.Int("status", resp.StatusCode),
+			zap.String("zone_id", zoneID),
+			zap.String("body", string(bodyBytes)))
+		return fmt.Errorf("PowerDNS returned status %d", resp.StatusCode)
 	}
 
 	c.logger.Info("Zone deleted from PowerDNS",

--- a/internal/service/dns/powerdns_client_test.go
+++ b/internal/service/dns/powerdns_client_test.go
@@ -237,12 +237,40 @@ func TestUpdateZoneRRSets(t *testing.T) {
 			mockError:    errors.New("network error"),
 			expectError:  true,
 		},
+		{
+			name:   "RRSet update with 422 from PowerDNS",
+			zoneID: "example.com.",
+			rrsets: []powerdns.RRSet{
+				{
+					Changetype: powerdns.REPLACE,
+					Name:       "test.example.com.",
+					Type:       "CNAME",
+					Ttl:        intPtr(300),
+					Records: []powerdns.Record{
+						{Content: "target.example.com."},
+					},
+				},
+			},
+			mockResponse: &http.Response{
+				StatusCode: http.StatusUnprocessableEntity,
+				Body:       io.NopCloser(bytes.NewBufferString(`{"error": "CNAME conflict"}`)),
+			},
+			expectError: true,
+		},
+		{
+			name:   "RRSet update with nil response",
+			zoneID: "example.com.",
+			rrsets: []powerdns.RRSet{},
+			mockResponse: nil,
+			mockError:    nil,
+			expectError:  true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			logger := zap.NewNop()
-	coreLogger := &core.Logger{Logger: logger}
+			coreLogger := &core.Logger{Logger: logger}
 			mockClient := &mockHTTPClient{
 				response: tt.mockResponse,
 				err:      tt.mockError,
@@ -293,12 +321,28 @@ func TestDeleteZone(t *testing.T) {
 			mockError:   errors.New("network error"),
 			expectError: true,
 		},
+		{
+			name:   "zone deletion with 404 from PowerDNS",
+			zoneID: "example.com.",
+			mockResponse: &http.Response{
+				StatusCode: http.StatusNotFound,
+				Body:       io.NopCloser(bytes.NewBufferString(`{"error": "Zone not found"}`)),
+			},
+			expectError: true,
+		},
+		{
+			name:         "zone deletion with nil response",
+			zoneID:       "example.com.",
+			mockResponse: nil,
+			mockError:    nil,
+			expectError:  true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			logger := zap.NewNop()
-	coreLogger := &core.Logger{Logger: logger}
+			coreLogger := &core.Logger{Logger: logger}
 			mockClient := &mockHTTPClient{
 				response: tt.mockResponse,
 				err:      tt.mockError,


### PR DESCRIPTION
## Summary

- Check HTTP status codes in `UpdateZoneRRSets` and `DeleteZone` to surface actual PowerDNS errors (422, 409, etc.) instead of generic 500
- Add API-level `@` validation so invalid names like `subdomain.@` return 422 immediately
- Defense-in-depth panic in `buildFullName` for misplaced `@`
- Updated tests for new error behavior

* `develop` <!-- branch-stack -->
  - **fix(dns): check PowerDNS HTTP status codes and validate @ position** :point\_left:

***

<!-- kody-pr-summary:start -->

This PR fixes two issues in the DNS service:

1. **PowerDNS HTTP status code validation**: The `UpdateZoneRRSets` and `DeleteZone` methods in the PowerDNS client previously did not check HTTP response status codes, meaning errors from PowerDNS (e.g., 4xx/5xx responses) were silently ignored. These methods now validate that the response status is in the 2xx range and return a descriptive error (including the response body) if not. Nil responses are also now properly handled as errors.

2. **DNS record name `@` validation**: A new `validateRecordName` function ensures that the `@` character (apex shorthand) is only used as the sole character in a record name. Names like `subdomain.@` or `@.subdomain` are now rejected at the API layer in `createRecord`, `updateRecord`, and `deleteRecord`. A defensive panic was also added in `buildFullName` to catch any `@` misuse that bypasses API validation.

<!-- kody-pr-summary:end -->
