### PR TITLE
fix(dns): check PowerDNS HTTP status codes and validate @ position

### DIFF
--- a/internal/api/api_dns.go
+++ b/internal/api/api_dns.go
@@ -445,7 +445,7 @@ func (a *API) bulkRecords(c echo.Context) error {
 	}
 	if len(invalid) > 0 {
 		msg := strings.Join(invalid, "; ")
-		apiErr := NewError(ErrKeyInvalidRecordName, fmt.Errorf("%s", msg))
+		apiErr := NewError(ErrKeyInvalidRecordName, fmt.Errorf("%s", msg), msg)
 		return ctx.Error(apiErr, apiErr.HttpStatus())
 	}
 
@@ -522,7 +522,7 @@ func validateRecordName(name string) error {
 // error response if invalid. Use in API handlers that take a name param.
 func validateRecordNameAndRespond(ctx httputil.RequestContext, name string) error {
 	if err := validateRecordName(name); err != nil {
-		apiErr := NewError(ErrKeyInvalidRecordName, err)
+		apiErr := NewError(ErrKeyInvalidRecordName, err, err.Error())
 		return ctx.Error(apiErr, apiErr.HttpStatus())
 	}
 	return nil

--- a/internal/api/errors.go
+++ b/internal/api/errors.go
@@ -81,7 +81,7 @@ func init() {
 		ErrKeyInvalidDomainFormat:   {Key: ErrKeyInvalidDomainFormat, Message: "Invalid domain format"},
 		ErrKeyDuplicateRecord:       {Key: ErrKeyDuplicateRecord, Message: "Duplicate DNS record"},
 		ErrKeyValidationFailed:      {Key: ErrKeyValidationFailed, Message: "DNS validation failed"},
-		ErrKeyInvalidRecordName:     {Key: ErrKeyInvalidRecordName, Message: "Invalid DNS record name"},
+		ErrKeyInvalidRecordName:     {Key: ErrKeyInvalidRecordName, Message: "Invalid DNS record name: %v"},
 		ErrKeyPermissionDenied:      {Key: ErrKeyPermissionDenied, Message: "Permission denied"},
 		ErrKeyInvalidCID:            {Key: ErrKeyInvalidCID, Message: "Invalid CID provided"},
 		ErrKeyInvalidTarget:         {Key: ErrKeyInvalidTarget, Message: "Invalid target hash or peer ID provided"},


### PR DESCRIPTION
Fixes the 500 'UpdateFailed' error when creating DNS records by checking PowerDNS HTTP status codes. Also validates DNS record names to prevent malformed names like 'subdomain.@'.

Changes:

- UpdateZoneRRSets/DeleteZone now check resp.StatusCode and return errors for non-2xx
- buildFullName returns error instead of panicking on invalid @ usage
- API level name validation with 422 responses
- Bulk operations collect all validation errors into single response
- PowerDNS error bodies logged server-side, not leaked to clients
- Website DNS functions propagate errors instead of panicking

***

<!-- kody-pr-summary:start -->

This pull request fixes DNS error handling by adding PowerDNS HTTP status code validation and validating the position of the `@` character in DNS record names.

**PowerDNS HTTP status code checking**: The PowerDNS client (`UpdateZoneRRSets` and `DeleteZone`) previously did not check HTTP response status codes, meaning failed operations could go undetected. The client now checks for nil responses and non-2xx status codes, returning descriptive errors with the status code and response body. This ensures errors from PowerDNS (e.g., 500, 404, 422) are properly surfaced rather than silently ignored.

**DNS record name validation for `@`**: The `@` character is valid only as a standalone shorthand for apex records. The `buildFullName` function now returns an error when `@` appears in an invalid position (e.g., `subdomain.@`, `@.subdomain`, `a@b`). Validation is enforced at both the API layer (create, update, delete, and bulk record endpoints return a 422 error) and the service layer (all `buildFullName` callers handle the new error). Zone file import also collects these errors per-record rather than failing the entire import.

**Supporting changes**: A new `INVALID_RECORD_NAME` error type is added with HTTP 422 status. All existing tests are updated to handle the new error return from `buildFullName`, and new test cases cover invalid `@` positions and PowerDNS error responses.

<!-- kody-pr-summary:end -->

- `develop` <!-- branch-stack -->
  - **fix(dns): check PowerDNS HTTP status codes and validate @ position** :point\_left:
