### PR TITLE
fix(dns): include PowerDNS error body in error messages for debugging

### DIFF
--- a/internal/api/api_dns.go
+++ b/internal/api/api_dns.go
@@ -445,7 +445,7 @@ func (a *API) bulkRecords(c echo.Context) error {
 	}
 	if len(invalid) > 0 {
 		msg := strings.Join(invalid, "; ")
-		apiErr := NewError(ErrKeyInvalidRecordName, fmt.Errorf("%s", msg))
+		apiErr := NewError(ErrKeyInvalidRecordName, fmt.Errorf("%s", msg), msg)
 		return ctx.Error(apiErr, apiErr.HttpStatus())
 	}
 
@@ -522,7 +522,7 @@ func validateRecordName(name string) error {
 // error response if invalid. Use in API handlers that take a name param.
 func validateRecordNameAndRespond(ctx httputil.RequestContext, name string) error {
 	if err := validateRecordName(name); err != nil {
-		apiErr := NewError(ErrKeyInvalidRecordName, err)
+		apiErr := NewError(ErrKeyInvalidRecordName, err, err.Error())
 		return ctx.Error(apiErr, apiErr.HttpStatus())
 	}
 	return nil

--- a/internal/api/errors.go
+++ b/internal/api/errors.go
@@ -81,7 +81,7 @@ func init() {
 		ErrKeyInvalidDomainFormat:   {Key: ErrKeyInvalidDomainFormat, Message: "Invalid domain format"},
 		ErrKeyDuplicateRecord:       {Key: ErrKeyDuplicateRecord, Message: "Duplicate DNS record"},
 		ErrKeyValidationFailed:      {Key: ErrKeyValidationFailed, Message: "DNS validation failed"},
-		ErrKeyInvalidRecordName:     {Key: ErrKeyInvalidRecordName, Message: "Invalid DNS record name"},
+		ErrKeyInvalidRecordName:     {Key: ErrKeyInvalidRecordName, Message: "Invalid DNS record name: %v"},
 		ErrKeyPermissionDenied:      {Key: ErrKeyPermissionDenied, Message: "Permission denied"},
 		ErrKeyInvalidCID:            {Key: ErrKeyInvalidCID, Message: "Invalid CID provided"},
 		ErrKeyInvalidTarget:         {Key: ErrKeyInvalidTarget, Message: "Invalid target hash or peer ID provided"},


### PR DESCRIPTION
Includes the raw PowerDNS response body in error messages so server logs show the actual validation failure reason.

This is a diagnostic fix to help identify why PowerDNS returns 422 for CNAME records like the Bing verification subdomain.

- `develop` <!-- branch-stack -->
  - **fix(dns): include PowerDNS error body in error messages for debugging** :point\_left:

---

<!-- kody-pr-summary:start -->
This pull request improves error reporting for DNS-related operations by including more detailed error information to aid in debugging.

**Changes:**

1. **PowerDNS client error messages**: The `UpdateZoneRRSets` and `DeleteZone` methods now include the response body in error messages when PowerDNS returns a non-success status code, instead of only including the HTTP status code. This provides visibility into the actual error details returned by PowerDNS.

2. **Invalid record name error messages**: The error message template for `ErrKeyInvalidRecordName` now includes a `%v` placeholder, allowing the specific validation error details to be surfaced to the caller. The corresponding `NewError` calls in `api_dns.go` have been updated to pass the error details as a third argument so the message is properly populated.

Overall, these changes make DNS errors more informative by exposing underlying error details (both from PowerDNS responses and record name validation) rather than returning generic error messages.
<!-- kody-pr-summary:end -->