### PR TITLE
fix(dns): append trailing dot to CNAME/MX/NS content for PowerDNS

### DIFF
--- a/internal/service/dns/dns_helpers.go
+++ b/internal/service/dns/dns_helpers.go
@@ -234,7 +234,22 @@ func formatRecordContent(recordType, content string) string {
 	if strings.EqualFold(recordType, "TXT") {
 		return formatTXTContent(content)
 	}
+	// PowerDNS requires fully-qualified domain names for CNAME, MX, NS
+	// Append trailing dot if missing so the name is absolute, not relative
+	if strings.EqualFold(recordType, "CNAME") || strings.EqualFold(recordType, "MX") || strings.EqualFold(recordType, "NS") {
+		return ensureTrailingDot(content)
+	}
 	return content
+}
+
+// ensureTrailingDot appends a dot to a domain name if it doesn't already have one.
+// PowerDNS requires FQDNs to end with a dot to be treated as absolute.
+func ensureTrailingDot(name string) string {
+	name = strings.TrimSpace(name)
+	if name == "" || strings.HasSuffix(name, ".") {
+		return name
+	}
+	return name + "."
 }
 
 // stripTXTQuotes removes surrounding double quotes from TXT record content


### PR DESCRIPTION
PowerDNS requires FQDN content for CNAME, MX, and NS records to end with a trailing dot. Without it, PowerDNS returns 422:

> Record 65e1e2471bd2ee6879cba19982316e6b.urma.xyz./CNAME 'verify.bing.com': Not in expected format (parsed as 'verify.bing.com.')

This normalizes record content in formatRecordContent() by adding a trailing dot when missing, ensuring these record types are accepted.

Fixes DNS record creation for CNAME verification records (e.g., Bing, Google).

- `develop` <!-- branch-stack -->
  - **fix(dns): append trailing dot to CNAME/MX/NS content for PowerDNS** :point\_left:

---

<!-- kody-pr-summary:start -->
This pull request fixes DNS record formatting for PowerDNS by appending a trailing dot to CNAME, MX, and NS record content when one is missing. PowerDNS requires fully-qualified domain names to end with a dot to be treated as absolute rather than relative. A new helper function `ensureTrailingDot` was added to handle this normalization, which trims whitespace and appends a dot only if the domain name doesn't already end with one.
<!-- kody-pr-summary:end -->