### PR TITLE
fix: adapt dht.New calls to go-libp2p-kad-dht v0.42.1 API

### DIFF
--- a/internal/protocol/ipfs/node.go
+++ b/internal/protocol/ipfs/node.go
@@ -563,7 +563,7 @@ func NewNode(ctx core.Context, cfg *config.ProtocolConfig, rs pluginCore.Reprovi
 	switch cfg.DHTMode {
 	case config.DHTModeBasic:
 		// Use basic DHT
-		basicDHT, dhtErr := dht.New(ctx, node, dhtOpts...)
+		basicDHT, dhtErr := dht.New(node, dhtOpts...)
 		if dhtErr != nil {
 			return nil, fmt.Errorf("failed to create basic dht: %w", dhtErr)
 		}
@@ -580,7 +580,7 @@ func NewNode(ctx core.Context, cfg *config.ProtocolConfig, rs pluginCore.Reprovi
 		// inbound DHT queries (FIND_NODE, GET_PROVIDER, PUT_VALUE). A
 		// companion IpfsDHT in server mode runs alongside it to handle
 		// inbound queries and keep this node's multiaddrs discoverable.
-		companion, dhtErr := dht.New(ctx, node, dhtOpts...)
+		companion, dhtErr := dht.New(node, dhtOpts...)
 		if dhtErr != nil {
 			return nil, fmt.Errorf("failed to create companion DHT: %w", dhtErr)
 		}

--- a/internal/protocol/tests/op_retrieve_test.go
+++ b/internal/protocol/tests/op_retrieve_test.go
@@ -77,7 +77,7 @@ func setupTestSecondNode(t *testing.T) *TestSecondNodeInfo {
 		dht.Datastore(secondDstore),
 		dht.ProtocolExtension("/lan"),
 	}
-	testDHT, err := dht.New(context.Background(), secondHost, dhtOpts...)
+	testDHT, err := dht.New(secondHost, dhtOpts...)
 	require.NoError(t, err, "Failed to create test DHT")
 
 	// Create bitswap exchange using bsnet.NewFromIpfsHost for network functionality


### PR DESCRIPTION
- `develop` <!-- branch-stack -->
  - **fix: adapt dht.New calls to go-libp2p-kad-dht v0.42.1 API** :point\_left:

***

<!-- kody-pr-summary:start -->

This pull request updates the DHT initialization code to align with the breaking API change introduced in `go-libp2p-kad-dht` v0.42.1, where `dht.New` no longer accepts a context as its first argument.

The change removes the `ctx` parameter from both the basic DHT and companion DHT constructor calls in `internal/protocol/ipfs/node.go`. This ensures the IPFS node can successfully initialize its DHT components when built against the updated dependency version, restoring compatibility and preventing build or runtime failures caused by the signature mismatch.

<!-- kody-pr-summary:end -->
