### PR TITLE
fix(blockstore): check metadata store in virtual mode for Has and GetSize

### DIFF
--- a/internal/protocol/store/blockstore.go
+++ b/internal/protocol/store/blockstore.go
@@ -79,8 +79,19 @@ func (bs *BlockStore) Has(ctx context.Context, c cid.Cid) (bool, error) {
 	log := bs.log.Named("Has").With(zap.Stringer("cid", c))
 
 	if pc.IsVirtualReadEnabled(ctx) {
-		log.Debug("virtual read enabled, assuming block does not exist")
-		return false, nil
+		// In virtual mode, still check the metadata store for existence.
+		// This allows the blockservice to return locally-stored blocks without
+		// roundtripping through bitswap when blocks already exist from a prior
+		// upload by any user. Virtual mode only skips storage (Put), not reads.
+		err := bs.metadata.BlockExists(ctx, c)
+		if format.IsNotFound(err) {
+			log.Debug("virtual read enabled, block not found in metadata store")
+			return false, nil
+		} else if err != nil {
+			return false, fmt.Errorf("failed to get block location: %w", err)
+		}
+		log.Debug("virtual read enabled, block exists in metadata store")
+		return true, nil
 	}
 
 	start := time.Now()
@@ -201,12 +212,26 @@ func (bs *BlockStore) GetSize(ctx context.Context, c cid.Cid) (int, error) {
 	log := bs.log.Named("GetSize").With(zap.Stringer("cid", c), zap.String("key", key))
 
 	if pc.IsVirtualReadEnabled(ctx) {
-		log.Debug("virtual read enabled, fetching block size without storing")
-		block, err := bs.Get(ctx, c)
-		if err != nil {
-			return 0, err
+		// In virtual mode, query the metadata store for size instead of
+		// downloading the full block. This avoids unnecessary network I/O
+		// when the block already exists locally.
+		if err := bs.metadata.BlockExists(ctx, c); err != nil {
+			if !format.IsNotFound(err) {
+				return 0, fmt.Errorf("failed to get block location: %w", err)
+			}
+			// Block not in metadata store — fall through to downloader
+			log.Debug("virtual read enabled, block not in metadata store, fetching from downloader")
+			block, err := bs.Get(ctx, c)
+			if err != nil {
+				return 0, err
+			}
+			return len(block.RawData()), nil
 		}
-		return len(block.RawData()), nil
+		size, err := bs.metadata.Size(ctx, c)
+		if err != nil {
+			return 0, fmt.Errorf("failed to query block size: %w", err)
+		}
+		return int(size), nil
 	}
 
 	err := bs.metadata.BlockExists(ctx, c)

--- a/internal/protocol/store/tests/blockstore_test.go
+++ b/internal/protocol/store/tests/blockstore_test.go
@@ -8,6 +8,7 @@ import (
 
 	blocks "github.com/ipfs/go-block-format"
 	"github.com/ipfs/go-cid"
+	format "github.com/ipfs/go-ipld-format"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -664,13 +665,15 @@ func TestBlockStore_VirtualReadEnabled(t *testing.T) {
 		require.NoError(tb, err)
 		assert.Equal(tb, testBlock, block)
 
-		// Test Has
+		// Test Has — in virtual mode, now checks metadata store
+		mockMetadata.EXPECT().BlockExists(mock.Anything, testCid).Return(nil).Once()
 		has, err := bs.Has(readCtx, testCid)
 		require.NoError(tb, err)
-		assert.False(tb, has)
+		assert.True(tb, has)
 
-		// Test GetSize
-		mockDownloader.EXPECT().Get(mock.Anything, testCid).Return(testBlock, nil).Once()
+		// Test GetSize — in virtual mode, now checks BlockExists then metadata store for size
+		mockMetadata.EXPECT().BlockExists(mock.Anything, testCid).Return(nil).Once()
+		mockMetadata.EXPECT().Size(mock.Anything, testCid).Return(uint64(len(testData)), nil).Once()
 		size, err := bs.GetSize(readCtx, testCid)
 		require.NoError(tb, err)
 		assert.Equal(tb, len(testData), size)
@@ -690,6 +693,100 @@ func TestBlockStore_VirtualReadEnabled(t *testing.T) {
 		_, ok := <-ch
 		assert.False(tb, ok, "AllKeysChan should return a closed channel when virtual read is enabled")
 
+	}, ipfsTestConfig)
+}
+
+func TestBlockStore_VirtualReadHas_BlockExists(t *testing.T) {
+	coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		mockDownloader := localMocks.NewMockBlockDownloader(t)
+		mockMetadata := localMocks.NewMockMetadataStore(t)
+
+		bs, err := store.NewBlockStore(ctx, mockDownloader, mockMetadata, nil)
+		require.NoError(tb, err)
+
+		testData := "test data"
+		testCid := generateCid(t, testData)
+
+		// In virtual mode, Has checks metadata store — block exists
+		mockMetadata.EXPECT().BlockExists(mock.Anything, testCid).Return(nil).Once()
+
+		readCtx := pc.VirtualReadOption(context.Background(), true)
+		has, err := bs.Has(readCtx, testCid)
+
+		assert.NoError(tb, err)
+		assert.True(tb, has, "Has should return true when block exists in metadata store in virtual mode")
+	}, ipfsTestConfig)
+}
+
+func TestBlockStore_VirtualReadHas_BlockNotFound(t *testing.T) {
+	coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		mockDownloader := localMocks.NewMockBlockDownloader(t)
+		mockMetadata := localMocks.NewMockMetadataStore(t)
+
+		bs, err := store.NewBlockStore(ctx, mockDownloader, mockMetadata, nil)
+		require.NoError(tb, err)
+
+		testData := "test data"
+		testCid := generateCid(t, testData)
+
+		// In virtual mode, Has checks metadata store — block not found
+		mockMetadata.EXPECT().BlockExists(mock.Anything, testCid).
+			Return(format.ErrNotFound{Cid: testCid}).Once()
+
+		readCtx := pc.VirtualReadOption(context.Background(), true)
+		has, err := bs.Has(readCtx, testCid)
+
+		assert.NoError(tb, err)
+		assert.False(tb, has, "Has should return false when block is not in metadata store in virtual mode")
+	}, ipfsTestConfig)
+}
+
+func TestBlockStore_VirtualReadGetSize_FromMetadata(t *testing.T) {
+	coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		mockDownloader := localMocks.NewMockBlockDownloader(t)
+		mockMetadata := localMocks.NewMockMetadataStore(t)
+
+		bs, err := store.NewBlockStore(ctx, mockDownloader, mockMetadata, nil)
+		require.NoError(tb, err)
+
+		testData := "test data"
+		testCid := generateCid(t, testData)
+		expectedSize := uint64(42)
+
+		// In virtual mode, GetSize checks BlockExists then queries metadata store for size
+		mockMetadata.EXPECT().BlockExists(mock.Anything, testCid).Return(nil).Once()
+		mockMetadata.EXPECT().Size(mock.Anything, testCid).Return(expectedSize, nil).Once()
+
+		readCtx := pc.VirtualReadOption(context.Background(), true)
+		size, err := bs.GetSize(readCtx, testCid)
+
+		assert.NoError(tb, err)
+		assert.Equal(tb, int(expectedSize), size, "GetSize should return size from metadata store in virtual mode")
+	}, ipfsTestConfig)
+}
+
+func TestBlockStore_VirtualReadGetSize_FallbackToDownloader(t *testing.T) {
+	coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		mockDownloader := localMocks.NewMockBlockDownloader(t)
+		mockMetadata := localMocks.NewMockMetadataStore(t)
+
+		bs, err := store.NewBlockStore(ctx, mockDownloader, mockMetadata, nil)
+		require.NoError(tb, err)
+
+		testData := "test data"
+		testCid := generateCid(t, testData)
+		testBlock, err := blocks.NewBlockWithCid([]byte(testData), testCid)
+		require.NoError(t, err)
+
+		// BlockExists returns not-found → falls back to downloader.Get
+		mockMetadata.EXPECT().BlockExists(mock.Anything, testCid).Return(format.ErrNotFound{Cid: testCid}).Once()
+		mockDownloader.EXPECT().Get(mock.Anything, testCid).Return(testBlock, nil).Once()
+
+		readCtx := pc.VirtualReadOption(context.Background(), true)
+		size, err := bs.GetSize(readCtx, testCid)
+
+		assert.NoError(tb, err)
+		assert.Equal(tb, len(testData), size, "GetSize should fall back to downloader when block not in metadata store")
 	}, ipfsTestConfig)
 }
 


### PR DESCRIPTION
## Problem

Virtual discovery in the blockstore forces bitswap roundtrips even when blocks are already in local storage, because `Has()` unconditionally returns `false` in virtual mode and `GetSize()` downloads the full block instead of querying the metadata store.

## Changes

### Blockstore virtual mode (`store/blockstore.go`)

- **`Has()`**: In virtual mode, now checks the metadata store instead of blindly returning `false`. This allows the blockservice to return locally-stored blocks without roundtripping through bitswap.
- **`GetSize()`**: In virtual mode, now queries the metadata store for the block size instead of downloading the full block via `Get()`. Falls back to the downloader only when the block is not in the metadata store.

## Impact

- Virtual discovery avoids unnecessary bitswap roundtrips for locally-stored DAGs
- When a user pins a DAG (full or partial) that is already in local storage from a prior upload by any user, the blockservice returns blocks from local storage instead of fetching from the network
- Quota accounting is **unaffected** — every user who pins a block is charged quota per-user-per-pin. The dedup is purely a storage and bandwidth optimization

## Testing

- `go build ./...` ✓
- `go vet ./internal/...` ✓
- `go generate ./...` ✓
- Blockstore unit tests (6 tests including 4 new):
  - `TestBlockStore_VirtualReadEnabled` — updated for new metadata store behavior
  - `TestBlockStore_VirtualReadHas_BlockExists` — new, Has returns true when block in metadata
  - `TestBlockStore_VirtualReadHas_BlockNotFound` — new, Has returns false when not in metadata
  - `TestBlockStore_VirtualReadGetSize_FromMetadata` — new, GetSize from metadata store
  - `TestBlockStore_VirtualReadGetSize_FallbackToDownloader` — new, fallback when not in metadata
- Integration tests (all pass, exercise the full modified code paths):
  - `TestRetrieveOperationHandler_Execute_Integration` ✓
  - `TestTUSUploadOperationHandler_Execute_Integration` ✓
  - `TestPostUploadOperationHandler_Execute_Integration` ✓
  - `TestPostUploadOperation_RepinAfterDelete` ✓
  - `TestTUSUploadOperation_RepinAfterDelete` ✓
  - `TestPostUploadOperation_PinDeletePinStatusConsistency` ✓
  - `TestTUSUploadOperation_PinStatus` ✓
  - `TestPostUploadOperation_PinStatus` ✓

* `develop` <!-- branch-stack -->
  - **fix(blockstore): check metadata store in virtual mode for Has and GetSize** :point\_left:
