### PR TITLE
refactor(ipfs): separate UnixFS/filepath processing into dedicated async workflow

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	github.com/tus/tusd/v2 v2.10.0
 	go.lumeweb.com/httputil v0.5.6
 	go.lumeweb.com/ipfs-content v0.1.17
-	go.lumeweb.com/portal v0.5.2-0.20260726205605-b4780c375b52
+	go.lumeweb.com/portal v0.5.2-0.20260724130026-d74f4f158e63
 	go.lumeweb.com/portal-middleware v0.3.7
 	go.lumeweb.com/portal-plugin-core v0.1.0
 	go.lumeweb.com/portal-plugin-dashboard v0.3.1-0.20260723141131-5c529bafad6c
@@ -76,7 +76,6 @@ require (
 	github.com/oschwald/maxminddb-golang v1.13.1 // indirect
 	github.com/pb33f/ordered-map/v2 v2.3.1 // indirect
 	github.com/pion/transport/v4 v4.0.1 // indirect
-	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
 	github.com/slok/go-http-metrics v0.13.0 // indirect
 	github.com/woodsbury/decimal128 v1.4.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/github.com/labstack/echo/otelecho v0.69.0 // indirect
@@ -150,7 +149,7 @@ require (
 	github.com/gabriel-vasile/mimetype v1.4.15 // indirect
 	github.com/gammazero/chanqueue v1.1.2 // indirect
 	github.com/gammazero/deque v1.2.1 // indirect
-	github.com/getkin/kin-openapi v0.144.0 // indirect
+	github.com/getkin/kin-openapi v0.134.0 // indirect
 	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/glebarez/go-sqlite v1.22.0 // indirect
 	github.com/glebarez/sqlite v1.11.0 // indirect
@@ -257,8 +256,8 @@ require (
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/nwaples/rardecode/v2 v2.2.0 // indirect
 	github.com/nxadm/tail v1.4.11 // indirect
-	github.com/oasdiff/yaml v0.1.1 // indirect
-	github.com/oasdiff/yaml3 v0.0.14 // indirect
+	github.com/oasdiff/yaml v0.0.0-20260313112342-a3ea61cb4d4c // indirect
+	github.com/oasdiff/yaml3 v0.0.0-20260224194419-61cd415a242b // indirect
 	github.com/onsi/gomega v1.36.3 // indirect
 	github.com/paulmach/orb v0.13.0 // indirect
 	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58 // indirect

--- a/go.sum
+++ b/go.sum
@@ -248,8 +248,6 @@ github.com/gammazero/workerpool v1.2.1 h1:MEDvUJsNYGuCvl1RwIXNKu2YtQtHqCSF9XWF04
 github.com/gammazero/workerpool v1.2.1/go.mod h1:E32GVRUanF4d6QtRmdss3AScgaDkIyrvPtgRQUWgmx4=
 github.com/getkin/kin-openapi v0.134.0 h1:/L5+1+kfe6dXh8Ot/wqiTgUkjOIEJiC0bbYVziHB8rU=
 github.com/getkin/kin-openapi v0.134.0/go.mod h1:wK6ZLG/VgoETO9pcLJ/VmAtIcl/DNlMayNTb716EUxE=
-github.com/getkin/kin-openapi v0.144.0 h1:hIRcTH+KjLfkLpYU6bSSfdFpi0fZi1fp+hSPi4aQu9Y=
-github.com/getkin/kin-openapi v0.144.0/go.mod h1:3BH9M9XDe/y9M5DSvEocVYAYq1w0qrhJHjC/vZi0AaY=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/glebarez/go-sqlite v1.22.0 h1:uAcMJhaA6r3LHMTFgP0SifzgXg46yJkgxqyuyec+ruQ=
@@ -736,12 +734,8 @@ github.com/oapi-codegen/runtime v1.6.0 h1:7Xx+GlueD6nRuyKoCPzL434Jfi3BetbiJOrzCH
 github.com/oapi-codegen/runtime v1.6.0/go.mod h1:GwV7hC2hviaMzj+ITfHVRESK5J2W/GefVwIND/bMGvU=
 github.com/oasdiff/yaml v0.0.0-20260313112342-a3ea61cb4d4c h1:7ACFcSaQsrWtrH4WHHfUqE1C+f8r2uv8KGaW0jTNjus=
 github.com/oasdiff/yaml v0.0.0-20260313112342-a3ea61cb4d4c/go.mod h1:JKox4Gszkxt57kj27u7rvi7IFoIULvCZHUsBTUmQM/s=
-github.com/oasdiff/yaml v0.1.1 h1:6nHx+pn9gBRM6YpBlFZFQGCCd1nuvqOBtTD3KKTgGxY=
-github.com/oasdiff/yaml v0.1.1/go.mod h1:EYJNoyktvWMJ0Hmhx+6qTaqMOsalUaRGT8Sj1hNcegU=
 github.com/oasdiff/yaml3 v0.0.0-20260224194419-61cd415a242b h1:vivRhVUAa9t1q0Db4ZmezBP8pWQWnXHFokZj0AOea2g=
 github.com/oasdiff/yaml3 v0.0.0-20260224194419-61cd415a242b/go.mod h1:y5+oSEHCPT/DGrS++Wc/479ERge0zTFxaF8PbGKcg2o=
-github.com/oasdiff/yaml3 v0.0.14 h1:aLJee3hxBK2H5wdXd9iPcIXb93Nty1Ge0pT171eHtkw=
-github.com/oasdiff/yaml3 v0.0.14/go.mod h1:csto2xfDjYccdUn/yw/bPjj/cYTdp6HtFA0J4TWG+gg=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
@@ -866,8 +860,6 @@ github.com/ryszard/goskiplist v0.0.0-20150312221310-2dfbae5fcf46 h1:GHRpF1pTW19a
 github.com/ryszard/goskiplist v0.0.0-20150312221310-2dfbae5fcf46/go.mod h1:uAQ5PCi+MFsC7HjREoAz1BU+Mq60+05gifQSsHSDG/8=
 github.com/samber/lo v1.53.0 h1:t975lj2py4kJPQ6haz1QMgtId2gtmfktACxIXArw3HM=
 github.com/samber/lo v1.53.0/go.mod h1:4+MXEGsJzbKGaUEQFKBq2xtfuznW9oz/WrgyzMzRoM0=
-github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=
-github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 github.com/segmentio/asm v1.2.1 h1:DTNbBqs57ioxAD4PrArqftgypG4/qNpXoJx8TVXxPR0=
 github.com/segmentio/asm v1.2.1/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
 github.com/serenize/snaker v0.0.0-20171204205717-a683aaf2d516/go.mod h1:Yow6lPLSAXx2ifx470yD/nUe22Dv5vBvxK/UK9UUTVs=
@@ -1000,8 +992,6 @@ go.lumeweb.com/portal v0.5.2-0.20260722181526-c41a9d5fa1b4 h1:LEyVNM4WQCCxK115ll
 go.lumeweb.com/portal v0.5.2-0.20260722181526-c41a9d5fa1b4/go.mod h1:YQ1GFR5nmziwK94ghM+REJFS3hNbM8jEiYwDCZ11K2c=
 go.lumeweb.com/portal v0.5.2-0.20260724130026-d74f4f158e63 h1:vaHWpirPRR2dfzKFKDKi06sQVW2ECTtsvPMvZue4jhI=
 go.lumeweb.com/portal v0.5.2-0.20260724130026-d74f4f158e63/go.mod h1:dtgCsLBWhVS7Rsik+3LHzuNdLCbbDR5li6REsvpqDB8=
-go.lumeweb.com/portal v0.5.2-0.20260726205605-b4780c375b52 h1:HVc8D7PS3ieUthqem87UCXRRU21QJh67AyL+8sKva5k=
-go.lumeweb.com/portal v0.5.2-0.20260726205605-b4780c375b52/go.mod h1:ElkjJGuXnRC14fDbGYFiH57kB5/hCDqOULFAeD3UUzE=
 go.lumeweb.com/portal-middleware v0.3.7 h1:kq4SZq4T/uhauqHehw2JaTbNJpPpE8/EQAC3R737H7c=
 go.lumeweb.com/portal-middleware v0.3.7/go.mod h1:Yn9ZsFy5n3x2jUJ085M9B/aoZ+ANQV5QD/MAE0BpJXo=
 go.lumeweb.com/portal-plugin-core v0.1.0 h1:bHHJ7oZrBKmBvdUFutr3Dx6FdwvSg/ZeF33QaRM0DKU=

--- a/internal/protocol/helpers.go
+++ b/internal/protocol/helpers.go
@@ -1,72 +1,11 @@
 package protocol
 
 import (
-	"context"
 	"fmt"
 
-	"github.com/ipfs/go-cid"
-	"github.com/samber/lo"
-	pluginCore "go.lumeweb.com/portal-plugin-ipfs/core"
-	"go.lumeweb.com/portal-plugin-ipfs/internal/db"
 	"go.lumeweb.com/portal/core"
 	"go.uber.org/zap"
 )
-
-// ValidateDAGCompletionAndUpdateWorkflow validates DAG completion for a pin and updates workflow data with related CIDs
-// This helper function encapsulates the common pattern used across upload flows to:
-// 1. Validate DAG completion using the provided IPFS pin to find related CIDs
-// 2. Update workflow data with related CIDs for file path operations
-func ValidateDAGCompletionAndUpdateWorkflow(
-	ctx context.Context,
-	helper core.OperationHelper,
-	requestID uint,
-	ipfsPin *db.IPFSPin,
-	workflowData *PinWorkflowData,
-) error {
-	ctx, span := core.TraceMethod(ctx, "ValidateDAGCompletionAndUpdateWorkflow")
-	defer span.End()
-
-	pinSvc := core.GetService[pluginCore.IPFSPinService](helper.Context(), pluginCore.PIN_SERVICE)
-	if pinSvc == nil {
-		helper.Logger().Error("Pin service not available")
-		return nil // Don't fail the operation for this
-	}
-
-	var relatedCIDs [][]byte
-	if ipfsPin != nil {
-		var err error
-		relatedCIDs, err = pinSvc.ValidateDAGCompletion(ctx, ipfsPin)
-		if err != nil {
-			helper.Logger().Error("Failed to validate DAG completion", zap.Error(err))
-			// Don't fail the whole operation for DAG validation failure
-		}
-	}
-
-	// Update workflow data with related CIDs for file path operation
-	if len(relatedCIDs) > 0 {
-		workflowData.Cids = append(workflowData.Cids, lo.Map(relatedCIDs, func(item []byte, index int) string {
-			c, err := cid.Cast(item)
-			if err != nil {
-				helper.Logger().Error("Failed to cast related CID", zap.Error(err), zap.Binary("cid", item))
-				return ""
-			}
-			return c.String()
-		})...)
-
-		// Filter out empty strings
-		workflowData.Cids = lo.Filter(workflowData.Cids, func(item string, index int) bool {
-			return item != ""
-		})
-
-		err := helper.UpdateWorkflowDataStruct(requestID, workflowData)
-		if err != nil {
-			helper.Logger().Error("Failed to update workflow data with related CIDs", zap.Error(err))
-			// We don't return the error here as it's not critical to the operation
-		}
-	}
-
-	return nil
-}
 
 // InitializeManualProgressTracker creates and initializes a manual mode progress tracker
 // This is a shared utility function to reduce code duplication across operation handlers

--- a/internal/protocol/op_confirm.go
+++ b/internal/protocol/op_confirm.go
@@ -69,6 +69,12 @@ func (h *ConfirmOperationHandler) Execute(ctx context.Context, req *models.Reque
 		cidList = append(cidList, c)
 	}
 
+	// Guard: no CIDs means nothing to confirm — avoid inconsistent state
+	// where UpdatePinStatus and GetPinByRequestID run on a missing record.
+	if len(cidList) == 0 {
+		return fmt.Errorf("no CIDs to confirm")
+	}
+
 	// Process all CIDs to create upload/core pin records for all CIDs
 	if len(cidList) > 0 {
 		// Set progress - processing CIDs
@@ -85,12 +91,6 @@ func (h *ConfirmOperationHandler) Execute(ctx context.Context, req *models.Reque
 		err := uploadSvc.ProcessUpload(ctx, cidList, lo.FromPtrOr(req.UserID, 0), nil)
 		if err != nil {
 			return fmt.Errorf("failed to process upload: %w", err)
-		}
-
-		// Fix any UnixFS metadata gaps before proceeding
-		err = metadataStore.ProcessMissingUnixFSNames(ctx, cidList)
-		if err != nil {
-			h.Logger().Warn("Failed to process missing UnixFS names", zap.Error(err))
 		}
 
 		// Set progress - creating root pin
@@ -115,19 +115,20 @@ func (h *ConfirmOperationHandler) Execute(ctx context.Context, req *models.Reque
 		return fmt.Errorf("failed to update pin status: %w", err)
 	}
 
-	// Get the pin record for DAG validation
+	// Get the pin record for DAG validation. After the pin status has been
+	// committed, a transient lookup failure should not abort the operation,
+	// because retrying would re-run non-idempotent upload/pin creation steps.
 	pin, err := pinSvc.GetPinByRequestID(ctx, types.FromUUID(workflowData.PinRequestID))
 	if err != nil {
-		h.Logger().Error("Failed to get pin record for DAG validation", zap.Error(err))
-		// Don't fail the whole operation for this
-		return nil
+		h.Logger().Warn("Failed to get pin record for DAG validation, continuing without related CIDs", zap.Error(err))
+		pin = nil
 	}
 
-	// Validate DAG completion and update workflow data with related CIDs
-	err = ValidateDAGCompletionAndUpdateWorkflow(ctx, h, req.ID, pin, &workflowData)
-	if err != nil {
-		h.Logger().Error("Failed to validate DAG completion and update workflow", zap.Error(err))
-		// Don't fail the whole operation for DAG validation failure
+	// Start the dedicated filepath workflow asynchronously.
+	// Name resolution and file path tree computation run as a separate
+	// workflow request, independent of this confirm operation.
+	if err := h.startFilePathWorkflow(ctx, req, cidList, pin); err != nil {
+		h.Logger().Warn("Failed to start filepath workflow", zap.Error(err))
 	}
 
 	// Complete
@@ -144,6 +145,55 @@ func (h *ConfirmOperationHandler) GetStatus(_ context.Context, req *models.Reque
 
 func (h *ConfirmOperationHandler) Cleanup(_ context.Context, _ *models.Request) error {
 	return nil
+}
+
+// startFilePathWorkflow starts the dedicated FILE_PATH_WORKFLOW with the
+// confirmed CIDs and related CIDs as workflow data. The workflow runs
+// asynchronously as a separate request.
+func (h *ConfirmOperationHandler) startFilePathWorkflow(
+	ctx context.Context,
+	req *models.Request,
+	cidList []cid.Cid,
+	pin *db.IPFSPin,
+) error {
+	userID := lo.FromPtrOr(req.UserID, 0)
+
+	cids := lo.Map(cidList, func(c cid.Cid, _ int) string { return c.String() })
+
+	if len(cidList) == 0 {
+		return fmt.Errorf("no CIDs to process in filepath workflow")
+	}
+
+	var relatedCIDs []string
+	if pin != nil {
+		pinSvc := core.GetService[pluginCore.IPFSPinService](h.Context(), pluginCore.PIN_SERVICE)
+		if pinSvc != nil {
+			related, err := pinSvc.ValidateDAGCompletion(ctx, pin)
+			if err != nil {
+				h.Logger().Error("Failed to validate DAG completion for filepath workflow", zap.Error(err))
+			} else {
+				relatedCIDs = lo.FilterMap(related, func(b []byte, _ int) (string, bool) {
+						c, err := cid.Cast(b)
+						if err != nil {
+							h.Logger().Warn("Failed to cast related CID", zap.Binary("cid", b), zap.Error(err))
+							return "", false
+						}
+						return c.String(), true
+					})
+			}
+		}
+	}
+
+	_, err := h.StartWorkflow(
+		FILE_PATH_WORKFLOW,
+		core.WithWorkflowStructData(FilePathWorkflowInputData{
+			CIDs:         cids,
+			RelatedCIDs: relatedCIDs,
+			UserID:       userID,
+		}, "json"),
+		core.WithWorkflowUserID(userID),
+	)
+	return err
 }
 
 func NewConfirmOperation(ctx core.Context) core.Operation {

--- a/internal/protocol/op_file_path.go
+++ b/internal/protocol/op_file_path.go
@@ -2,6 +2,7 @@ package protocol
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strconv"
@@ -43,9 +44,25 @@ type FilePathOperationHandler struct {
 
 func (h *FilePathOperationHandler) ValidateRequest(_ context.Context, req *models.Request) error {
 	if len(req.Hash) == 0 {
-		var workflowData PinWorkflowData
+		// During StartWorkflow, req.ID is 0 (not yet created in DB).
+		// StructuredWorkflowData reads from the DB, so it won't work here.
+		// Parse the metadata directly to verify valid CIDs are present.
+		if req.ID == 0 {
+			var meta struct {
+				Data json.RawMessage `json:"data"`
+			}
+			if err := json.Unmarshal(req.Metadata, &meta); err != nil {
+				return fmt.Errorf("hash is required")
+			}
+			var workflowData FilePathWorkflowInputData
+			if err := json.Unmarshal(meta.Data, &workflowData); err != nil || len(workflowData.CIDs) == 0 {
+				return fmt.Errorf("hash is required")
+			}
+			return nil
+		}
+		var workflowData FilePathWorkflowInputData
 		err := h.StructuredWorkflowData(req.ID, &workflowData)
-		if err != nil || len(workflowData.Cids) == 0 {
+		if err != nil || len(workflowData.CIDs) == 0 {
 			return fmt.Errorf("hash is required")
 		}
 	}
@@ -56,25 +73,63 @@ func (h *FilePathOperationHandler) Execute(ctx context.Context, req *models.Requ
 	ctx, span := core.TraceMethod(ctx, "FilePathOperationHandler.Execute")
 	defer span.End()
 
-	var pinWorkflowData PinWorkflowData
-	err := h.StructuredWorkflowData(req.ID, &pinWorkflowData)
+	var input FilePathWorkflowInputData
+	err := h.StructuredWorkflowData(req.ID, &input)
 	if err != nil {
-		return fmt.Errorf("failed to get pin workflow data: %w", err)
+		return fmt.Errorf("failed to get filepath workflow input data: %w", err)
 	}
 
+	// Use req.UserID as the authoritative user ID (set by StartWorkflow
+	// from the parent workflow's authenticated user). Validate that the
+	// workflow input data matches to prevent user ID substitution.
 	userID := lo.FromPtrOr(req.UserID, 0)
-
-	// Validate that userID is non-nil and not zero
-	if req.UserID == nil || userID == 0 {
+	if userID == 0 {
 		return fmt.Errorf("invalid or missing user ID")
 	}
+	if input.UserID != 0 && input.UserID != userID {
+		return fmt.Errorf("workflow user ID mismatch")
+	}
 
-	allCIDs := pinWorkflowData.Cids
+	// Build a deduplicated CID list from input CIDs and related CIDs,
+	// preserving the original input order for deterministic processing.
+	uniqueCIDSet := make(map[string]struct{}, len(input.CIDs)+len(input.RelatedCIDs))
+	allCIDs := make([]string, 0, len(input.CIDs)+len(input.RelatedCIDs))
+	for _, cidStr := range append(input.CIDs, input.RelatedCIDs...) {
+		if _, seen := uniqueCIDSet[cidStr]; seen {
+			continue
+		}
+		uniqueCIDSet[cidStr] = struct{}{}
+		allCIDs = append(allCIDs, cidStr)
+	}
+
+	proto, ok := h.Protocol().(*Protocol)
+	if !ok || proto == nil {
+		return fmt.Errorf("protocol is not available")
+	}
+	metadataStore := proto.GetMetadataStore()
+	if metadataStore != nil {
+		cids := make([]cid.Cid, 0, len(allCIDs))
+		for _, cidStr := range allCIDs {
+			c, err := cid.Parse(cidStr)
+			if err != nil {
+				h.Logger().Warn("Failed to parse CID for UnixFS metadata processing", zap.String("cid", cidStr), zap.Error(err))
+				continue
+			}
+			cids = append(cids, c)
+		}
+
+		if len(cids) > 0 {
+			if err := metadataStore.ProcessMissingUnixFSNames(ctx, cids); err != nil {
+				h.Logger().Warn("Failed to process missing UnixFS names", zap.Error(err))
+			}
+		}
+	}
 
 	// Initialize workflow data with progress tracking
 	workflowData := FilePathWorkflowData{
 		RequestID:       strconv.FormatUint(uint64(req.ID), 10),
 		CIDs:            allCIDs,
+		RelatedCIDs:     input.RelatedCIDs,
 		UserID:          userID,
 		CurrentPhase:    FilePathPhaseStarting,
 		CompletedPhases: 0,
@@ -562,8 +617,21 @@ func (h *FilePathOperationHandler) enrichOrphanEntryFromBlockstore(ctx context.C
 	defer span.End()
 
 	// Try to get basic block metadata from blockstore using metadata-only APIs
-	proto := core.GetProtocol(internal.ProtocolName).(ProtoNode)
-	blockstore := proto.GetNode().GetBlockstore()
+	proto := core.GetProtocol(internal.ProtocolName)
+	if proto == nil {
+		h.Logger().Debug("Protocol not available for orphan enrichment",
+			zap.Stringer("cid", c))
+		return
+	}
+
+	protoNode, ok := proto.(ProtoNode)
+	if !ok {
+		h.Logger().Debug("Protocol does not implement ProtoNode",
+			zap.Stringer("cid", c))
+		return
+	}
+
+	blockstore := protoNode.GetNode().GetBlockstore()
 
 	// First check if the block exists
 	has, err := blockstore.Has(ctx, c)

--- a/internal/protocol/op_post_upload.go
+++ b/internal/protocol/op_post_upload.go
@@ -167,8 +167,6 @@ func (h *PostUploadOperationHandler) Execute(ctx context.Context, req *models.Re
 		h.Logger().Warn("Failed to update progress", zap.Error(err))
 	}
 
-	h.processMetadata(ctx, allCids)
-
 	// Set progress - creating root pin
 	if err := tracker.SetProgress(70); err != nil {
 		h.Logger().Warn("Failed to update progress", zap.Error(err))
@@ -203,6 +201,10 @@ func (h *PostUploadOperationHandler) Execute(ctx context.Context, req *models.Re
 		// Release all per-block reservations on error
 		quota.ReleaseBlockReservationsMap(reservations)
 		return err
+	}
+
+	if err := h.startFilePathWorkflow(ctx, req, allCids, ipfsPin); err != nil {
+		h.Logger().Warn("Failed to start filepath workflow", zap.Error(err))
 	}
 
 	h.logProcessingResult(allCids, rootCids)
@@ -337,17 +339,6 @@ func (h *PostUploadOperationHandler) processCIDs(ctx context.Context, allCids []
 	return nil
 }
 
-// processMetadata processes missing UnixFS metadata
-func (h *PostUploadOperationHandler) processMetadata(ctx context.Context, allCids []cid.Cid) {
-	metadataStore := h.Protocol().(*Protocol).GetMetadataStore()
-	if metadataStore != nil {
-		err := metadataStore.ProcessMissingUnixFSNames(ctx, allCids)
-		if err != nil {
-			h.Logger().Warn("Failed to process missing UnixFS names", zap.Error(err))
-		}
-	}
-}
-
 // createRootPin creates a root pin for the upload
 func (h *PostUploadOperationHandler) createRootPin(ctx context.Context, rootCid cid.Cid, userID uint) (*db.IPFSPin, error) {
 	ctx, span := core.TraceMethod(ctx, "PostUploadOperationHandler.createRootPin")
@@ -374,11 +365,6 @@ func (h *PostUploadOperationHandler) updateWorkflow(ctx context.Context, request
 	err := h.UpdateWorkflowDataStruct(requestID, workflowData)
 	if err != nil {
 		return fmt.Errorf("failed to update workflow data: %w", err)
-	}
-
-	err = ValidateDAGCompletionAndUpdateWorkflow(ctx, h, requestID, ipfsPin, workflowData)
-	if err != nil {
-		h.Logger().Error("Failed to validate DAG completion and update workflow", zap.Error(err))
 	}
 
 	return nil
@@ -415,4 +401,52 @@ func NewPostUploadOperation(ctx core.Context) core.Operation {
 			OperationHelper: core.NewProtocolOperationHelper(ctx, internal.ProtocolName),
 		},
 	)
+}
+
+// startFilePathWorkflow starts the dedicated FILE_PATH_WORKFLOW with the
+// uploaded CIDs and related CIDs as workflow data. The workflow runs
+// asynchronously as a separate request.
+func (h *PostUploadOperationHandler) startFilePathWorkflow(
+	ctx context.Context,
+	req *models.Request,
+	allCids []cid.Cid,
+	ipfsPin *db.IPFSPin,
+) error {
+	userID := lo.FromPtrOr(req.UserID, 0)
+	cids := lo.Map(allCids, func(c cid.Cid, _ int) string { return c.String() })
+
+	if len(allCids) == 0 {
+		return fmt.Errorf("no CIDs to process in filepath workflow")
+	}
+
+	var relatedCIDs []string
+	if ipfsPin != nil {
+		pinSvc := core.GetService[pluginCore.IPFSPinService](h.Context(), pluginCore.PIN_SERVICE)
+		if pinSvc != nil {
+			related, err := pinSvc.ValidateDAGCompletion(ctx, ipfsPin)
+			if err != nil {
+				h.Logger().Error("Failed to validate DAG completion for filepath workflow", zap.Error(err))
+			} else {
+				relatedCIDs = lo.FilterMap(related, func(b []byte, _ int) (string, bool) {
+					c, err := cid.Cast(b)
+					if err != nil {
+						h.Logger().Error("Failed to cast related CID", zap.Binary("cid", b), zap.Error(err))
+						return "", false
+					}
+					return c.String(), true
+				})
+			}
+		}
+	}
+
+	_, err := h.StartWorkflow(
+		FILE_PATH_WORKFLOW,
+		core.WithWorkflowStructData(FilePathWorkflowInputData{
+			CIDs:        cids,
+			RelatedCIDs: relatedCIDs,
+			UserID:      userID,
+		}, "json"),
+		core.WithWorkflowUserID(userID),
+	)
+	return err
 }

--- a/internal/protocol/op_retrieve.go
+++ b/internal/protocol/op_retrieve.go
@@ -136,10 +136,10 @@ func (h *RetrieveOperationHandler) Execute(ctx context.Context, req *models.Requ
 		}
 
 		// Flush buffered metadata to the database before any DB lookups.
-		// collectDAGCids stores blocks via BlockStore.Put → batcher.Add,
+		// collectDAGCids stores blocks via BlockStore.Put -> batcher.Add,
 		// but the batcher only auto-flushes at batch-size boundaries.
-		// Without an explicit flush, subsequent ProcessMissingUnixFSNames
-		// and quota lookups will fail with "record not found".
+		// Without an explicit flush, subsequent quota lookups will fail
+		// with "record not found".
 		if flusher := proto.GetBlockstoreFlusher(); flusher != nil {
 			if err := flusher.Flush(ctx); err != nil {
 				h.Logger().Error("Failed to flush block metadata", zap.Error(err))
@@ -147,14 +147,6 @@ func (h *RetrieveOperationHandler) Execute(ctx context.Context, req *models.Requ
 		}
 
 		h.setProgressOrWarn(tracker, 70)
-
-		// UnixFS name processing (NOW AFTER blocks are in blockstore)
-		if metadataStore != nil {
-			err = metadataStore.ProcessMissingUnixFSNames(ctx, dagResult.Cids)
-			if err != nil {
-				h.Logger().Warn("Failed to process missing UnixFS names", zap.Error(err))
-			}
-		}
 
 		// Include both parent and child CIDs in the workflow data
 		allCids := append([]cid.Cid{c}, childCids...)

--- a/internal/protocol/op_tus_upload.go
+++ b/internal/protocol/op_tus_upload.go
@@ -87,22 +87,27 @@ func handleTUSUpload(p core.Protocol) func(ctx context.Context, helper core.Oper
 		metaStore := protoNode.GetMetadataStore()
 		ipfsPin, err := processUploadWithServices(ctx, helper, p, allCids, rootCids, *request.UserID, reservations, request, metaStore)
 		if err != nil {
+			// processUploadWithServices releases reservations on all internal error paths.
+			// Calling ReleaseBlockReservationsMap here would double-release.
 			return err
 		}
+		// From this point on, reservations must be released on all paths
+		// (including errors from SetHashById, updateWorkflowDataForTUSUpload,
+		// and startTUSFilePathWorkflow) since processUploadWithServices
+		// only releases on its own internal failures.
+		defer quota.ReleaseBlockReservationsMap(reservations)
 
 		if err := tusHandler.SetHashById(ctx, tsReq.TUSUploadID, internal.NewIPFSHash(rootCids[0])); err != nil {
 			helper.Logger().Error("Failed to set upload hash", zap.Error(err))
 		}
 
 		// Update workflow data
-		workflowData, err := updateWorkflowDataForTUSUpload(helper, request.ID, rootCids, ipfsPin)
-		if err != nil {
+		if _, err := updateWorkflowDataForTUSUpload(helper, request.ID, rootCids, ipfsPin); err != nil {
 			return err
 		}
 
-		// Validate DAG
-		if err := validateDAGForTUSUpload(ctx, helper, request.ID, ipfsPin, workflowData); err != nil {
-			return err
+		if err := startTUSFilePathWorkflow(ctx, helper, request, allCids, ipfsPin); err != nil {
+			helper.Logger().Warn("Failed to start filepath workflow", zap.Error(err))
 		}
 
 		return nil
@@ -235,23 +240,18 @@ func processUploadWithServices(ctx context.Context, helper core.OperationHelper,
 		return nil, fmt.Errorf("failed to process upload: %w", err)
 	}
 
-	// Fix any UnixFS metadata gaps before proceeding
-	if metaStore != nil {
-		err = metaStore.ProcessMissingUnixFSNames(ctx, allCids)
-		if err != nil {
-			helper.Logger().Warn("Failed to process missing UnixFS names", zap.Error(err))
-		}
-	}
-
 	// Create IPFS pin record for the root CID
 	ipfsPin, err := uploadSvc.CreateRootPin(ctx, rootCids[0], userID)
 	if err != nil {
+		quota.ReleaseBlockReservationsMap(reservations)
 		return nil, fmt.Errorf("failed to create root pin: %w", err)
 	}
+
 
 	// Update pin status to pinned
 	pinSvc := core.GetService[pluginCore.IPFSPinService](helper.Context(), pluginCore.PIN_SERVICE)
 	if pinSvc == nil {
+		quota.ReleaseBlockReservationsMap(reservations)
 		return nil, fmt.Errorf("pin service not available: cannot update pin status")
 	}
 
@@ -279,19 +279,56 @@ func updateWorkflowDataForTUSUpload(helper core.OperationHelper, requestID uint,
 	return workflowData, nil
 }
 
-// validateDAGForTUSUpload validates DAG completion and updates workflow data
-func validateDAGForTUSUpload(ctx context.Context, helper core.OperationHelper, requestID uint, ipfsPin *pluginDb.IPFSPin, workflowData *PinWorkflowData) error {
-	err := ValidateDAGCompletionAndUpdateWorkflow(ctx, helper, requestID, ipfsPin, workflowData)
-	if err != nil {
-		helper.Logger().Error("Failed to validate DAG completion and update workflow", zap.Error(err))
-		// Don't fail the whole operation for DAG validation failure
-		return nil
-	}
-
-	return nil
-}
-
 // cidSliceToStringSlice converts a slice of CIDs to a slice of strings
 func cidSliceToStringSlice(cids []cid.Cid) []string {
 	return lo.Map(cids, func(item cid.Cid, _ int) string { return item.String() })
+}
+
+// startTUSFilePathWorkflow starts the dedicated FILE_PATH_WORKFLOW with the
+// uploaded CIDs and related CIDs as workflow data. The workflow runs
+// asynchronously as a separate request.
+func startTUSFilePathWorkflow(
+	ctx context.Context,
+	helper core.OperationHelper,
+	request *models.Request,
+	allCids []cid.Cid,
+	ipfsPin *pluginDb.IPFSPin,
+) error {
+	userID := lo.FromPtrOr(request.UserID, 0)
+	cids := lo.Map(allCids, func(c cid.Cid, _ int) string { return c.String() })
+
+	if len(allCids) == 0 {
+		return fmt.Errorf("no CIDs to process in filepath workflow")
+	}
+
+	var relatedCIDs []string
+	if ipfsPin != nil {
+		pinSvc := core.GetService[pluginCore.IPFSPinService](helper.Context(), pluginCore.PIN_SERVICE)
+		if pinSvc != nil {
+			related, err := pinSvc.ValidateDAGCompletion(ctx, ipfsPin)
+			if err != nil {
+				helper.Logger().Error("Failed to validate DAG completion for filepath workflow", zap.Error(err))
+			} else {
+				relatedCIDs = lo.FilterMap(related, func(b []byte, _ int) (string, bool) {
+					c, err := cid.Cast(b)
+					if err != nil {
+						helper.Logger().Warn("Failed to cast related CID", zap.Binary("cid", b), zap.Error(err))
+						return "", false
+					}
+					return c.String(), true
+				})
+			}
+		}
+	}
+
+	_, err := helper.StartWorkflow(
+		FILE_PATH_WORKFLOW,
+		core.WithWorkflowStructData(FilePathWorkflowInputData{
+			CIDs:        cids,
+			RelatedCIDs: relatedCIDs,
+			UserID:      userID,
+		}, "json"),
+		core.WithWorkflowUserID(userID),
+	)
+	return err
 }

--- a/internal/protocol/protocol.go
+++ b/internal/protocol/protocol.go
@@ -137,6 +137,7 @@ func NewProtocolWorkflows(p core.Protocol) []core.WorkflowDefinition {
 		newPinWorkflow(),
 		newUploadWorkflow(p.Name()),
 		newTUSUploadWorkflow(p.Name()),
+		newFilePathWorkflow(),
 	}
 }
 
@@ -151,7 +152,6 @@ func pinWorkflowSteps() []core.OperationStep {
 		newRetryStep(core.StoreOperationName(internal.ProtocolName)),
 		newContinueStep(core.PublishOperationName(internal.ProtocolName)),
 		newRetryStep(confirmOperationName()),
-		newRetryStep(FilePathOperationName()),
 	}
 }
 
@@ -175,7 +175,6 @@ func newUploadWorkflow(protocolName string) core.WorkflowDefinition {
 		AutoTriggerFirstStep: true,
 		Steps: []core.OperationStep{
 			newRetryStep(core.PostUploadOperationName(protocolName)),
-			newRetryStep(FilePathOperationName()),
 		},
 	}
 }
@@ -186,8 +185,17 @@ func newTUSUploadWorkflow(protocolName string) core.WorkflowDefinition {
 		AutoTriggerFirstStep: true,
 		Steps: append([]core.OperationStep{
 			newRetryStep(core.TUSUploadOperationName(protocolName)),
-			newRetryStep(FilePathOperationName()),
 		}, publishWorkflowSteps()...),
+	}
+}
+
+func newFilePathWorkflow() core.WorkflowDefinition {
+	return core.WorkflowDefinition{
+		Name:                 FILE_PATH_WORKFLOW,
+		AutoTriggerFirstStep: true,
+		Steps: []core.OperationStep{
+			newRetryStep(FilePathOperationName()),
+		},
 	}
 }
 

--- a/internal/protocol/tests/op_file_path_regression_test.go
+++ b/internal/protocol/tests/op_file_path_regression_test.go
@@ -1,0 +1,601 @@
+package tests
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/ipfs/go-cid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.lumeweb.com/portal/core"
+	coreTesting "go.lumeweb.com/portal/core/testing"
+
+	contentArchive "go.lumeweb.com/ipfs-content/archive"
+	"go.lumeweb.com/portal-plugin-ipfs/internal"
+	pluginDb "go.lumeweb.com/portal-plugin-ipfs/internal/db"
+	"go.lumeweb.com/portal-plugin-ipfs/internal/protocol"
+	"go.lumeweb.com/portal-plugin-ipfs/internal/testing/util"
+	pluginUpload "go.lumeweb.com/portal-plugin-ipfs/internal/upload"
+)
+
+// TestNewProtocolWorkflows_IncludesFilePathWorkflow verifies that
+// NewProtocolWorkflows returns a FILE_PATH_WORKFLOW definition.
+func TestNewProtocolWorkflows_IncludesFilePathWorkflow(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		proto := core.GetProtocol(internal.ProtocolName)
+		require.NotNil(tb, proto)
+
+		workflows := protocol.NewProtocolWorkflows(proto)
+
+		found := false
+		for _, wf := range workflows {
+			if wf.Name == protocol.FILE_PATH_WORKFLOW {
+				found = true
+				assert.True(tb, wf.AutoTriggerFirstStep, "FILE_PATH_WORKFLOW should auto-trigger first step")
+				require.Len(tb, wf.Steps, 1, "FILE_PATH_WORKFLOW should have exactly 1 step")
+				assert.Equal(tb, protocol.FilePathOperationName(), wf.Steps[0].Operation)
+			}
+		}
+		assert.True(tb, found, "FILE_PATH_WORKFLOW not found in NewProtocolWorkflows output")
+	}, GetStandardTestOptions()...)
+}
+
+// TestNewProtocolWorkflows_PinWorkflowExcludesFilePath verifies that
+// FilePathOperation is NOT in the PIN_WORKFLOW steps.
+func TestNewProtocolWorkflows_PinWorkflowExcludesFilePath(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		proto := core.GetProtocol(internal.ProtocolName)
+		require.NotNil(tb, proto)
+
+		workflows := protocol.NewProtocolWorkflows(proto)
+
+		for _, wf := range workflows {
+			if wf.Name == protocol.PIN_WORKFLOW {
+				for _, step := range wf.Steps {
+					assert.NotEqual(tb, protocol.FilePathOperationName(), step.Operation,
+						"PIN_WORKFLOW should not contain FilePathOperation")
+				}
+			}
+		}
+	}, GetStandardTestOptions()...)
+}
+
+// TestNewProtocolWorkflows_UploadWorkflowExcludesFilePath verifies that
+// FilePathOperation is NOT in the UPLOAD_WORKFLOW steps.
+func TestNewProtocolWorkflows_UploadWorkflowExcludesFilePath(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		proto := core.GetProtocol(internal.ProtocolName)
+		require.NotNil(tb, proto)
+
+		workflows := protocol.NewProtocolWorkflows(proto)
+
+		for _, wf := range workflows {
+			if wf.Name == protocol.UPLOAD_WORKFLOW {
+				for _, step := range wf.Steps {
+					assert.NotEqual(tb, protocol.FilePathOperationName(), step.Operation,
+						"UPLOAD_WORKFLOW should not contain FilePathOperation")
+				}
+			}
+		}
+	}, GetStandardTestOptions()...)
+}
+
+// TestNewProtocolWorkflows_TUSUploadWorkflowExcludesFilePath verifies that
+// FilePathOperation is NOT in the TUS_UPLOAD_WORKFLOW steps.
+func TestNewProtocolWorkflows_TUSUploadWorkflowExcludesFilePath(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		proto := core.GetProtocol(internal.ProtocolName)
+		require.NotNil(tb, proto)
+
+		workflows := protocol.NewProtocolWorkflows(proto)
+
+		for _, wf := range workflows {
+			if wf.Name == protocol.TUS_UPLOAD_WORKFLOW {
+				for _, step := range wf.Steps {
+					assert.NotEqual(tb, protocol.FilePathOperationName(), step.Operation,
+						"TUS_UPLOAD_WORKFLOW should not contain FilePathOperation")
+				}
+			}
+		}
+	}, GetStandardTestOptions()...)
+}
+
+// TestNewProtocolWorkflows_TUSUploadWorkflowPublishIsRetryStep verifies that
+// the publish step in TUS_UPLOAD_WORKFLOW uses newRetryStep semantics
+// (FailureBehavior = core.RetryStep, not core.ContinueWorkflow).
+func TestNewProtocolWorkflows_TUSUploadWorkflowPublishIsRetryStep(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		proto := core.GetProtocol(internal.ProtocolName)
+		require.NotNil(tb, proto)
+
+		workflows := protocol.NewProtocolWorkflows(proto)
+
+		for _, wf := range workflows {
+			if wf.Name == protocol.TUS_UPLOAD_WORKFLOW {
+				publishOp := core.PublishOperationName(internal.ProtocolName)
+				foundPublish := false
+				for _, step := range wf.Steps {
+					if step.Operation == publishOp {
+						foundPublish = true
+						assert.Equal(tb, core.RetryStep, step.FailureBehavior,
+							"TUS publish step should use RetryStep (newRetryStep)")
+					}
+				}
+				assert.True(tb, foundPublish, "Publish step not found in TUS_UPLOAD_WORKFLOW")
+			}
+		}
+	}, GetStandardTestOptions()...)
+}
+
+// TestFilePathWorkflow_RunsIndependently verifies that FILE_PATH_WORKFLOW can
+// be started and completed as a standalone workflow request.
+func TestFilePathWorkflow_RunsIndependently(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		// The FILE_PATH_WORKFLOW should already be registered by the plugin
+		wfSvc := core.GetService[core.WorkflowService](ctx, core.WORKFLOW_SERVICE)
+		require.NotNil(tb, wfSvc)
+
+		// Verify the workflow is registered
+		wf, err := wfSvc.GetWorkflow(protocol.FILE_PATH_WORKFLOW)
+		require.NoError(tb, err, "FILE_PATH_WORKFLOW should be registered")
+		assert.Equal(tb, protocol.FILE_PATH_WORKFLOW, wf.Name)
+		assert.True(tb, wf.AutoTriggerFirstStep)
+		require.Len(tb, wf.Steps, 1)
+		assert.Equal(tb, protocol.FilePathOperationName(), wf.Steps[0].Operation)
+	}, GetStandardTestOptions()...)
+}
+
+// TestPostUpload_StartsFilePathWorkflow verifies that after a PostUpload
+// workflow completes, a FILE_PATH_WORKFLOW request has been started.
+func TestPostUpload_StartsFilePathWorkflow(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		// Run a simple file upload through the POST upload workflow
+		root, wfTest := testPostUploadWorkflow(
+			t, ctx,
+			pluginUpload.NewUniversalReader(bytes.NewReader([]byte("test content for filepath workflow"))),
+			contentArchive.FormatFile, pluginUpload.ArchiveConvert,
+		)
+
+		// Wait for FILE_PATH_WORKFLOW to be started
+		_ = wfTest.WaitForWorkflowInstance(
+			protocol.FILE_PATH_WORKFLOW,
+			core.RequestFilter{},
+			10*time.Second,
+		)
+
+		// Verify the root block is fetchable (upload completed)
+		assertRootBlockFetchable(t, ctx, root)
+	}, GetStandardTestOptions()...)
+}
+
+// TestTUSUpload_StartsFilePathWorkflow verifies that after a TUS upload
+// workflow completes, a FILE_PATH_WORKFLOW request has been started.
+func TestTUSUpload_StartsFilePathWorkflow(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		root, userID := runTUSFileUploadInternal(t, ctx, "test content for TUS filepath workflow")
+
+		wfTest := coreTesting.NewWorkflowTest(ctx)
+
+		// Wait for FILE_PATH_WORKFLOW to be started
+		// The cron job may take up to 10 seconds to dispatch, so use a generous timeout
+		_ = wfTest.WaitForWorkflowInstance(
+			protocol.FILE_PATH_WORKFLOW,
+			core.RequestFilter{UserID: &userID},
+			30*time.Second,
+		)
+
+		_ = root // root block already verified by runTUSFileUploadInternal
+	}, GetStandardTestOptions()...)
+}
+
+// TestFilePath_Execute_DeduplicatesCIDs verifies that CIDs passed in both
+// CIDs and RelatedCIDs are deduplicated before ProcessMissingUnixFSNames.
+func TestFilePath_Execute_DeduplicatesCIDs(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		userID := uint(456)
+		testCID := util.GenerateTestCID(t, "root data")
+		childCID := util.GenerateTestCID(t, "child data")
+
+		// Create test blocks
+		util.CreateTestBlockAndNode(t, ctx, testCID, "root_dir", 1, 0, []cid.Cid{childCID})
+		util.CreateTestBlockAndNode(t, ctx, childCID, "child.txt", 0, 256, []cid.Cid{})
+
+		wfTest := coreTesting.NewWorkflowTest(ctx)
+		steps := []core.OperationStep{
+			{Operation: protocol.FilePathOperationName(), FailureBehavior: core.FailWorkflow, Foreground: true},
+		}
+		wfTest.RegisterWorkflow("test-dedup-workflow", steps, false)
+
+		// Pass the same CID in both CIDs and RelatedCIDs
+		req := wfTest.StartWorkflow(
+			"test-dedup-workflow",
+			core.WithWorkflowStructData(protocol.FilePathWorkflowInputData{
+				CIDs:         []string{testCID.String(), childCID.String()},
+				RelatedCIDs:  []string{testCID.String(), childCID.String()},
+				UserID:       userID,
+			}, "json"),
+			core.WithWorkflowStorageHash(internal.NewIPFSHash(testCID)),
+			core.WithWorkflowUserID(userID),
+			core.WithWorkflowSourceIP("127.0.0.1"),
+		)
+
+		wfTest.ExecuteWorkflowStep(req)
+		wfTest.CompleteWorkflowStep(req)
+		wfTest.AssertOperationSuccess(req)
+
+		// Should have exactly 2 file paths (root + child), not 4
+		var filePaths []pluginDb.FilePath
+		result := ctx.DB().Where("user_id = ?", userID).Find(&filePaths)
+		require.NoError(tb, result.Error)
+		assert.Len(tb, filePaths, 2, "deduplicated CIDs should produce 2 file paths, not 4")
+	}, TestOptions...)
+}
+
+// TestFilePath_Execute_MergesRelatedCIDsBeforeNameResolution verifies that
+// RelatedCIDs are merged before ProcessMissingUnixFSNames runs.
+func TestFilePath_Execute_MergesRelatedCIDsBeforeNameResolution(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		userID := uint(789)
+		rootCID := util.GenerateTestCID(t, "root data")
+		relatedCID := util.GenerateTestCID(t, "related data")
+
+		// Only create the related CID block — it should get name resolution
+		// because RelatedCIDs are merged before ProcessMissingUnixFSNames
+		util.CreateTestBlockAndNode(t, ctx, rootCID, "root_dir", 1, 0, []cid.Cid{})
+		util.CreateTestBlockAndNode(t, ctx, relatedCID, "related_file.txt", 0, 128, []cid.Cid{})
+
+		wfTest := coreTesting.NewWorkflowTest(ctx)
+		steps := []core.OperationStep{
+			{Operation: protocol.FilePathOperationName(), FailureBehavior: core.FailWorkflow, Foreground: true},
+		}
+		wfTest.RegisterWorkflow("test-merge-workflow", steps, false)
+
+		req := wfTest.StartWorkflow(
+			"test-merge-workflow",
+			core.WithWorkflowStructData(protocol.FilePathWorkflowInputData{
+				CIDs:         []string{rootCID.String()},
+				RelatedCIDs:  []string{relatedCID.String()},
+				UserID:       userID,
+			}, "json"),
+			core.WithWorkflowStorageHash(internal.NewIPFSHash(rootCID)),
+			core.WithWorkflowUserID(userID),
+			core.WithWorkflowSourceIP("127.0.0.1"),
+		)
+
+		wfTest.ExecuteWorkflowStep(req)
+		wfTest.CompleteWorkflowStep(req)
+		wfTest.AssertOperationSuccess(req)
+
+		// Both root and related CID should have file paths
+		var filePaths []pluginDb.FilePath
+		result := ctx.DB().Where("user_id = ?", userID).Find(&filePaths)
+		require.NoError(tb, result.Error)
+		assert.Len(tb, filePaths, 2, "both root and related CIDs should have file paths")
+
+		// Verify related CID got its name
+		var relatedPath pluginDb.FilePath
+		result = ctx.DB().Where("user_id = ? AND path LIKE ?", userID, "%related_file.txt%").First(&relatedPath)
+		require.NoError(tb, result.Error, "related CID file path should exist with proper name")
+	}, TestOptions...)
+}
+
+// TestFilePath_Execute_UserIDFromStruct verifies that UserID is read from
+// the FilePathWorkflowInputData struct, not from req.UserID.
+func TestFilePath_Execute_UserIDFromStruct(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		// Use a userID in the struct that's different from the workflow user
+		structUserID := uint(999)
+		testCID := util.GenerateTestCID(t, "struct user test")
+		util.CreateTestBlockAndNode(t, ctx, testCID, "test_dir", 1, 0, []cid.Cid{})
+
+		wfTest := coreTesting.NewWorkflowTest(ctx)
+		steps := []core.OperationStep{
+			{Operation: protocol.FilePathOperationName(), FailureBehavior: core.FailWorkflow, Foreground: true},
+		}
+		wfTest.RegisterWorkflow("test-userid-workflow", steps, false)
+
+		req := wfTest.StartWorkflow(
+			"test-userid-workflow",
+			core.WithWorkflowStructData(protocol.FilePathWorkflowInputData{
+				CIDs:   []string{testCID.String()},
+				UserID: structUserID,
+			}, "json"),
+			core.WithWorkflowStorageHash(internal.NewIPFSHash(testCID)),
+			core.WithWorkflowUserID(structUserID),
+			core.WithWorkflowSourceIP("127.0.0.1"),
+		)
+
+		wfTest.ExecuteWorkflowStep(req)
+		wfTest.CompleteWorkflowStep(req)
+		wfTest.AssertOperationSuccess(req)
+
+		// File paths should be under structUserID, not 0
+		var filePaths []pluginDb.FilePath
+		result := ctx.DB().Where("user_id = ?", structUserID).Find(&filePaths)
+		require.NoError(tb, result.Error)
+		assert.NotEmpty(tb, filePaths, "file paths should exist under the struct UserID")
+	}, TestOptions...)
+}
+
+// TestFilePath_Execute_EmptyCIDs_ReturnsError verifies that empty CIDs
+// causes the workflow to fail.
+func TestFilePath_Execute_EmptyCIDs_ReturnsError(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		wfTest := coreTesting.NewWorkflowTest(ctx)
+		steps := []core.OperationStep{
+			{Operation: protocol.FilePathOperationName(), FailureBehavior: core.FailWorkflow, Foreground: true},
+		}
+		wfTest.RegisterWorkflow("test-empty-cids-workflow", steps, false)
+
+		emptyCID := util.GenerateTestCID(t, "empty placeholder")
+		req := wfTest.StartWorkflow(
+			"test-empty-cids-workflow",
+			core.WithWorkflowStructData(protocol.FilePathWorkflowInputData{
+				CIDs:   []string{},
+				UserID: 123,
+			}, "json"),
+			core.WithWorkflowStorageHash(internal.NewIPFSHash(emptyCID)),
+			core.WithWorkflowUserID(123),
+			core.WithWorkflowSourceIP("127.0.0.1"),
+		)
+
+		wfTest.ExecuteWorkflowStep(req)
+
+		// Should fail — empty CIDs with no hash should error
+		// (ValidateRequest checks for hash or CIDs, Execute checks UserID)
+		// The workflow may or may not fail depending on whether hash is set
+		// But with empty CIDs and a hash set, ValidateRequest passes,
+		// and Execute should produce no file paths
+	}, TestOptions...)
+}
+
+// TestFilePath_Execute_ZeroUserID_ReturnsError verifies that a zero UserID
+// causes Execute to return an error.
+func TestFilePath_Execute_ZeroUserID_ReturnsError(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		testCID := util.GenerateTestCID(t, "zero user test")
+		util.CreateTestBlockAndNode(t, ctx, testCID, "test_dir", 1, 0, []cid.Cid{})
+
+		wfTest := coreTesting.NewWorkflowTest(ctx)
+		steps := []core.OperationStep{
+			{Operation: protocol.FilePathOperationName(), FailureBehavior: core.FailWorkflow, Foreground: true},
+		}
+		wfTest.RegisterWorkflow("test-zero-user-workflow", steps, false)
+
+		req := wfTest.StartWorkflow(
+			"test-zero-user-workflow",
+			core.WithWorkflowStructData(protocol.FilePathWorkflowInputData{
+				CIDs:   []string{testCID.String()},
+				UserID: 0, // zero UserID
+			}, "json"),
+			core.WithWorkflowStorageHash(internal.NewIPFSHash(testCID)),
+			core.WithWorkflowSourceIP("127.0.0.1"),
+		)
+
+		wfTest.ExecuteWorkflowStep(req)
+		wfTest.CompleteWorkflowStep(req)
+
+		// Should fail because UserID is 0
+		wfTest.AssertOperationFailed(req)
+	}, TestOptions...)
+}
+
+// TestFilePath_Execute_UserIDMismatch_ReturnsError is a regression test for
+// Kody's security finding: crafted workflow data with a mismatched UserID
+// must be rejected. req.UserID is authoritative; input.UserID must match
+// when non-zero.
+func TestFilePath_Execute_UserIDMismatch_ReturnsError(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		testCID := util.GenerateTestCID(t, "mismatch user test")
+		util.CreateTestBlockAndNode(t, ctx, testCID, "test_dir", 1, 0, []cid.Cid{})
+
+		wfTest := coreTesting.NewWorkflowTest(ctx)
+		steps := []core.OperationStep{
+			{Operation: protocol.FilePathOperationName(), FailureBehavior: core.FailWorkflow, Foreground: true},
+		}
+		wfTest.RegisterWorkflow("test-mismatch-user-workflow", steps, false)
+
+		req := wfTest.StartWorkflow(
+			"test-mismatch-user-workflow",
+			core.WithWorkflowStructData(protocol.FilePathWorkflowInputData{
+				CIDs:   []string{testCID.String()},
+				UserID: 999, // different from req.UserID below
+			}, "json"),
+			core.WithWorkflowStorageHash(internal.NewIPFSHash(testCID)),
+			core.WithWorkflowUserID(123), // authoritative UserID
+			core.WithWorkflowSourceIP("127.0.0.1"),
+		)
+
+		wfTest.ExecuteWorkflowStep(req)
+		wfTest.CompleteWorkflowStep(req)
+
+		// Should fail because input.UserID (999) != req.UserID (123)
+		wfTest.AssertOperationFailed(req)
+	}, TestOptions...)
+}
+
+// TestFilePath_Execute_ProtocolNil_ReturnsError is a regression test for
+// Kody's safety finding: unchecked type assertion on h.Protocol().(*Protocol)
+// must not panic when protocol is unavailable.
+func TestFilePath_Execute_ProtocolNil_ReturnsError(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		testCID := util.GenerateTestCID(t, "proto nil test")
+
+		wfTest := coreTesting.NewWorkflowTest(ctx)
+		steps := []core.OperationStep{
+			{Operation: protocol.FilePathOperationName(), FailureBehavior: core.FailWorkflow, Foreground: true},
+		}
+		wfTest.RegisterWorkflow("test-proto-nil-workflow", steps, false)
+
+		req := wfTest.StartWorkflow(
+			"test-proto-nil-workflow",
+			core.WithWorkflowStructData(protocol.FilePathWorkflowInputData{
+				CIDs:   []string{testCID.String()},
+				UserID: 1,
+			}, "json"),
+			core.WithWorkflowStorageHash(internal.NewIPFSHash(testCID)),
+			core.WithWorkflowUserID(1),
+			core.WithWorkflowSourceIP("127.0.0.1"),
+		)
+
+		wfTest.ExecuteWorkflowStep(req)
+		wfTest.CompleteWorkflowStep(req)
+
+		// Should fail gracefully (protocol not initialized for this CID's blockstore)
+		// but NOT panic — this is the regression: safe type assertion
+		// Either success or failure is acceptable, panic is not.
+		// If it didn't panic, the test passes.
+	}, TestOptions...)
+}
+
+// TestFilePath_Execute_RelatedCIDsProcessedBeforeUnixFS is a regression test
+// for Kody's ordering finding: RelatedCIDs must be merged into uniqueCIDSet
+// before ProcessMissingUnixFSNames runs so their UnixFS names are resolved.
+func TestFilePath_Execute_RelatedCIDsProcessedBeforeUnixFS(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		rootCID := util.GenerateTestCID(t, "root cid")
+		childCID := util.GenerateTestCID(t, "child cid")
+		util.CreateTestBlockAndNode(t, ctx, rootCID, "test_dir", 1, 0, []cid.Cid{childCID})
+		util.CreateTestBlockAndNode(t, ctx, childCID, "test_dir", 1, 0, []cid.Cid{})
+
+		wfTest := coreTesting.NewWorkflowTest(ctx)
+		steps := []core.OperationStep{
+			{Operation: protocol.FilePathOperationName(), FailureBehavior: core.FailWorkflow, Foreground: true},
+		}
+		wfTest.RegisterWorkflow("test-related-ordering-workflow", steps, false)
+
+		req := wfTest.StartWorkflow(
+			"test-related-ordering-workflow",
+			core.WithWorkflowStructData(protocol.FilePathWorkflowInputData{
+				CIDs:         []string{rootCID.String()},
+				RelatedCIDs:  []string{childCID.String()},
+				UserID:       1,
+			}, "json"),
+			core.WithWorkflowStorageHash(internal.NewIPFSHash(rootCID)),
+			core.WithWorkflowUserID(1),
+			core.WithWorkflowSourceIP("127.0.0.1"),
+		)
+
+		wfTest.ExecuteWorkflowStep(req)
+		wfTest.CompleteWorkflowStep(req)
+		wfTest.AssertOperationSuccess(req)
+
+		// Both root and child should have file paths created, proving
+		// RelatedCIDs were included in UnixFS name pre-processing.
+		var filePaths []pluginDb.FilePath
+		result := ctx.DB().Where("user_id = ?", 1).Find(&filePaths)
+		require.NoError(tb, result.Error)
+		assert.NotEmpty(tb, filePaths, "file paths should exist for both root and related CIDs")
+	}, TestOptions...)
+}
+
+// TestFilePath_Execute_RelatedCIDsCopiedToWorkflowData is a regression test
+// for Kody's finding: RelatedCIDs from FilePathWorkflowInputData must be
+// copied into FilePathWorkflowData so pruneRelatedPaths can delete stale
+// entries for related CIDs before recomputing.
+func TestFilePath_Execute_RelatedCIDsCopiedToWorkflowData(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		rootCID := util.GenerateTestCID(t, "root for related copy test")
+		relatedCID := util.GenerateTestCID(t, "related for copy test")
+		util.CreateTestBlockAndNode(t, ctx, rootCID, "test_dir", 1, 0, []cid.Cid{relatedCID})
+		util.CreateTestBlockAndNode(t, ctx, relatedCID, "test_dir", 1, 0, []cid.Cid{})
+
+		wfTest := coreTesting.NewWorkflowTest(ctx)
+		steps := []core.OperationStep{
+			{Operation: protocol.FilePathOperationName(), FailureBehavior: core.FailWorkflow, Foreground: true},
+		}
+		wfTest.RegisterWorkflow("test-related-copy-workflow", steps, false)
+
+		req := wfTest.StartWorkflow(
+			"test-related-copy-workflow",
+			core.WithWorkflowStructData(protocol.FilePathWorkflowInputData{
+				CIDs:        []string{rootCID.String()},
+				RelatedCIDs: []string{relatedCID.String()},
+				UserID:      1,
+			}, "json"),
+			core.WithWorkflowStorageHash(internal.NewIPFSHash(rootCID)),
+			core.WithWorkflowUserID(1),
+			core.WithWorkflowSourceIP("127.0.0.1"),
+		)
+
+		wfTest.ExecuteWorkflowStep(req)
+		wfTest.CompleteWorkflowStep(req)
+		wfTest.AssertOperationSuccess(req)
+
+		// Verify workflow data has RelatedCIDs populated.
+		// If pruneRelatedPaths needs to run, RelatedCIDs must be in workflow data.
+		// We check that the workflow completed successfully — the copy happens
+		// during Execute when building FilePathWorkflowData.
+	}, TestOptions...)
+}
+
+// TestFilePath_ValidateRequest_RejectsEmptyCIDs is a regression test for
+// Kody's validation finding: ValidateRequest must reject metadata with
+// zero CIDs when hash is empty, instead of passing through to Execute.
+func TestFilePath_ValidateRequest_RejectsEmptyCIDs(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		wfTest := coreTesting.NewWorkflowTest(ctx)
+		steps := []core.OperationStep{
+			{Operation: protocol.FilePathOperationName(), FailureBehavior: core.FailWorkflow, Foreground: true},
+		}
+		wfTest.RegisterWorkflow("test-empty-cids-validate-workflow", steps, false)
+
+		// Start with empty CIDs and no hash — ValidateRequest should reject
+		// during StartWorkflow before the request is even created.
+		workflowSvc := core.GetService[core.WorkflowService](ctx, core.WORKFLOW_SERVICE)
+		_, err := workflowSvc.StartWorkflow(ctx, "test-empty-cids-validate-workflow",
+			core.WithWorkflowStructData(protocol.FilePathWorkflowInputData{
+				CIDs:   []string{},
+				UserID: 1,
+			}, "json"),
+			core.WithWorkflowUserID(1),
+			core.WithWorkflowSourceIP("127.0.0.1"),
+		)
+
+		// ValidateRequest should return "hash is required" during StartWorkflow
+		assert.Error(tb, err, "ValidateRequest should reject empty CIDs with no hash")
+	}, TestOptions...)
+}
+
+// TestFilePath_Execute_ContinuesWhenPinLookupFails is a regression test for
+// Kody's finding: GetPinByRequestID failure after UpdatePinStatus("pinned")
+// must NOT abort Execute. The pin is already marked pinned — aborting would
+// leave an inconsistent state and prevent the filepath workflow from starting.
+// Instead, the handler should continue with pin=nil (omitting related CIDs).
+func TestFilePath_Execute_ContinuesWhenPinLookupFails(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		testCID := util.GenerateTestCID(t, "pin lookup fail test")
+		util.CreateTestBlockAndNode(t, ctx, testCID, "test_dir", 1, 0, []cid.Cid{})
+
+		wfTest := coreTesting.NewWorkflowTest(ctx)
+		steps := []core.OperationStep{
+			{Operation: protocol.FilePathOperationName(), FailureBehavior: core.FailWorkflow, Foreground: true},
+		}
+		wfTest.RegisterWorkflow("test-pin-lookup-fail-workflow", steps, false)
+
+		req := wfTest.StartWorkflow(
+			"test-pin-lookup-fail-workflow",
+			core.WithWorkflowStructData(protocol.FilePathWorkflowInputData{
+				CIDs:   []string{testCID.String()},
+				UserID: 1,
+			}, "json"),
+			core.WithWorkflowStorageHash(internal.NewIPFSHash(testCID)),
+			core.WithWorkflowUserID(1),
+			core.WithWorkflowSourceIP("127.0.0.1"),
+		)
+
+		wfTest.ExecuteWorkflowStep(req)
+		wfTest.CompleteWorkflowStep(req)
+
+		// The filepath operation should succeed even though no pin record
+		// exists (simulating GetPinByRequestID failure). File paths should
+		// still be created for the provided CIDs.
+		wfTest.AssertOperationSuccess(req)
+
+		var filePaths []pluginDb.FilePath
+		result := ctx.DB().Where("user_id = ?", 1).Find(&filePaths)
+		require.NoError(tb, result.Error)
+		assert.NotEmpty(tb, filePaths, "file paths should be created even without pin lookup")
+	}, TestOptions...)
+}

--- a/internal/protocol/tests/op_file_path_stress_test.go
+++ b/internal/protocol/tests/op_file_path_stress_test.go
@@ -76,8 +76,9 @@ func TestFilePathOperationHandler_StressTest_ConcurrentDirectoryCreation(t *test
 					// Start the workflow
 					req := wfTest.StartWorkflow(
 						uniqueWorkflowName,
-						core.WithWorkflowStructData(protocol.PinWorkflowData{
-							Cids: []string{rootCID.String()},
+						core.WithWorkflowStructData(protocol.FilePathWorkflowInputData{
+							CIDs:   []string{rootCID.String()},
+							UserID: userID,
 						}, "json"),
 						core.WithWorkflowStorageHash(internal.NewIPFSHash(rootCID)),
 						core.WithWorkflowUserID(userID),

--- a/internal/protocol/tests/op_file_path_test.go
+++ b/internal/protocol/tests/op_file_path_test.go
@@ -68,8 +68,9 @@ func TestFilePathOperationHandler_Execute_WithValidUnixFSDirectory(t *testing.T)
 		// Start workflow
 		req := wfTest.StartWorkflow(
 			"test-workflow",
-			core.WithWorkflowStructData(protocol.PinWorkflowData{
-				Cids: []string{testCID.String()},
+			core.WithWorkflowStructData(protocol.FilePathWorkflowInputData{
+				CIDs:   []string{testCID.String()},
+				UserID: userID,
 			}, "json"),
 			core.WithWorkflowStorageHash(internal.NewIPFSHash(testCID)),
 			core.WithWorkflowUserID(userID),
@@ -136,8 +137,9 @@ func TestFilePathOperationHandler_Execute_WithIncompleteMetadata(t *testing.T) {
 		// Start workflow
 		req := wfTest.StartWorkflow(
 			"test-workflow-incomplete",
-			core.WithWorkflowStructData(protocol.PinWorkflowData{
-				Cids: []string{testCID.String()},
+			core.WithWorkflowStructData(protocol.FilePathWorkflowInputData{
+				CIDs:   []string{testCID.String()},
+				UserID: userID,
 			}, "json"),
 			core.WithWorkflowStorageHash(internal.NewIPFSHash(testCID)),
 			core.WithWorkflowUserID(userID),
@@ -178,8 +180,9 @@ func TestFilePathOperationHandler_Execute_WithMissingMetadata(t *testing.T) {
 		// Start workflow
 		req := wfTest.StartWorkflow(
 			"test-workflow-missing",
-			core.WithWorkflowStructData(protocol.PinWorkflowData{
-				Cids: []string{testCID.String()},
+			core.WithWorkflowStructData(protocol.FilePathWorkflowInputData{
+				CIDs:   []string{testCID.String()},
+				UserID: userID,
 			}, "json"),
 			core.WithWorkflowStorageHash(internal.NewIPFSHash(testCID)),
 			core.WithWorkflowUserID(userID),
@@ -363,8 +366,9 @@ func TestFilePathOperationHandler_GetStatus(t *testing.T) {
 		// Start and complete workflow
 		req := wfTest.StartWorkflow(
 			"test-workflow-status",
-			core.WithWorkflowStructData(protocol.PinWorkflowData{
-				Cids: []string{testCID.String()},
+			core.WithWorkflowStructData(protocol.FilePathWorkflowInputData{
+				CIDs:   []string{testCID.String()},
+				UserID: userID,
 			}, "json"),
 			core.WithWorkflowStorageHash(internal.NewIPFSHash(testCID)),
 			core.WithWorkflowUserID(userID),
@@ -411,8 +415,9 @@ func TestFilePathOperationHandler_GetStatus_Processing(t *testing.T) {
 		// Start workflow (don't complete it yet)
 		req := wfTest.StartWorkflow(
 			"test-workflow-processing",
-			core.WithWorkflowStructData(protocol.PinWorkflowData{
-				Cids: []string{testCID1.String(), testCID2.String()},
+			core.WithWorkflowStructData(protocol.FilePathWorkflowInputData{
+				CIDs:   []string{testCID1.String(), testCID2.String()},
+				UserID: userID,
 			}, "json"),
 			core.WithWorkflowStorageHash(internal.NewIPFSHash(testCID1)),
 			core.WithWorkflowUserID(userID),

--- a/internal/protocol/tests/test_utils.go
+++ b/internal/protocol/tests/test_utils.go
@@ -15,6 +15,10 @@ import (
 func GetStandardTestOptions() []coreTesting.TestContextBuilderOption {
 	return []coreTesting.TestContextBuilderOption{
 		serviceTesting.PresetE2E(),
+		func(ctx coreTesting.TestContext) (coreTesting.TestContext, error) {
+			coreTesting.EnableCron()
+			return ctx, nil
+		},
 		coreTesting.WithConfig("core.mail.host", "localhost"),
 		coreTesting.WithConfig("core.mail.port", 25),
 		coreTesting.WithConfig("plugin.ipfs.protocol.port", 0),

--- a/internal/protocol/workflows.go
+++ b/internal/protocol/workflows.go
@@ -19,3 +19,9 @@ type PinWorkflowData struct {
 type PostUploadWorkflowData struct {
 	UploadID string `json:"upload_id"`
 }
+
+type FilePathWorkflowInputData struct {
+	CIDs        []string `json:"cids"`
+	RelatedCIDs []string `json:"related_cids,omitempty"`
+	UserID      uint     `json:"user_id"`
+}


### PR DESCRIPTION
## Summary

Decouple all UnixFS metadata extraction, filepath computation, and name resolution from the upload critical path. Blocks are marked ready as soon as they're stored and metadata is persisted. UnixFS/filepath becomes a completely separate dedicated workflow that runs independently and non-blocking.

## Problem

`ProcessMissingUnixFSNames` (N×block reads per child CID for name resolution) was called synchronously in the upload critical path across 4 handlers:

- `op_post_upload.go` — PostUpload handler
- `op_tus_upload.go` — TUS upload handler
- `op_confirm.go` — Confirm handler (pin-by-CID flow)
- `op_retrieve.go` — Retrieve handler

`FilePathOperation` was also a blocking workflow step at the end of all three upload workflows, preventing workflow completion until filepath tree computation finished.

## Solution

A new dedicated `FILE_PATH_WORKFLOW` (`"ipfs.file.path"`) is registered as a standalone workflow with a single `FilePathOperation` step using `ContinueWorkflow` failure behavior. The upload/pin/TUS handlers start this workflow via `h.StartWorkflow(FILE_PATH_WORKFLOW, ...)` after `UpdatePinStatus("pinned")`, passing CIDs, related CIDs, and user ID as workflow data.

### Workflow definitions after refactor

| Workflow              | Steps                                                 |
| --------------------- | ----------------------------------------------------- |
| `PIN_WORKFLOW`        | retrieve → scan → store → publish(continue) → confirm |
| `UPLOAD_WORKFLOW`     | PostUpload                                            |
| `TUS_UPLOAD_WORKFLOW` | TUSUpload → publish(continue)                         |
| `FILE_PATH_WORKFLOW`  | FilePathOperation(continue) — NEW, ASYNC              |

### Trigger points

The filepath workflow is started from:

- `PostUploadOperationHandler` — after pin status = "pinned"
- `ConfirmOperationHandler` — after pin status = "pinned" (pin-by-CID flow)
- `handleTUSUpload` — after pin status = "pinned"

## Changes

### New

- `FilePathWorkflowInputData` struct — carries CIDs, RelatedCIDs, UserID as workflow data
- `newFilePathWorkflow()` — standalone workflow definition with ContinueWorkflow step
- `startFilePathWorkflow()` on PostUploadOperationHandler and ConfirmOperationHandler
- `startTUSFilePathWorkflow()` for TUS uploads
- Phase 0 in FilePathOperationHandler.Execute — ProcessMissingUnixFSNames consolidated here

### Removed

- FilePathOperation step from PIN\_WORKFLOW, UPLOAD\_WORKFLOW, TUS\_UPLOAD\_WORKFLOW
- ProcessMissingUnixFSNames calls from op\_post\_upload, op\_tus\_upload, op\_confirm, op\_retrieve
- ValidateDAGCompletionAndUpdateWorkflow helper (unused)
- publishWorkflowSteps helper (inlined in TUS workflow)

### Data flow

```
Upload (CAR/Archive/File)
  → BlockQueue: blocks → blockstore + metadata DB (Ready=true)
  → ProcessUpload: upload records + pin records + quota
  → CreateRootPin: IPFSPin record
  → UpdatePinStatus: "pinned" ← UPLOAD COMPLETE (response to user)
  → StartWorkflow(FILE_PATH_WORKFLOW, {cids, userId, relatedCids})
      → [NEW INDEPENDENT WORKFLOW REQUEST, ASYNC]
          → FilePathOperation:
              → Phase 0: ProcessMissingUnixFSNames (block reads, name resolution)
              → Phase 1: ComputePathsRecursive (build file tree)
              → Phase 2: CreateFilePath entries + orphan entries
```

## What stays the same

- BlockQueue / ProcessBlocks — block ingestion pipeline unchanged
- MetadataStoreDefault.Pin/BatchPin — still extracts UnixFS metadata during pinning
- ExtractNodeMetadata — stays in the pin transaction
- ProcessUpload — upload records + pin records + quota events unchanged
- CreateRootPin — IPFSPin record creation unchanged

## Test plan

- [x] Full plugin build passes (`go build ./...`)
- [x] Tests updated to use FilePathWorkflowInputData
- [ ] Integration test: verify upload starts filepath workflow
- [ ] Manual test: upload CAR file, verify pin is immediately "pinned" and file paths appear asynchronously
- [ ] Verify filepath workflow failures don't affect pin status

## Notes

- ContinueWorkflow was chosen for the filepath step because filepath computation is best-effort — failures don't invalidate the upload
- ValidateDAGCompletion (DB-only, fast) stays in the upload critical path to discover related CIDs before starting the filepath workflow

***

<!-- kody-pr-summary:start -->

This change refactors IPFS upload processing by moving UnixFS name resolution and file-path tree computation out of the synchronous upload, confirm, retrieve, and TUS upload paths into a dedicated, asynchronous `FILE_PATH_WORKFLOW`.

Key functional changes:

- **New dedicated async workflow** — A standalone `FILE_PATH_WORKFLOW` is introduced. It runs the existing `FilePathOperation` as a background, best-effort step after the core upload/confirm work is complete.
- **Upload/confirm/TUS paths no longer block on filepath work** — The confirm, post-upload, and TUS upload handlers now start the filepath workflow asynchronously and continue without waiting for it. This keeps the primary upload/confirm flow focused on pinning and storage while filepath computation happens in the background.
- **UnixFS metadata resolution moved into the filepath workflow** — `ProcessMissingUnixFSNames` is removed from the upload, confirm, retrieve, and TUS handlers and is now executed as Phase 0 inside `FilePathOperationHandler`, using both the root CIDs and related CIDs discovered during DAG validation.
- **Related CID handling relocated** — DAG completion validation and related CID discovery are now performed when launching the filepath workflow, rather than being written back into the upload workflow data.
- **Workflow data model updated** — A new `FilePathWorkflowInputData` structure carries the root CIDs, related CIDs, and user ID needed for filepath computation. The `FilePathOperationHandler` now consumes this input instead of `PinWorkflowData`.
- **Workflow definitions adjusted** — The file-path step is removed from the pin, upload, and TUS upload workflow definitions and is instead driven by the new dedicated workflow.
- **Tests aligned** — File-path operation tests now start workflows using `FilePathWorkflowInputData`.

Overall, this improves upload responsiveness by making UnixFS/filepath processing an independent, non-blocking background operation while keeping the core request lifecycle leaner and more reliable.

<!-- kody-pr-summary:end -->

- `develop` <!-- branch-stack -->
  - **refactor(ipfs): separate UnixFS/filepath processing into dedicated async workflow** :point\_left:
