### PR TITLE
feat(sse): website lifecycle events + SSE endpoint for gateway

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -64,6 +64,7 @@ require (
 	filippo.io/bigmod v0.1.1-0.20260103110540-f8a47775ebe5 // indirect
 	filippo.io/keygen v0.0.0-20260114151900-8e2790ea4c5b // indirect
 	github.com/apapsch/go-jsonmerge/v2 v2.0.0 // indirect
+	github.com/apt304/sse-go v0.0.3 // indirect
 	github.com/btcsuite/btcd/btcec/v2 v2.3.5 // indirect
 	github.com/dchest/uniuri v1.2.0 // indirect
 	github.com/go-kiss/monkey v0.0.0-20240508030602-d03795257a64 // indirect

--- a/go.sum
+++ b/go.sum
@@ -74,6 +74,8 @@ github.com/andybalholm/brotli v1.2.2 h1:HzTuoo2ErYQqf5qvcJInB8uvqSVxRttzkFexPWtn
 github.com/andybalholm/brotli v1.2.2/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0 h1:axGnT1gRIfimI7gJifB699GoE/oq+F2MU7Dml6nw9rQ=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0/go.mod h1:lvDnEdqiQrp0O42VQGgmlKpxL1AP2+08jFMw88y4klk=
+github.com/apt304/sse-go v0.0.3 h1:ADru/Utu51Dod1QtDEpbMiRtjvqmuaMC9Yk9lLMsEzY=
+github.com/apt304/sse-go v0.0.3/go.mod h1:lp6MWVDAeJKca5qO1zMq8fh4NiM4AoJ8ZQYHVzwV1ro=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/avast/retry-go/v5 v5.0.0 h1:kf1Qc2UsTZ4qq8elDymqfbISvkyMuhgRxuJqX2NHP7k=
 github.com/avast/retry-go/v5 v5.0.0/go.mod h1://d+usmKWio1agtZfS1H/ltTqwtIfBnRq9zEwjc3eH8=

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -53,6 +53,7 @@ type API struct {
 	requestService       core.RequestService
 	tus                  core.TusHandler
 	ipfs                 protocol.ProtoNode
+	sse                  *sseState
 }
 
 func NewAPI() (core.API, []core.ContextBuilderOption, error) {
@@ -124,6 +125,11 @@ func NewAPI() (core.API, []core.ContextBuilderOption, error) {
 			})
 
 			api.ipfs = proto.(protocol.ProtoNode)
+
+			// Initialize SSE server for website event streaming
+			if err := api.initSSEServer(ctx); err != nil {
+				return fmt.Errorf("failed to initialize SSE server: %w", err)
+			}
 
 			return nil
 		}),
@@ -1033,6 +1039,16 @@ See also:.*`),
 					DefineErrorResponse(http.StatusInternalServerError, "Internal server error occurred"),
 					router.DefineResponse(http.StatusGone, "Website is broken or deleted", router.WithJSONContent(dto.GatewayWebsiteStatusResponse{})),
 				)),
+			),
+		),
+		router.NewRoute(http.MethodGet, "/internal/websites/events", a.handleWebsiteSSE,
+			router.WithSwagger(
+				router.WithSummary("Stream website events via SSE"),
+				router.WithDescription(`Server-Sent Events endpoint for gateway-to-portal communication.
+Streams website lifecycle events (published, removed) in real time.
+Requires X-Gateway-Secret header for authentication.`),
+				router.WithTags("Gateway"),
+				router.WithSuccessResponse(http.StatusOK, "SSE event stream"),
 			),
 		),
 	)

--- a/internal/api/api_sse.go
+++ b/internal/api/api_sse.go
@@ -1,0 +1,113 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	sseServer "github.com/apt304/sse-go/server"
+	"go.lumeweb.com/portal/core"
+	pluginEvent "go.lumeweb.com/portal-plugin-ipfs/internal/event"
+	"go.uber.org/zap"
+)
+
+// sseState holds the SSE server for website event streaming.
+type sseState struct {
+	server *sseServer.Server
+}
+
+// initSSEServer initializes the SSE server and registers event listeners
+// for website lifecycle events.
+func (a *API) initSSEServer(ctx core.Context) error {
+	subscriber := sseServer.NewDropOldestSubscriber(sseServer.Options{
+		Buffer:            100,              // Store up to 100 events per subscriber
+		HeartbeatInterval: 15 * time.Second, // Send heartbeat every 15s to keep connections alive
+	})
+
+	a.sse = &sseState{
+		server: sseServer.NewServer(sseServer.Config{}, subscriber),
+	}
+
+	// Register event listeners for website events
+	a.registerWebsiteEventListeners(ctx)
+
+	ctx.Logger().Info("SSE server initialized for website event streaming")
+
+	return nil
+}
+
+// registerWebsiteEventListeners registers the SSE server as a listener to
+// website lifecycle events. When website events occur, they are published
+// to the "gateway" SSE topic.
+func (a *API) registerWebsiteEventListeners(coreCtx core.Context) {
+	// Listen for website published events (create + update with target hash change)
+	pluginEvent.OnWebsitePublished(coreCtx, func(ctx context.Context, ev pluginEvent.WebsitePublishedEvent) error {
+		return a.publishWebsiteEvent("site_published", ev)
+	})
+
+	// Listen for website removed events (delete)
+	pluginEvent.OnWebsiteRemoved(coreCtx, func(ctx context.Context, ev pluginEvent.WebsiteRemovedEvent) error {
+		return a.publishWebsiteEvent("site_removed", ev)
+	})
+
+	coreCtx.Logger().Info("SSE server registered as listener to website events")
+}
+
+// publishWebsiteEvent publishes a website event to the "gateway" SSE topic.
+func (a *API) publishWebsiteEvent(eventType string, eventData any) error {
+	// Create SSE event wrapper for client consumption
+	sseEvent := pluginEvent.NewSSEEvent(eventType, eventData)
+
+	eventJSON, err := json.Marshal(sseEvent)
+	if err != nil {
+		a.Logger().Error("failed to marshal website event for SSE",
+			zap.String("event_type", eventType),
+			zap.Error(err))
+		return err
+	}
+
+	// Create SSE event
+	topic := "gateway"
+	event := sseServer.Event{
+		ID:    fmt.Sprintf("website-%d", time.Now().UnixNano()),
+		Type:  eventType,
+		Data:  eventJSON,
+		Retry: 3000, // Recommended retry interval in milliseconds
+	}
+
+	if err := a.sse.server.Publish(event, topic); err != nil {
+		a.Logger().Error("failed to publish website event to SSE",
+			zap.String("topic", topic),
+			zap.String("event_type", eventType),
+			zap.Error(err))
+		return err
+	}
+
+	a.Logger().Debug("published website event to SSE",
+		zap.String("event_type", eventType),
+		zap.String("topic", topic))
+	return nil
+}
+
+// handleWebsiteSSE establishes a Server-Sent Events connection for website
+// lifecycle events. The gateway connects to this endpoint to receive
+// real-time notifications when websites are published, updated, or removed.
+func (a *API) handleWebsiteSSE(c echo.Context) error {
+	hooks := sseServer.LifecycleHooks{
+		OnConnect: func(sub sseServer.Subscription) {
+			a.Logger().Debug("gateway SSE client connected",
+				zap.Strings("topics", sub.Topics))
+		},
+		OnDisconnect: func(sub sseServer.Subscription) {
+			a.Logger().Debug("gateway SSE client disconnected",
+				zap.Strings("topics", sub.Topics))
+		},
+	}
+
+	// Single "gateway" topic — one gateway consumer per portal instance
+	a.sse.server.ServeHTTP(c.Response(), c.Request(), []string{"gateway"}, hooks)
+
+	return nil
+}

--- a/internal/event/website_events.go
+++ b/internal/event/website_events.go
@@ -1,0 +1,88 @@
+package event
+
+import (
+	"context"
+	"time"
+
+	"go.lumeweb.com/portal/core"
+)
+
+const (
+	// EVENT_WEBSITE_PUBLISHED is fired when a website is created or updated
+	// with a new target hash (i.e., content is published/republished).
+	EVENT_WEBSITE_PUBLISHED = "website.published"
+
+	// EVENT_WEBSITE_REMOVED is fired when a website is deleted.
+	EVENT_WEBSITE_REMOVED = "website.removed"
+)
+
+// WebsitePublishedEvent is fired when a website is created or updated
+// with a new target hash.
+type WebsitePublishedEvent struct {
+	Ctx         context.Context `json:"-"`
+	Domain      string          `json:"domain"`
+	CID         string          `json:"cid"`
+	UserID      uint            `json:"-"`
+	WebsiteID   uint            `json:"-"`
+	PublishedAt time.Time       `json:"published_at"`
+}
+
+// WebsiteRemovedEvent is fired when a website is deleted.
+type WebsiteRemovedEvent struct {
+	Ctx       context.Context `json:"-"`
+	Domain    string          `json:"domain"`
+	UserID    uint            `json:"-"`
+	WebsiteID uint            `json:"-"`
+	RemovedAt time.Time       `json:"removed_at"`
+}
+
+// NewWebsitePublishedEvent creates a WebsitePublishedEvent.
+func NewWebsitePublishedEvent(ctx context.Context, domain, cid string, userID, websiteID uint) *WebsitePublishedEvent {
+	return &WebsitePublishedEvent{
+		Ctx:         ctx,
+		Domain:      domain,
+		CID:         cid,
+		UserID:      userID,
+		WebsiteID:   websiteID,
+		PublishedAt: time.Now(),
+	}
+}
+
+// NewWebsiteRemovedEvent creates a WebsiteRemovedEvent.
+func NewWebsiteRemovedEvent(ctx context.Context, domain string, userID, websiteID uint) *WebsiteRemovedEvent {
+	return &WebsiteRemovedEvent{
+		Ctx:        ctx,
+		Domain:     domain,
+		UserID:     userID,
+		WebsiteID:  websiteID,
+		RemovedAt:  time.Now(),
+	}
+}
+
+// OnWebsitePublished registers a listener for website publish events.
+func OnWebsitePublished(ctx core.Context, handler func(context.Context, WebsitePublishedEvent) error, priority ...int) {
+	core.Listen[WebsitePublishedEvent](ctx, EVENT_WEBSITE_PUBLISHED, func(e *core.CoreEvent[WebsitePublishedEvent]) error {
+		return handler(e.Data.Ctx, e.Data)
+	}, priority...)
+}
+
+// OnWebsiteRemoved registers a listener for website removal events.
+func OnWebsiteRemoved(ctx core.Context, handler func(context.Context, WebsiteRemovedEvent) error, priority ...int) {
+	core.Listen[WebsiteRemovedEvent](ctx, EVENT_WEBSITE_REMOVED, func(e *core.CoreEvent[WebsiteRemovedEvent]) error {
+		return handler(e.Data.Ctx, e.Data)
+	}, priority...)
+}
+
+// SSEEvent wraps a website event with a type field for client-side consumption.
+type SSEEvent struct {
+	Type string `json:"type"`
+	Data any    `json:"data"`
+}
+
+// NewSSEEvent creates a new SSE event wrapper.
+func NewSSEEvent(eventType string, data any) *SSEEvent {
+	return &SSEEvent{
+		Type: eventType,
+		Data: data,
+	}
+}

--- a/internal/service/website/website.go
+++ b/internal/service/website/website.go
@@ -19,6 +19,7 @@ import (
 	"go.lumeweb.com/portal-plugin-ipfs/internal/api/dto"
 	pluginConfig "go.lumeweb.com/portal-plugin-ipfs/internal/config"
 	pluginDb "go.lumeweb.com/portal-plugin-ipfs/internal/db"
+	pluginEvent "go.lumeweb.com/portal-plugin-ipfs/internal/event"
 	domsvc "go.lumeweb.com/portal-plugin-ipfs/internal/service/domain"
 
 	"go.lumeweb.com/portal-plugin-ipfs/internal/protocol/encoding"
@@ -347,6 +348,11 @@ func (s *WebsiteServiceDefault) CreateWebsite(ctx context.Context, website *plug
 				zap.String("target_hash", website.TargetHash()),
 				zap.Bool("enabled", website.Enabled))
 
+			// Emit website published event for SSE gateway notification
+			core.Fire(s.Context(), pluginEvent.EVENT_WEBSITE_PUBLISHED, pluginEvent.NewWebsitePublishedEvent(
+				ctx, website.Domain, website.TargetHash(), website.UserID, website.ID,
+			))
+
 			// Send notification to admin
 			if err := s.notifyAdminWebsiteCreated(ctx, website, ""); err != nil {
 				s.Logger().Warn("Failed to send website created notification", zap.Error(err))
@@ -511,6 +517,7 @@ func (s *WebsiteServiceDefault) UpdateWebsite(ctx context.Context, userID uint, 
 	var updatedWebsite *pluginDb.Website
 	var oldEnabled bool
 	var dnsEnabledChanged bool
+	var targetHashChanged bool
 
 	err := core.MetricTrack(
 		UpdateWebsiteDuration.WithLabelValues(),
@@ -532,7 +539,7 @@ func (s *WebsiteServiceDefault) UpdateWebsite(ctx context.Context, userID uint, 
 				oldTargetHash := website.TargetHash()
 				oldTargetType := pluginDb.WebsiteTargetType(website.TargetType)
 				oldEnabled = website.Enabled
-				targetHashChanged := false
+				targetHashChanged = false
 				dnsEnabledChanged = false
 				ipnsAutoCreated := false
 				var newTargetHashStr string
@@ -772,6 +779,13 @@ func (s *WebsiteServiceDefault) UpdateWebsite(ctx context.Context, userID uint, 
 		zap.Uint("id", websiteID),
 		zap.Uint("user_id", userID),
 		zap.Any("updates", updates))
+
+	// Emit website published event if target hash changed (content was republished)
+	if targetHashChanged && updatedWebsite != nil {
+		core.Fire(s.Context(), pluginEvent.EVENT_WEBSITE_PUBLISHED, pluginEvent.NewWebsitePublishedEvent(
+			ctx, updatedWebsite.Domain, updatedWebsite.TargetHash(), updatedWebsite.UserID, updatedWebsite.ID,
+		))
+	}
 
 	// Send notification to admin
 	if err := s.notifyAdminWebsiteUpdated(ctx, updatedWebsite, "", updates); err != nil {
@@ -1026,6 +1040,11 @@ func (s *WebsiteServiceDefault) DeleteWebsite(ctx context.Context, userID uint, 
 			s.Logger().Info("Website deleted",
 				zap.Uint("id", websiteID),
 				zap.Uint("user_id", userID))
+
+			// Emit website removed event for SSE gateway notification
+			core.Fire(s.Context(), pluginEvent.EVENT_WEBSITE_REMOVED, pluginEvent.NewWebsiteRemovedEvent(
+				ctx, websiteDomain, userID, websiteID,
+			))
 
 			// Clean up DNS records if DNS hosting was enabled
 			// Note: We do NOT delete the zone itself as zones are independent from websites


### PR DESCRIPTION
## Summary

Adds Server-Sent Events endpoint (`GET /internal/websites/events`) on the portal that streams website publish/remove events to the gateway in real time, replacing the need for polling.

Forked from `alt-root-domains` due to the internal changes happening on that branch.

## Changes

### New files

- **`internal/event/website_events.go`** — `WebsitePublishedEvent` / `WebsiteRemovedEvent` types, event constants, `OnWebsitePublished` / `OnWebsiteRemoved` listener helpers, `SSEEvent` wrapper (follows `portal-plugin-billing` pattern)
- **`internal/api/api_sse.go`** — SSE server init (`sse-go` with `DropOldestSubscriber`, buffer=100, 15s heartbeat), event listener registration → publishes to `gateway` topic, `handleWebsiteSSE` handler

### Modified files

- **`internal/service/website/website.go`** — `core.Fire` calls:
  - `CreateWebsite()`: fires `EVENT_WEBSITE_PUBLISHED` after DB commit
  - `UpdateWebsite()`: fires `EVENT_WEBSITE_PUBLISHED` only when `targetHashChanged` is true
  - `DeleteWebsite()`: fires `EVENT_WEBSITE_REMOVED` after soft-delete
- **`internal/api/api.go`** — `sse *sseState` field on `API` struct, `initSSEServer` in startup func, `GET /internal/websites/events` route in `gatewayRoutes` group (shares `gatewayAuthMw` / `X-Gateway-Secret`)
- **`go.mod`** — added `github.com/apt304/sse-go v0.0.3`

## Design decisions

- **Events fire from the service layer** (not API handlers) — admin operations and internal workflows also trigger SSE
- **Single `gateway` topic** — one gateway consumer per portal instance
- **`core.Fire`** (not `core.Emit` — that doesn't exist in portal core; billing plugin uses `core.Fire`)
- **SSE endpoint in `gatewayRoutes`** — same `X-Gateway-Secret` auth as existing `/internal/websites/:domain` routes
- **Forked from `alt-root-domains`** — internal changes on that branch are prerequisites

## Part of a 3-plan series

- **Plan 1 (this PR):** Portal — website events + SSE endpoint
- Plan 2: SDK — swagger spec + `StreamWebsiteEvents()` method
- Plan 3: Gateway — SSE client with reconnection and event handlers

Plans 2 and 3 are blocked on this PR merging.

## Testing

- [ ] Unit test event emission from `WebsiteService`
- [ ] Unit test SSE handler with mock subscriber
- [ ] Integration test: emit event → SSE client receives it

***

- `develop` <!-- branch-stack -->
  - **feat(sse): website lifecycle events + SSE endpoint for gateway** :point\_left:

***

<!-- kody-pr-summary:start -->

This pull request introduces a Server-Sent Events (SSE) endpoint that enables real-time gateway notification of website lifecycle events.

**What changed:**

- **New SSE endpoint:** Added `GET /internal/websites/events` under the gateway router, protected by gateway authentication (`X-Gateway-Secret`). The endpoint streams website lifecycle events to connected gateway clients.
- **Website lifecycle events:** Defined two new event types:
  - `website.published` — fired when a website is created or updated with a new target content hash (CID).
  - `website.removed` — fired when a website is deleted.
- **Event publishing integration:** Updated the website service to emit these events at the appropriate points:
  - On website creation.
  - On website update when the target hash changes.
  - On website deletion.
- **SSE server infrastructure:** Added an SSE server using a drop-oldest subscriber policy with a 100-event buffer, 15-second heartbeat keep-alives, and a dedicated `gateway` topic. Events are serialized as JSON with type identifiers (`site_published`, `site_removed`) and a 3-second retry recommendation.

**Functional impact:**

The gateway can now maintain a live connection to the portal and receive immediate notifications when website content is published, republished, or removed, allowing the gateway to keep its cache/routing state synchronized without polling.

<!-- kody-pr-summary:end -->
