### PR TITLE
feat: implement ProtocolDAGProvider with recursive SQL and DAG query API

### DIFF
--- a/core/metadata_store.go
+++ b/core/metadata_store.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/ipfs/go-cid"
 	format "github.com/ipfs/go-ipld-format"
+	"go.lumeweb.com/portal/core"
 )
 
 // A MetadataStore is a store for IPFS block metadata. It is used to
@@ -24,6 +25,11 @@ type MetadataStore interface {
 	ProcessMissingUnixFSNames(ctx context.Context, cids []cid.Cid) error
 	UpdateUnixFSMetadata(c cid.Cid, metadata any) error
 	MarkBlockReady(c cid.Cid, ready bool) error
+
+	// ResolveDAG resolves the complete block graph rooted at rootCID in a single
+	// recursive SQL query. Returns all blocks in the DAG with their sizes and
+	// ordered parent→child link relationships.
+	ResolveDAG(ctx context.Context, rootCID cid.Cid) ([]core.DAGBlockNode, error)
 }
 
 type PinnedBlock struct {

--- a/go.mod
+++ b/go.mod
@@ -45,7 +45,7 @@ require (
 	go.lumeweb.com/dane v0.0.1
 	go.lumeweb.com/httputil v0.5.6
 	go.lumeweb.com/ipfs-content v0.1.17
-	go.lumeweb.com/portal v0.5.2-0.20260727134630-81cb4868c2ce
+	go.lumeweb.com/portal v0.5.2-0.20260727183439-11ece2045795
 	go.lumeweb.com/portal-middleware v0.3.7
 	go.lumeweb.com/portal-plugin-core v0.1.0
 	go.lumeweb.com/portal-plugin-dashboard v0.3.1-0.20260727133751-97cacf77fad2
@@ -358,7 +358,7 @@ require (
 	go.uber.org/zap/exp v0.3.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	go4.org v0.0.0-20230225012048-214862532bf5 // indirect
-	golang.org/x/exp v0.0.0-20260718201538-764159d718ef // indirect
+	golang.org/x/exp v0.0.0-20260727155853-b88d891fe743 // indirect
 	golang.org/x/image v0.34.0 // indirect
 	golang.org/x/mod v0.38.0 // indirect
 	golang.org/x/net v0.57.0

--- a/go.sum
+++ b/go.sum
@@ -1016,6 +1016,8 @@ go.lumeweb.com/portal v0.5.2-0.20260727130906-c632318fe632 h1:5Dp4xQr3vhb7o9/VvI
 go.lumeweb.com/portal v0.5.2-0.20260727130906-c632318fe632/go.mod h1:ElkjJGuXnRC14fDbGYFiH57kB5/hCDqOULFAeD3UUzE=
 go.lumeweb.com/portal v0.5.2-0.20260727134630-81cb4868c2ce h1:M3ewhDvlqZTwKbkJrQ04wqclqnscXF1L7bluRS63N48=
 go.lumeweb.com/portal v0.5.2-0.20260727134630-81cb4868c2ce/go.mod h1:ElkjJGuXnRC14fDbGYFiH57kB5/hCDqOULFAeD3UUzE=
+go.lumeweb.com/portal v0.5.2-0.20260727183439-11ece2045795 h1:52KRdJH3z61wu3dDDbENGkwSqBC1JYr3FzLVt8PC71E=
+go.lumeweb.com/portal v0.5.2-0.20260727183439-11ece2045795/go.mod h1:ZRACzuG0WlaML/5qRUKe9QmHU3elU/uc5pyJCukxgMc=
 go.lumeweb.com/portal-middleware v0.3.7 h1:kq4SZq4T/uhauqHehw2JaTbNJpPpE8/EQAC3R737H7c=
 go.lumeweb.com/portal-middleware v0.3.7/go.mod h1:Yn9ZsFy5n3x2jUJ085M9B/aoZ+ANQV5QD/MAE0BpJXo=
 go.lumeweb.com/portal-plugin-core v0.1.0 h1:bHHJ7oZrBKmBvdUFutr3Dx6FdwvSg/ZeF33QaRM0DKU=
@@ -1152,6 +1154,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20260718201538-764159d718ef h1:LkZ48HFgy/TvhTI0bcWkjgFkgLyKUwcTbDjS0DUjw+A=
 golang.org/x/exp v0.0.0-20260718201538-764159d718ef/go.mod h1:EdfpwwqSu+0Li0mzskwHU6FWDV3t9Q+RZDo3QMUtL3Q=
+golang.org/x/exp v0.0.0-20260727155853-b88d891fe743 h1:ex206bKw+v3K0dm3andkrIF+ijyQKJG1pLgwQ2PYdQM=
+golang.org/x/exp v0.0.0-20260727155853-b88d891fe743/go.mod h1:EdfpwwqSu+0Li0mzskwHU6FWDV3t9Q+RZDo3QMUtL3Q=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/image v0.34.0 h1:33gCkyw9hmwbZJeZkct8XyR11yH889EQt/QH4VmXMn8=

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -425,6 +425,22 @@ See also:.*`),
 				router.WithRequestBody(&dto.GetBlockMetaBatchRequest{}, "Batch request for block metadata", true),
 			),
 		),
+		router.NewRoute(http.MethodGet, "/dag/:cid", a.handleGetDAG,
+			router.WithAccess(core.ACCESS_USER_ROLE),
+			router.WithSwagger(
+				router.WithSummary("Resolve block DAG"),
+				router.WithDescription(`Resolves the complete block graph (DAG) for a root CID in a single query.
+
+Returns all blocks reachable from the root CID, including their sizes and ordered child relationships. Uses a recursive SQL query internally for efficient batch resolution instead of per-block round-trips.
+
+Only blocks with ready status are included. Blocks appearing in multiple paths are deduplicated.
+
+See also: GET /block/meta/:cid (single block metadata)`),
+				router.WithTags("Content"),
+				router.WithPathParam("cid", "Root content identifier (CID) of the DAG to resolve. Example: bafybeieffnocaq7t4w4daagvydl32igft5oziyyaebqr6vx6rb3fwh2ab4", ""),
+				router.WithSuccessResponse(http.StatusOK, "DAG resolved successfully", router.WithJSONContent(dto.DAGResponse{})),
+			),
+		),
 	)
 
 	if err := router.RegisterRoutes(apiGroup, accessSvc, a.Subdomain(), ipfsRoutes, router.WithMiddlewares(authMw), router.WithCors()); err != nil {

--- a/internal/api/api_dag.go
+++ b/internal/api/api_dag.go
@@ -1,0 +1,66 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+	"go.lumeweb.com/httputil"
+	"go.lumeweb.com/portal-plugin-ipfs/internal/api/dto"
+	"go.lumeweb.com/portal/core"
+	"go.uber.org/zap"
+)
+
+// handleGetDAG resolves the complete block graph for a given CID.
+//
+// This endpoint is intentionally not user-scoped: IPFS content is public and
+// content-addressed by design. The DAG topology (block sizes, child link CIDs)
+// is encoded in the IPLD blocks themselves and is retrievable from any IPFS
+// gateway by anyone who has the root CID. No ownership or pin check is applied
+// because the data exposed here is not secret — it can be derived by fetching
+// and parsing the raw blocks from the public network.
+//
+// If the portal ever introduces private pins or access-controlled content,
+// this endpoint must be revisited to add a user-scoped ownership check before
+// calling ResolveDAG.
+func (a *API) handleGetDAG(c echo.Context) error {
+	ctx := httputil.Context(c)
+
+	req := dto.GetDAGRequest{}
+	model, ok := httputil.DecodeAndValidateRequest(ctx, &req)
+	if !ok {
+		return nil
+	}
+
+	proto := core.GetProtocol(a.ipfs.Name())
+	if proto == nil {
+		a.Logger().Error("IPFS protocol not available")
+		apiErr := NewError(ErrKeyMetadataFetchFailed, nil)
+		return ctx.Error(apiErr, apiErr.HttpStatus())
+	}
+
+	dagProvider, ok := proto.(core.ProtocolDAGProvider)
+	if !ok {
+		a.Logger().Error("IPFS protocol does not support DAG traversal")
+		apiErr := NewError(ErrKeyMetadataFetchFailed, nil)
+		return ctx.Error(apiErr, apiErr.HttpStatus())
+	}
+
+	nodes, err := dagProvider.ResolveDAG(ctx.Request().Context(), model.CID)
+	if err != nil {
+		a.Logger().Error("Failed to resolve DAG", zap.Error(err))
+		apiErr := NewError(ErrKeyMetadataFetchFailed, err)
+		return ctx.Error(apiErr, apiErr.HttpStatus())
+	}
+
+	if len(nodes) == 0 {
+		apiErr := NewError(ErrKeyBlockNotFound, nil)
+		return ctx.Error(apiErr, http.StatusNotFound)
+	}
+
+	result := &dto.DAGResolution{
+		RootCID: model.CID,
+		Nodes:   nodes,
+	}
+
+	return httputil.EncodeResponse(ctx, result, &dto.DAGResponse{})
+}

--- a/internal/api/dto/dag.go
+++ b/internal/api/dto/dag.go
@@ -1,0 +1,73 @@
+package dto
+
+import (
+	"github.com/Oudwins/zog"
+	"github.com/ipfs/go-cid"
+	"go.lumeweb.com/httputil"
+	"go.lumeweb.com/portal-plugin-ipfs/internal/protocol/encoding"
+	"go.lumeweb.com/portal/core"
+)
+
+var _ httputil.DTOValidator = (*GetDAGRequest)(nil)
+var _ httputil.DTORequest[*GetDAGParsedRequest] = (*GetDAGRequest)(nil)
+var _ httputil.DTOResponse[*DAGResolution] = (*DAGResponse)(nil)
+
+type GetDAGRequest struct {
+	CID string `json:"cid" param:"cid"`
+}
+
+func (g GetDAGRequest) ToModel() (*GetDAGParsedRequest, error) {
+	_cid, err := cid.Parse(g.CID)
+	if err != nil {
+		return nil, err
+	}
+
+	return &GetDAGParsedRequest{
+		CID: _cid,
+	}, nil
+}
+
+func (g GetDAGRequest) Schema() *zog.StructSchema {
+	return zog.Struct(zog.Shape{
+		"CID": cidValidator.Required(),
+	})
+}
+
+type GetDAGParsedRequest struct {
+	CID cid.Cid `json:"cid"`
+}
+
+// DAGResolution is the model returned by the protocol layer's ResolveDAG.
+type DAGResolution struct {
+	RootCID cid.Cid
+	Nodes   []core.DAGBlockNode
+}
+
+// DAGBlockNodeResponse represents a single block in the resolved DAG.
+type DAGBlockNodeResponse struct {
+	CID      string   `json:"cid"`
+	Size     uint64   `json:"size"`
+	Children []string `json:"children"`
+}
+
+type DAGResponse struct {
+	RootCID string                 `json:"root_cid"`
+	Nodes   []DAGBlockNodeResponse `json:"nodes"`
+}
+
+func (r *DAGResponse) FromModel(model *DAGResolution) error {
+	r.RootCID = encoding.ToV1(model.RootCID).String()
+	r.Nodes = make([]DAGBlockNodeResponse, 0, len(model.Nodes))
+	for _, node := range model.Nodes {
+		children := make([]string, 0, len(node.Children))
+		for _, child := range node.Children {
+			children = append(children, encoding.ToV1(child).String())
+		}
+		r.Nodes = append(r.Nodes, DAGBlockNodeResponse{
+			CID:      encoding.ToV1(node.CID).String(),
+			Size:     node.Size,
+			Children: children,
+		})
+	}
+	return nil
+}

--- a/internal/protocol/protocol.go
+++ b/internal/protocol/protocol.go
@@ -39,6 +39,7 @@ import (
 var _ core.Protocol = (*Protocol)(nil)
 var _ core.StorageProtocol = (*Protocol)(nil)
 var _ core.ProtocolGetPinHandler = (*Protocol)(nil)
+var _ core.ProtocolDAGProvider = (*Protocol)(nil)
 var _ core.ProtocolPinHandler = (*pinHandler)(nil)
 
 // Helper functions for operation names
@@ -304,6 +305,24 @@ func (p *Protocol) GetPeerTracker() *ipfs.BlockRequestTracker {
 
 func (p *Protocol) GetMetadataStore() pluginCore.MetadataStore {
 	return p.metadataStore
+}
+
+// BlockChildren returns the ordered child CIDs of a block.
+// Delegates to MetadataStore.
+func (p *Protocol) BlockChildren(ctx context.Context, c cid.Cid, max *int) ([]cid.Cid, error) {
+	return p.GetMetadataStore().BlockChildren(ctx, c, max)
+}
+
+// BlockSize returns the size of a block in bytes.
+// Delegates to MetadataStore.Size.
+func (p *Protocol) BlockSize(ctx context.Context, c cid.Cid) (uint64, error) {
+	return p.GetMetadataStore().Size(ctx, c)
+}
+
+// ResolveDAG resolves the complete block graph rooted at rootCID in a single
+// batch SQL query (recursive CTE). Delegates to MetadataStore.
+func (p *Protocol) ResolveDAG(ctx context.Context, rootCID cid.Cid) ([]core.DAGBlockNode, error) {
+	return p.GetMetadataStore().ResolveDAG(ctx, rootCID)
 }
 
 func (p *Protocol) GetNodeFactory() *ipfs.NodeFactory {

--- a/internal/protocol/store/batcher_test.go
+++ b/internal/protocol/store/batcher_test.go
@@ -45,6 +45,9 @@ func (m *mockBatchStore) ProcessMissingUnixFSNames(ctx context.Context, cids []c
 }
 func (m *mockBatchStore) UpdateUnixFSMetadata(c cid.Cid, metadata any) error { return nil }
 func (m *mockBatchStore) MarkBlockReady(c cid.Cid, ready bool) error        { return nil }
+func (m *mockBatchStore) ResolveDAG(ctx context.Context, rootCID cid.Cid) ([]core.DAGBlockNode, error) {
+	return nil, nil
+}
 
 func makePinnedBlock(data string) pluginCore.PinnedBlock {
 	c, _ := cid.V1Builder{Codec: 0x55, MhType: 0x12}.Sum([]byte(data))

--- a/internal/protocol/store/metadata.go
+++ b/internal/protocol/store/metadata.go
@@ -703,6 +703,134 @@ func (s *MetadataStoreDefault) Size(ctx context.Context, c cid.Cid) (uint64, err
 	return size, nil
 }
 
+// ResolveDAG resolves the complete block graph rooted at rootCID in a single
+// recursive SQL query. It collects all blocks reachable from the root via
+// ipfs_linked_blocks, along with their sizes and ordered child CIDs.
+//
+// The query uses a recursive CTE with UNION (not UNION ALL) to deduplicate
+// by block ID, preventing infinite recursion on cycles. Only blocks with
+// ready = true are included, matching BlockChildren behavior.
+//
+// A single query collects both block metadata and parent→child link
+// relationships in one result set: the CTE is traversed once, then LEFT
+// JOINed to ipfs_linked_blocks and self-joined to dag_blocks for child
+// CIDs. Leaf blocks produce rows with NULL child columns.
+//
+// The results are assembled in Go into []core.DAGBlockNode.
+func (s *MetadataStoreDefault) ResolveDAG(ctx context.Context, rootCID cid.Cid) (nodes []core.DAGBlockNode, err error) {
+	ctx, span := core.TraceMethod(ctx, "MetadataStoreDefault.ResolveDAG")
+	defer core.EndSpanWithErr(span, err)
+
+	rootCID = encoding.NormalizeCid(rootCID)
+
+	// Single recursive CTE + LEFT JOIN: one traversal, one result set.
+	// The CTE collects all ready blocks reachable from the root.
+	// The LEFT JOIN to ipfs_linked_blocks gets each block's children;
+	// the self-join back to dag_blocks filters to ready children and
+	// retrieves their CIDs. Leaf blocks get NULL child columns.
+	const dagQuery = `
+		WITH RECURSIVE dag_blocks AS (
+			SELECT b.id, b.cid, b.size
+			FROM ipfs_blocks b
+			WHERE b.cid = ? AND b.ready = 1
+
+			UNION
+
+			SELECT child.id, child.cid, child.size
+			FROM dag_blocks dag
+			INNER JOIN ipfs_linked_blocks lb ON lb.parent_id = dag.id
+			INNER JOIN ipfs_blocks child ON child.id = lb.child_id
+			WHERE child.ready = 1
+		)
+		SELECT b.id, b.cid, b.size, child.cid AS child_cid, lb.link_index
+		FROM dag_blocks b
+		LEFT JOIN ipfs_linked_blocks lb ON lb.parent_id = b.id
+		LEFT JOIN dag_blocks child ON child.id = lb.child_id
+		ORDER BY b.id, lb.link_index
+	`
+
+	type dagRow struct {
+		ID       uint64
+		CID      []byte
+		Size     uint64
+		ChildCID []byte // nil for leaf blocks (no children)
+		LinkIndex *int  // nil for leaf blocks
+	}
+
+	blockByID := make(map[uint64]core.DAGBlockNode)
+	childrenByParent := make(map[uint64][]cid.Cid)
+	var orderedIDs []uint64
+
+	if err = db.RetryableTransaction(ctx, s.db, func(tx *gorm.DB) *gorm.DB {
+		ret := tx.Raw(dagQuery, rootCID.Bytes())
+		if ret.Error != nil {
+			_ = tx.AddError(ret.Error)
+			return tx
+		}
+		rows, err := ret.Rows()
+		if err != nil {
+			_ = tx.AddError(err)
+			return tx
+		}
+		defer rows.Close()
+
+		for rows.Next() {
+			var r dagRow
+			if scanErr := rows.Scan(&r.ID, &r.CID, &r.Size, &r.ChildCID, &r.LinkIndex); scanErr != nil {
+				_ = tx.AddError(fmt.Errorf("failed to scan dag row: %w", scanErr))
+				return tx
+			}
+
+			// Register the block (dedup by ID — a block with N children appears N times)
+			if _, ok := blockByID[r.ID]; !ok {
+				nodeCID, err := cid.Parse(r.CID)
+				if err != nil {
+					_ = tx.AddError(fmt.Errorf("failed to parse block CID: %w", err))
+					return tx
+				}
+				blockByID[r.ID] = core.DAGBlockNode{
+					CID:      nodeCID,
+					Size:     r.Size,
+					Children: []cid.Cid{}, // initialize non-nil for consistency
+				}
+				orderedIDs = append(orderedIDs, r.ID)
+			}
+
+			// If child columns are present, record the parent→child link
+			if r.ChildCID != nil && r.LinkIndex != nil {
+				childCID, err := cid.Parse(r.ChildCID)
+				if err != nil {
+					_ = tx.AddError(fmt.Errorf("failed to parse child CID: %w", err))
+					return tx
+				}
+				childrenByParent[r.ID] = append(childrenByParent[r.ID], childCID)
+			}
+		}
+		if rows.Err() != nil {
+			_ = tx.AddError(fmt.Errorf("failed to iterate dag rows: %w", rows.Err()))
+			return tx
+		}
+
+		return tx
+	}); err != nil {
+		return nil, fmt.Errorf("failed to resolve DAG: %w", err)
+	}
+
+	// Assemble the result: one DAGBlockNode per block, with ordered children.
+	// Iterate orderedIDs (SQL query order) instead of ranging over blockByID
+	// (map iteration is nondeterministic) to produce stable output.
+	nodes = make([]core.DAGBlockNode, 0, len(orderedIDs))
+	for _, id := range orderedIDs {
+		blk := blockByID[id]
+		if children, ok := childrenByParent[id]; ok {
+			blk.Children = children
+		}
+		nodes = append(nodes, blk)
+	}
+
+	return nodes, nil
+}
+
 func (s *MetadataStoreDefault) ProcessMissingUnixFSNames(ctx context.Context, cids []cid.Cid) error {
 	// Skip quota check for internal name resolution - this is metadata extraction from already-pinned data
 	ctx = pc.SkipQuotaCheckOption(ctx, true)

--- a/internal/protocol/store/tests/metadata_dag_test.go
+++ b/internal/protocol/store/tests/metadata_dag_test.go
@@ -1,0 +1,345 @@
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ipfs/go-cid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.lumeweb.com/portal-plugin-ipfs/internal"
+	"go.lumeweb.com/portal-plugin-ipfs/internal/protocol"
+	"go.lumeweb.com/portal-plugin-ipfs/internal/protocol/store"
+	"go.lumeweb.com/portal/core"
+	coreTesting "go.lumeweb.com/portal/core/testing"
+	pluginCore "go.lumeweb.com/portal-plugin-ipfs/core"
+)
+
+// newTestMetadataStore creates a MetadataStore bound to the test protocol.
+func newTestMetadataStore(tb coreTesting.TB, ctx coreTesting.TestContext) pluginCore.MetadataStore {
+	tb.Helper()
+	return store.NewMetadataStore(ctx, core.GetProtocol(internal.ProtocolName).(protocol.ProtoNode))
+}
+
+// pinBlocks pins all blocks in order, failing the test on the first error.
+func pinBlocks(tb coreTesting.TB, store pluginCore.MetadataStore, blocks ...pluginCore.PinnedBlock) {
+	tb.Helper()
+	for _, blk := range blocks {
+		require.NoError(tb, store.Pin(context.Background(), blk))
+	}
+}
+
+// nodesToMap converts a DAG node slice into a map keyed by CID string.
+func nodesToMap(nodes []core.DAGBlockNode) map[string]core.DAGBlockNode {
+	m := make(map[string]core.DAGBlockNode, len(nodes))
+	for _, node := range nodes {
+		m[node.CID.String()] = node
+	}
+	return m
+}
+
+// childCIDs extracts a node's children as a string slice for order-sensitive assertion.
+func childCIDs(node core.DAGBlockNode) []string {
+	cids := make([]string, len(node.Children))
+	for i, c := range node.Children {
+		cids[i] = c.String()
+	}
+	return cids
+}
+
+// resolveDAG pins blocks, resolves the DAG from rootCid, and returns a node map.
+// Use this for tests that don't need to manipulate store state between pin and resolve.
+func resolveDAG(tb coreTesting.TB, ctx coreTesting.TestContext, rootCid cid.Cid, blocks ...pluginCore.PinnedBlock) map[string]core.DAGBlockNode {
+	tb.Helper()
+	ms := newTestMetadataStore(tb, ctx)
+	pinBlocks(tb, ms, blocks...)
+	nodes, err := ms.ResolveDAG(context.Background(), rootCid)
+	require.NoError(tb, err)
+	return nodesToMap(nodes)
+}
+
+// TestMetadataStore_ResolveDAG_SimpleTree verifies ResolveDAG returns all blocks
+// in a simple parent → [child1, child2] tree with correct sizes and children.
+func TestMetadataStore_ResolveDAG_SimpleTree(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		child1Data := "child1 data"
+		child2Data := "child2 data"
+		child1CID := generateCid(t, child1Data)
+		child2CID := generateCid(t, child2Data)
+
+		parentBlock := createPinnedBlock(tb, ctx, "parent data")
+		parentBlock.Links = []cid.Cid{child1CID, child2CID}
+
+		nodeMap := resolveDAG(tb, ctx, parentBlock.Cid,
+			parentBlock,
+			createPinnedBlock(tb, ctx, child1Data),
+			createPinnedBlock(tb, ctx, child2Data),
+		)
+
+		require.Len(tb, nodeMap, 3, "should return root + 2 children")
+
+		// Root: correct size, 2 children in link_index order
+		rootNode := nodeMap[parentBlock.Cid.String()]
+		assert.Equal(tb, uint64(len("parent data")), rootNode.Size)
+		assert.Equal(tb, []string{child1CID.String(), child2CID.String()}, childCIDs(rootNode))
+
+		// Children: no children of their own
+		for _, childCID := range []cid.Cid{child1CID, child2CID} {
+			assert.Empty(tb, nodeMap[childCID.String()].Children)
+		}
+	}, ipfsTestConfig)
+}
+
+// TestMetadataStore_ResolveDAG_DeepChain verifies ResolveDAG traverses a multi-level
+// chain: root → middle → leaf.
+func TestMetadataStore_ResolveDAG_DeepChain(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		leafData := "leaf data"
+		middleData := "middle data"
+		leafCID := generateCid(t, leafData)
+		middleCID := generateCid(t, middleData)
+
+		leafBlock := createPinnedBlock(tb, ctx, leafData)
+
+		middleBlock := createPinnedBlock(tb, ctx, middleData)
+		middleBlock.Links = []cid.Cid{leafCID}
+
+		rootBlock := createPinnedBlock(tb, ctx, "root data")
+		rootBlock.Links = []cid.Cid{middleCID}
+
+		nodeMap := resolveDAG(tb, ctx, rootBlock.Cid, leafBlock, middleBlock, rootBlock)
+
+		require.Len(tb, nodeMap, 3, "should return root + middle + leaf")
+
+		assert.Equal(tb, []string{middleCID.String()}, childCIDs(nodeMap[rootBlock.Cid.String()]))
+		assert.Equal(tb, []string{leafCID.String()}, childCIDs(nodeMap[middleCID.String()]))
+		assert.Empty(tb, nodeMap[leafCID.String()].Children)
+	}, ipfsTestConfig)
+}
+
+// TestMetadataStore_ResolveDAG_Diamond verifies ResolveDAG deduplicates blocks
+// that appear in multiple paths. Diamond structure:
+//
+//	root → childA → shared
+//	     → childB → shared
+//
+// The shared block should appear only once in the result.
+func TestMetadataStore_ResolveDAG_Diamond(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		sharedData := "shared data"
+		childAData := "childA data"
+		childBData := "childB data"
+		sharedCID := generateCid(t, sharedData)
+		childACID := generateCid(t, childAData)
+		childBCID := generateCid(t, childBData)
+
+		sharedBlock := createPinnedBlock(tb, ctx, sharedData)
+
+		childABlock := createPinnedBlock(tb, ctx, childAData)
+		childABlock.Links = []cid.Cid{sharedCID}
+
+		childBBlock := createPinnedBlock(tb, ctx, childBData)
+		childBBlock.Links = []cid.Cid{sharedCID}
+
+		rootBlock := createPinnedBlock(tb, ctx, "root data")
+		rootBlock.Links = []cid.Cid{childACID, childBCID}
+
+		nodeMap := resolveDAG(tb, ctx, rootBlock.Cid, sharedBlock, childABlock, childBBlock, rootBlock)
+
+		require.Len(tb, nodeMap, 4, "shared block should appear only once despite multiple paths")
+
+		_, exists := nodeMap[sharedCID.String()]
+		assert.True(tb, exists, "shared block should be present")
+
+		assert.Equal(tb, []string{sharedCID.String()}, childCIDs(nodeMap[childACID.String()]))
+		assert.Equal(tb, []string{sharedCID.String()}, childCIDs(nodeMap[childBCID.String()]))
+	}, ipfsTestConfig)
+}
+
+// TestMetadataStore_ResolveDAG_NotFound verifies ResolveDAG returns empty result
+// for a CID that doesn't exist in the store.
+func TestMetadataStore_ResolveDAG_NotFound(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		ms := newTestMetadataStore(tb, ctx)
+		pinBlocks(tb, ms, createPinnedBlock(tb, ctx, "filler"))
+
+		nodes, err := ms.ResolveDAG(context.Background(), generateCid(t, "nonexistent root"))
+		require.NoError(tb, err)
+		assert.Empty(tb, nodes, "should return empty slice for nonexistent root")
+	}, ipfsTestConfig)
+}
+
+// TestMetadataStore_ResolveDAG_SingleBlock verifies ResolveDAG returns just the root
+// when it has no children.
+func TestMetadataStore_ResolveDAG_SingleBlock(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		testData := "lone block data"
+		block := createPinnedBlock(tb, ctx, testData)
+
+		nodeMap := resolveDAG(tb, ctx, block.Cid, block)
+
+		require.Len(tb, nodeMap, 1)
+		node := nodeMap[block.Cid.String()]
+		assert.Equal(tb, uint64(len(testData)), node.Size)
+		assert.Empty(tb, node.Children)
+	}, ipfsTestConfig)
+}
+
+// TestMetadataStore_ResolveDAG_NotReadyRoot verifies ResolveDAG excludes the DAG
+// entirely when the root block is not ready.
+func TestMetadataStore_ResolveDAG_NotReadyRoot(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		ms := newTestMetadataStore(tb, ctx)
+
+		childCID := generateCid(t, "child data")
+		rootBlock := createPinnedBlock(tb, ctx, "root data")
+		rootBlock.Links = []cid.Cid{childCID}
+
+		pinBlocks(tb, ms, createPinnedBlock(tb, ctx, "child data"), rootBlock)
+		require.NoError(tb, ms.MarkBlockReady(rootBlock.Cid, false))
+
+		nodes, err := ms.ResolveDAG(context.Background(), rootBlock.Cid)
+		require.NoError(tb, err)
+		assert.Empty(tb, nodes, "should return empty when root is not ready")
+	}, ipfsTestConfig)
+}
+
+// TestMetadataStore_ResolveDAG_NotReadyChild verifies ResolveDAG excludes children
+// that are not ready from the traversal. The root is ready, but a child is not —
+// the not-ready child should be absent from the result and its descendants
+// should not be traversed.
+func TestMetadataStore_ResolveDAG_NotReadyChild(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		ms := newTestMetadataStore(tb, ctx)
+
+		leafData := "leaf data"
+		leafCID := generateCid(t, leafData)
+
+		middleData := "middle data"
+		middleCID := generateCid(t, middleData)
+		middleBlock := createPinnedBlock(tb, ctx, middleData)
+		middleBlock.Links = []cid.Cid{leafCID}
+
+		rootBlock := createPinnedBlock(tb, ctx, "root data")
+		rootBlock.Links = []cid.Cid{middleCID}
+
+		pinBlocks(tb, ms, createPinnedBlock(tb, ctx, leafData), middleBlock, rootBlock)
+		require.NoError(tb, ms.MarkBlockReady(middleCID, false))
+
+		nodeMap := nodesToMap(mustResolveDAG(tb, ms, rootBlock.Cid))
+
+		assert.Contains(tb, nodeMap, rootBlock.Cid.String(), "root should be present")
+
+		_, ok := nodeMap[middleCID.String()]
+		assert.False(tb, ok, "not-ready child should be excluded from DAG")
+
+		_, ok = nodeMap[leafCID.String()]
+		assert.False(tb, ok, "descendant of not-ready block should not be traversed")
+	}, ipfsTestConfig)
+}
+
+// TestMetadataStore_ResolveDAG_ChildOrder verifies ResolveDAG returns children
+// in link_index order, not insertion or CID order.
+func TestMetadataStore_ResolveDAG_ChildOrder(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		child1Data := "alpha"
+		child2Data := "beta"
+		child3Data := "gamma"
+		child1CID := generateCid(t, child1Data)
+		child2CID := generateCid(t, child2Data)
+		child3CID := generateCid(t, child3Data)
+
+		// Link children in a non-sequential order to verify link_index ordering
+		parentBlock := createPinnedBlock(tb, ctx, "parent")
+		parentBlock.Links = []cid.Cid{child3CID, child1CID, child2CID}
+
+		nodeMap := resolveDAG(tb, ctx, parentBlock.Cid,
+			parentBlock,
+			createPinnedBlock(tb, ctx, child1Data),
+			createPinnedBlock(tb, ctx, child2Data),
+			createPinnedBlock(tb, ctx, child3Data),
+		)
+
+		expected := []string{child3CID.String(), child1CID.String(), child2CID.String()}
+		assert.Equal(tb, expected, childCIDs(nodeMap[parentBlock.Cid.String()]), "children must be in link_index order")
+	}, ipfsTestConfig)
+}
+
+// TestMetadataStore_ResolveDAG_UnpinnedChild verifies ResolveDAG silently excludes
+// children that have a link record but no ipfs_blocks row (never pinned). The
+// recursive CTE inner-joins on ipfs_blocks, so orphaned links are skipped.
+func TestMetadataStore_ResolveDAG_UnpinnedChild(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		ms := newTestMetadataStore(tb, ctx)
+
+		// Pin only the parent with a link to a child that is never pinned
+		ghostChildCID := generateCid(t, "never pinned")
+		parentBlock := createPinnedBlock(tb, ctx, "parent data")
+		parentBlock.Links = []cid.Cid{ghostChildCID}
+		pinBlocks(tb, ms, parentBlock)
+
+		nodes, err := ms.ResolveDAG(context.Background(), parentBlock.Cid)
+		require.NoError(tb, err)
+
+		require.Len(tb, nodes, 1, "only the parent should be in the DAG; unpinned child excluded")
+		assert.Equal(tb, parentBlock.Cid.String(), nodes[0].CID.String())
+		assert.Empty(tb, nodes[0].Children, "unpinned child should not appear in children list")
+	}, ipfsTestConfig)
+}
+
+// TestMetadataStore_ResolveDAG_NodeOrder verifies that the returned node slice
+// has deterministic, stable ordering across repeated calls. This is a
+// regression test for map-iteration nondeterminism in the assembly step.
+func TestMetadataStore_ResolveDAG_NodeOrder(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		leafData := "leaf data"
+		middleData := "middle data"
+		leafCID := generateCid(t, leafData)
+		middleCID := generateCid(t, middleData)
+
+		leafBlock := createPinnedBlock(tb, ctx, leafData)
+
+		middleBlock := createPinnedBlock(tb, ctx, middleData)
+		middleBlock.Links = []cid.Cid{leafCID}
+
+		rootBlock := createPinnedBlock(tb, ctx, "root data")
+		rootBlock.Links = []cid.Cid{middleCID}
+
+		ms := newTestMetadataStore(tb, ctx)
+		pinBlocks(tb, ms, leafBlock, middleBlock, rootBlock)
+
+		// Run multiple times and verify the ordering is identical every time
+		var firstOrder []string
+		for i := 0; i < 10; i++ {
+			nodes, err := ms.ResolveDAG(context.Background(), rootBlock.Cid)
+			require.NoError(tb, err)
+			require.Len(tb, nodes, 3)
+
+			order := make([]string, 3)
+			for j, n := range nodes {
+				order[j] = n.CID.String()
+			}
+
+			if firstOrder == nil {
+				firstOrder = order
+			} else {
+				assert.Equal(tb, firstOrder, order,
+					"node ordering must be deterministic across calls (iteration %d)", i)
+			}
+		}
+
+		// Verify all expected nodes are present
+		require.Len(tb, firstOrder, 3)
+		assert.Contains(tb, firstOrder, rootBlock.Cid.String())
+		assert.Contains(tb, firstOrder, middleCID.String())
+		assert.Contains(tb, firstOrder, leafCID.String())
+	}, ipfsTestConfig)
+}
+
+// mustResolveDAG resolves the DAG and fails the test on error.
+func mustResolveDAG(tb coreTesting.TB, ms pluginCore.MetadataStore, rootCid cid.Cid) []core.DAGBlockNode {
+	tb.Helper()
+	nodes, err := ms.ResolveDAG(context.Background(), rootCid)
+	require.NoError(tb, err)
+	return nodes
+}

--- a/internal/testing/mocks/MockMetadataStore.go
+++ b/internal/testing/mocks/MockMetadataStore.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ipfs/go-cid"
 	mock "github.com/stretchr/testify/mock"
 	"go.lumeweb.com/portal-plugin-ipfs/core"
+	portalcore "go.lumeweb.com/portal/core"
 )
 
 // NewMockMetadataStore creates a new instance of MockMetadataStore. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
@@ -542,6 +543,56 @@ func (_c *MockMetadataStore_ProcessMissingUnixFSNames_Call) Return(err error) *M
 }
 
 func (_c *MockMetadataStore_ProcessMissingUnixFSNames_Call) RunAndReturn(run func(ctx context.Context, cids []cid.Cid) error) *MockMetadataStore_ProcessMissingUnixFSNames_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ResolveDAG provides a mock function for the type MockMetadataStore
+func (_mock *MockMetadataStore) ResolveDAG(ctx context.Context, rootCID cid.Cid) ([]portalcore.DAGBlockNode, error) {
+	ret := _mock.Called(ctx, rootCID)
+
+	if len(ret) == 0 {
+		panic("ResolveDAG requires at least 1 return value")
+	}
+
+	var r0 []portalcore.DAGBlockNode
+	if ret[0] != nil {
+		r0 = ret[0].([]portalcore.DAGBlockNode)
+	}
+
+	var r1 error
+	if len(ret) > 1 && ret[1] != nil {
+		r1 = ret[1].(error)
+	}
+
+	return r0, r1
+}
+
+// MockMetadataStore_ResolveDAG_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ResolveDAG'
+type MockMetadataStore_ResolveDAG_Call struct {
+	*mock.Call
+}
+
+// ResolveDAG is a helper method to define mock.On call
+//   - ctx context.Context
+//   - rootCID cid.Cid
+func (_e *MockMetadataStore_Expecter) ResolveDAG(ctx interface{}, rootCID interface{}) *MockMetadataStore_ResolveDAG_Call {
+	return &MockMetadataStore_ResolveDAG_Call{Call: _e.mock.On("ResolveDAG", ctx, rootCID)}
+}
+
+func (_c *MockMetadataStore_ResolveDAG_Call) Run(run func(ctx context.Context, rootCID cid.Cid)) *MockMetadataStore_ResolveDAG_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(cid.Cid))
+	})
+	return _c
+}
+
+func (_c *MockMetadataStore_ResolveDAG_Call) Return(nodes []portalcore.DAGBlockNode, err error) *MockMetadataStore_ResolveDAG_Call {
+	_c.Call.Return(nodes, err)
+	return _c
+}
+
+func (_c *MockMetadataStore_ResolveDAG_Call) RunAndReturn(run func(ctx context.Context, rootCID cid.Cid) ([]portalcore.DAGBlockNode, error)) *MockMetadataStore_ResolveDAG_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
## Summary

Implements the `ProtocolDAGProvider` interface (merged in [portal#1707](https://github.com/LumeWeb/portal/pull/1707)) in the IPFS plugin, with a recursive SQL DAG resolver and a user-facing API endpoint.

## Changes

- **`core/metadata_store.go`** — Added `ResolveDAG(ctx, rootCID) ([]core.DAGBlockNode, error)` to the `MetadataStore` interface
- **`internal/protocol/store/metadata.go`** — Implemented `ResolveDAG` on `MetadataStoreDefault` using a recursive CTE with `UNION` (not `UNION ALL`) to deduplicate blocks reachable via multiple paths. Two queries in one transaction: collects all block IDs/CIDs/sizes, then resolves ordered children via `ipfs_linked_blocks`. Filters on `ready = 1`.
- **`internal/protocol/protocol.go`** — Added `core.ProtocolDAGProvider` interface assertion and delegation methods (`BlockChildren`, `BlockSize`, `ResolveDAG`) on `*Protocol`
- **`internal/api/dto/dag.go`** — `GetDAGRequest` / `DAGResponse` DTOs following existing zog validation + `FromModel` pattern
- **`internal/api/api_dag.go`** — `handleGetDAG` handler: resolves protocol, casts to `ProtocolDAGProvider`, calls `ResolveDAG`, returns JSON. Returns 404 if no blocks found.
- **`internal/api/api.go`** — Registered `GET /api/dag/:cid` route under the user-facing API group
- **`internal/testing/mocks/MockMetadataStore.go`** — Hand-added `ResolveDAG` mock method
- **`internal/protocol/store/tests/metadata_dag_test.go`** — 6 test cases

## API

| Method | Path            | Description                                   |
| ------ | --------------- | --------------------------------------------- |
| `GET`  | `/api/dag/:cid` | Resolve the complete block DAG for a root CID |

Returns all blocks reachable from the root CID with their sizes and ordered child relationships.

## Test Coverage

- `TestMetadataStore_ResolveDAG_SimpleTree` — parent to \[child1, child2]
- `TestMetadataStore_ResolveDAG_DeepChain` — root to middle to leaf
- `TestMetadataStore_ResolveDAG_Diamond` — dedup of shared block across multiple paths
- `TestMetadataStore_ResolveDAG_NotFound` — nonexistent root CID returns empty
- `TestMetadataStore_ResolveDAG_SingleBlock` — root with no children
- `TestMetadataStore_ResolveDAG_NotReady` — blocks with ready=false excluded

## Design Notes

- Recursive CTE uses `UNION` to deduplicate by block ID, preventing infinite loops on cycles
- CTE is re-declared for the children query because SQLite/MySQL scope CTEs to single statements
- Bumps portal dependency to include `ProtocolDAGProvider` interface from portal develop

## Base Branch

Targeting `alt-root-domains` since this branch is based off it.

***

<!-- kody-pr-summary:start -->

This pull request introduces two major functional areas: (1) a protocol-level DAG resolution API backed by recursive SQL, and (2) a delegated domain management system that supports both ICANN and alt-root namespaces (Handshake/HNS) with DANE/TLSA certificate handling.

## DAG Resolution API (`ProtocolDAGProvider`)

- Implements the `ProtocolDAGProvider` interface on the IPFS protocol, exposing `BlockChildren`, `BlockSize`, and `ResolveDAG`.
- Adds `ResolveDAG` to the metadata store, which resolves the complete block graph for a root CID in a single batch using a recursive SQL CTE. The query deduplicates blocks, respects `ready` status, and returns each block's size and ordered child relationships.
- Exposes a new authenticated API endpoint `GET /dag/:cid` that returns the resolved DAG as JSON, including root CID, block CIDs, sizes, and children.
- Adds comprehensive unit tests covering simple trees, deep chains, diamond-shaped DAGs (deduplication), missing roots, single blocks, and not-ready blocks.

## Delegated Domain Management

- Introduces a new `website_domains` table (with MySQL and SQLite migrations) that supports multiple domain bindings per website across namespaces (`icann`, `hns`). Existing single-domain websites are backfilled into the new table.
- Adds a new `DelegatedDomainService` with a pluggable provider registry:
  - `ICANNProvider`: standard domain delegation with nameserver instructions.
  - `HNSProvider`: Handshake namespace support with delegated and inline delegation modes, TLSA records, and DNSSEC DS record generation.
- Adds domain CRUD API endpoints under `/websites/:id/domains` and a `/websites/:id/domains/:domain_id/verify` endpoint to trigger delegation verification.
- Adds a new `delegation_pending` validation reason for websites bound to domains that have not yet published their delegation records.

## DNS, DANE/TLSA, and DNSSEC

- Extends the DNS service with `CreateDNSLinkRecord`, `CreateALIASRecord`, and `EnableDNSSEC`.
- Implements DNSSEC enablement through the PowerDNS cryptokeys API and computes DS records from the returned DNSKEY.
- Adds internal gateway-authenticated endpoints `POST /internal/dns/tlsa` and `POST /internal/dns/cert` for Caddy to push certificates and receive computed TLSA records. The service stores the TLSA data on the matching `WebsiteDomain` record and updates HNS authoritative records when applicable.
- Adds `HNSResolver` to DNS configuration so HNS names can be resolved through an HNS-aware resolver instead of the system default.

## Website Validation Integration

- Updates `WebsiteServiceDefault` to look up websites by domain through the new `website_domains` table first, falling back to the legacy column.
- Refactors DNS validation to support namespace-specific resolvers (e.g., HNS resolver for `.hns` domains).
- Skips TXT token checks for domains whose ownership is proven via delegation verification.
- Verifies attached domain delegations during DNS validation and marks the result as pending if verification fails.
- Adds a janitor task that periodically verifies pending domain delegations in batches.

## Testing and Tooling

- Generates random gateway secrets for tests instead of hard-coding values.
- Adds and updates mocks for `DomainProvider`, `DNSZoneService`, `MetadataStore`, `DNSResolver`, and `DNSService`.
- Adds unit and integration tests for delegated domain creation, HNS delegation, TLSA computation, and delegation-aware DNS validation.

<!-- kody-pr-summary:end -->

- \#814 <!-- branch-stack -->
  - **feat: implement ProtocolDAGProvider with recursive SQL and DAG query API** :point\_left:
