### PR TITLE
fix: use UUID for SSE event IDs to prevent collisions

### DIFF
--- a/internal/api/api_sse.go
+++ b/internal/api/api_sse.go
@@ -3,9 +3,9 @@ package api
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
 	sseServer "github.com/apt304/sse-go/server"
 	"go.lumeweb.com/portal/core"
@@ -71,7 +71,7 @@ func (a *API) publishWebsiteEvent(eventType string, eventData any) error {
 	// Create SSE event
 	topic := "gateway"
 	event := sseServer.Event{
-		ID:    fmt.Sprintf("website-%d", time.Now().UnixNano()),
+		ID:    uuid.New().String(),
 		Type:  eventType,
 		Data:  eventJSON,
 		Retry: 3000, // Recommended retry interval in milliseconds


### PR DESCRIPTION
## Summary

Fixes SSE event ID collisions when multiple website lifecycle events fire within the same nanosecond.

- Replace `time.Now().UnixNano()` with `uuid.New().String()` for SSE event IDs in `api_sse.go`, guaranteeing uniqueness and preventing client-side de-duplication from silently dropping events.

The swagger description containing `X-Gateway-Secret` in `api.go` is a false positive — it's the literal HTTP header name in documentation, not a hard-coded secret value. The actual secret is loaded from config at runtime.

- `develop` <!-- branch-stack -->
  - **fix: use UUID for SSE event IDs to prevent collisions** :point\_left:

---

<!-- kody-pr-summary:start -->
 This pull request fixes a potential collision issue with Server-Sent Events (SSE) event IDs by replacing the timestamp-based ID generation with UUIDs.

Previously, SSE event IDs were generated using `fmt.Sprintf("website-%d", time.Now().UnixNano())`, which could produce duplicate IDs if multiple events were published within the same nanosecond. This change uses `uuid.New().String()` to generate globally unique event IDs, ensuring reliable event identification and preventing collisions in SSE event streams.
<!-- kody-pr-summary:end -->