### PR TITLE
feat: expose namespace on GatewayWebsiteResponse

### DIFF
--- a/.mockery.yaml
+++ b/.mockery.yaml
@@ -1,6 +1,4 @@
 template: testify
-template-data:
-  unroll-variadic: true
 filename: "Mock{{.InterfaceName}}.go"
 pkgname: "mocks"
 dir: ./internal/testing/mocks

--- a/core/website.go
+++ b/core/website.go
@@ -42,8 +42,10 @@ type WebsiteService interface {
 	// GetWebsite retrieves a single website by ID
 	GetWebsite(ctx context.Context, userID uint, websiteID uint) (*pluginDb.Website, error)
 
-	// GetWebsiteByDomain retrieves a website by domain name
-	GetWebsiteByDomain(ctx context.Context, domain string) (*pluginDb.Website, error)
+	// GetWebsiteByDomain retrieves a website by domain name, along with its
+	// namespace (icann, hns). For legacy ipfs_websites.domain lookups the
+	// namespace defaults to ICANN.
+	GetWebsiteByDomain(ctx context.Context, domain string) (*pluginDb.Website, pluginDb.DomainNamespace, error)
 
 	// ListWebsites retrieves a paginated and filtered list of websites
 	ListWebsites(ctx context.Context, userID uint, filter []queryutil.CrudFilter, sort []filter.Sort, pagination queryutil.Pagination) ([]*pluginDb.Website, int64, error)

--- a/internal/api/api_dns_test.go
+++ b/internal/api/api_dns_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/api/dto"
-	"go.lumeweb.com/portal-plugin-ipfs/internal/db"
+	pluginDb "go.lumeweb.com/portal-plugin-ipfs/internal/db"
 	mocks "go.lumeweb.com/portal-plugin-ipfs/internal/testing/mocks"
 	"gorm.io/gorm"
 	pluginCore "go.lumeweb.com/portal-plugin-ipfs/core"
@@ -34,9 +34,9 @@ const (
 )
 
 // createMockDNSZone creates a standardized DNSZone mock object
-func createMockDNSZone(id, userID uint, domain string, status db.DNSZoneStatus, powerDNSZoneID string) *db.DNSZone {
+func createMockDNSZone(id, userID uint, domain string, status pluginDb.DNSZoneStatus, powerDNSZoneID string) *pluginDb.DNSZone {
 	now := time.Now()
-	return &db.DNSZone{
+	return &pluginDb.DNSZone{
 		Model:                  gorm.Model{ID: id, CreatedAt: now, UpdatedAt: now},
 		UserID:                 userID,
 		Domain:                 domain,
@@ -56,7 +56,7 @@ func TestAPI_CreateZone(t *testing.T) {
 
 			mockDNSService := core.GetService[*mocks.MockDNSService](ctx, pluginCore.DNS_SERVICE)
 
-			mockZone := createMockDNSZone(TestZoneID, userID, TestZoneDomain, db.DNSZoneStatusPendingNameserver, "pdns-123")
+			mockZone := createMockDNSZone(TestZoneID, userID, TestZoneDomain, pluginDb.DNSZoneStatusPendingNameserver, "pdns-123")
 
 			mockDNSService.EXPECT().CreateZone(mock.Anything, TestZoneDomain, userID).Return(mockZone, nil)
 
@@ -81,7 +81,7 @@ func TestAPI_CreateZone(t *testing.T) {
 
 			mockDNSService := core.GetService[*mocks.MockDNSService](ctx, pluginCore.DNS_SERVICE)
 
-			mockZone := createMockDNSZone(TestZoneID, userID, TestZoneDomain, db.DNSZoneStatusPendingNameserver, "pdns-123")
+			mockZone := createMockDNSZone(TestZoneID, userID, TestZoneDomain, pluginDb.DNSZoneStatusPendingNameserver, "pdns-123")
 
 			mockDNSService.EXPECT().CreateZone(mock.Anything, TestZoneDomain, userID).Return(mockZone, nil)
 
@@ -174,10 +174,10 @@ func TestAPI_ListZones(t *testing.T) {
 
 			mockDNSService := core.GetService[*mocks.MockDNSService](ctx, pluginCore.DNS_SERVICE)
 
-			mockZone1 := createMockDNSZone(TestZoneID, userID, TestZoneDomain, db.DNSZoneStatusActive, "pdns-123")
-			mockZone2 := createMockDNSZone(TestZoneID2, userID, "test.com", db.DNSZoneStatusPendingNameserver, "pdns-456")
+			mockZone1 := createMockDNSZone(TestZoneID, userID, TestZoneDomain, pluginDb.DNSZoneStatusActive, "pdns-123")
+			mockZone2 := createMockDNSZone(TestZoneID2, userID, "test.com", pluginDb.DNSZoneStatusPendingNameserver, "pdns-456")
 
-			mockDNSService.EXPECT().ListZones(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]*db.DNSZone{mockZone1, mockZone2}, int64(2), nil)
+			mockDNSService.EXPECT().ListZones(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]*pluginDb.DNSZone{mockZone1, mockZone2}, int64(2), nil)
 
 			rec := helper.makeAuthenticatedRequest(http.MethodGet, "/api/dns/zones", token, nil)
 
@@ -201,9 +201,9 @@ func TestAPI_ListZones(t *testing.T) {
 
 			mockDNSService := core.GetService[*mocks.MockDNSService](ctx, pluginCore.DNS_SERVICE)
 
-			mockZone := createMockDNSZone(TestZoneID, userID, TestZoneDomain, db.DNSZoneStatusActive, "pdns-123")
+			mockZone := createMockDNSZone(TestZoneID, userID, TestZoneDomain, pluginDb.DNSZoneStatusActive, "pdns-123")
 
-			mockDNSService.EXPECT().ListZones(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]*db.DNSZone{mockZone}, int64(10), nil)
+			mockDNSService.EXPECT().ListZones(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]*pluginDb.DNSZone{mockZone}, int64(10), nil)
 
 			rec := helper.makeAuthenticatedRequest(http.MethodGet, "/api/dns/zones?page=1&limit=1", token, nil)
 
@@ -227,7 +227,7 @@ func TestAPI_ListZones(t *testing.T) {
 
 			mockDNSService := core.GetService[*mocks.MockDNSService](ctx, pluginCore.DNS_SERVICE)
 
-			mockDNSService.EXPECT().ListZones(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]*db.DNSZone{}, int64(0), nil)
+			mockDNSService.EXPECT().ListZones(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]*pluginDb.DNSZone{}, int64(0), nil)
 
 			rec := helper.makeAuthenticatedRequest(http.MethodGet, "/api/dns/zones", token, nil)
 
@@ -276,9 +276,9 @@ func TestAPI_ListZones(t *testing.T) {
 
 			mockDNSService := core.GetService[*mocks.MockDNSService](ctx, pluginCore.DNS_SERVICE)
 
-			mockZone := createMockDNSZone(TestZoneID, userID, TestZoneDomain, db.DNSZoneStatusActive, "pdns-123")
+			mockZone := createMockDNSZone(TestZoneID, userID, TestZoneDomain, pluginDb.DNSZoneStatusActive, "pdns-123")
 
-			mockDNSService.EXPECT().ListZones(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]*db.DNSZone{mockZone}, int64(1), nil)
+			mockDNSService.EXPECT().ListZones(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]*pluginDb.DNSZone{mockZone}, int64(1), nil)
 
 			rec := helper.makeAuthenticatedRequest(http.MethodGet, "/api/dns/zones?filter[status]=active", token, nil)
 
@@ -295,7 +295,7 @@ func TestAPI_GetZone(t *testing.T) {
 
 			mockDNSService := core.GetService[*mocks.MockDNSService](ctx, pluginCore.DNS_SERVICE)
 
-			mockZone := createMockDNSZone(TestZoneID, userID, TestZoneDomain, db.DNSZoneStatusActive, "pdns-123")
+			mockZone := createMockDNSZone(TestZoneID, userID, TestZoneDomain, pluginDb.DNSZoneStatusActive, "pdns-123")
 
 			mockDNSService.EXPECT().GetZone(mock.Anything, TestZoneID).Return(mockZone, nil)
 
@@ -344,7 +344,7 @@ func TestAPI_GetZone(t *testing.T) {
 			mockDNSService := core.GetService[*mocks.MockDNSService](ctx, pluginCore.DNS_SERVICE)
 
 			otherUserID := userID + 1
-			mockZone := createMockDNSZone(TestZoneID, otherUserID, TestZoneDomain, db.DNSZoneStatusActive, "pdns-123")
+			mockZone := createMockDNSZone(TestZoneID, otherUserID, TestZoneDomain, pluginDb.DNSZoneStatusActive, "pdns-123")
 
 			mockDNSService.EXPECT().GetZone(mock.Anything, TestZoneID).Return(mockZone, nil)
 
@@ -374,7 +374,7 @@ func TestAPI_UpdateZone(t *testing.T) {
 
 			mockDNSService := core.GetService[*mocks.MockDNSService](ctx, pluginCore.DNS_SERVICE)
 
-			mockZone := createMockDNSZone(TestZoneID, userID, TestZoneDomain, db.DNSZoneStatusActive, "pdns-123")
+			mockZone := createMockDNSZone(TestZoneID, userID, TestZoneDomain, pluginDb.DNSZoneStatusActive, "pdns-123")
 
 			mockDNSService.EXPECT().GetZone(mock.Anything, TestZoneID).Return(mockZone, nil)
 
@@ -426,7 +426,7 @@ func TestAPI_UpdateZone(t *testing.T) {
 			mockDNSService := core.GetService[*mocks.MockDNSService](ctx, pluginCore.DNS_SERVICE)
 
 			otherUserID := userID + 1
-			mockZone := createMockDNSZone(TestZoneID, otherUserID, TestZoneDomain, db.DNSZoneStatusActive, "pdns-123")
+			mockZone := createMockDNSZone(TestZoneID, otherUserID, TestZoneDomain, pluginDb.DNSZoneStatusActive, "pdns-123")
 
 			mockDNSService.EXPECT().GetZone(mock.Anything, TestZoneID).Return(mockZone, nil)
 
@@ -470,7 +470,7 @@ func TestAPI_DeleteZone(t *testing.T) {
 
 			mockDNSService := core.GetService[*mocks.MockDNSService](ctx, pluginCore.DNS_SERVICE)
 
-			mockZone := createMockDNSZone(TestZoneID, userID, TestZoneDomain, db.DNSZoneStatusActive, "pdns-123")
+			mockZone := createMockDNSZone(TestZoneID, userID, TestZoneDomain, pluginDb.DNSZoneStatusActive, "pdns-123")
 
 			mockDNSService.EXPECT().GetZone(mock.Anything, TestZoneID).Return(mockZone, nil)
 			mockDNSService.EXPECT().DeleteZone(mock.Anything, TestZoneID).Return(nil)
@@ -514,7 +514,7 @@ func TestAPI_DeleteZone(t *testing.T) {
 			mockDNSService := core.GetService[*mocks.MockDNSService](ctx, pluginCore.DNS_SERVICE)
 
 			otherUserID := userID + 1
-			mockZone := createMockDNSZone(TestZoneID, otherUserID, TestZoneDomain, db.DNSZoneStatusActive, "pdns-123")
+			mockZone := createMockDNSZone(TestZoneID, otherUserID, TestZoneDomain, pluginDb.DNSZoneStatusActive, "pdns-123")
 
 			mockDNSService.EXPECT().GetZone(mock.Anything, TestZoneID).Return(mockZone, nil)
 
@@ -531,7 +531,7 @@ func TestAPI_DeleteZone(t *testing.T) {
 
 			mockDNSService := core.GetService[*mocks.MockDNSService](ctx, pluginCore.DNS_SERVICE)
 
-			mockZone := createMockDNSZone(TestZoneID, userID, TestZoneDomain, db.DNSZoneStatusActive, "pdns-123")
+			mockZone := createMockDNSZone(TestZoneID, userID, TestZoneDomain, pluginDb.DNSZoneStatusActive, "pdns-123")
 
 			mockDNSService.EXPECT().GetZone(mock.Anything, TestZoneID).Return(mockZone, nil)
 			mockDNSService.EXPECT().DeleteZone(mock.Anything, TestZoneID).Return(errors.New("delete failed"))
@@ -562,7 +562,7 @@ func TestAPI_ValidateZone(t *testing.T) {
 
 			mockDNSService := core.GetService[*mocks.MockDNSService](ctx, pluginCore.DNS_SERVICE)
 
-			mockZone := createMockDNSZone(TestZoneID, userID, TestZoneDomain, db.DNSZoneStatusActive, "pdns-123")
+			mockZone := createMockDNSZone(TestZoneID, userID, TestZoneDomain, pluginDb.DNSZoneStatusActive, "pdns-123")
 
 			mockDNSService.EXPECT().GetZone(mock.Anything, TestZoneID).Return(mockZone, nil)
 			mockDNSService.EXPECT().ValidateNameservers(mock.Anything, TestZoneID).Return(true, nil)
@@ -586,7 +586,7 @@ func TestAPI_ValidateZone(t *testing.T) {
 
 			mockDNSService := core.GetService[*mocks.MockDNSService](ctx, pluginCore.DNS_SERVICE)
 
-			mockZone := createMockDNSZone(TestZoneID, userID, TestZoneDomain, db.DNSZoneStatusPendingNameserver, "pdns-123")
+			mockZone := createMockDNSZone(TestZoneID, userID, TestZoneDomain, pluginDb.DNSZoneStatusPendingNameserver, "pdns-123")
 
 			mockDNSService.EXPECT().GetZone(mock.Anything, TestZoneID).Return(mockZone, nil)
 			mockDNSService.EXPECT().ValidateNameservers(mock.Anything, TestZoneID).Return(false, nil)
@@ -636,7 +636,7 @@ func TestAPI_ValidateZone(t *testing.T) {
 			mockDNSService := core.GetService[*mocks.MockDNSService](ctx, pluginCore.DNS_SERVICE)
 
 			otherUserID := userID + 1
-			mockZone := createMockDNSZone(TestZoneID, otherUserID, TestZoneDomain, db.DNSZoneStatusActive, "pdns-123")
+			mockZone := createMockDNSZone(TestZoneID, otherUserID, TestZoneDomain, pluginDb.DNSZoneStatusActive, "pdns-123")
 
 			mockDNSService.EXPECT().GetZone(mock.Anything, TestZoneID).Return(mockZone, nil)
 
@@ -653,7 +653,7 @@ func TestAPI_ValidateZone(t *testing.T) {
 
 			mockDNSService := core.GetService[*mocks.MockDNSService](ctx, pluginCore.DNS_SERVICE)
 
-			mockZone := createMockDNSZone(TestZoneID, userID, TestZoneDomain, db.DNSZoneStatusActive, "pdns-123")
+			mockZone := createMockDNSZone(TestZoneID, userID, TestZoneDomain, pluginDb.DNSZoneStatusActive, "pdns-123")
 
 			mockDNSService.EXPECT().GetZone(mock.Anything, TestZoneID).Return(mockZone, nil)
 			mockDNSService.EXPECT().ValidateNameservers(mock.Anything, TestZoneID).Return(false, errors.New("validation failed"))
@@ -684,7 +684,7 @@ func TestAPI_GetZoneStatus(t *testing.T) {
 
 			mockDNSService := core.GetService[*mocks.MockDNSService](ctx, pluginCore.DNS_SERVICE)
 
-			mockZone := createMockDNSZone(TestZoneID, userID, TestZoneDomain, db.DNSZoneStatusActive, "pdns-123")
+			mockZone := createMockDNSZone(TestZoneID, userID, TestZoneDomain, pluginDb.DNSZoneStatusActive, "pdns-123")
 
 			mockDNSService.EXPECT().GetZone(mock.Anything, TestZoneID).Return(mockZone, nil)
 
@@ -697,7 +697,7 @@ func TestAPI_GetZoneStatus(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, TestZoneID, response.ID)
 			assert.Equal(t, TestZoneDomain, response.Domain)
-			assert.Equal(t, string(db.DNSZoneStatusActive), response.Status)
+			assert.Equal(t, string(pluginDb.DNSZoneStatusActive), response.Status)
 		}, TestOptions)
 	})
 
@@ -734,7 +734,7 @@ func TestAPI_GetZoneStatus(t *testing.T) {
 			mockDNSService := core.GetService[*mocks.MockDNSService](ctx, pluginCore.DNS_SERVICE)
 
 			otherUserID := userID + 1
-			mockZone := createMockDNSZone(TestZoneID, otherUserID, TestZoneDomain, db.DNSZoneStatusActive, "pdns-123")
+			mockZone := createMockDNSZone(TestZoneID, otherUserID, TestZoneDomain, pluginDb.DNSZoneStatusActive, "pdns-123")
 
 			mockDNSService.EXPECT().GetZone(mock.Anything, TestZoneID).Return(mockZone, nil)
 

--- a/internal/api/api_domains_test.go
+++ b/internal/api/api_domains_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.lumeweb.com/portal-plugin-ipfs/internal/db"
+	pluginDb "go.lumeweb.com/portal-plugin-ipfs/internal/db"
 	coreTesting "go.lumeweb.com/portal/core/testing"
 )
 
@@ -17,16 +17,16 @@ func TestAPI_DeleteDomain(t *testing.T) {
 			token, userID, testCID, _ := helper.SetupAuthenticatedTest()
 
 			// Create a website to attach the domain to.
-			website := createTestIPFSGatewayWebsite(1, userID, "example.com", testCID, db.WebsiteStatusActive)
+			website := createTestIPFSGatewayWebsite(1, userID, "example.com", testCID, pluginDb.WebsiteStatusActive)
 			require.NoError(t, ctx.DB().Create(website).Error)
 
 			// Create a domain binding.
-			wd := &db.WebsiteDomain{
+			wd := &pluginDb.WebsiteDomain{
 				WebsiteID: 1,
 				UserID:    userID,
 				Domain:    "example.com",
-				Namespace: db.DomainNamespaceICANN,
-				Status:    db.DomainStatusDraft,
+				Namespace: pluginDb.DomainNamespaceICANN,
+				Status:    pluginDb.DomainStatusDraft,
 			}
 			require.NoError(t, ctx.DB().Create(wd).Error)
 
@@ -36,16 +36,16 @@ func TestAPI_DeleteDomain(t *testing.T) {
 
 			// The record should be gone (hard-deleted, not soft-deleted).
 			var count int64
-			ctx.DB().Unscoped().Model(&db.WebsiteDomain{}).Where("domain = ? AND namespace = ?", "example.com", db.DomainNamespaceICANN).Count(&count)
+			ctx.DB().Unscoped().Model(&pluginDb.WebsiteDomain{}).Where("domain = ? AND namespace = ?", "example.com", pluginDb.DomainNamespaceICANN).Count(&count)
 			assert.Zero(t, count, "domain should be hard-deleted, not soft-deleted")
 
 			// Re-create the same domain+namespace — should succeed (no unique collision).
-			wd2 := &db.WebsiteDomain{
+			wd2 := &pluginDb.WebsiteDomain{
 				WebsiteID: 1,
 				UserID:    userID,
 				Domain:    "example.com",
-				Namespace: db.DomainNamespaceICANN,
-				Status:    db.DomainStatusDraft,
+				Namespace: pluginDb.DomainNamespaceICANN,
+				Status:    pluginDb.DomainStatusDraft,
 			}
 			err := ctx.DB().Create(wd2).Error
 			assert.NoError(t, err, "re-creating same domain+namespace after hard delete should succeed")
@@ -58,16 +58,16 @@ func TestAPI_DeleteDomain(t *testing.T) {
 			token, userID, testCID, _ := helper.SetupAuthenticatedTest()
 
 			// Create a website owned by the authenticated user.
-			website := createTestIPFSGatewayWebsite(1, userID, "other.com", testCID, db.WebsiteStatusActive)
+			website := createTestIPFSGatewayWebsite(1, userID, "other.com", testCID, pluginDb.WebsiteStatusActive)
 			require.NoError(t, ctx.DB().Create(website).Error)
 
 			// Create a domain binding owned by a different user.
-			wd := &db.WebsiteDomain{
+			wd := &pluginDb.WebsiteDomain{
 				WebsiteID: 1,
 				UserID:    userID + 100, // different user
 				Domain:    "other.com",
-				Namespace: db.DomainNamespaceICANN,
-				Status:    db.DomainStatusDraft,
+				Namespace: pluginDb.DomainNamespaceICANN,
+				Status:    pluginDb.DomainStatusDraft,
 			}
 			require.NoError(t, ctx.DB().Create(wd).Error)
 

--- a/internal/api/api_gateway.go
+++ b/internal/api/api_gateway.go
@@ -22,7 +22,7 @@ func (a *API) getGatewayWebsite(c echo.Context) error {
 	}
 
 	// Get website by domain
-	website, err := a.websiteService.GetWebsiteByDomain(reqCtx, domain)
+	website, ns, err := a.websiteService.GetWebsiteByDomain(reqCtx, domain)
 	if err != nil {
 		a.Logger().Error("Failed to get website by domain", zap.String("domain", domain), zap.Error(err))
 		return ctx.Error(err, http.StatusInternalServerError)
@@ -40,7 +40,8 @@ func (a *API) getGatewayWebsite(c echo.Context) error {
 		})
 	}
 
-	return httputil.EncodeResponse(ctx, website, &dto.GatewayWebsiteResponse{})
+	resp := &dto.GatewayWebsiteResponse{Namespace: ns}
+	return httputil.EncodeResponse(ctx, website, resp)
 }
 
 // getGatewayWebsiteStatus retrieves website status for the gateway
@@ -54,7 +55,7 @@ func (a *API) getGatewayWebsiteStatus(c echo.Context) error {
 	}
 
 	// Get website by domain
-	website, err := a.websiteService.GetWebsiteByDomain(reqCtx, domain)
+	website, _, err := a.websiteService.GetWebsiteByDomain(reqCtx, domain)
 	if err != nil {
 		a.Logger().Error("Failed to get website by domain", zap.String("domain", domain), zap.Error(err))
 		return ctx.Error(err, http.StatusInternalServerError)

--- a/internal/api/api_gateway_test.go
+++ b/internal/api/api_gateway_test.go
@@ -58,7 +58,7 @@ func createTestDeletedIPFSGatewayWebsite(id, userID uint, domain string, testCID
 }
 
 func TestAPI_GetGatewayWebsite(t *testing.T) {
-	coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 		// Arrange
 		helper := newMockHelper(t, ctx)
 		domain := TestDomain
@@ -129,7 +129,7 @@ func TestAPI_GetGatewayWebsite_InvalidSecret(t *testing.T) {
 }
 
 func TestAPI_GetGatewayWebsite_BrokenSite(t *testing.T) {
-	coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 		// Arrange
 		helper := newMockHelper(t, ctx)
 		domain := "broken.example.com"
@@ -158,7 +158,7 @@ func TestAPI_GetGatewayWebsite_BrokenSite(t *testing.T) {
 }
 
 func TestAPI_GetGatewayWebsite_DeletedSite(t *testing.T) {
-	coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 		// Arrange
 		helper := newMockHelper(t, ctx)
 		domain := "deleted.example.com"
@@ -186,7 +186,7 @@ func TestAPI_GetGatewayWebsite_DeletedSite(t *testing.T) {
 }
 
 func TestAPI_GetGatewayWebsite_NotFound(t *testing.T) {
-	coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 		// Arrange
 		helper := newMockHelper(t, ctx)
 		domain := "nonexistent.example.com"
@@ -285,12 +285,12 @@ func TestAPI_GetGatewayWebsiteStatus_NotFound(t *testing.T) {
 }
 
 func TestAPI_GetGatewayWebsite_ServiceError(t *testing.T) {
-	coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 		helper := newMockHelper(t, ctx)
 		domain := "error.example.com"
 		
 		mockWebsiteService := core.GetService[*mocks.MockWebsiteService](helper.ctx, pluginCore.WEBSITE_SERVICE)
-		mockWebsiteService.EXPECT().GetWebsiteByDomain(mock.Anything, domain).Return(nil, errors.New("database error"))
+		mockWebsiteService.EXPECT().GetWebsiteByDomain(mock.Anything, domain).Return(nil, pluginDb.DomainNamespaceICANN, errors.New("database error"))
 		
 		req := ctx.NewAPIRequest(http.MethodGet, "/internal/websites/"+domain, nil)
 		req.Header.Set("X-Gateway-Secret", testGatewaySecret())

--- a/internal/api/api_ipns_test.go
+++ b/internal/api/api_ipns_test.go
@@ -17,15 +17,15 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/api/dto"
-	"go.lumeweb.com/portal-plugin-ipfs/internal/db"
+	pluginDb "go.lumeweb.com/portal-plugin-ipfs/internal/db"
 	coreTesting "go.lumeweb.com/portal/core/testing"
 	"gorm.io/gorm"
 )
 
 // Helper function to create a test IPNS key
-func createTestIPNSKey(id, userID uint, name string, peerIDStr string) db.IPFSIPNSKey {
+func createTestIPNSKey(id, userID uint, name string, peerIDStr string) pluginDb.IPFSIPNSKey {
 	pid, _ := peer.Decode(peerIDStr)
-	return db.IPFSIPNSKey{
+	return pluginDb.IPFSIPNSKey{
 		ID:              id,
 		UserID:          userID,
 		Name:            name,
@@ -69,7 +69,7 @@ func TestAPI_CreateIPNSKey(t *testing.T) {
 			mockIPNSKeyService := helper.SetupIPNSServiceMocksNoDefaults(userID)
 
 			testPeerID, _ := peer.Decode(TestPeerID)
-			mockKey := &db.IPFSIPNSKey{
+			mockKey := &pluginDb.IPFSIPNSKey{
 				ID:              1,
 				UserID:          userID,
 				Name:            "imported-key",
@@ -138,13 +138,13 @@ func TestAPI_ListIPNSKeys(t *testing.T) {
 
 			mockIPNSKeyService := helper.SetupIPNSServiceMocks(userID)
 
-			mockKeys := []db.IPFSIPNSKey{
+			mockKeys := []pluginDb.IPFSIPNSKey{
 				createTestIPNSKey(1, userID, "key1", TestPeerID),
 				createTestIPNSKey(2, userID, "key2", "k51qzi5uqu5dljj4y7g7lq43z7z8p9c0f1e2d3c4b5a6987654321fedcba"),
 			}
 
 			// New implementation uses ListKeysWithFilters
-			keyPointers := []*db.IPFSIPNSKey{&mockKeys[0], &mockKeys[1]}
+			keyPointers := []*pluginDb.IPFSIPNSKey{&mockKeys[0], &mockKeys[1]}
 			mockIPNSKeyService.EXPECT().ListKeysWithFilters(
 				mock.Anything,
 				userID,
@@ -181,7 +181,7 @@ func TestAPI_ListIPNSKeys(t *testing.T) {
 				mock.Anything,
 				mock.Anything,
 				mock.Anything,
-			).Return([]*db.IPFSIPNSKey{}, int64(0), nil)
+			).Return([]*pluginDb.IPFSIPNSKey{}, int64(0), nil)
 
 			rec := helper.makeAuthenticatedRequest(http.MethodGet, "/api/ipns/keys", token, nil)
 

--- a/internal/api/api_websites.go
+++ b/internal/api/api_websites.go
@@ -401,7 +401,7 @@ func (a *API) getSSLStatus(c echo.Context) error {
 		return ctx.Error(apiErr, http.StatusBadRequest)
 	}
 
-	website, err := a.websiteService.GetWebsiteByDomain(reqCtx, domain)
+	website, _, err := a.websiteService.GetWebsiteByDomain(reqCtx, domain)
 	if err != nil {
 		if strings.Contains(err.Error(), "website not found") {
 			apiErr := NewError(pluginEvents.ErrWebsiteNotFound, err)

--- a/internal/api/api_websites_test.go
+++ b/internal/api/api_websites_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/api/dto"
-	"go.lumeweb.com/portal-plugin-ipfs/internal/db"
+	pluginDb "go.lumeweb.com/portal-plugin-ipfs/internal/db"
 	mocks "go.lumeweb.com/portal-plugin-ipfs/internal/testing/mocks"
 	pluginCore "go.lumeweb.com/portal-plugin-ipfs/core"
 	coreTesting "go.lumeweb.com/portal/core/testing"
@@ -23,14 +23,14 @@ import (
 )
 
 // Helper function to create a mock IPFS website
-func createMockIPFSWebsite(id, userID uint, domain string, testCID string, status db.WebsiteStatus, token string) *db.Website {
+func createMockIPFSWebsite(id, userID uint, domain string, testCID string, status pluginDb.WebsiteStatus, token string) *pluginDb.Website {
 	c := cid.MustParse(testCID)
 	version := uint8(c.Version())
-	return &db.Website{
+	return &pluginDb.Website{
 		ID:              id,
 		UserID:          userID,
 		Domain:          domain,
-		TargetType:      string(db.WebsiteTargetTypeIPFS),
+		TargetType:      string(pluginDb.WebsiteTargetTypeIPFS),
 		TargetMultihash: c.Hash(),
 		CIDVersion:      &version,
 		Status:          string(status),
@@ -39,13 +39,13 @@ func createMockIPFSWebsite(id, userID uint, domain string, testCID string, statu
 }
 
 // Helper function to create a mock IPNS website
-func createMockIPNSWebsite(id, userID uint, domain string, peerIDStr string, status db.WebsiteStatus, token string) *db.Website {
-	target, _ := db.NewIPNSTargetFromString(peerIDStr)
-	return &db.Website{
+func createMockIPNSWebsite(id, userID uint, domain string, peerIDStr string, status pluginDb.WebsiteStatus, token string) *pluginDb.Website {
+	target, _ := pluginDb.NewIPNSTargetFromString(peerIDStr)
+	return &pluginDb.Website{
 		ID:              id,
 		UserID:          userID,
 		Domain:          domain,
-		TargetType:      string(db.WebsiteTargetTypeIPNS),
+		TargetType:      string(pluginDb.WebsiteTargetTypeIPNS),
 		TargetMultihash: target.ToMultihash(),
 		CIDVersion:      nil,
 		Status:          string(status),
@@ -69,7 +69,7 @@ func TestAPI_CreateWebsite(t *testing.T) {
 
 			mockWebsiteService := core.GetService[*mocks.MockWebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
 
-			mockWebsite := createMockIPFSWebsite(1, userID, TestDomain, TestCID, db.WebsiteStatusPendingValidation, "test-token")
+			mockWebsite := createMockIPFSWebsite(1, userID, TestDomain, TestCID, pluginDb.WebsiteStatusPendingValidation, "test-token")
 
 			mockWebsiteService.EXPECT().CreateWebsite(mock.Anything, mock.AnythingOfType("*db.Website")).Return(mockWebsite, nil)
 
@@ -97,7 +97,7 @@ func TestAPI_CreateWebsite(t *testing.T) {
 
 			mockWebsiteService := core.GetService[*mocks.MockWebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
 
-			mockWebsite := createMockIPNSWebsite(1, userID, TestDomain, TestPeerID, db.WebsiteStatusPendingValidation, "test-token")
+			mockWebsite := createMockIPNSWebsite(1, userID, TestDomain, TestPeerID, pluginDb.WebsiteStatusPendingValidation, "test-token")
 
 			mockWebsiteService.EXPECT().CreateWebsite(mock.Anything, mock.AnythingOfType("*db.Website")).Return(mockWebsite, nil)
 
@@ -186,7 +186,7 @@ func TestAPI_CreateWebsite(t *testing.T) {
 
 			mockWebsiteService := core.GetService[*mocks.MockWebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
 
-			mockWebsite := createMockIPFSWebsite(1, userID, TestDomain, TestCID, db.WebsiteStatusBroken, "test-token")
+			mockWebsite := createMockIPFSWebsite(1, userID, TestDomain, TestCID, pluginDb.WebsiteStatusBroken, "test-token")
 
 			mockWebsiteService.EXPECT().CreateWebsite(mock.Anything, mock.AnythingOfType("*db.Website")).Return(mockWebsite, nil)
 
@@ -220,17 +220,17 @@ func TestAPI_GetSSLStatus(t *testing.T) {
 			mockWebsiteService := core.GetService[*mocks.MockWebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
 
 			timestamp := time.Now().UTC()
-			mockWebsite := &db.Website{
+			mockWebsite := &pluginDb.Website{
 				ID:              1,
 				UserID:          userID,
 				Domain:          TestDomain,
-				TargetType:      string(db.WebsiteTargetTypeIPFS),
-				Status:          string(db.WebsiteStatusActive),
-				SSLStatus:       string(db.SSLStatusReady),
+				TargetType:      string(pluginDb.WebsiteTargetTypeIPFS),
+				Status:          string(pluginDb.WebsiteStatusActive),
+				SSLStatus:       string(pluginDb.SSLStatusReady),
 				SSLLastUpdatedAt: &timestamp,
 			}
 
-			mockWebsiteService.EXPECT().GetWebsiteByDomain(mock.Anything, TestDomain).Return(mockWebsite, nil)
+			mockWebsiteService.EXPECT().GetWebsiteByDomain(mock.Anything, TestDomain).Return(mockWebsite, pluginDb.DomainNamespaceICANN, nil)
 
 			rec := helper.makeRequest(http.MethodGet, "/api/websites/"+TestDomain+"/ssl-status", nil)
 
@@ -253,17 +253,17 @@ func TestAPI_GetSSLStatus(t *testing.T) {
 			mockWebsiteService := core.GetService[*mocks.MockWebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
 
 			timestamp := time.Now().UTC()
-			mockWebsite := &db.Website{
+			mockWebsite := &pluginDb.Website{
 				ID:              1,
 				UserID:          userID,
 				Domain:          TestDomain,
-				TargetType:      string(db.WebsiteTargetTypeIPFS),
-				Status:          string(db.WebsiteStatusActive),
-				SSLStatus:       string(db.SSLStatusPending),
+				TargetType:      string(pluginDb.WebsiteTargetTypeIPFS),
+				Status:          string(pluginDb.WebsiteStatusActive),
+				SSLStatus:       string(pluginDb.SSLStatusPending),
 				SSLLastUpdatedAt: &timestamp,
 			}
 
-			mockWebsiteService.EXPECT().GetWebsiteByDomain(mock.Anything, TestDomain).Return(mockWebsite, nil)
+			mockWebsiteService.EXPECT().GetWebsiteByDomain(mock.Anything, TestDomain).Return(mockWebsite, pluginDb.DomainNamespaceICANN, nil)
 
 			rec := helper.makeRequest(http.MethodGet, "/api/websites/"+TestDomain+"/ssl-status", nil)
 
@@ -282,7 +282,7 @@ func TestAPI_GetSSLStatus(t *testing.T) {
 
 			mockWebsiteService := core.GetService[*mocks.MockWebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
 
-			mockWebsiteService.EXPECT().GetWebsiteByDomain(mock.Anything, TestDomain).Return(nil, nil)
+			mockWebsiteService.EXPECT().GetWebsiteByDomain(mock.Anything, TestDomain).Return(nil, pluginDb.DomainNamespaceICANN, nil)
 
 			rec := helper.makeRequest(http.MethodGet, "/api/websites/"+TestDomain+"/ssl-status", nil)
 
@@ -311,17 +311,17 @@ func TestAPI_UpdateSSLStatus_Webhook(t *testing.T) {
 			mockWebsiteService := core.GetService[*mocks.MockWebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
 
 			timestamp := time.Now().UTC()
-			mockWebsite := &db.Website{
+			mockWebsite := &pluginDb.Website{
 				ID:              1,
 				UserID:          userID,
 				Domain:          TestDomain,
-				TargetType:      string(db.WebsiteTargetTypeIPFS),
-				Status:          string(db.WebsiteStatusActive),
-				SSLStatus:       string(db.SSLStatusReady),
+				TargetType:      string(pluginDb.WebsiteTargetTypeIPFS),
+				Status:          string(pluginDb.WebsiteStatusActive),
+				SSLStatus:       string(pluginDb.SSLStatusReady),
 				SSLLastUpdatedAt: &timestamp,
 			}
 
-			mockWebsiteService.EXPECT().UpdateSSLStatus(mock.Anything, TestDomain, db.SSLStatusReady, "", mock.AnythingOfType("*time.Time")).Return(mockWebsite, nil)
+			mockWebsiteService.EXPECT().UpdateSSLStatus(mock.Anything, TestDomain, pluginDb.SSLStatusReady, "", mock.AnythingOfType("*time.Time")).Return(mockWebsite, nil)
 
 			reqBody := fmt.Sprintf(`{"status":"ready","timestamp":"%s"}`, timestamp.Format(time.RFC3339))
 			rec := helper.makeGatewayAuthenticatedRequest(http.MethodPost, "/internal/websites/"+TestDomain+"/ssl-status", testGatewaySecret(), []byte(reqBody))
@@ -345,18 +345,18 @@ func TestAPI_UpdateSSLStatus_Webhook(t *testing.T) {
 			mockWebsiteService := core.GetService[*mocks.MockWebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
 
 			timestamp := time.Now().UTC()
-			mockWebsite := &db.Website{
+			mockWebsite := &pluginDb.Website{
 				ID:              1,
 				UserID:          userID,
 				Domain:          TestDomain,
-				TargetType:      string(db.WebsiteTargetTypeIPFS),
-				Status:          string(db.WebsiteStatusActive),
-				SSLStatus:       string(db.SSLStatusFailed),
+				TargetType:      string(pluginDb.WebsiteTargetTypeIPFS),
+				Status:          string(pluginDb.WebsiteStatusActive),
+				SSLStatus:       string(pluginDb.SSLStatusFailed),
 				SSLError:        "certificate validation failed",
 				SSLLastUpdatedAt: &timestamp,
 			}
 
-			mockWebsiteService.EXPECT().UpdateSSLStatus(mock.Anything, TestDomain, db.SSLStatusFailed, "certificate validation failed", mock.AnythingOfType("*time.Time")).Return(mockWebsite, nil)
+			mockWebsiteService.EXPECT().UpdateSSLStatus(mock.Anything, TestDomain, pluginDb.SSLStatusFailed, "certificate validation failed", mock.AnythingOfType("*time.Time")).Return(mockWebsite, nil)
 
 			reqBody := fmt.Sprintf(`{"status":"failed","error":"certificate validation failed","timestamp":"%s"}`, timestamp.Format(time.RFC3339))
 			rec := helper.makeGatewayAuthenticatedRequest(http.MethodPost, "/internal/websites/"+TestDomain+"/ssl-status", testGatewaySecret(), []byte(reqBody))
@@ -381,17 +381,17 @@ func TestAPI_UpdateSSLStatus_Webhook(t *testing.T) {
 			mockWebsiteService := core.GetService[*mocks.MockWebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
 
 			timestamp := time.Now().UTC()
-			mockWebsite := &db.Website{
+			mockWebsite := &pluginDb.Website{
 				ID:              1,
 				UserID:          userID,
 				Domain:          TestDomain,
-				TargetType:      string(db.WebsiteTargetTypeIPFS),
-				Status:          string(db.WebsiteStatusActive),
-				SSLStatus:       string(db.SSLStatusPending),
+				TargetType:      string(pluginDb.WebsiteTargetTypeIPFS),
+				Status:          string(pluginDb.WebsiteStatusActive),
+				SSLStatus:       string(pluginDb.SSLStatusPending),
 				SSLLastUpdatedAt: &timestamp,
 			}
 
-			mockWebsiteService.EXPECT().UpdateSSLStatus(mock.Anything, TestDomain, db.SSLStatusPending, "", mock.AnythingOfType("*time.Time")).Return(mockWebsite, nil)
+			mockWebsiteService.EXPECT().UpdateSSLStatus(mock.Anything, TestDomain, pluginDb.SSLStatusPending, "", mock.AnythingOfType("*time.Time")).Return(mockWebsite, nil)
 
 			reqBody := fmt.Sprintf(`{"status":"pending","timestamp":"%s"}`, timestamp.Format(time.RFC3339))
 			rec := helper.makeGatewayAuthenticatedRequest(http.MethodPost, "/internal/websites/"+TestDomain+"/ssl-status", testGatewaySecret(), []byte(reqBody))
@@ -415,17 +415,17 @@ func TestAPI_UpdateSSLStatus_Webhook(t *testing.T) {
 			mockWebsiteService := core.GetService[*mocks.MockWebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
 
 			timestamp := time.Now().UTC()
-			mockWebsite := &db.Website{
+			mockWebsite := &pluginDb.Website{
 				ID:              1,
 				UserID:          userID,
 				Domain:          TestDomain,
-				TargetType:      string(db.WebsiteTargetTypeIPFS),
-				Status:          string(db.WebsiteStatusActive),
-				SSLStatus:       string(db.SSLStatusIssuing),
+				TargetType:      string(pluginDb.WebsiteTargetTypeIPFS),
+				Status:          string(pluginDb.WebsiteStatusActive),
+				SSLStatus:       string(pluginDb.SSLStatusIssuing),
 				SSLLastUpdatedAt: &timestamp,
 			}
 
-			mockWebsiteService.EXPECT().UpdateSSLStatus(mock.Anything, TestDomain, db.SSLStatusIssuing, "", mock.AnythingOfType("*time.Time")).Return(mockWebsite, nil)
+			mockWebsiteService.EXPECT().UpdateSSLStatus(mock.Anything, TestDomain, pluginDb.SSLStatusIssuing, "", mock.AnythingOfType("*time.Time")).Return(mockWebsite, nil)
 
 			reqBody := fmt.Sprintf(`{"status":"issuing","timestamp":"%s"}`, timestamp.Format(time.RFC3339))
 			rec := helper.makeGatewayAuthenticatedRequest(http.MethodPost, "/internal/websites/"+TestDomain+"/ssl-status", testGatewaySecret(), []byte(reqBody))
@@ -501,7 +501,7 @@ func TestAPI_UpdateSSLStatus_Webhook(t *testing.T) {
 
 			mockWebsiteService := core.GetService[*mocks.MockWebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
 
-			mockWebsiteService.EXPECT().UpdateSSLStatus(mock.Anything, TestDomain, db.SSLStatusReady, "", (*time.Time)(nil)).Return(nil, errors.New("website not found"))
+			mockWebsiteService.EXPECT().UpdateSSLStatus(mock.Anything, TestDomain, pluginDb.SSLStatusReady, "", (*time.Time)(nil)).Return(nil, errors.New("website not found"))
 
 			reqBody := `{"status":"ready"}`
 			rec := helper.makeGatewayAuthenticatedRequest(http.MethodPost, "/internal/websites/"+TestDomain+"/ssl-status", testGatewaySecret(), []byte(reqBody))
@@ -516,7 +516,7 @@ func TestAPI_UpdateSSLStatus_Webhook(t *testing.T) {
 
 			mockWebsiteService := core.GetService[*mocks.MockWebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
 
-			mockWebsiteService.EXPECT().UpdateSSLStatus(mock.Anything, TestDomain, db.SSLStatusReady, "", (*time.Time)(nil)).Return(nil, errors.New("database error"))
+			mockWebsiteService.EXPECT().UpdateSSLStatus(mock.Anything, TestDomain, pluginDb.SSLStatusReady, "", (*time.Time)(nil)).Return(nil, errors.New("database error"))
 
 			reqBody := `{"status":"ready"}`
 			rec := helper.makeGatewayAuthenticatedRequest(http.MethodPost, "/internal/websites/"+TestDomain+"/ssl-status", testGatewaySecret(), []byte(reqBody))
@@ -533,17 +533,17 @@ func TestAPI_UpdateSSLStatus_Webhook(t *testing.T) {
 			mockWebsiteService := core.GetService[*mocks.MockWebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
 
 			timestamp := time.Now().UTC()
-			mockWebsite := &db.Website{
+			mockWebsite := &pluginDb.Website{
 				ID:              1,
 				UserID:          userID,
 				Domain:          TestDomain,
-				TargetType:      string(db.WebsiteTargetTypeIPFS),
-				Status:          string(db.WebsiteStatusActive),
-				SSLStatus:       string(db.SSLStatusReady),
+				TargetType:      string(pluginDb.WebsiteTargetTypeIPFS),
+				Status:          string(pluginDb.WebsiteStatusActive),
+				SSLStatus:       string(pluginDb.SSLStatusReady),
 				SSLLastUpdatedAt: &timestamp,
 			}
 
-			mockWebsiteService.EXPECT().UpdateSSLStatus(mock.Anything, TestDomain, db.SSLStatusReady, "", mock.AnythingOfType("*time.Time")).Return(mockWebsite, nil).Times(2)
+			mockWebsiteService.EXPECT().UpdateSSLStatus(mock.Anything, TestDomain, pluginDb.SSLStatusReady, "", mock.AnythingOfType("*time.Time")).Return(mockWebsite, nil).Times(2)
 
 			reqBody := fmt.Sprintf(`{"status":"ready","timestamp":"%s"}`, timestamp.Format(time.RFC3339))
 
@@ -566,39 +566,39 @@ func TestAPI_UpdateSSLStatus_Webhook(t *testing.T) {
 			timestamp2 := timestamp1.Add(time.Minute)
 			timestamp3 := timestamp2.Add(time.Hour)
 
-			mockWebsitePending := &db.Website{
+			mockWebsitePending := &pluginDb.Website{
 				ID:              1,
 				UserID:          userID,
 				Domain:          TestDomain,
-				TargetType:      string(db.WebsiteTargetTypeIPFS),
-				Status:          string(db.WebsiteStatusActive),
-				SSLStatus:       string(db.SSLStatusPending),
+				TargetType:      string(pluginDb.WebsiteTargetTypeIPFS),
+				Status:          string(pluginDb.WebsiteStatusActive),
+				SSLStatus:       string(pluginDb.SSLStatusPending),
 				SSLLastUpdatedAt: &timestamp1,
 			}
 
-			mockWebsiteIssuing := &db.Website{
+			mockWebsiteIssuing := &pluginDb.Website{
 				ID:              1,
 				UserID:          userID,
 				Domain:          TestDomain,
-				TargetType:      string(db.WebsiteTargetTypeIPFS),
-				Status:          string(db.WebsiteStatusActive),
-				SSLStatus:       string(db.SSLStatusIssuing),
+				TargetType:      string(pluginDb.WebsiteTargetTypeIPFS),
+				Status:          string(pluginDb.WebsiteStatusActive),
+				SSLStatus:       string(pluginDb.SSLStatusIssuing),
 				SSLLastUpdatedAt: &timestamp2,
 			}
 
-			mockWebsiteReady := &db.Website{
+			mockWebsiteReady := &pluginDb.Website{
 				ID:              1,
 				UserID:          userID,
 				Domain:          TestDomain,
-				TargetType:      string(db.WebsiteTargetTypeIPFS),
-				Status:          string(db.WebsiteStatusActive),
-				SSLStatus:       string(db.SSLStatusReady),
+				TargetType:      string(pluginDb.WebsiteTargetTypeIPFS),
+				Status:          string(pluginDb.WebsiteStatusActive),
+				SSLStatus:       string(pluginDb.SSLStatusReady),
 				SSLLastUpdatedAt: &timestamp3,
 			}
 
-			mockWebsiteService.EXPECT().UpdateSSLStatus(mock.Anything, TestDomain, db.SSLStatusPending, "", mock.AnythingOfType("*time.Time")).Return(mockWebsitePending, nil)
-			mockWebsiteService.EXPECT().UpdateSSLStatus(mock.Anything, TestDomain, db.SSLStatusIssuing, "", mock.AnythingOfType("*time.Time")).Return(mockWebsiteIssuing, nil)
-			mockWebsiteService.EXPECT().UpdateSSLStatus(mock.Anything, TestDomain, db.SSLStatusReady, "", mock.AnythingOfType("*time.Time")).Return(mockWebsiteReady, nil)
+			mockWebsiteService.EXPECT().UpdateSSLStatus(mock.Anything, TestDomain, pluginDb.SSLStatusPending, "", mock.AnythingOfType("*time.Time")).Return(mockWebsitePending, nil)
+			mockWebsiteService.EXPECT().UpdateSSLStatus(mock.Anything, TestDomain, pluginDb.SSLStatusIssuing, "", mock.AnythingOfType("*time.Time")).Return(mockWebsiteIssuing, nil)
+			mockWebsiteService.EXPECT().UpdateSSLStatus(mock.Anything, TestDomain, pluginDb.SSLStatusReady, "", mock.AnythingOfType("*time.Time")).Return(mockWebsiteReady, nil)
 
 			reqBody1 := fmt.Sprintf(`{"status":"pending","timestamp":"%s"}`, timestamp1.Format(time.RFC3339))
 			rec1 := helper.makeGatewayAuthenticatedRequest(http.MethodPost, "/internal/websites/"+TestDomain+"/ssl-status", testGatewaySecret(), []byte(reqBody1))
@@ -640,9 +640,9 @@ func TestAPI_ListWebsites(t *testing.T) {
 
 			mockWebsiteService := core.GetService[*mocks.MockWebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
 
-			mockWebsites := []*db.Website{
-				createMockIPFSWebsite(1, userID, "example1.com", TestCID, db.WebsiteStatusActive, ""),
-				createMockIPNSWebsite(2, userID, "example2.com", TestPeerID, db.WebsiteStatusPendingValidation, ""),
+			mockWebsites := []*pluginDb.Website{
+				createMockIPFSWebsite(1, userID, "example1.com", TestCID, pluginDb.WebsiteStatusActive, ""),
+				createMockIPNSWebsite(2, userID, "example2.com", TestPeerID, pluginDb.WebsiteStatusPendingValidation, ""),
 			}
 
 			mockWebsiteService.EXPECT().ListWebsites(mock.Anything, userID, mock.Anything, mock.Anything, mock.Anything).Return(mockWebsites, int64(2), nil)
@@ -668,8 +668,8 @@ func TestAPI_ListWebsites(t *testing.T) {
 
 			mockWebsiteService := core.GetService[*mocks.MockWebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
 
-			mockWebsites := []*db.Website{
-				createMockIPFSWebsite(1, userID, TestDomain, TestCID, db.WebsiteStatusActive, ""),
+			mockWebsites := []*pluginDb.Website{
+				createMockIPFSWebsite(1, userID, TestDomain, TestCID, pluginDb.WebsiteStatusActive, ""),
 			}
 
 			mockWebsiteService.EXPECT().ListWebsites(mock.Anything, userID, mock.Anything, mock.Anything, mock.Anything).Return(mockWebsites, int64(1), nil)
@@ -692,7 +692,7 @@ func TestAPI_ListWebsites(t *testing.T) {
 
 			mockWebsiteService := core.GetService[*mocks.MockWebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
 
-			mockWebsiteService.EXPECT().ListWebsites(mock.Anything, userID, mock.Anything, mock.Anything, mock.Anything).Return([]*db.Website{}, int64(0), nil)
+			mockWebsiteService.EXPECT().ListWebsites(mock.Anything, userID, mock.Anything, mock.Anything, mock.Anything).Return([]*pluginDb.Website{}, int64(0), nil)
 
 			rec := helper.makeAuthenticatedRequest(http.MethodGet, "/api/websites", token, nil)
 
@@ -714,9 +714,9 @@ func TestAPI_ListWebsites(t *testing.T) {
 			mockWebsiteService := core.GetService[*mocks.MockWebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
 
 			// Create 5 websites, but return only 2 for page 1
-			mockWebsites := []*db.Website{
-				createMockIPFSWebsite(1, userID, "example1.com", TestCID, db.WebsiteStatusActive, ""),
-				createMockIPNSWebsite(2, userID, "example2.com", TestPeerID, db.WebsiteStatusPendingValidation, ""),
+			mockWebsites := []*pluginDb.Website{
+				createMockIPFSWebsite(1, userID, "example1.com", TestCID, pluginDb.WebsiteStatusActive, ""),
+				createMockIPNSWebsite(2, userID, "example2.com", TestPeerID, pluginDb.WebsiteStatusPendingValidation, ""),
 			}
 
 			mockWebsiteService.EXPECT().ListWebsites(mock.Anything, userID, mock.Anything, mock.Anything, mock.Anything).Return(mockWebsites, int64(5), nil)
@@ -768,7 +768,7 @@ func TestAPI_GetWebsite(t *testing.T) {
 
 			mockWebsiteService := core.GetService[*mocks.MockWebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
 
-			mockWebsite := createMockIPFSWebsite(1, userID, TestDomain, TestCID, db.WebsiteStatusActive, "")
+			mockWebsite := createMockIPFSWebsite(1, userID, TestDomain, TestCID, pluginDb.WebsiteStatusActive, "")
 
 			mockWebsiteService.EXPECT().GetWebsite(mock.Anything, userID, uint(1)).Return(mockWebsite, nil)
 
@@ -817,7 +817,7 @@ func TestAPI_GetWebsite(t *testing.T) {
 
 			mockWebsiteService := core.GetService[*mocks.MockWebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
 
-			mockWebsite := createMockIPFSWebsite(1, userID, TestDomain, TestCID, db.WebsiteStatusBroken, "")
+			mockWebsite := createMockIPFSWebsite(1, userID, TestDomain, TestCID, pluginDb.WebsiteStatusBroken, "")
 
 			mockWebsiteService.EXPECT().GetWebsite(mock.Anything, userID, uint(1)).Return(mockWebsite, nil)
 
@@ -845,7 +845,7 @@ func TestAPI_UpdateWebsite(t *testing.T) {
 
 			mockWebsiteService := core.GetService[*mocks.MockWebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
 
-			mockWebsite := createMockIPFSWebsite(1, userID, "updated-example.com", TestCID, db.WebsiteStatusActive, "")
+			mockWebsite := createMockIPFSWebsite(1, userID, "updated-example.com", TestCID, pluginDb.WebsiteStatusActive, "")
 
 			mockWebsiteService.EXPECT().UpdateWebsite(mock.Anything, userID, uint(1), mock.AnythingOfType("map[string]interface {}")).Return(mockWebsite, nil)
 
@@ -869,7 +869,7 @@ func TestAPI_UpdateWebsite(t *testing.T) {
 
 			mockWebsiteService := core.GetService[*mocks.MockWebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
 
-			mockWebsite := createMockIPFSWebsite(1, userID, "example.com", TestCID, db.WebsiteStatusActive, "")
+			mockWebsite := createMockIPFSWebsite(1, userID, "example.com", TestCID, pluginDb.WebsiteStatusActive, "")
 
 			mockWebsiteService.EXPECT().UpdateWebsite(mock.Anything, userID, uint(1), mock.AnythingOfType("map[string]interface {}")).Return(mockWebsite, nil)
 
@@ -904,7 +904,7 @@ func TestAPI_UpdateWebsite(t *testing.T) {
 
 			mockWebsiteService := core.GetService[*mocks.MockWebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
 
-			mockWebsite := createMockIPFSWebsite(1, userID, "example.com", TestCID, db.WebsiteStatusActive, "")
+			mockWebsite := createMockIPFSWebsite(1, userID, "example.com", TestCID, pluginDb.WebsiteStatusActive, "")
 
 			mockWebsiteService.EXPECT().UpdateWebsite(mock.Anything, userID, uint(1), mock.AnythingOfType("map[string]interface {}")).Return(mockWebsite, nil)
 
@@ -1094,7 +1094,7 @@ func TestAPI_ValidateWebsiteDNS(t *testing.T) {
 
 			mockWebsiteService := core.GetService[*mocks.MockWebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
 
-			mockWebsite := createMockIPFSWebsite(1, userID, TestDomain, TestCID, db.WebsiteStatusActive, "")
+			mockWebsite := createMockIPFSWebsite(1, userID, TestDomain, TestCID, pluginDb.WebsiteStatusActive, "")
 
 			mockWebsiteService.EXPECT().ValidateDNS(mock.Anything, userID, uint(1)).Return(pluginCore.ValidateDNSResult{Valid: true, Message: "DNS validation successful for test.example.com", Reason: pluginCore.ValidationReasonValidated}, nil)
 			mockWebsiteService.EXPECT().GetWebsite(mock.Anything, userID, uint(1)).Return(mockWebsite, nil)
@@ -1120,7 +1120,7 @@ func TestAPI_ValidateWebsiteDNS(t *testing.T) {
 
 			mockWebsiteService := core.GetService[*mocks.MockWebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
 
-			mockWebsite := createMockIPFSWebsite(1, userID, TestDomain, TestCID, db.WebsiteStatusPendingValidation, "")
+			mockWebsite := createMockIPFSWebsite(1, userID, TestDomain, TestCID, pluginDb.WebsiteStatusPendingValidation, "")
 
 			mockWebsiteService.EXPECT().ValidateDNS(mock.Anything, userID, uint(1)).Return(pluginCore.ValidateDNSResult{Valid: false, Message: "DNS validation failed: missing validation token for test.example.com", Reason: pluginCore.ValidationReasonTokenMissing}, nil)
 			mockWebsiteService.EXPECT().GetWebsite(mock.Anything, userID, uint(1)).Return(mockWebsite, nil)

--- a/internal/api/dto/gateway.go
+++ b/internal/api/dto/gateway.go
@@ -8,10 +8,11 @@ import (
 
 // GatewayWebsiteResponse contains website configuration for the gateway
 type GatewayWebsiteResponse struct {
-	Domain     string `json:"domain"`
-	TargetType string `json:"target_type"` // db.WebsiteTargetTypeIPFS or db.WebsiteTargetTypeIPNS
-	TargetHash string `json:"target_hash"` // CID or IPNS name
-	Status     string `json:"status"`      // pending_validation, active, broken
+	Domain     string                  `json:"domain"`
+	TargetType string                  `json:"target_type"` // db.WebsiteTargetTypeIPFS or db.WebsiteTargetTypeIPNS
+	TargetHash string                  `json:"target_hash"` // CID or IPNS name
+	Status     string                  `json:"status"`      // pending_validation, active, broken
+	Namespace  db.DomainNamespace      `json:"namespace,omitempty" jsonschema:"enum=icann,enum=hns"`
 }
 
 // GatewayWebsiteStatusResponse contains website status information

--- a/internal/api/test_helpers_test.go
+++ b/internal/api/test_helpers_test.go
@@ -190,9 +190,9 @@ func (m *mockHelper) SetupWebsiteServiceMocks(domain string, website *pluginDb.W
 	mockWebsiteService := core.GetService[*mocks.MockWebsiteService](m.ctx, pluginCore.WEBSITE_SERVICE)
 
 	if website != nil {
-		mockWebsiteService.EXPECT().GetWebsiteByDomain(mock.Anything, domain).Return(website, nil).Maybe()
+		mockWebsiteService.EXPECT().GetWebsiteByDomain(mock.Anything, domain).Return(website, pluginDb.DomainNamespaceICANN, nil).Maybe()
 	} else {
-		mockWebsiteService.EXPECT().GetWebsiteByDomain(mock.Anything, domain).Return(nil, nil).Maybe()
+		mockWebsiteService.EXPECT().GetWebsiteByDomain(mock.Anything, domain).Return(nil, pluginDb.DomainNamespaceICANN, nil).Maybe()
 	}
 
 	return mockWebsiteService

--- a/internal/service/website/website.go
+++ b/internal/service/website/website.go
@@ -195,7 +195,7 @@ func (s *WebsiteServiceDefault) CreateWebsite(ctx context.Context, website *plug
 			}
 
 			// Check if domain already exists
-			existing, err := s.GetWebsiteByDomain(ctx, website.Domain)
+			existing, _, err := s.GetWebsiteByDomain(ctx, website.Domain)
 			if err != nil && err != gorm.ErrRecordNotFound {
 				return nil, fmt.Errorf("failed to check existing domain: %w", err)
 			}
@@ -397,16 +397,18 @@ func (s *WebsiteServiceDefault) GetWebsite(ctx context.Context, userID uint, web
 	)
 }
 
-// GetWebsiteByDomain retrieves a website by domain name.
-// It first checks the website_domains join table (for alt-root/DANE domains),
-// then falls back to the legacy ipfs_websites.domain column for backward compatibility.
-func (s *WebsiteServiceDefault) GetWebsiteByDomain(ctx context.Context, domain string) (*pluginDb.Website, error) {
+// GetWebsiteByDomain retrieves a website by domain name, along with its
+// namespace. For alt-root domains the namespace comes from website_domains;
+// for legacy ipfs_websites.domain lookups it defaults to ICANN.
+func (s *WebsiteServiceDefault) GetWebsiteByDomain(ctx context.Context, domain string) (*pluginDb.Website, pluginDb.DomainNamespace, error) {
 	ctx, span := core.TraceMethod(ctx, "WebsiteServiceDefault.GetWebsiteByDomain")
 	defer span.End()
 
 	domain = domsvc.NormalizeDomain(domain)
 
-	return core.MetricTrackResult(
+	var namespace pluginDb.DomainNamespace
+
+	website, err := core.MetricTrackResult(
 		GetWebsiteByDomainDuration.WithLabelValues(),
 		GetWebsiteByDomainTotal.WithLabelValues(LabelStatusError),
 		func() (*pluginDb.Website, error) {
@@ -415,15 +417,16 @@ func (s *WebsiteServiceDefault) GetWebsiteByDomain(ctx context.Context, domain s
 				wd, err := s.delegatedDomainSvc.GetWebsiteDomainByName(ctx, domain)
 				if err == nil && wd != nil && !wd.DeletedAt.Valid {
 					var website pluginDb.Website
-						if err := s.DB().WithContext(ctx).
-							Where("id = ?", wd.WebsiteID).
-							First(&website).Error; err != nil {
-							if errors.Is(err, gorm.ErrRecordNotFound) {
-								return nil, nil
-							}
-							return nil, fmt.Errorf("failed to get website by domain (join): %w", err)
+					if err := s.DB().WithContext(ctx).
+						Where("id = ?", wd.WebsiteID).
+						First(&website).Error; err != nil {
+						if errors.Is(err, gorm.ErrRecordNotFound) {
+							return nil, nil
 						}
-						return &website, nil
+						return nil, fmt.Errorf("failed to get website by domain (join): %w", err)
+					}
+					namespace = wd.Namespace
+					return &website, nil
 				}
 			}
 
@@ -442,6 +445,13 @@ func (s *WebsiteServiceDefault) GetWebsiteByDomain(ctx context.Context, domain s
 			return &website, nil
 		},
 	)
+	if err != nil {
+		return nil, pluginDb.DomainNamespaceICANN, err
+	}
+	if namespace == "" {
+		namespace = pluginDb.DomainNamespaceICANN
+	}
+	return website, namespace, err
 }
 
 // ListWebsites retrieves a paginated and filtered list of websites

--- a/internal/service/website/website_test.go
+++ b/internal/service/website/website_test.go
@@ -613,7 +613,7 @@ func TestWebsiteService_GetWebsiteByDomain(t *testing.T) {
 		require.NoError(tb, err)
 
 		// Act
-		retrievedWebsite, err := websiteService.GetWebsiteByDomain(context.Background(), "domain-test.com")
+		retrievedWebsite, _, err := websiteService.GetWebsiteByDomain(context.Background(), "domain-test.com")
 
 		// Assert
 		require.NoError(tb, err)
@@ -630,7 +630,7 @@ func TestWebsiteService_GetWebsiteByDomain_NotFound(t *testing.T) {
 		require.NotNil(tb, websiteService)
 
 		// Act
-		retrievedWebsite, err := websiteService.GetWebsiteByDomain(context.Background(), "nonexistent.com")
+		retrievedWebsite, _, err := websiteService.GetWebsiteByDomain(context.Background(), "nonexistent.com")
 
 		// Assert - GetWebsiteByDomain returns (nil, nil) for not found (no error)
 		require.NoError(tb, err)
@@ -1095,7 +1095,7 @@ func TestWebsiteService_UpdateSSLStatus_IssuedAtSetOnlyOnReadyTransition(t *test
 		require.NoError(tb, err)
 
 		// Check website after first update
-		websiteAfterIssuing, err := websiteService.GetWebsiteByDomain(context.Background(), createdWebsite.Domain)
+		websiteAfterIssuing, _, err := websiteService.GetWebsiteByDomain(context.Background(), createdWebsite.Domain)
 		require.NoError(tb, err)
 		assert.Nil(tb, websiteAfterIssuing.SSLIssuedAt)
 
@@ -1104,7 +1104,7 @@ func TestWebsiteService_UpdateSSLStatus_IssuedAtSetOnlyOnReadyTransition(t *test
 		require.NoError(tb, err)
 
 		// Check website after ready transition
-		websiteAfterReady, err := websiteService.GetWebsiteByDomain(context.Background(), createdWebsite.Domain)
+		websiteAfterReady, _, err := websiteService.GetWebsiteByDomain(context.Background(), createdWebsite.Domain)
 		require.NoError(tb, err)
 		assert.NotNil(tb, websiteAfterReady.SSLIssuedAt)
 
@@ -1115,7 +1115,7 @@ func TestWebsiteService_UpdateSSLStatus_IssuedAtSetOnlyOnReadyTransition(t *test
 		require.NoError(tb, err)
 
 		// Check website after second ready update
-		websiteAfterSecondReady, err := websiteService.GetWebsiteByDomain(context.Background(), createdWebsite.Domain)
+		websiteAfterSecondReady, _, err := websiteService.GetWebsiteByDomain(context.Background(), createdWebsite.Domain)
 		require.NoError(tb, err)
 		assert.NotNil(tb, websiteAfterSecondReady.SSLIssuedAt)
 		assert.Equal(tb, originalIssuedAt.Unix(), websiteAfterSecondReady.SSLIssuedAt.Unix(), "issued_at should not change when already ready")
@@ -1165,7 +1165,7 @@ func TestWebsiteService_UpdateSSLStatus_ErrorClearedOnStatusChange(t *testing.T)
 		require.NoError(tb, err)
 
 		// Verify error is set
-		websiteAfterFailed, err := websiteService.GetWebsiteByDomain(context.Background(), createdWebsite.Domain)
+		websiteAfterFailed, _, err := websiteService.GetWebsiteByDomain(context.Background(), createdWebsite.Domain)
 		require.NoError(tb, err)
 		assert.Equal(tb, testErrorMsg, websiteAfterFailed.SSLError)
 
@@ -1234,7 +1234,7 @@ func TestWebsiteService_UpdateSSLStatus_AtomicUpdates(t *testing.T) {
 		}
 
 		// Assert - Final state should be consistent (no data corruption)
-		finalWebsite, err := websiteService.GetWebsiteByDomain(context.Background(), createdWebsite.Domain)
+		finalWebsite, _, err := websiteService.GetWebsiteByDomain(context.Background(), createdWebsite.Domain)
 		require.NoError(tb, err)
 		assert.NotNil(tb, finalWebsite)
 
@@ -2303,7 +2303,7 @@ func TestWebsiteService_CreateWebsite_InheritsSSLFromSoftDeletedWebsite(t *testi
 		err = websiteService.DeleteWebsite(context.Background(), testUserID1, createdWebsite.ID)
 		require.NoError(tb, err)
 
-		_, err = websiteService.GetWebsiteByDomain(context.Background(), domain)
+		_, _, err = websiteService.GetWebsiteByDomain(context.Background(), domain)
 		require.NoError(tb, err)
 
 		newWebsite := createTestIPFSWebsite(testUserID1, domain, testCID.String())

--- a/internal/testing/mocks/MockIPNSPublisher.go
+++ b/internal/testing/mocks/MockIPNSPublisher.go
@@ -179,15 +179,13 @@ func (_c *MockIPNSPublisher_ListPublished_Call) RunAndReturn(run func(ctx contex
 
 // Publish provides a mock function for the type MockIPNSPublisher
 func (_mock *MockIPNSPublisher) Publish(ctx context.Context, privKey crypto.PrivKey, ipnsPath path.Path, options ...namesys.PublishOption) error {
-	// namesys.PublishOption
-	_va := make([]any, len(options))
-	for _i := range options {
-		_va[_i] = options[_i]
+	var tmpRet mock.Arguments
+	if len(options) > 0 {
+		tmpRet = _mock.Called(ctx, privKey, ipnsPath, options)
+	} else {
+		tmpRet = _mock.Called(ctx, privKey, ipnsPath)
 	}
-	var _ca []any
-	_ca = append(_ca, ctx, privKey, ipnsPath)
-	_ca = append(_ca, _va...)
-	ret := _mock.Called(_ca...)
+	ret := tmpRet
 
 	if len(ret) == 0 {
 		panic("no return value specified for Publish")
@@ -232,11 +230,9 @@ func (_c *MockIPNSPublisher_Publish_Call) Run(run func(ctx context.Context, priv
 			arg2 = args[2].(path.Path)
 		}
 		var arg3 []namesys.PublishOption
-		variadicArgs := make([]namesys.PublishOption, len(args)-3)
-		for i, a := range args[3:] {
-			if a != nil {
-				variadicArgs[i] = a.(namesys.PublishOption)
-			}
+		var variadicArgs []namesys.PublishOption
+		if len(args) > 3 {
+			variadicArgs = args[3].([]namesys.PublishOption)
 		}
 		arg3 = variadicArgs
 		run(

--- a/internal/testing/mocks/MockMetadataStore.go
+++ b/internal/testing/mocks/MockMetadataStore.go
@@ -10,7 +10,7 @@ import (
 	"github.com/ipfs/go-cid"
 	mock "github.com/stretchr/testify/mock"
 	"go.lumeweb.com/portal-plugin-ipfs/core"
-	portalcore "go.lumeweb.com/portal/core"
+	core0 "go.lumeweb.com/portal/core"
 )
 
 // NewMockMetadataStore creates a new instance of MockMetadataStore. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
@@ -548,23 +548,30 @@ func (_c *MockMetadataStore_ProcessMissingUnixFSNames_Call) RunAndReturn(run fun
 }
 
 // ResolveDAG provides a mock function for the type MockMetadataStore
-func (_mock *MockMetadataStore) ResolveDAG(ctx context.Context, rootCID cid.Cid) ([]portalcore.DAGBlockNode, error) {
+func (_mock *MockMetadataStore) ResolveDAG(ctx context.Context, rootCID cid.Cid) ([]core0.DAGBlockNode, error) {
 	ret := _mock.Called(ctx, rootCID)
 
 	if len(ret) == 0 {
-		panic("ResolveDAG requires at least 1 return value")
+		panic("no return value specified for ResolveDAG")
 	}
 
-	var r0 []portalcore.DAGBlockNode
-	if ret[0] != nil {
-		r0 = ret[0].([]portalcore.DAGBlockNode)
-	}
-
+	var r0 []core0.DAGBlockNode
 	var r1 error
-	if len(ret) > 1 && ret[1] != nil {
-		r1 = ret[1].(error)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, cid.Cid) ([]core0.DAGBlockNode, error)); ok {
+		return returnFunc(ctx, rootCID)
 	}
-
+	if returnFunc, ok := ret.Get(0).(func(context.Context, cid.Cid) []core0.DAGBlockNode); ok {
+		r0 = returnFunc(ctx, rootCID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]core0.DAGBlockNode)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, cid.Cid) error); ok {
+		r1 = returnFunc(ctx, rootCID)
+	} else {
+		r1 = ret.Error(1)
+	}
 	return r0, r1
 }
 
@@ -576,23 +583,34 @@ type MockMetadataStore_ResolveDAG_Call struct {
 // ResolveDAG is a helper method to define mock.On call
 //   - ctx context.Context
 //   - rootCID cid.Cid
-func (_e *MockMetadataStore_Expecter) ResolveDAG(ctx interface{}, rootCID interface{}) *MockMetadataStore_ResolveDAG_Call {
+func (_e *MockMetadataStore_Expecter) ResolveDAG(ctx any, rootCID any) *MockMetadataStore_ResolveDAG_Call {
 	return &MockMetadataStore_ResolveDAG_Call{Call: _e.mock.On("ResolveDAG", ctx, rootCID)}
 }
 
 func (_c *MockMetadataStore_ResolveDAG_Call) Run(run func(ctx context.Context, rootCID cid.Cid)) *MockMetadataStore_ResolveDAG_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(cid.Cid))
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 cid.Cid
+		if args[1] != nil {
+			arg1 = args[1].(cid.Cid)
+		}
+		run(
+			arg0,
+			arg1,
+		)
 	})
 	return _c
 }
 
-func (_c *MockMetadataStore_ResolveDAG_Call) Return(nodes []portalcore.DAGBlockNode, err error) *MockMetadataStore_ResolveDAG_Call {
-	_c.Call.Return(nodes, err)
+func (_c *MockMetadataStore_ResolveDAG_Call) Return(dAGBlockNodes []core0.DAGBlockNode, err error) *MockMetadataStore_ResolveDAG_Call {
+	_c.Call.Return(dAGBlockNodes, err)
 	return _c
 }
 
-func (_c *MockMetadataStore_ResolveDAG_Call) RunAndReturn(run func(ctx context.Context, rootCID cid.Cid) ([]portalcore.DAGBlockNode, error)) *MockMetadataStore_ResolveDAG_Call {
+func (_c *MockMetadataStore_ResolveDAG_Call) RunAndReturn(run func(ctx context.Context, rootCID cid.Cid) ([]core0.DAGBlockNode, error)) *MockMetadataStore_ResolveDAG_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/testing/mocks/MockWebsiteService.go
+++ b/internal/testing/mocks/MockWebsiteService.go
@@ -567,7 +567,7 @@ func (_c *MockWebsiteService_GetWebsite_Call) RunAndReturn(run func(ctx context.
 }
 
 // GetWebsiteByDomain provides a mock function for the type MockWebsiteService
-func (_mock *MockWebsiteService) GetWebsiteByDomain(ctx context.Context, domain string) (*db.Website, error) {
+func (_mock *MockWebsiteService) GetWebsiteByDomain(ctx context.Context, domain string) (*db.Website, db.DomainNamespace, error) {
 	ret := _mock.Called(ctx, domain)
 
 	if len(ret) == 0 {
@@ -575,8 +575,9 @@ func (_mock *MockWebsiteService) GetWebsiteByDomain(ctx context.Context, domain 
 	}
 
 	var r0 *db.Website
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (*db.Website, error)); ok {
+	var r1 db.DomainNamespace
+	var r2 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (*db.Website, db.DomainNamespace, error)); ok {
 		return returnFunc(ctx, domain)
 	}
 	if returnFunc, ok := ret.Get(0).(func(context.Context, string) *db.Website); ok {
@@ -586,12 +587,17 @@ func (_mock *MockWebsiteService) GetWebsiteByDomain(ctx context.Context, domain 
 			r0 = ret.Get(0).(*db.Website)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) db.DomainNamespace); ok {
 		r1 = returnFunc(ctx, domain)
 	} else {
-		r1 = ret.Error(1)
+		r1 = ret.Get(1).(db.DomainNamespace)
 	}
-	return r0, r1
+	if returnFunc, ok := ret.Get(2).(func(context.Context, string) error); ok {
+		r2 = returnFunc(ctx, domain)
+	} else {
+		r2 = ret.Error(2)
+	}
+	return r0, r1, r2
 }
 
 // MockWebsiteService_GetWebsiteByDomain_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetWebsiteByDomain'
@@ -624,12 +630,12 @@ func (_c *MockWebsiteService_GetWebsiteByDomain_Call) Run(run func(ctx context.C
 	return _c
 }
 
-func (_c *MockWebsiteService_GetWebsiteByDomain_Call) Return(website *db.Website, err error) *MockWebsiteService_GetWebsiteByDomain_Call {
-	_c.Call.Return(website, err)
+func (_c *MockWebsiteService_GetWebsiteByDomain_Call) Return(website *db.Website, domainNamespace db.DomainNamespace, err error) *MockWebsiteService_GetWebsiteByDomain_Call {
+	_c.Call.Return(website, domainNamespace, err)
 	return _c
 }
 
-func (_c *MockWebsiteService_GetWebsiteByDomain_Call) RunAndReturn(run func(ctx context.Context, domain string) (*db.Website, error)) *MockWebsiteService_GetWebsiteByDomain_Call {
+func (_c *MockWebsiteService_GetWebsiteByDomain_Call) RunAndReturn(run func(ctx context.Context, domain string) (*db.Website, db.DomainNamespace, error)) *MockWebsiteService_GetWebsiteByDomain_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
## Summary

Add `namespace` field to `GatewayWebsiteResponse` so gateway clients (e.g. Caddy cert-webhook plugin) can determine whether a domain is DANE-enabled by reading the portal's authoritative namespace instead of inferring from domain structure (single-label heuristic).

## Changes

- `dto/gateway.go`: Add `Namespace string` field with `json:"namespace,omitempty"`
- `api_gateway.go`: Populate namespace from `website_domains` via `delegatedDomainSvc.GetWebsiteDomainByName` in `getGatewayWebsite` handler

## Why

The Caddy cert-webhook plugin needs to know if a domain is DANE-enabled (alt-root) to decide whether to generate a self-signed cert and push TLSA records. Currently it infers from domain structure (single-label = alt-root). Exposing namespace from the portal's own `website_domains` table gives an authoritative answer.

- `develop` <!-- branch-stack -->
  - **feat: expose namespace on GatewayWebsiteResponse** :point\_left:

***

<!-- kody-pr-summary:start -->

This pull request extends the gateway website lookup API response to include the domain's namespace.

Previously, `getGatewayWebsite` returned a `GatewayWebsiteResponse` mapped only from the website model. With these changes, the handler now explicitly populates the response using `FromModel`, then queries the delegated domain service for the matching `website_domains` record by domain name. If found, it sets the new `Namespace` field on the response.

The `GatewayWebsiteResponse` DTO now includes an optional `namespace` field that communicates the domain's namespace source—such as `icann` or `altroot`—allowing API consumers to distinguish how the requested gateway domain is registered.

<!-- kody-pr-summary:end -->
