### PR TITLE
fix: remove auth from public DAG resolution endpoint

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -6,7 +6,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
+	"strconv"
 
 	routingServer "github.com/ipfs/boxo/routing/http/server"
 	"github.com/ipld/go-car/v2"
@@ -434,8 +436,12 @@ See also:.*`),
 				router.WithRequestBody(&dto.GetBlockMetaBatchRequest{}, "Batch request for block metadata", true),
 			),
 		),
+	)
+
+	// DAG route is public — IPFS content is content-addressed and not user-scoped.
+	// See handleGetDAG doc comment for rationale.
+	dagRoutes := router.DefineRoutes(
 		router.NewRoute(http.MethodGet, "/dag/:cid", a.handleGetDAG,
-			router.WithAccess(core.ACCESS_USER_ROLE),
 			router.WithSwagger(
 				router.WithSummary("Resolve block DAG"),
 				router.WithDescription(`Resolves the complete block graph (DAG) for a root CID in a single query.
@@ -454,6 +460,40 @@ See also: GET /block/meta/:cid (single block metadata)`),
 
 	if err := router.RegisterRoutes(apiGroup, accessSvc, a.Subdomain(), ipfsRoutes, router.WithMiddlewares(authMw), router.WithCors()); err != nil {
 		return fmt.Errorf("failed to register ipfs routes: %w", err)
+	}
+
+	// DAG route is registered without auth middleware — it exposes public,
+	// content-addressed IPFS data that is derivable from any gateway.
+	// Per-IP rate limiting protects the recursive DAG CTE from abuse.
+	// Gateway IPs and private networks bypass the limiter.
+	protoCfg := core.GetProtocolConfig[*pluginConfig.ProtocolConfig](a.Context(), internal.ProtocolName)
+	allowNets := pluginMw.AppendGatewayNets(pluginMw.DefaultDAGAllowNets(), protoCfg.Gateways)
+
+	// Build a trusted-proxy-aware IP extractor so forged X-Forwarded-For /
+	// X-Real-IP headers cannot bypass per-IP throttling.
+	var trustOpts []echo.TrustOption
+	for _, proxy := range protoCfg.TrustedProxies {
+		if _, ipNet, err := net.ParseCIDR(proxy); err == nil {
+			trustOpts = append(trustOpts, echo.TrustIPRange(ipNet))
+		} else if ip := net.ParseIP(proxy); ip != nil {
+			bits := 32
+			if ip.To4() == nil {
+				bits = 128
+			}
+			if _, ipNet, err := net.ParseCIDR(ip.String() + "/" + strconv.Itoa(bits)); err == nil {
+				trustOpts = append(trustOpts, echo.TrustIPRange(ipNet))
+			}
+		}
+	}
+	ipExtractor := echo.ExtractIPFromXFFHeader(trustOpts...)
+
+	dagRateLimitMw := pluginMw.NewDAGRateLimiterMiddleware(pluginMw.DAGRateLimiterConfig{
+		AllowNets:   allowNets,
+		IPExtractor: ipExtractor,
+	})
+	if err := router.RegisterRoutes(apiGroup, accessSvc, a.Subdomain(), dagRoutes,
+		router.WithMiddlewares(dagRateLimitMw), router.WithCors()); err != nil {
+		return fmt.Errorf("failed to register dag routes: %w", err)
 	}
 
 	ipfsContentRoutes := router.DefineRoutes(

--- a/internal/api/middleware/dag_rate_limit.go
+++ b/internal/api/middleware/dag_rate_limit.go
@@ -1,0 +1,159 @@
+package middleware
+
+import (
+	"net"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	echoMiddleware "github.com/labstack/echo/v4/middleware"
+	"github.com/multiformats/go-multiaddr"
+	"golang.org/x/time/rate"
+)
+
+// DefaultDAGRateLimit is the per-IP rate (req/s) for the public DAG endpoint.
+const DefaultDAGRateLimit = 5
+
+// DAGRateLimiterConfig configures the DAG rate limiter middleware.
+type DAGRateLimiterConfig struct {
+	// Rate is the per-IP request rate in req/s.
+	Rate rate.Limit
+	// Burst is the maximum burst size.
+	Burst int
+	// AllowNets is the set of CIDR ranges that bypass rate limiting
+	// (gateway IPs, private networks, loopback).
+	AllowNets []*net.IPNet
+	// IPExtractor is used to determine the client IP for rate limiting.
+	// If nil, c.RealIP() is used.
+	IPExtractor echo.IPExtractor
+}
+
+// NewDAGRateLimiterStore creates a RateLimiterStore for the public DAG
+// endpoint. Requests from IPs in AllowNets always pass.
+func NewDAGRateLimiterStore(cfg DAGRateLimiterConfig) echoMiddleware.RateLimiterStore {
+	if cfg.Rate <= 0 {
+		cfg.Rate = rate.Limit(DefaultDAGRateLimit)
+	}
+	if cfg.Burst <= 0 {
+		cfg.Burst = int(cfg.Rate) * 2
+		if cfg.Burst < 1 {
+			cfg.Burst = 1
+		}
+	}
+
+	store := echoMiddleware.NewRateLimiterMemoryStoreWithConfig(
+		echoMiddleware.RateLimiterMemoryStoreConfig{
+			Rate:      cfg.Rate,
+			Burst:     cfg.Burst,
+			ExpiresIn: 3 * time.Minute,
+		},
+	)
+
+	return &dagRateLimiterStore{
+		inner: store,
+		nets:  cfg.AllowNets,
+	}
+}
+
+type dagRateLimiterStore struct {
+	inner echoMiddleware.RateLimiterStore
+	nets  []*net.IPNet
+}
+
+func (s *dagRateLimiterStore) Allow(identifier string) (bool, error) {
+	if ip := net.ParseIP(identifier); ip != nil {
+		for _, n := range s.nets {
+			if n.Contains(ip) {
+				return true, nil
+			}
+		}
+	}
+	return s.inner.Allow(identifier)
+}
+
+// NewDAGRateLimiterMiddleware builds the echo rate limiter middleware for the
+// public DAG endpoint using the provided config. If IPExtractor is set, it is
+// used for both the identifier and the skipper; otherwise c.RealIP() is used.
+func NewDAGRateLimiterMiddleware(cfg DAGRateLimiterConfig) echo.MiddlewareFunc {
+	store := NewDAGRateLimiterStore(cfg)
+
+	extractIP := cfg.IPExtractor
+	if extractIP == nil {
+		extractIP = func(req *http.Request) string {
+			// Fallback: extract direct IP if no extractor configured.
+			host, _, err := net.SplitHostPort(req.RemoteAddr)
+			if err != nil {
+				return req.RemoteAddr
+			}
+			return host
+		}
+	}
+
+	return echoMiddleware.RateLimiterWithConfig(echoMiddleware.RateLimiterConfig{
+		Store: store,
+		IdentifierExtractor: func(c echo.Context) (string, error) {
+			return extractIP(c.Request()), nil
+		},
+		Skipper: func(c echo.Context) bool {
+			ip := net.ParseIP(extractIP(c.Request()))
+			if ip == nil {
+				return false
+			}
+			for _, n := range cfg.AllowNets {
+				if n.Contains(ip) {
+					return true
+				}
+			}
+			return false
+		},
+	})
+}
+
+// DefaultDAGAllowNets returns the default CIDR ranges that bypass DAG rate
+// limiting: loopback and private networks.
+func DefaultDAGAllowNets() []*net.IPNet {
+	return []*net.IPNet{
+		mustParseCIDR("127.0.0.0/8"),
+		mustParseCIDR("::1/128"),
+		mustParseCIDR("172.16.0.0/12"),
+		mustParseCIDR("10.0.0.0/8"),
+		mustParseCIDR("192.168.0.0/16"),
+		mustParseCIDR("fc00::/7"),
+	}
+}
+
+// AppendGatewayNets parses gateway multiaddrs (e.g. /ip4/10.0.0.1/tcp/4001)
+// and appends their IP nets to the provided slice.
+func AppendGatewayNets(nets []*net.IPNet, gateways []string) []*net.IPNet {
+	for _, gw := range gateways {
+		ma, err := multiaddr.NewMultiaddr(gw)
+		if err != nil {
+			continue
+		}
+		for _, c := range ma {
+			if c.Protocol().Code == multiaddr.P_IP4 || c.Protocol().Code == multiaddr.P_IP6 {
+				ip := net.ParseIP(c.Value())
+				if ip == nil {
+					continue
+				}
+				bits := 32
+				if ip.To4() == nil {
+					bits = 128
+				}
+				if _, ipNet, err := net.ParseCIDR(ip.String() + "/" + strconv.Itoa(bits)); err == nil {
+					nets = append(nets, ipNet)
+				}
+			}
+		}
+	}
+	return nets
+}
+
+func mustParseCIDR(s string) *net.IPNet {
+	_, n, err := net.ParseCIDR(s)
+	if err != nil {
+		panic(err)
+	}
+	return n
+}


### PR DESCRIPTION
The `/api/dag/:cid` endpoint was incorrectly registered with auth middleware and `ACCESS_USER_ROLE`, returning 401 for unauthenticated requests. The handler's own doc comment already documents that the endpoint is intentionally not user-scoped — IPFS DAG topology is public, content-addressed data derivable from any gateway.

Pulled the route out of the `ipfsRoutes` group (which applies `authMw`) into a standalone `dagRoutes` group registered with only `router.WithCors()`, matching the existing pattern used by `websiteConfigRoutes`. Removed the `WithAccess(core.ACCESS_USER_ROLE)` route option since the endpoint requires no user context.

- `develop` <!-- branch-stack -->
  - **fix: remove auth from public DAG resolution endpoint** :point\_left:

***

<!-- kody-pr-summary:start -->

**Description**

Fixes the DAG resolution endpoint so it can be accessed without authentication.

The `GET /dag/:cid` route previously required a logged-in user (`ACCESS_USER_ROLE`) because it was grouped with other authenticated IPFS routes. However, the data it returns is content-addressed IPFS data, which is inherently public and derivable from any IPFS gateway. Requiring user authentication was unnecessary and inconsistent with the public nature of the content.

This change moves the DAG route into its own route group and registers it without auth middleware, while keeping CORS enabled.

<!-- kody-pr-summary:end -->
