### PR TITLE
feat: implement ProtocolExportAccessController for IPFS

### DIFF
--- a/internal/protocol/protocol.go
+++ b/internal/protocol/protocol.go
@@ -40,6 +40,7 @@ var _ core.Protocol = (*Protocol)(nil)
 var _ core.StorageProtocol = (*Protocol)(nil)
 var _ core.ProtocolGetPinHandler = (*Protocol)(nil)
 var _ core.ProtocolDAGProvider = (*Protocol)(nil)
+var _ core.ProtocolExportAccessController = (*Protocol)(nil)
 var _ core.ProtocolPinHandler = (*pinHandler)(nil)
 
 // Helper functions for operation names
@@ -311,6 +312,13 @@ func (p *Protocol) GetMetadataStore() pluginCore.MetadataStore {
 // Delegates to MetadataStore.
 func (p *Protocol) BlockChildren(ctx context.Context, c cid.Cid, max *int) ([]cid.Cid, error) {
 	return p.GetMetadataStore().BlockChildren(ctx, c, max)
+}
+
+// CanExportCID allows export of any CID. IPFS content is public and
+// content-addressed — there are no protocol-level access restrictions
+// on reading block data or DAG structure.
+func (p *Protocol) CanExportCID(ctx context.Context, cidStr string) (bool, error) {
+	return true, nil
 }
 
 // BlockSize returns the size of a block in bytes.


### PR DESCRIPTION
## Summary

Implements `core.ProtocolExportAccessController` on the IPFS protocol so that `portal-plugin-meta` export endpoints (`/api/export/cid/:cid/dag`, `/api/export/cid/:cid/sia-object`) work for IPFS-pinned CIDs.

## Problem

`portal-plugin-meta` gates exports behind `checkExportAllowed`, which type-asserts the protocol to `ProtocolExportAccessController` and returns `ErrExportDenied` if the protocol doesn't implement it. The IPFS protocol implemented `ProtocolDAGProvider` (so DAG resolution works) but not the ACL interface, so all export requests were denied.

## Fix

Added `CanExportCID(ctx, cidStr) (bool, error)` to the IPFS `Protocol` — always returns `(true, nil)`. IPFS content is public and content-addressed; there are no protocol-level access restrictions on reading block data or DAG structure.

## Changes

- `internal/protocol/protocol.go` — added interface assertion, `CanExportCID` method

## Tests

Build and vet pass. Existing tests require a running IPFS node (integration tests).

- `develop` <!-- branch-stack -->
  - **feat: implement ProtocolExportAccessController for IPFS** :point\_left:

---

<!-- kody-pr-summary:start -->
 This PR adds support for the `ProtocolExportAccessController` interface in the IPFS protocol.

- Implements `CanExportCID` on `Protocol`, which always returns `true`.
- This reflects IPFS's public, content-addressed nature: there are no protocol-level restrictions on exporting block data or DAG structure.
- Adds the corresponding interface assertion to ensure `Protocol` satisfies `core.ProtocolExportAccessController`.
<!-- kody-pr-summary:end -->