### PR TITLE
fix: add configurable timeout to reprovider ProvideMany call

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -60,6 +60,10 @@ type (
 		ErrorSleep     time.Duration `config:"error_sleep"`
 		// BacklogSleep is how long to wait between batches while draining a backlog.
 		BacklogSleep   time.Duration `config:"backlog_sleep"`
+		// ProvideManyTimeout is the max duration for a single ProvideMany call.
+		// FullRT connects to all routing table peers per call; if one hangs,
+		// the entire reprovider loop blocks forever without this timeout.
+		ProvideManyTimeout time.Duration `config:"provide_many_timeout"`
 	}
 
 	// IPNS configures IPNS record publishing and republishing
@@ -100,6 +104,7 @@ func (I IPFSProvider) Defaults() map[string]any {
 		"EmptySleep":     10 * time.Minute,
 		"ErrorSleep":     time.Minute,
 		"BacklogSleep":   time.Minute,
+		"ProvideManyTimeout": 5 * time.Minute,
 	}
 }
 

--- a/internal/protocol/ipfs/provide.go
+++ b/internal/protocol/ipfs/provide.go
@@ -333,7 +333,10 @@ func (r *Reprovider) performProvide(ctx context.Context, trigger string) time.Du
 
 	start := time.Now()
 
-	if err := r.provider.ProvideMany(ctx, keys); err != nil {
+	provideCtx, provideCancel := context.WithTimeout(ctx, r.cfg.ProvideManyTimeout)
+	defer provideCancel()
+
+	if err := r.provider.ProvideMany(provideCtx, keys); err != nil {
 		ReprovideDuration.WithLabelValues().Observe(time.Since(start).Seconds())
 		ReprovideFailuresTotal.Inc()
 

--- a/internal/protocol/ipfs/provide.go
+++ b/internal/protocol/ipfs/provide.go
@@ -104,8 +104,11 @@ func (b *basicDHTProvider) ProvideMany(ctx context.Context, keys []multihash.Mul
 	g, gctx := errgroup.WithContext(ctx)
 	g.SetLimit(workers)
 
-	for _, k := range keys {
+	for i, k := range keys {
 		if gctx.Err() != nil {
+			mu.Lock()
+			failed = append(failed, keys[i:]...)
+			mu.Unlock()
 			break
 		}
 


### PR DESCRIPTION
Prevents the reprovider loop from blocking forever when ProvideMany
hangs on a degraded DHT peer. Adds `ProvideManyTimeout` config
(default 5m). Failed keys are retried on the next cycle.

- `develop` <!-- branch-stack -->
  - **fix: add configurable timeout to reprovider ProvideMany call** :point\_left:

***

<!-- kody-pr-summary:start -->

## Summary

This pull request fixes a potential hang in the IPFS reprovider loop by adding a configurable timeout to the `ProvideMany` call.

## Changes

### Added configurable timeout option

- Added a new `ProvideManyTimeout` configuration field to the reprovider settings
- Default value set to **5 minutes**
- The timeout is configurable via the `provide_many_timeout` config key

### Applied timeout to ProvideMany call

- Wrapped the `ProvideMany` call in a context with the configured timeout
- If the call exceeds the timeout duration, it will be canceled and treated as a failure (incrementing failure metrics)

## Why

The `ProvideMany` call connects to all routing table peers per invocation. If any single peer hangs, the entire reprovider loop blocks indefinitely without this timeout. This change ensures the reprovider loop continues even if the routing call hangs, preventing a permanent stall.

<!-- kody-pr-summary:end -->
