### PR TITLE
fix: derive connmgr low-water from GetConnLimit

### DIFF
--- a/internal/protocol/ipfs/node.go
+++ b/internal/protocol/ipfs/node.go
@@ -466,7 +466,12 @@ func NewNode(ctx core.Context, cfg *config.ProtocolConfig, rs pluginCore.Reprovi
 		return nil, fmt.Errorf("failed to create resource manager: %w", err)
 	}
 
-	cmgr, err := connmgr.NewConnManager(900, rm.(libp2pCoreConnmgr.GetConnLimiter).GetConnLimit())
+	connLimit := rm.(libp2pCoreConnmgr.GetConnLimiter).GetConnLimit()
+	lowWater := int(float64(connLimit) * 0.5)
+	if lowWater < 160 {
+		lowWater = 160
+	}
+	cmgr, err := connmgr.NewConnManager(lowWater, connLimit)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create connection manager: %w", err)
 	}


### PR DESCRIPTION
connmgr low-water was hardcoded to 900, but high-water is GetConnLimit(). With InfiniteLimits the connmgr never trims — FullRT opens connections unchecked during routing refreshes, causing memory spikes and bitswap latency degradation.

Derive low-water from GetConnLimit(), floor 160. Scales correctly with both InfiniteLimits and AutoScale.

Set auto\_scale\_resource\_limits: true to enable resource limits. Gateway is whitelisted (rate limit bypass + 1024 connection slots) and unaffected.

- `develop` <!-- branch-stack -->
  - **feat(connmgr): derive low-water from connection manager limit** :point\_left:
