### PR TITLE
feat(domain): allow alt-root providers to define their own nameservers

### DIFF
--- a/internal/config/dns.go
+++ b/internal/config/dns.go
@@ -20,6 +20,12 @@ type DnsConfig struct {
 	// Approved nameservers for validation
 	Nameservers []string `config:"nameservers"`
 
+	// HNS nameservers for the HNS namespace delegation/validation.
+	// Alt-root namespaces (e.g. HNS) must delegate to nameservers that are
+	// themselves members of that namespace, which differ from the ICANN
+	// nameservers in Nameservers. Provided by the operator, not the user.
+	HNSNameservers []string `config:"hns_nameservers"`
+
 	// HNSResolver is the address (host:port) of an HNS-aware DNS resolver
 	// used for HNS namespace:
 	// - Delegation verification (NS lookup via HNSProvider)
@@ -44,6 +50,7 @@ func (c DnsConfig) Defaults() map[string]any {
 		"PowerDNSAPIURL":               "",
 		"PowerDNSAPIKey":               "",
 		"Nameservers":                  []string{},
+		"HNSNameservers":               []string{},
 		"HNSResolver":                  "",
 		"GatewayDomain":                "",
 		"VerificationTokenKey":         "lumeweb-verify",

--- a/internal/config/dns_test.go
+++ b/internal/config/dns_test.go
@@ -1,0 +1,18 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDnsConfig_Defaults(t *testing.T) {
+	d := DnsConfig{}
+	defs := d.Defaults()
+
+	// HNS nameservers default to empty and are distinct from ICANN nameservers.
+	_, hasHNSNS := defs["HNSNameservers"]
+	assert.True(t, hasHNSNS, "DnsConfig defaults must include HNSNameservers")
+	assert.Equal(t, []string{}, defs["HNSNameservers"])
+	assert.Equal(t, []string{}, defs["Nameservers"])
+}

--- a/internal/service/domain/delegated_domain_service.go
+++ b/internal/service/domain/delegated_domain_service.go
@@ -62,7 +62,6 @@ func (s *DelegatedDomainService) gatewayHost() string {
 	return dnsCfg.GatewayDomain
 }
 
-
 func (s *DelegatedDomainService) CreateDomain(ctx context.Context,
 	namespace, domain string, websiteID, userID uint, config json.RawMessage) (*pluginDb.WebsiteDomain, error) {
 
@@ -382,13 +381,20 @@ func NewDelegatedDomainServiceFactory() (core.Service, []core.ContextBuilderOpti
 
 			dnsCfg := core.GetServiceConfig[*pluginConfig.DnsConfig](ctx, pluginCore.DNS_SERVICE)
 			var nsList []string
+			var hnsNSList []string
 			hnsResolver := ""
 			if dnsCfg != nil {
 				nsList = dnsCfg.Nameservers
+				hnsNSList = dnsCfg.HNSNameservers
+				// Fall back to the ICANN list if no HNS-specific nameservers
+				// are configured, so existing deployments keep working.
+				if len(hnsNSList) == 0 {
+					hnsNSList = nsList
+				}
 				hnsResolver = dnsCfg.HNSResolver
 			}
 			reg.Register(NewICANNProvider(nsList))
-			hnsProv := NewHNSProvider(hnsResolver, nsList, TLSASource{})
+			hnsProv := NewHNSProvider(hnsResolver, hnsNSList, TLSASource{})
 			dns := core.GetService[pluginCore.DNSService](ctx, pluginCore.DNS_SERVICE)
 			if dns != nil {
 				hnsProv.SetDNSService(dns)

--- a/internal/service/domain/hns_provider.go
+++ b/internal/service/domain/hns_provider.go
@@ -199,7 +199,7 @@ func (p *HNSProvider) BuildDelegation(ctx context.Context, zoneID uint,
 		dsRecords = ds
 	}
 
-	nsRecords := p.getNSRecords(zoneName)
+	nsRecords := p.Nameservers()
 
 	var bundle DelegationBundle
 
@@ -376,7 +376,10 @@ func (p *HNSProvider) buildTLSA(ctx context.Context, zoneName string) (string, e
 	return spkiHash, nil
 }
 
-func (p *HNSProvider) getNSRecords(zoneName string) []string {
+// Nameservers returns the HNS nameservers configured for the namespace.
+// Alt-root namespaces delegate to nameservers that are themselves members
+// of the namespace (e.g. HNS domain names), distinct from ICANN's.
+func (p *HNSProvider) Nameservers() []string {
 	if len(p.nsRecords) == 0 {
 		return nil
 	}
@@ -407,7 +410,7 @@ func (p *HNSProvider) VerifyDelegation(ctx context.Context, domain string,
 		return false, fmt.Errorf("HNS resolver query failed: %w", err)
 	}
 
-	expectedNS := p.getNSRecords(domain + ".")
+	expectedNS := p.Nameservers()
 	for _, ns := range nss {
 		for _, expected := range expectedNS {
 			if strings.TrimSuffix(ns.Host, ".") == strings.TrimSuffix(expected, ".") {

--- a/internal/service/domain/hns_provider_test.go
+++ b/internal/service/domain/hns_provider_test.go
@@ -27,6 +27,15 @@ func TestHNSProvider_Protocol(t *testing.T) {
 	assert.Equal(t, "hns", p.Protocol())
 }
 
+func TestHNSProvider_Nameservers(t *testing.T) {
+	// HNS declares its own namespace-specific nameservers, distinct from ICANN.
+	p := NewHNSProvider("", []string{"ns1.hns.\nns2.hns."}, TLSASource{})
+	assert.Equal(t, []string{"ns1.hns.\nns2.hns."}, p.Nameservers())
+
+	empty := NewHNSProvider("", nil, TLSASource{})
+	assert.Nil(t, empty.Nameservers())
+}
+
 func TestHNSProvider_Validate(t *testing.T) {
 	p := NewHNSProvider("", nil, TLSASource{})
 

--- a/internal/service/domain/icann_provider.go
+++ b/internal/service/domain/icann_provider.go
@@ -57,3 +57,8 @@ func (p *ICANNProvider) VerifyDelegation(ctx context.Context, domain string,
 func (p *ICANNProvider) OnCertAvailable(ctx context.Context, domain string, certPEM string) error {
 	return nil
 }
+
+// Nameservers returns the ICANN nameservers configured for the namespace.
+func (p *ICANNProvider) Nameservers() []string {
+	return p.nameservers
+}

--- a/internal/service/domain/icann_provider_test.go
+++ b/internal/service/domain/icann_provider_test.go
@@ -38,3 +38,11 @@ func TestICANNProvider_VerifyDelegation(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, verified)
 }
+
+func TestICANNProvider_Nameservers(t *testing.T) {
+	p := NewICANNProvider([]string{"ns1.example.com.", "ns2.example.com."})
+	assert.Equal(t, []string{"ns1.example.com.", "ns2.example.com."}, p.Nameservers())
+
+	empty := NewICANNProvider(nil)
+	assert.Nil(t, empty.Nameservers())
+}

--- a/internal/service/domain/provider.go
+++ b/internal/service/domain/provider.go
@@ -17,6 +17,12 @@ type DomainProvider interface {
 	// Providers can use it to update TLSA in delegation data or trigger
 	// namespace-specific protocol updates. Can be nil-safe by returning nil.
 	OnCertAvailable(ctx context.Context, domain string, certPEM string) error
+	// Nameservers returns the nameservers this provider publishes and
+	// validates delegation against for its namespace. Alt-root providers
+	// (e.g. HNS) return their own namespace-specific nameservers, which
+	// differ from ICANN's; these are operator-provided, not user-provided.
+	// Returns the namespace's nameservers, or nil/empty when none are set.
+	Nameservers() []string
 }
 
 type Registry struct {

--- a/internal/testing/mocks/MockDomainProvider.go
+++ b/internal/testing/mocks/MockDomainProvider.go
@@ -78,7 +78,7 @@ type MockDomainProvider_BuildDelegation_Call struct {
 //   - domain string
 //   - website *db.Website
 //   - config json.RawMessage
-func (_e *MockDomainProvider_Expecter) BuildDelegation(ctx any, zoneID any, domain any, website any, config any) *MockDomainProvider_BuildDelegation_Call {
+func (_e *MockDomainProvider_Expecter) BuildDelegation(ctx interface{}, zoneID interface{}, domain interface{}, website interface{}, config interface{}) *MockDomainProvider_BuildDelegation_Call {
 	return &MockDomainProvider_BuildDelegation_Call{Call: _e.mock.On("BuildDelegation", ctx, zoneID, domain, website, config)}
 }
 
@@ -125,6 +125,52 @@ func (_c *MockDomainProvider_BuildDelegation_Call) RunAndReturn(run func(ctx con
 	return _c
 }
 
+// Nameservers provides a mock function for the type MockDomainProvider
+func (_mock *MockDomainProvider) Nameservers() []string {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for Nameservers")
+	}
+
+	var r0 []string
+	if returnFunc, ok := ret.Get(0).(func() []string); ok {
+		r0 = returnFunc()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
+	}
+	return r0
+}
+
+// MockDomainProvider_Nameservers_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Nameservers'
+type MockDomainProvider_Nameservers_Call struct {
+	*mock.Call
+}
+
+// Nameservers is a helper method to define mock.On call
+func (_e *MockDomainProvider_Expecter) Nameservers() *MockDomainProvider_Nameservers_Call {
+	return &MockDomainProvider_Nameservers_Call{Call: _e.mock.On("Nameservers")}
+}
+
+func (_c *MockDomainProvider_Nameservers_Call) Run(run func()) *MockDomainProvider_Nameservers_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockDomainProvider_Nameservers_Call) Return(strings []string) *MockDomainProvider_Nameservers_Call {
+	_c.Call.Return(strings)
+	return _c
+}
+
+func (_c *MockDomainProvider_Nameservers_Call) RunAndReturn(run func() []string) *MockDomainProvider_Nameservers_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // OnCertAvailable provides a mock function for the type MockDomainProvider
 func (_mock *MockDomainProvider) OnCertAvailable(ctx context.Context, domain string, certPEM string) error {
 	ret := _mock.Called(ctx, domain, certPEM)
@@ -151,7 +197,7 @@ type MockDomainProvider_OnCertAvailable_Call struct {
 //   - ctx context.Context
 //   - domain string
 //   - certPEM string
-func (_e *MockDomainProvider_Expecter) OnCertAvailable(ctx any, domain any, certPEM any) *MockDomainProvider_OnCertAvailable_Call {
+func (_e *MockDomainProvider_Expecter) OnCertAvailable(ctx interface{}, domain interface{}, certPEM interface{}) *MockDomainProvider_OnCertAvailable_Call {
 	return &MockDomainProvider_OnCertAvailable_Call{Call: _e.mock.On("OnCertAvailable", ctx, domain, certPEM)}
 }
 
@@ -256,7 +302,7 @@ type MockDomainProvider_Validate_Call struct {
 
 // Validate is a helper method to define mock.On call
 //   - domain string
-func (_e *MockDomainProvider_Expecter) Validate(domain any) *MockDomainProvider_Validate_Call {
+func (_e *MockDomainProvider_Expecter) Validate(domain interface{}) *MockDomainProvider_Validate_Call {
 	return &MockDomainProvider_Validate_Call{Call: _e.mock.On("Validate", domain)}
 }
 
@@ -318,7 +364,7 @@ type MockDomainProvider_VerifyDelegation_Call struct {
 //   - ctx context.Context
 //   - domain string
 //   - delegationData json.RawMessage
-func (_e *MockDomainProvider_Expecter) VerifyDelegation(ctx any, domain any, delegationData any) *MockDomainProvider_VerifyDelegation_Call {
+func (_e *MockDomainProvider_Expecter) VerifyDelegation(ctx interface{}, domain interface{}, delegationData interface{}) *MockDomainProvider_VerifyDelegation_Call {
 	return &MockDomainProvider_VerifyDelegation_Call{Call: _e.mock.On("VerifyDelegation", ctx, domain, delegationData)}
 }
 


### PR DESCRIPTION
## Summary

The IPFS domain provider system used a single shared `Nameservers` list for both ICANN and alt-root namespaces. Alt-root namespaces like HNS must delegate to nameservers that are themselves members of that namespace (HNS domains), which differ from ICANN's. That distinction was hardcoded per-namespace in the service factory, so each new alt-root required bespoke factory wiring and HNS couldn't declare its own operator-provided nameservers.

## Change

- `DomainProvider` interface: added `Nameservers() []string` so any alt-root provider self-describes its namespace-specific nameservers.
- `HNSProvider`: implements `Nameservers()` returning its own HNS-domain nameserver list; `BuildDelegation` and `VerifyDelegation` now consume it.
- `ICANNProvider`: implements `Nameservers()` returning the global/ICANN list.
- `DnsConfig`: new operator field `HNSNameservers` (`hns_nameservers`), distinct from `Nameservers`.
- Factory: wires `HNSProvider` from `HNSNameservers`, falling back to `Nameservers` when unset (backward-compatible).
- `MockDomainProvider` regenerated with mockery v3 (adds `Nameservers()`).
- Tests: `Nameservers()` coverage for ICANN + HNS providers and config default.

## Validation

- `go test ./internal/service/domain/... ./internal/config/...` — pass
- `go vet` / `gofmt` — clean

## Notes

Future alt-roots: implement `Nameservers()` + a config source; no per-namespace factory changes.

- `develop` <!-- branch-stack -->
  - **feat(domain): allow alt-root providers to define their own nameservers** :point\_left:

---

<!-- kody-pr-summary:start -->
This pull request introduces support for alt-root providers (like HNS) to define their own namespace-specific nameservers, which are distinct from the standard ICANN nameservers.

**Key Changes:**

1. **New configuration option**: Added `HNSNameservers` to the DNS configuration, allowing operators to specify dedicated nameservers for HNS namespace delegation and validation. This is separate from the existing `Nameservers` field used for ICANN validation.

2. **Provider interface enhancement**: Extended the `DomainProvider` interface with a new `Nameservers()` method that returns the nameservers each provider publishes and validates against. Both `ICANNProvider` and `HNSProvider` now implement this method.

3. **HNS delegation update**: Modified the HNS provider to use its dedicated nameservers when building and verifying delegations, instead of relying on the ICANN nameservers list. This ensures HNS domains delegate to nameservers that are members of the HNS namespace.

4. **Backward compatibility**: Implemented a fallback mechanism where the ICANN nameservers are used if no HNS-specific nameservers are configured, ensuring existing deployments continue to work without configuration changes.

5. **Code cleanup**: Removed an unused method and updated the mock domain provider to include the new `Nameservers()` method.

6. **Testing**: Added unit tests to verify the new functionality, including testing the HNS provider's nameservers behavior and the new configuration default.
<!-- kody-pr-summary:end -->