### PR TITLE
fix(api): emit structured error responses for website domain endpoints

### DIFF
--- a/internal/api/api_domains.go
+++ b/internal/api/api_domains.go
@@ -30,7 +30,7 @@ func (a *API) createDomain(c echo.Context) error {
 
 	websiteID, err := strconv.ParseUint(c.Param("id"), 10, 64)
 	if err != nil {
-		apiErr := NewError(ErrKeyInvalidRequest, errors.New("invalid website ID"))
+		apiErr := NewError(ErrKeyInvalidPathID, errors.New("invalid website ID"))
 		return ctx.Error(apiErr, apiErr.HttpStatus())
 	}
 
@@ -73,7 +73,7 @@ func (a *API) listDomains(c echo.Context) error {
 
 	websiteID, err := strconv.ParseUint(c.Param("id"), 10, 64)
 	if err != nil {
-		apiErr := NewError(ErrKeyInvalidRequest, errors.New("invalid website ID"))
+		apiErr := NewError(ErrKeyInvalidPathID, errors.New("invalid website ID"))
 		return ctx.Error(apiErr, apiErr.HttpStatus())
 	}
 
@@ -132,13 +132,13 @@ func (a *API) deleteDomain(c echo.Context) error {
 
 	websiteID, err := strconv.ParseUint(c.Param("id"), 10, 64)
 	if err != nil {
-		apiErr := NewError(ErrKeyInvalidRequest, errors.New("invalid website ID"))
+		apiErr := NewError(ErrKeyInvalidPathID, errors.New("invalid website ID"))
 		return ctx.Error(apiErr, apiErr.HttpStatus())
 	}
 
 	domainID, err := strconv.ParseUint(c.Param("domain_id"), 10, 64)
 	if err != nil {
-		apiErr := NewError(ErrKeyInvalidRequest, errors.New("invalid domain ID"))
+		apiErr := NewError(ErrKeyInvalidPathID, errors.New("invalid domain ID"))
 		return ctx.Error(apiErr, apiErr.HttpStatus())
 	}
 
@@ -168,13 +168,13 @@ func (a *API) verifyDomain(c echo.Context) error {
 
 	websiteID, err := strconv.ParseUint(c.Param("id"), 10, 64)
 	if err != nil {
-		apiErr := NewError(ErrKeyInvalidRequest, errors.New("invalid website ID"))
+		apiErr := NewError(ErrKeyInvalidPathID, errors.New("invalid website ID"))
 		return ctx.Error(apiErr, apiErr.HttpStatus())
 	}
 
 	domainID, err := strconv.ParseUint(c.Param("domain_id"), 10, 64)
 	if err != nil {
-		apiErr := NewError(ErrKeyInvalidRequest, errors.New("invalid domain ID"))
+		apiErr := NewError(ErrKeyInvalidPathID, errors.New("invalid domain ID"))
 		return ctx.Error(apiErr, apiErr.HttpStatus())
 	}
 

--- a/internal/api/api_domains.go
+++ b/internal/api/api_domains.go
@@ -10,10 +10,11 @@ import (
 	"github.com/labstack/echo/v4"
 	"go.lumeweb.com/httputil"
 	mcontext "go.lumeweb.com/portal-middleware/context"
-	pluginDb "go.lumeweb.com/portal-plugin-ipfs/internal/db"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/api/dto"
+	pluginDb "go.lumeweb.com/portal-plugin-ipfs/internal/db"
 	"go.lumeweb.com/queryutil"
 	queryutilHttp "go.lumeweb.com/queryutil/http"
+	"go.uber.org/zap"
 	"gorm.io/gorm"
 )
 
@@ -29,7 +30,8 @@ func (a *API) createDomain(c echo.Context) error {
 
 	websiteID, err := strconv.ParseUint(c.Param("id"), 10, 64)
 	if err != nil {
-		return ctx.Error(errors.New("invalid website ID"), http.StatusBadRequest)
+		apiErr := NewError(ErrKeyInvalidRequest, errors.New("invalid website ID"))
+		return ctx.Error(apiErr, apiErr.HttpStatus())
 	}
 
 	req := dto.DomainRequest{}
@@ -49,12 +51,15 @@ func (a *API) createDomain(c echo.Context) error {
 
 	wd, err := a.delegatedDomainSvc.CreateDomain(reqCtx, req.Namespace, req.Domain, uint(websiteID), userID, configRaw)
 	if err != nil {
-		return ctx.Error(err, http.StatusInternalServerError)
+		a.Logger().Error("Failed to create domain", zap.Error(err))
+		apiErr := NewError(ErrKeyValidationFailed, err)
+		return ctx.Error(apiErr, apiErr.HttpStatus())
 	}
 
 	resp := dto.DomainResponse{}
 	if err := resp.FromModel(wd); err != nil {
-		return ctx.Error(err, http.StatusInternalServerError)
+		apiErr := NewError(ErrKeyFileProcessingFailed, err)
+		return ctx.Error(apiErr, apiErr.HttpStatus())
 	}
 	ctx.Response().Before(func() {
 		ctx.Response().Status = http.StatusCreated
@@ -68,7 +73,8 @@ func (a *API) listDomains(c echo.Context) error {
 
 	websiteID, err := strconv.ParseUint(c.Param("id"), 10, 64)
 	if err != nil {
-		return ctx.Error(errors.New("invalid website ID"), http.StatusBadRequest)
+		apiErr := NewError(ErrKeyInvalidRequest, errors.New("invalid website ID"))
+		return ctx.Error(apiErr, apiErr.HttpStatus())
 	}
 
 	user, err := mcontext.GetUserID(c)
@@ -126,22 +132,26 @@ func (a *API) deleteDomain(c echo.Context) error {
 
 	websiteID, err := strconv.ParseUint(c.Param("id"), 10, 64)
 	if err != nil {
-		return ctx.Error(errors.New("invalid website ID"), http.StatusBadRequest)
+		apiErr := NewError(ErrKeyInvalidRequest, errors.New("invalid website ID"))
+		return ctx.Error(apiErr, apiErr.HttpStatus())
 	}
 
 	domainID, err := strconv.ParseUint(c.Param("domain_id"), 10, 64)
 	if err != nil {
-		return ctx.Error(errors.New("invalid domain ID"), http.StatusBadRequest)
+		apiErr := NewError(ErrKeyInvalidRequest, errors.New("invalid domain ID"))
+		return ctx.Error(apiErr, apiErr.HttpStatus())
 	}
 
 	res := a.DB().WithContext(reqCtx).
 		Where("id = ? AND website_id = ? AND user_id = ?", domainID, websiteID, userID).
 		Unscoped().Delete(&pluginDb.WebsiteDomain{})
 	if res.Error != nil {
-		return ctx.Error(res.Error, http.StatusInternalServerError)
+		apiErr := NewError(ErrKeyFileProcessingFailed, res.Error)
+		return ctx.Error(apiErr, apiErr.HttpStatus())
 	}
 	if res.RowsAffected == 0 {
-		return ctx.Error(errors.New("domain not found"), http.StatusNotFound)
+		apiErr := NewError(ErrKeyDomainNotFound, errors.New("domain not found"))
+		return ctx.Error(apiErr, apiErr.HttpStatus())
 	}
 
 	return ctx.NoContent(http.StatusNoContent)
@@ -158,12 +168,14 @@ func (a *API) verifyDomain(c echo.Context) error {
 
 	websiteID, err := strconv.ParseUint(c.Param("id"), 10, 64)
 	if err != nil {
-		return ctx.Error(errors.New("invalid website ID"), http.StatusBadRequest)
+		apiErr := NewError(ErrKeyInvalidRequest, errors.New("invalid website ID"))
+		return ctx.Error(apiErr, apiErr.HttpStatus())
 	}
 
 	domainID, err := strconv.ParseUint(c.Param("domain_id"), 10, 64)
 	if err != nil {
-		return ctx.Error(errors.New("invalid domain ID"), http.StatusBadRequest)
+		apiErr := NewError(ErrKeyInvalidRequest, errors.New("invalid domain ID"))
+		return ctx.Error(apiErr, apiErr.HttpStatus())
 	}
 
 	var wd pluginDb.WebsiteDomain
@@ -171,9 +183,11 @@ func (a *API) verifyDomain(c echo.Context) error {
 		Where("id = ? AND website_id = ? AND user_id = ?", domainID, websiteID, userID).
 		First(&wd).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return ctx.Error(errors.New("domain not found"), http.StatusNotFound)
+			apiErr := NewError(ErrKeyDomainNotFound, errors.New("domain not found"))
+			return ctx.Error(apiErr, apiErr.HttpStatus())
 		}
-		return ctx.Error(err, http.StatusInternalServerError)
+		apiErr := NewError(ErrKeyFileProcessingFailed, err)
+		return ctx.Error(apiErr, apiErr.HttpStatus())
 	}
 
 	if a.delegatedDomainSvc == nil {
@@ -182,12 +196,15 @@ func (a *API) verifyDomain(c echo.Context) error {
 	}
 
 	if _, err := a.delegatedDomainSvc.VerifyDomain(reqCtx, &wd); err != nil {
-		return ctx.Error(err, http.StatusInternalServerError)
+		a.Logger().Error("Failed to verify domain", zap.Error(err))
+		apiErr := NewError(ErrKeyValidationFailed, err)
+		return ctx.Error(apiErr, apiErr.HttpStatus())
 	}
 
 	resp := dto.DomainResponse{}
 	if err := resp.FromModel(&wd); err != nil {
-		return ctx.Error(err, http.StatusInternalServerError)
+		apiErr := NewError(ErrKeyFileProcessingFailed, err)
+		return ctx.Error(apiErr, apiErr.HttpStatus())
 	}
 	return httputil.EncodeResponse(ctx, &wd, &resp)
 }

--- a/internal/api/errors.go
+++ b/internal/api/errors.go
@@ -3,10 +3,10 @@ package api
 import (
 	"net/http"
 
-	router "go.lumeweb.com/portal-router"
 	swagger "go.lumeweb.com/gswagger"
-	core "go.lumeweb.com/portal/core"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/errors"
+	router "go.lumeweb.com/portal-router"
+	core "go.lumeweb.com/portal/core"
 )
 
 // Error keys
@@ -51,6 +51,9 @@ const (
 	// Website validation error types
 	ErrKeyInvalidCID    core.ErrorType = "INVALID_CID"
 	ErrKeyInvalidTarget core.ErrorType = "INVALID_TARGET"
+
+	// Website domain binding error types
+	ErrKeyDomainNotFound core.ErrorType = "DOMAIN_NOT_FOUND"
 )
 
 func init() {
@@ -85,6 +88,7 @@ func init() {
 		ErrKeyPermissionDenied:      {Key: ErrKeyPermissionDenied, Message: "Permission denied"},
 		ErrKeyInvalidCID:            {Key: ErrKeyInvalidCID, Message: "Invalid CID provided"},
 		ErrKeyInvalidTarget:         {Key: ErrKeyInvalidTarget, Message: "Invalid target hash or peer ID provided"},
+		ErrKeyDomainNotFound:        {Key: ErrKeyDomainNotFound, Message: "Domain not found"},
 		ErrKeyDeleteFailed:          {Key: ErrKeyDeleteFailed, Message: "Failed to delete zone"},
 		ErrKeyUpdateFailed:          {Key: ErrKeyUpdateFailed, Message: "Failed to update zone"},
 	})
@@ -114,6 +118,7 @@ func init() {
 		ErrKeyInvalidCID:            http.StatusUnprocessableEntity,
 		ErrKeyInvalidTarget:         http.StatusUnprocessableEntity,
 		ErrKeyPermissionDenied:      http.StatusForbidden,
+		ErrKeyDomainNotFound:        http.StatusNotFound,
 		ErrKeyDeleteFailed:          http.StatusInternalServerError,
 		ErrKeyUpdateFailed:          http.StatusInternalServerError,
 	})

--- a/internal/api/errors.go
+++ b/internal/api/errors.go
@@ -54,6 +54,7 @@ const (
 
 	// Website domain binding error types
 	ErrKeyDomainNotFound core.ErrorType = "DOMAIN_NOT_FOUND"
+	ErrKeyInvalidPathID  core.ErrorType = "INVALID_PATH_ID"
 )
 
 func init() {
@@ -89,6 +90,7 @@ func init() {
 		ErrKeyInvalidCID:            {Key: ErrKeyInvalidCID, Message: "Invalid CID provided"},
 		ErrKeyInvalidTarget:         {Key: ErrKeyInvalidTarget, Message: "Invalid target hash or peer ID provided"},
 		ErrKeyDomainNotFound:        {Key: ErrKeyDomainNotFound, Message: "Domain not found"},
+		ErrKeyInvalidPathID:         {Key: ErrKeyInvalidPathID, Message: "Invalid path parameter: %s"},
 		ErrKeyDeleteFailed:          {Key: ErrKeyDeleteFailed, Message: "Failed to delete zone"},
 		ErrKeyUpdateFailed:          {Key: ErrKeyUpdateFailed, Message: "Failed to update zone"},
 	})
@@ -119,6 +121,7 @@ func init() {
 		ErrKeyInvalidTarget:         http.StatusUnprocessableEntity,
 		ErrKeyPermissionDenied:      http.StatusForbidden,
 		ErrKeyDomainNotFound:        http.StatusNotFound,
+		ErrKeyInvalidPathID:         http.StatusBadRequest,
 		ErrKeyDeleteFailed:          http.StatusInternalServerError,
 		ErrKeyUpdateFailed:          http.StatusInternalServerError,
 	})


### PR DESCRIPTION
## Problem

`pinner website domains add <website> <domain> --namespace hns` fails with:

```
Error: json: cannot unmarshal string into Go struct field ErrorResponse.error of type client.ErrorDetail
```

The website domain endpoints (`createDomain`, `listDomains`, `deleteDomain`, `verifyDomain`) returned **plain errors** through `httputil.RequestContext.Error()`. That helper only emits the structured `{"error": {"reason": ..., "details": ...}}` body when the error is a `*core.Error` (a `json.Marshaler`); for any other error it falls back to `{"error": "<string>"}`.

The ipfs-sdk swagger declares `ErrorResponse.error` as the **object** `ErrorDetail {reason, details}`. So when these handlers produced a plain error, the server returned a string body that the SDK's generated client could not parse, and the real underlying failure was hidden behind a JSON unmarshal error.

## Fix

Make the domain handlers return `core.Error` via the existing `api.NewError(...)` helper (matching the convention already used by `api_pins.go` / `api_upload.go`), so every error path marshals to the documented `{"error": {reason, details}}` shape:

- **Create / verify failures** → `ErrKeyValidationFailed`, original message preserved in `details`
- **Invalid website/domain IDs** → `ErrKeyInvalidRequest`
- **Database / internal errors** → `ErrKeyFileProcessingFailed`
- **Delete / verify not-found** → new `ErrKeyDomainNotFound` (HTTP 404)

This also surfaces the actual cause (e.g. HNS validation, zone creation, delegation) to the CLI user instead of the parse error.

## Files changed

- `internal/api/api_domains.go` — wrap all error returns in `api.NewError(...)`
- `internal/api/errors.go` — register `ErrKeyDomainNotFound` message + 404 code

## Validation

- `develop` <!-- branch-stack -->
  - **fix(api): emit structured error responses for website domain endpoints** :point\_left:

***

<!-- kody-pr-summary:start -->

## Summary

This pull request refactors the website domain API endpoints to return structured error responses instead of plain HTTP errors, improving API consistency and error handling.

## Changes

### Domain Endpoint Error Handling (api\_domains.go)

- **Structured errors for all domain endpoints**: Replaced all direct `ctx.Error()` calls with `NewError()` instances that map to standardized error keys with proper HTTP status codes:
  - Invalid website/domain ID parameters → `ErrKeyInvalidRequest` (400 Bad Request)
  - Domain creation/verification failures → `ErrKeyValidationFailed` (422 Unprocessable Entity)
  - File processing failures → `ErrKeyFileProcessingFailed` (500 Internal Server Error)
  - Domain not found → `ErrKeyDomainNotFound` (404 Not Found)

- **Added structured logging**: Domain creation and verification failures now log detailed error information via `zap.Logger` before returning error responses.

### Error Registry Expansion (errors.go)

- **New error type added**: `ErrKeyDomainNotFound` with:
  - Response message "Domain not found"
  - HTTP status code 404 (Not Found)
  - Registered in both the error messages registry and status code mapping

## Impact

All website domain-related API endpoints (create, list, delete, verify) now return consistent, structured JSON error responses with standardized error keys and appropriate HTTP status codes. This improves API contract consistency, simplifies client-side error handling, and provides better diagnostic information through structured logging.

<!-- kody-pr-summary:end -->
