### PR TITLE
fix(api): semantic 400-vs-422 error status classification

### DIFF
--- a/internal/api/api_dns_test.go
+++ b/internal/api/api_dns_test.go
@@ -361,7 +361,7 @@ func TestAPI_GetZone(t *testing.T) {
 
 			rec := helper.makeAuthenticatedRequest(http.MethodGet, "/api/dns/zones/invalid", token, nil)
 
-			assert.Equal(t, http.StatusUnprocessableEntity, rec.Code)
+			assert.Equal(t, http.StatusBadRequest, rec.Code)
 		}, TestOptions)
 	})
 }
@@ -457,7 +457,7 @@ func TestAPI_UpdateZone(t *testing.T) {
 			reqBody := fmt.Sprintf(`{"domain":"%s"}`, TestZoneDomain)
 			rec := helper.makeAuthenticatedRequest(http.MethodPut, "/api/dns/zones/invalid", token, []byte(reqBody))
 
-			assert.Equal(t, http.StatusUnprocessableEntity, rec.Code)
+			assert.Equal(t, http.StatusBadRequest, rec.Code)
 		}, TestOptions)
 	})
 }
@@ -549,7 +549,7 @@ func TestAPI_DeleteZone(t *testing.T) {
 
 			rec := helper.makeAuthenticatedRequest(http.MethodDelete, "/api/dns/zones/invalid", token, nil)
 
-			assert.Equal(t, http.StatusUnprocessableEntity, rec.Code)
+			assert.Equal(t, http.StatusBadRequest, rec.Code)
 		}, TestOptions)
 	})
 }
@@ -671,7 +671,7 @@ func TestAPI_ValidateZone(t *testing.T) {
 
 			rec := helper.makeAuthenticatedRequest(http.MethodPost, "/api/dns/zones/invalid/validate", token, nil)
 
-			assert.Equal(t, http.StatusUnprocessableEntity, rec.Code)
+			assert.Equal(t, http.StatusBadRequest, rec.Code)
 		}, TestOptions)
 	})
 }
@@ -751,7 +751,7 @@ func TestAPI_GetZoneStatus(t *testing.T) {
 
 			rec := helper.makeAuthenticatedRequest(http.MethodGet, "/api/dns/zones/invalid/status", token, nil)
 
-			assert.Equal(t, http.StatusUnprocessableEntity, rec.Code)
+			assert.Equal(t, http.StatusBadRequest, rec.Code)
 		}, TestOptions)
 	})
 }

--- a/internal/api/api_websites.go
+++ b/internal/api/api_websites.go
@@ -13,10 +13,10 @@ import (
 	"go.lumeweb.com/httputil"
 	mcontext "go.lumeweb.com/portal-middleware/context"
 	pluginCore "go.lumeweb.com/portal-plugin-ipfs/core"
+	"go.lumeweb.com/portal-plugin-ipfs/internal/api/dto"
+	pluginDb "go.lumeweb.com/portal-plugin-ipfs/internal/db"
 	pluginEvents "go.lumeweb.com/portal-plugin-ipfs/internal/errors"
 	pluginservice "go.lumeweb.com/portal-plugin-ipfs/internal/service/website"
-	pluginDb "go.lumeweb.com/portal-plugin-ipfs/internal/db"
-	"go.lumeweb.com/portal-plugin-ipfs/internal/api/dto"
 	"go.lumeweb.com/queryutil"
 	"go.lumeweb.com/queryutil/filter"
 	"go.uber.org/zap"
@@ -81,30 +81,30 @@ func (a *API) handleWebsiteValidationError(err error, c echo.Context) (error, bo
 	if err == nil {
 		return nil, false
 	}
-	
+
 	ctx := httputil.Context(c)
-	
+
 	// Check for specific validation errors using errors.Is
 	if errors.Is(err, pluginservice.ErrInvalidCID) {
 		apiErr := NewError(ErrKeyInvalidCID, err)
 		return ctx.Error(apiErr, apiErr.HttpStatus()), true
 	}
-	
+
 	if errors.Is(err, pluginservice.ErrInvalidIPNS) {
 		apiErr := NewError(ErrKeyInvalidTarget, err)
 		return ctx.Error(apiErr, apiErr.HttpStatus()), true
 	}
-	
+
 	if errors.Is(err, pluginservice.ErrInvalidTarget) {
 		apiErr := NewError(ErrKeyInvalidTarget, err)
 		return ctx.Error(apiErr, apiErr.HttpStatus()), true
 	}
-	
+
 	if errors.Is(err, pluginservice.ErrInvalidDomain) {
 		apiErr := NewError(ErrKeyInvalidDomainFormat, err)
 		return ctx.Error(apiErr, apiErr.HttpStatus()), true
 	}
-	
+
 	return err, false
 }
 
@@ -230,7 +230,7 @@ func (a *API) getWebsite(c echo.Context) error {
 
 	websiteID, err := strconv.ParseUint(c.Param("id"), 10, 64)
 	if err != nil {
-		apiErr := NewError(ErrKeyInvalidRequest, err)
+		apiErr := NewError(ErrKeyInvalidPathID, err)
 		return ctx.Error(apiErr, apiErr.HttpStatus())
 	}
 
@@ -275,7 +275,7 @@ func (a *API) updateWebsite(c echo.Context) error {
 
 	websiteID, err := strconv.ParseUint(c.Param("id"), 10, 64)
 	if err != nil {
-		apiErr := NewError(ErrKeyInvalidRequest, err)
+		apiErr := NewError(ErrKeyInvalidPathID, err)
 		return ctx.Error(apiErr, apiErr.HttpStatus())
 	}
 
@@ -339,7 +339,7 @@ func (a *API) deleteWebsite(c echo.Context) error {
 
 	websiteID, err := strconv.ParseUint(c.Param("id"), 10, 64)
 	if err != nil {
-		apiErr := NewError(ErrKeyInvalidRequest, err)
+		apiErr := NewError(ErrKeyInvalidPathID, err)
 		return ctx.Error(apiErr, apiErr.HttpStatus())
 	}
 
@@ -362,7 +362,7 @@ func (a *API) validateWebsiteDNS(c echo.Context) error {
 
 	websiteID, err := strconv.ParseUint(c.Param("id"), 10, 64)
 	if err != nil {
-		apiErr := NewError(ErrKeyInvalidRequest, err)
+		apiErr := NewError(ErrKeyInvalidPathID, err)
 		return ctx.Error(apiErr, apiErr.HttpStatus())
 	}
 

--- a/internal/api/api_websites_test.go
+++ b/internal/api/api_websites_test.go
@@ -791,7 +791,7 @@ func TestAPI_GetWebsite(t *testing.T) {
 
 			rec := helper.makeAuthenticatedRequest(http.MethodGet, "/api/websites/invalid", token, nil)
 
-			assert.Equal(t, http.StatusUnprocessableEntity, rec.Code)
+			assert.Equal(t, http.StatusBadRequest, rec.Code)
 		}, TestOptions)
 	})
 
@@ -935,7 +935,7 @@ func TestAPI_UpdateWebsite(t *testing.T) {
 			reqBody := fmt.Sprintf(`{"domain":"%s","target_type":"ipfs","target_hash":"%s"}`, TestDomain, TestCID)
 			rec := helper.makeAuthenticatedRequest(http.MethodPut, "/api/websites/invalid", token, []byte(reqBody))
 
-			assert.Equal(t, http.StatusUnprocessableEntity, rec.Code)
+			assert.Equal(t, http.StatusBadRequest, rec.Code)
 		}, TestOptions)
 	})
 
@@ -1042,7 +1042,7 @@ func TestAPI_DeleteWebsite(t *testing.T) {
 
 			rec := helper.makeAuthenticatedRequest(http.MethodDelete, "/api/websites/invalid", token, nil)
 
-			assert.Equal(t, http.StatusUnprocessableEntity, rec.Code)
+			assert.Equal(t, http.StatusBadRequest, rec.Code)
 		}, TestOptions)
 	})
 
@@ -1146,7 +1146,7 @@ func TestAPI_ValidateWebsiteDNS(t *testing.T) {
 
 			rec := helper.makeAuthenticatedRequest(http.MethodPost, "/api/websites/invalid/validate", token, nil)
 
-			assert.Equal(t, http.StatusUnprocessableEntity, rec.Code)
+			assert.Equal(t, http.StatusBadRequest, rec.Code)
 		}, TestOptions)
 	})
 

--- a/internal/api/dns_helpers.go
+++ b/internal/api/dns_helpers.go
@@ -11,8 +11,8 @@ import (
 	"github.com/samber/lo"
 	"go.lumeweb.com/httputil"
 	mcontext "go.lumeweb.com/portal-middleware/context"
-	"go.lumeweb.com/portal/core"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/db"
+	"go.lumeweb.com/portal/core"
 	"gorm.io/gorm"
 )
 
@@ -82,7 +82,7 @@ func parseZoneIDParam(c echo.Context) (uint, error) {
 func parseZoneIDParamWithResponse(c echo.Context) (uint, error) {
 	zoneIDRaw, err := strconv.ParseUint(c.Param("id"), 10, 64)
 	if err != nil {
-		apiErr := NewError(ErrKeyInvalidIdentifier, nil)
+		apiErr := NewError(ErrKeyInvalidPathID, nil)
 		return 0, apiErr
 	}
 	return uint(zoneIDRaw), nil

--- a/internal/api/errors.go
+++ b/internal/api/errors.go
@@ -57,6 +57,16 @@ const (
 	ErrKeyInvalidPathID  core.ErrorType = "INVALID_PATH_ID"
 )
 
+// HTTP status classes (RFC 9110 / RFC 4918) — keep these consistent:
+//   - 400 Bad Request: malformed / unparseable request (e.g. a non-numeric
+//     path param, invalid JSON). Use ErrKeyInvalidPathID / DTO bind failures.
+//   - 422 Unprocessable Entity: request parses but fails semantic validation
+//     (empty field, bad field combination, invalid CID/TTL/domain/record
+//     value). Use the ErrKeyInvalid* validation keys / httputil.ValidationError.
+//
+// The ipfs-sdk swagger documents these statuses via portal-router's
+// DefaultCoreErrorResponses (400, 404, 422, 500) + auth (401, 403).
+
 func init() {
 	core.MustRegisterNamespace(Namespace)
 	core.MustRegisterDefaultErrorMessages(Namespace, map[core.ErrorType]core.ErrorDefinition{


### PR DESCRIPTION
Aligns portal-plugin-ipfs error responses to the RFC 9110/4918 semantic split: **malformed path param → 400**, **parses-but-invalid body → 422**. Resolves the seesaw over undocumented error statuses.

## Context

ipfs-sdk swagger documents error responses via portal-router DefaultCoreErrorResponses (400/404/500)+auth(401/403); PR #63 adds 422. Server emits 422 for body validation via httputil.ValidationError and registry keys, 400 for malformed path params via ErrKeyInvalidPathID (PR #843).

## Changes

- api\_websites.go: website get/update/delete/validate invalid path-ID sites → ErrKeyInvalidPathID (400).
- dns\_helpers.go: parseZoneIDParamWithResponse invalid zone-ID → ErrKeyInvalidPathID (400).
- errors.go: documents 400-vs-422 rule.
- api\_websites\_test.go / api\_dns\_test.go: malformed-ID assertions 422 → 400; semantic body-validation tests remain 422.

## Verification

- grep audit: no path-param site on a 422 key; all 16 path-param sites use a 400-mapped key.
- gofmt clean on changed non-test files.
- Full go test/build blocked by pre-existing toolchain/dependency drift (libp2p webtransport, otelzap) on baseline; not caused by this change. CI should run with a compatible toolchain.

Follow-up: regenerate ipfs-sdk once portal-router PR #63 releases.

- `develop` <!-- branch-stack -->
  - **fix(api): semantic 400-vs-422 error status classification** :point\_left:

---

<!-- kody-pr-summary:start -->
This pull request corrects the HTTP status code classification for API errors to properly distinguish between malformed requests (400 Bad Request) and semantic validation failures (422 Unprocessable Entity).

**Changes include:**

1. **Path parameter validation fix**: When a request contains a non-numeric ID in the URL path (e.g., `/api/websites/invalid` or `/api/dns/zones/invalid`), the API now returns `400 Bad Request` instead of `422 Unprocessable Entity`. This is because a non-numeric path parameter is a malformed/unparseable request, not a semantic validation failure.

2. **Error key standardization**: Replaced the generic `ErrKeyInvalidRequest` error key with the more specific `ErrKeyInvalidPathID` for all path parameter parsing failures in website endpoints, and updated DNS helpers to use the same consistent error key.

3. **Documentation update**: Added an inline comment in the errors module explaining the HTTP status classification rules:
   - **400 Bad Request**: For malformed/unparseable requests (non-numeric path params, invalid JSON)
   - **422 Unprocessable Entity**: For requests that parse correctly but fail semantic validation (empty fields, invalid CID/TTL/domain/record values)

4. **Test updates**: Updated all affected test assertions across DNS and Website API tests to expect `400 Bad Request` instead of `422 Unprocessable Entity` when invalid (non-numeric) IDs are provided in the URL path.

This change improves API consistency and aligns with HTTP semantics by ensuring that 422 is reserved exclusively for request bodies that are well-formed but semantically invalid, while 400 covers syntactically malformed requests.
<!-- kody-pr-summary:end -->