### PR TITLE
chore(deps): bump go.lumeweb.com/portal-router to v0.7.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	go.lumeweb.com/portal-plugin-core v0.1.0
 	go.lumeweb.com/portal-plugin-dashboard v0.3.1-0.20260728211030-fa71bb5211dc
 	go.lumeweb.com/portal-plugin-quota v0.1.0
-	go.lumeweb.com/portal-router v0.7.6
+	go.lumeweb.com/portal-router v0.7.7
 	go.lumeweb.com/queryutil v0.3.17
 	go.lumeweb.com/web/go/portal-plugin-ipfs v0.0.0-20260722190812-27c8d53607dd
 	go.uber.org/zap v1.28.0

--- a/go.sum
+++ b/go.sum
@@ -1164,6 +1164,8 @@ go.lumeweb.com/portal-plugin-quota v0.1.0 h1:q1G7wpC8XRILc+mEpkVMEJEOkgEMXWX1If0
 go.lumeweb.com/portal-plugin-quota v0.1.0/go.mod h1:DFdg/dVyfJEWlHdWvVUSAuAYCC/acQhG7YDOVhD9JQ8=
 go.lumeweb.com/portal-router v0.7.6 h1:9q4i4SqhaE39ecJSlLfBIDF6vZ5Jd2S+tYSOZb11cfk=
 go.lumeweb.com/portal-router v0.7.6/go.mod h1:hl51sHDKcgw8yxJ6RraYBOI1Vnufq33FhKwfKiqCkVg=
+go.lumeweb.com/portal-router v0.7.7 h1:6mUGkG2BtHDygIPqRZs1sRkPLkz9l2wTXMUhZmdp24E=
+go.lumeweb.com/portal-router v0.7.7/go.mod h1:hl51sHDKcgw8yxJ6RraYBOI1Vnufq33FhKwfKiqCkVg=
 go.lumeweb.com/queryutil v0.3.17 h1:rbMj1ZpG1KL1UUvMYS9+JYdjOcUW6YAfXjy0J2XPWYI=
 go.lumeweb.com/queryutil v0.3.17/go.mod h1:6bcNItUrPwjGAz9pBFPxO509apXcWU8VD1lc+vur/IA=
 go.lumeweb.com/web/go/portal-dashboard v0.0.0-20260722190812-27c8d53607dd h1:oMYEwGJ6tkkW7yc4+pHqx/nTgxzvMcpS3sDwnI7SBSo=


### PR DESCRIPTION
Follow-up to merged PR #845 — the dependency bump landed after that PR was merged.

**Change:** `go.mod` `go.lumeweb.com/portal-router` v0.7.6 → v0.7.7; `go.sum` updated.

**What v0.7.7 brings** (portal-router PR #63): `DefaultCoreErrorResponses()` now documents 422 Unprocessable Entity alongside 400/404/500, so the swagger contract matches the server's 422 semantic-validation responses.

See <https://github.com/LumeWeb/portal-router/releases/tag/v0.7.7>

Verified: `go mod verify` passes all modules.

- `develop` <!-- branch-stack -->
  - **chore(deps): bump go.lumeweb.com/portal-router to v0.7.7** :point\_left:
