### PR TITLE
fix(dns): normalize ALIAS record content to fully-qualified FQDN

### DIFF
--- a/internal/service/dns/dns_helpers.go
+++ b/internal/service/dns/dns_helpers.go
@@ -217,8 +217,6 @@ func recordToDTOWithZoneID(rrset powerdns.RRSet, record powerdns.Record, zoneDom
 	}
 }
 
-
-
 // formatTXTContent wraps TXT record content in double quotes as required by PowerDNS API.
 // PowerDNS expects TXT record values to be quoted strings (e.g., "v=spf1 ~all").
 func formatTXTContent(content string) string {
@@ -234,9 +232,9 @@ func formatRecordContent(recordType, content string) string {
 	if strings.EqualFold(recordType, "TXT") {
 		return formatTXTContent(content)
 	}
-	// PowerDNS requires fully-qualified domain names for CNAME, MX, NS
+	// PowerDNS requires fully-qualified domain names for CNAME, MX, NS, ALIAS
 	// Append trailing dot if missing so the name is absolute, not relative
-	if strings.EqualFold(recordType, "CNAME") || strings.EqualFold(recordType, "MX") || strings.EqualFold(recordType, "NS") {
+	if strings.EqualFold(recordType, "CNAME") || strings.EqualFold(recordType, "MX") || strings.EqualFold(recordType, "NS") || strings.EqualFold(recordType, "ALIAS") {
 		return ensureTrailingDot(content)
 	}
 	return content

--- a/internal/service/dns/dns_helpers_test.go
+++ b/internal/service/dns/dns_helpers_test.go
@@ -4,9 +4,9 @@ import (
 	"strings"
 	"testing"
 
-	pluginDb "go.lumeweb.com/portal-plugin-ipfs/internal/db"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	pluginDb "go.lumeweb.com/portal-plugin-ipfs/internal/db"
 )
 
 func TestParseZoneFile_EmptyContent(t *testing.T) {
@@ -569,6 +569,35 @@ func TestBuildTargetPath(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result := buildTargetPath(tt.targetHash, tt.targetType)
 			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestFormatRecordContent(t *testing.T) {
+	tests := []struct {
+		name       string
+		recordType string
+		content    string
+		expected   string
+	}{
+		// ALIAS targets must be absolute FQDNs (trailing dot) for PowerDNS.
+		{"alias no dot", "ALIAS", "ipfs.pub", "ipfs.pub."},
+		{"alias with dot", "ALIAS", "ipfs.pub.", "ipfs.pub."},
+		{"alias with spaces", "ALIAS", " gateway.example ", "gateway.example."},
+		// Existing FQDN-normalized types keep working.
+		{"cname no dot", "CNAME", "www.lumeweb", "www.lumeweb."},
+		{"ns no dot", "NS", "ns1.lumeweb", "ns1.lumeweb."},
+		{"mx no dot", "MX", "mail.lumeweb", "mail.lumeweb."},
+		// TXT gets quoted, not dotted.
+		{"txt quoted", "TXT", "dnslink=/ipfs/QmHash", `"dnslink=/ipfs/QmHash"`},
+		// Address types pass through unchanged.
+		{"a unchanged", "A", "185.150.189.208", "185.150.189.208"},
+		{"aaaa unchanged", "AAAA", "2001:db8::1", "2001:db8::1"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatRecordContent(tt.recordType, tt.content)
+			assert.Equal(t, tt.expected, got)
 		})
 	}
 }


### PR DESCRIPTION
## Problem

`CreateALIASRecord` (used by the delegated-domain create flow) passes the gateway host — e.g. `ipfs.pub` — to PowerDNS **without a trailing dot**. PowerDNS requires ALIAS targets to be **absolute FQDNs**, so this returned:

```
422: Record lumeweb./ALIAS 'ipfs.pub': Not in expected format (parsed as 'ipfs.pub.')
```

The 422 aborted website-domain creation and rolled back the just-created zone, causing the create → delete → retry loop seen in the logs.

## Root cause

`formatRecordContent` already normalized **CNAME / MX / NS** content via `ensureTrailingDot`, but **ALIAS was missing from that set** — so ALIAS targets were passed through raw. This is also inconsistent with the zone-creation ALIAS path (`dns_service_zone.go`), which already sends `GatewayDomain + "."`.

## Fix

Add `ALIAS` to the `formatRecordContent` FQDN-normalization set, so ALIAS targets get the required trailing dot, consistently with CNAME/MX/NS and with the zone-creation path.

## Changes

- `internal/service/dns/dns_helpers.go`: `formatRecordContent` now applies `ensureTrailingDot` to `ALIAS` as well as CNAME/MX/NS.
- `internal/service/dns/dns_helpers_test.go`: new `TestFormatRecordContent` covering ALIAS, CNAME, NS, MX, TXT, A, AAAA.

* `develop` <!-- branch-stack -->
  - **fix(dns): normalize ALIAS record content to fully-qualified FQDN** :point\_left:
