### PR TITLE
fix(dns): decode PowerDNS cryptokey response ds as string array

### DIFF
--- a/internal/service/dns/powerdns_client.go
+++ b/internal/service/dns/powerdns_client.go
@@ -238,10 +238,8 @@ func (c *PowerDNSClient) EnableDNSSEC(ctx context.Context, zoneID string) (strin
 	}
 
 	var result struct {
-		DNSKey string `json:"dnskey"`
-		DS    []struct {
-			Digest string `json:"digest"`
-		} `json:"ds"`
+		DNSKey string   `json:"dnskey"`
+		DS     []string `json:"ds"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
 		return "", fmt.Errorf("decode cryptokey response: %w", err)

--- a/internal/service/dns/powerdns_client_test.go
+++ b/internal/service/dns/powerdns_client_test.go
@@ -1035,6 +1035,63 @@ func TestIsDuplicateKeyError(t *testing.T) {
 
 // Helper functions
 
+func TestEnableDNSSEC(t *testing.T) {
+	t.Run("decodes cryptokey response with ds as string array", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPost {
+				t.Errorf("expected POST request, got %s", r.Method)
+			}
+			if r.URL.Path != "/servers/localhost/zones/lumeweb./cryptokeys" {
+				t.Errorf("unexpected path: %s", r.URL.Path)
+			}
+			// PowerDNS returns ds as an array of DS record strings.
+			body := `{"dnskey":"257 3 13 AwEAAaX9pZzY3eiw==","ds":["45688 13 2 1F287B0F9E0C1A2B3C4D5E6F7A8B9C0D1E2F3A4B5C6D7E8F9A0B1C2D3E4F5"]}`
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(body))
+		}))
+		defer server.Close()
+
+		logger := zap.NewNop()
+		coreLogger := &core.Logger{Logger: logger}
+		client, err := NewPowerDNSClient(server.URL, "test-api-key", coreLogger)
+		if err != nil {
+			t.Fatalf("NewPowerDNSClient failed: %v", err)
+		}
+
+		dnskey, err := client.EnableDNSSEC(context.Background(), "lumeweb.")
+		if err != nil {
+			t.Fatalf("EnableDNSSEC returned error: %v", err)
+		}
+		if dnskey != "257 3 13 AwEAAaX9pZzY3eiw==" {
+			t.Errorf("unexpected dnskey: %q", dnskey)
+		}
+	})
+
+	t.Run("propagates non-2xx response", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error": "zone not found"}`))
+		}))
+		defer server.Close()
+
+		logger := zap.NewNop()
+		coreLogger := &core.Logger{Logger: logger}
+		client, err := NewPowerDNSClient(server.URL, "test-api-key", coreLogger)
+		if err != nil {
+			t.Fatalf("NewPowerDNSClient failed: %v", err)
+		}
+
+		_, err = client.EnableDNSSEC(context.Background(), "lumeweb.")
+		if err == nil {
+			t.Fatal("expected error for non-2xx response, got nil")
+		}
+		if !strings.Contains(err.Error(), "status 400") {
+			t.Errorf("expected status 400 in error, got: %v", err)
+		}
+	})
+}
+
 func intPtr(i int) *int {
 	return &i
 }


### PR DESCRIPTION
## Problem

`EnableDNSSEC` fails to parse the PowerDNS `POST /cryptokeys` response when a zone is being delegated (HNS DNSLink site):

```
decode cryptokey response: json: cannot unmarshal string into Go struct
field .ds of type struct { Digest string }
```

The Go response struct declared `ds` as an **array of `{digest}` objects**, but PowerDNS's cryptokey creation endpoint actually returns `ds` as an **array of DS record strings**:

```json
{
  "dnskey": "257 3 13 AwEAA...",
  "ds": ["45688 13 2 1F287B0F9E0C..."]
}
```

The decode failure aborted domain-delegation creation and rolled back the zone (this is the next failure after the ALIAS 422 fix).

## Fix

Change the `ds` field in the `EnableDNSSEC` response struct from `[]struct{ Digest string }` to `[]string`. The only consumer is `len(result.DS) > 0`, so no logic change is required.

## Changes
- `internal/service/dns/powerdns_client.go`: `ds` decoded as `[]string`.
- `internal/service/dns/powerdns_client_test.go`: `TestEnableDNSSEC` covering the string-array decode and non-2xx error propagation.

---

<!-- kody-pr-summary:start -->
## Summary

This pull request fixes how the PowerDNS client decodes the DNSSEC cryptokey response when enabling DNSSEC for a zone.

## Changes

The fix adjusts the response parsing of the `EnableDNSSEC` function in the PowerDNS client. Previously, the code expected the `ds` field in the cryptokey response to be an array of objects, each containing a `digest` property. However, PowerDNS actually returns the `ds` field as a simple array of DS record strings.

**Key modification:**
- Changed the `DS` field structure in the response decoder from:
  ```go
  DS []struct{ Digest string `json:"digest"` }
  ```
  to:
  ```go
  DS []string
  ```

This change aligns the code with the actual PowerDNS API response format, ensuring proper decoding of the cryptokey response.

**Tests added:**
- Added `TestEnableDNSSEC` with two test cases:
  1. Verifies correct decoding when the API returns `ds` as a string array
  2. Confirms that non-2xx responses are properly propagated as errors

The fix resolves the issue where enabling DNSSEC would fail to decode the cryptokey response correctly due to the mismatched data structure.
<!-- kody-pr-summary:end -->