### PR TITLE
feat(domains): expose domain status in DomainResponse

### DIFF
--- a/internal/api/dto/domain.go
+++ b/internal/api/dto/domain.go
@@ -31,6 +31,7 @@ type DomainResponse struct {
 	ID        uint   `json:"id"`
 	Domain    string `json:"domain"`
 	Namespace string `json:"namespace"`
+	Status    string `json:"status,omitempty"`
 	ZoneName  string `json:"zone_name,omitempty"`
 }
 
@@ -38,6 +39,7 @@ func (r *DomainResponse) FromModel(m *db.WebsiteDomain) error {
 	r.ID = m.ID
 	r.Domain = m.Domain
 	r.Namespace = string(m.Namespace)
+	r.Status = string(m.Status)
 	r.ZoneName = m.ZoneName
 	return nil
 }


### PR DESCRIPTION
## Summary

Expose the domain lifecycle `Status` in the `DomainResponse` DTO so clients can tell whether a bound domain is verified/active.

The `WebsiteDomain` DB model already stores a `Status` (`draft`, `records_generated`, `waiting_delegation`, `active`, `error`; `active` = delegation confirmed/verified), but the API DTO dropped it. This surfaces it through `FromModel`, which is used by the create/list/verify handlers.

Part of a coordinated change to surface domain verification status:

- ipfs-sdk: add `status` to `DomainResponse` (PR #81)
- this repo: populate the DTO from the DB model
- pinner-cli: render a status column once the ipfs-sdk version is released + bumped

## Changes

- `internal/api/dto/domain.go`: added `Status string \`json:"status,omitempty"\``to`DomainResponse`and populate it in`FromModel`from`m.Status\`.

***

<!-- kody-pr-summary:start -->

This pull request adds a `Status` field to the `DomainResponse` DTO (Data Transfer Object) and populates it with the domain's current status when converting from the database model.

**Changes:**

- Added a new `Status` field to the `DomainResponse` struct with JSON serialization tag `status,omitempty`, meaning it will only appear in responses when non-empty.
- Updated the `FromModel` method to map the `Status` property from the `WebsiteDomain` database model to the response object.

The purpose is to expose the domain status information in API responses, allowing consumers to check the current status of each domain returned by the API.

<!-- kody-pr-summary:end -->

- `develop` <!-- branch-stack -->
  - **feat(domains): expose domain status in DomainResponse** :point\_left:
