### PR TITLE
test(ipfs): fix reprovider test failures from defaulted ProvideManyTimeout

### DIFF
--- a/internal/protocol/ipfs/provide_test.go
+++ b/internal/protocol/ipfs/provide_test.go
@@ -27,14 +27,15 @@ func newTestReprovider(t *testing.T) (*Reprovider, *mocks.MockProvider, *mocks.M
 	logger, _ := zap.NewDevelopment()
 
 	cfg := config.IPFSProvider{
-		BatchSize:     10,
-		Interval:      1 * time.Second,
-		PerCIDTimeout: 0,
-		TriggerDelay:  100 * time.Millisecond,
-		NotReadySleep: 50 * time.Millisecond,
-		EmptySleep:    10 * time.Minute,
-		ErrorSleep:    time.Minute,
-		BacklogSleep:  time.Minute,
+		BatchSize:          10,
+		Interval:           1 * time.Second,
+		PerCIDTimeout:      0,
+		TriggerDelay:       100 * time.Millisecond,
+		NotReadySleep:      50 * time.Millisecond,
+		EmptySleep:         10 * time.Minute,
+		ErrorSleep:         time.Minute,
+		BacklogSleep:       time.Minute,
+		ProvideManyTimeout: 3 * time.Second,
 	}
 
 	return NewReprovider(mockProvider, mockStore, logger, cfg), mockProvider, mockStore
@@ -228,13 +229,14 @@ func TestNewReprovider(t *testing.T) {
 
 func newTestReproviderCfg(interval time.Duration, batchSize int) config.IPFSProvider {
 	return config.IPFSProvider{
-		BatchSize:     batchSize,
-		Interval:      interval,
-		TriggerDelay:  100 * time.Millisecond,
-		NotReadySleep: 50 * time.Millisecond,
-		EmptySleep:    10 * time.Minute,
-		ErrorSleep:    time.Minute,
-		BacklogSleep:  time.Minute,
+		BatchSize:          batchSize,
+		Interval:           interval,
+		TriggerDelay:       100 * time.Millisecond,
+		NotReadySleep:      50 * time.Millisecond,
+		EmptySleep:         10 * time.Minute,
+		ErrorSleep:         time.Minute,
+		BacklogSleep:       time.Minute,
+		ProvideManyTimeout: 1 * time.Second,
 	}
 }
 
@@ -748,5 +750,3 @@ func mustMultihash(t *testing.T, data string) multihash.Multihash {
 	require.NoError(t, err)
 	return h
 }
-
-


### PR DESCRIPTION
## Problem

All `TestReprovider_performProvide_*` and `TestReprovider_Run_*` tests were failing with:

```
reprovider cycle cancelled during CountPinned {"error": "context deadline exceeded"}
MockReprovideStore.go: FAIL: ProvideCIDs(string,string,int) ... needs to make 1 more call(s)
MockProvider.go:      FAIL: ProvideMany(string,string)    ... needs to make 1 more call(s)
```

## Root cause

`performProvide` wraps the whole cycle with `context.WithTimeout(ctx, r.cfg.ProvideManyTimeout*2)`. The two reprovider test config helpers (`newTestReprovider` and `newTestReproviderCfg`) never set `ProvideManyTimeout`, so it defaulted to **0**. A zero timeout makes the context expire immediately — the cycle aborted during `CountPinned` before ever reaching `ProvideCIDs`/`ProvideMany`/`SetLastAnnouncement`, so the mock expectations were never exercised.

## Fix

Set a non-zero `ProvideManyTimeout` in both test helpers:

- `newTestReprovider` (Run tests): `3 * time.Second` — the Run tests cancel after 2s, so the cycle timeout (ProvideManyTimeout\*2 = 6s) must exceed that window so the tests own cancel terminates the run rather than the timeout.
- `newTestReproviderCfg` (performProvide tests): `1 * time.Second`.

## Verification

Full `internal/protocol/ipfs` package passes (includes all previously-failing reprovider tests); verified stable across repeated runs.

- `develop` <!-- branch-stack -->
  - **test(ipfs): fix reprovider test failures from defaulted ProvideManyTimeout** :point\_left:

---

<!-- kody-pr-summary:start -->
## Summary

This pull request fixes test failures in the IPFS reprovider tests caused by the defaulted `ProvideManyTimeout` configuration value.

## Changes

The patch updates test configuration setup in `internal/protocol/ipfs/provide_test.go` to explicitly set the `ProvideManyTimeout` field in the `config.IPFSProvider` struct used by test fixtures:

1. **`newTestReprovider` test helper**: Adds `ProvideManyTimeout: 3 * time.Second` to the provider configuration.

2. **`newTestReproviderCfg` test helper**: Adds `ProvideManyTimeout: 1 * time.Second` to the provider configuration.

By explicitly setting these timeout values in the test configuration objects, the tests no longer rely on the default `ProvideManyTimeout` behavior, which was causing inconsistent test results and failures.
<!-- kody-pr-summary:end -->