### PR TITLE
feat(api): surface domain DNS delegation requirements in DomainResponse

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -806,6 +806,17 @@ See also:.*`),
 				router.WithSuccessResponse(http.StatusOK, "Verification result", router.WithJSONContent(dto.DomainResponse{})),
 			),
 		),
+		router.NewRoute(http.MethodGet, "/websites/:id/domains/:domain_id/dns-requirements", a.domainDNSRequirements,
+			router.WithAccess(core.ACCESS_USER_ROLE),
+			router.WithSwagger(
+				router.WithSummary("Get domain DNS delegation requirements"),
+				router.WithDescription(`Returns the DNS records a user must publish to complete domain delegation for a bound domain. For HNS this includes the DS/NS/GLUE parent records (publish in the HNS wallet) and authoritative NS/TLSA records; for ICANN it returns the nameservers.`),
+				router.WithTags("Websites", "Domains"),
+				router.WithPathParam("id", "Website ID", ""),
+				router.WithPathParam("domain_id", "Domain ID", ""),
+				router.WithSuccessResponse(http.StatusOK, "Domain DNS requirements", router.WithJSONContent(dto.DomainResponse{})),
+			),
+		),
 	)
 
 	if err := router.RegisterRoutes(apiGroup, accessSvc, a.Subdomain(), websiteRoutes, router.WithMiddlewares(authMw), router.WithCors()); err != nil {

--- a/internal/api/api_domains.go
+++ b/internal/api/api_domains.go
@@ -208,3 +208,48 @@ func (a *API) verifyDomain(c echo.Context) error {
 	}
 	return httputil.EncodeResponse(ctx, &wd, &resp)
 }
+
+// domainDNSRequirements returns the DNS delegation requirements (DS/NS/GLUE/TLSA
+// parent + authoritative records and instructions) for a bound domain so a
+// client can render DNS/DNSSEC setup guidance after binding. It reuses the same
+// typed DomainResponse as create/verify so clients share one renderer.
+func (a *API) domainDNSRequirements(c echo.Context) error {
+	ctx := httputil.Context(c)
+	reqCtx := ctx.Context.Request().Context()
+
+	userID, err := mcontext.GetUserID(c)
+	if err != nil {
+		return ctx.Error(err, http.StatusUnauthorized)
+	}
+
+	websiteID, err := strconv.ParseUint(c.Param("id"), 10, 64)
+	if err != nil {
+		apiErr := NewError(ErrKeyInvalidPathID, errors.New("invalid website ID"))
+		return ctx.Error(apiErr, apiErr.HttpStatus())
+	}
+
+	domainID, err := strconv.ParseUint(c.Param("domain_id"), 10, 64)
+	if err != nil {
+		apiErr := NewError(ErrKeyInvalidPathID, errors.New("invalid domain ID"))
+		return ctx.Error(apiErr, apiErr.HttpStatus())
+	}
+
+	var wd pluginDb.WebsiteDomain
+	if err := a.DB().WithContext(reqCtx).
+		Where("id = ? AND website_id = ? AND user_id = ?", domainID, websiteID, userID).
+		First(&wd).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			apiErr := NewError(ErrKeyDomainNotFound, errors.New("domain not found"))
+			return ctx.Error(apiErr, apiErr.HttpStatus())
+		}
+		apiErr := NewError(ErrKeyFileProcessingFailed, err)
+		return ctx.Error(apiErr, apiErr.HttpStatus())
+	}
+
+	resp := dto.DomainResponse{}
+	if err := resp.FromModel(&wd); err != nil {
+		apiErr := NewError(ErrKeyFileProcessingFailed, err)
+		return ctx.Error(apiErr, apiErr.HttpStatus())
+	}
+	return httputil.EncodeResponse(ctx, &wd, &resp)
+}

--- a/internal/api/api_domains_test.go
+++ b/internal/api/api_domains_test.go
@@ -1,13 +1,16 @@
 package api
 
 import (
+	"encoding/json"
 	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.lumeweb.com/portal-plugin-ipfs/internal/api/dto"
 	pluginDb "go.lumeweb.com/portal-plugin-ipfs/internal/db"
 	coreTesting "go.lumeweb.com/portal/core/testing"
+	"gorm.io/datatypes"
 )
 
 func TestAPI_DeleteDomain(t *testing.T) {
@@ -73,6 +76,63 @@ func TestAPI_DeleteDomain(t *testing.T) {
 
 			// Authenticated user tries to delete the other user's domain.
 			rec := helper.makeAuthenticatedRequest(http.MethodDelete, "/api/websites/1/domains/1", token, nil)
+			assert.Equal(t, http.StatusNotFound, rec.Code)
+		}, TestOptions)
+	})
+}
+
+func TestAPI_DomainDNSRequirements(t *testing.T) {
+	t.Run("returns_delegation_for_bound_domain", func(t *testing.T) {
+		coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+			helper := newMockHelper(t, ctx)
+			token, userID, testCID, _ := helper.SetupAuthenticatedTest()
+
+			website := createTestIPFSGatewayWebsite(1, userID, "example.com", testCID, pluginDb.WebsiteStatusActive)
+			require.NoError(t, ctx.DB().Create(website).Error)
+
+			wd := &pluginDb.WebsiteDomain{
+				WebsiteID:   1,
+				UserID:      userID,
+				Domain:      "lumeweb",
+				Namespace:   pluginDb.DomainNamespaceHNS,
+				Status:      pluginDb.DomainStatusRecordsGenerated,
+				ZoneName:    "lumeweb.",
+				GatewayHost: "gateway.lumeweb.com",
+				DelegationData: datatypes.JSONMap{
+					"mode": "delegated",
+					"parent_records": []map[string]any{
+						{"type": "NS", "value": "ns1.lumeweb,ns2.lumeweb"},
+						{"type": "DS", "value": "lumeweb. 3600 IN DS 12345 13 2 <digest>"},
+					},
+					"authoritative_records": []map[string]any{
+						{"type": "NS", "value": "ns1.lumeweb\nns2.lumeweb"},
+					},
+					"instructions": "Publish the parent_records in your HNS wallet.",
+				},
+			}
+			require.NoError(t, ctx.DB().Create(wd).Error)
+
+			rec := helper.makeAuthenticatedRequest(http.MethodGet, "/api/websites/1/domains/1/dns-requirements", token, nil)
+			require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+
+			var resp dto.DomainResponse
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+			assert.Equal(t, "lumeweb", resp.Domain)
+			assert.Equal(t, "hns", resp.Namespace)
+			require.NotNil(t, resp.Delegation)
+			assert.Equal(t, "delegated", resp.Delegation.Mode)
+			assert.Equal(t, "lumeweb. 3600 IN DS 12345 13 2 <digest>", resp.Delegation.DS)
+			require.Len(t, resp.Delegation.ParentRecords, 2)
+			assert.Equal(t, "NS", resp.Delegation.ParentRecords[0].Type)
+		}, TestOptions)
+	})
+
+	t.Run("missing_domain_returns_404", func(t *testing.T) {
+		coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+			helper := newMockHelper(t, ctx)
+			token, _, _, _ := helper.SetupAuthenticatedTest()
+
+			rec := helper.makeAuthenticatedRequest(http.MethodGet, "/api/websites/1/domains/999/dns-requirements", token, nil)
 			assert.Equal(t, http.StatusNotFound, rec.Code)
 		}, TestOptions)
 	})

--- a/internal/api/dto/domain.go
+++ b/internal/api/dto/domain.go
@@ -1,6 +1,8 @@
 package dto
 
 import (
+	"encoding/json"
+
 	"github.com/Oudwins/zog"
 	"go.lumeweb.com/httputil"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/db"
@@ -21,18 +23,45 @@ func (r DomainRequest) Schema() *zog.StructSchema {
 	})
 }
 
-
 func (r *DomainRequest) ToModel() (*DomainRequest, error) {
 	return r, nil
 }
 
+// DNSDelegationRecord is a single DNS record in a domain delegation. The fields
+// mirror the provider Record type (hns_provider.go) so clients can render a
+// generic table regardless of namespace.
+type DNSDelegationRecord struct {
+	Type    string `json:"type"` // NS|GLUE4|GLUE6|SYNTH4|SYNTH6|DS|TLSA
+	Value   string `json:"value,omitempty"`
+	NS      string `json:"ns,omitempty"`
+	Address string `json:"address,omitempty"`
+}
+
+// DNSDelegation carries the namespace-specific records a user must publish to
+// complete domain delegation, plus human-readable instructions.
+//
+// Parent records (NS + optional GLUE/SYNTH + DS) are published in the parent
+// namespace — for HNS that is the HNS wallet/resource; for ICANN it is the
+// registrar. Authoritative records (NS + TLSA) are configured on the
+// authoritative DNS server. Nameservers is the ICANN shortcut.
+type DNSDelegation struct {
+	Mode                 string                `json:"mode,omitempty"`
+	Instructions         string                `json:"instructions,omitempty"`
+	Nameservers          []string              `json:"nameservers,omitempty"`
+	DS                   string                `json:"ds,omitempty"`
+	ParentRecords        []DNSDelegationRecord `json:"parent_records,omitempty"`
+	AuthoritativeRecords []DNSDelegationRecord `json:"authoritative_records,omitempty"`
+}
+
 // DomainResponse is a bound domain.
 type DomainResponse struct {
-	ID        uint   `json:"id"`
-	Domain    string `json:"domain"`
-	Namespace string `json:"namespace"`
-	Status    string `json:"status,omitempty"`
-	ZoneName  string `json:"zone_name,omitempty"`
+	ID          uint           `json:"id"`
+	Domain      string         `json:"domain"`
+	Namespace   string         `json:"namespace"`
+	Status      string         `json:"status,omitempty"`
+	ZoneName    string         `json:"zone_name,omitempty"`
+	GatewayHost string         `json:"gateway_host,omitempty"`
+	Delegation  *DNSDelegation `json:"delegation,omitempty"`
 }
 
 func (r *DomainResponse) FromModel(m *db.WebsiteDomain) error {
@@ -41,6 +70,67 @@ func (r *DomainResponse) FromModel(m *db.WebsiteDomain) error {
 	r.Namespace = string(m.Namespace)
 	r.Status = string(m.Status)
 	r.ZoneName = m.ZoneName
+	r.GatewayHost = m.GatewayHost
+
+	// Project the heterogeneous, provider-emitted DelegationData into the typed,
+	// provider-agnostic shape. If it fails to map, leave Delegation nil rather
+	// than erroring the whole domain response — the core fields are still valid.
+	if len(m.DelegationData) > 0 {
+		raw, _ := json.Marshal(m.DelegationData)
+		if len(raw) > 0 {
+			r.Delegation = mapDNSDelegation(raw)
+		}
+	}
+	return nil
+}
+
+// mapDNSDelegation converts the raw provider DelegationData (JSON) into the
+// typed DNSDelegation. HNS emits a DelegationBundle with parent_records,
+// authoritative_records and instructions; ICANN emits nameservers + instructions.
+// It returns nil when the payload cannot be interpreted.
+func mapDNSDelegation(raw []byte) *DNSDelegation {
+	if len(raw) == 0 {
+		return nil
+	}
+
+	// Try the HNS DelegationBundle shape first.
+	var hns struct {
+		Mode                 string                `json:"mode"`
+		Instructions         string                `json:"instructions"`
+		ParentRecords        []DNSDelegationRecord `json:"parent_records"`
+		AuthoritativeRecords []DNSDelegationRecord `json:"authoritative_records"`
+	}
+	if err := json.Unmarshal(raw, &hns); err == nil &&
+		(hns.Mode != "" || len(hns.ParentRecords) > 0 || len(hns.AuthoritativeRecords) > 0) {
+
+		d := &DNSDelegation{
+			Mode:                 hns.Mode,
+			Instructions:         hns.Instructions,
+			ParentRecords:        hns.ParentRecords,
+			AuthoritativeRecords: hns.AuthoritativeRecords,
+		}
+		// Promote a DS record from parent_records to the first-class DS field.
+		for _, rec := range hns.ParentRecords {
+			if rec.Type == "DS" {
+				d.DS = rec.Value
+				break
+			}
+		}
+		return d
+	}
+
+	// Fall back to the ICANN shape.
+	var icann struct {
+		Nameservers  []string `json:"nameservers"`
+		Instructions string   `json:"instructions"`
+	}
+	if err := json.Unmarshal(raw, &icann); err == nil && len(icann.Nameservers) > 0 {
+		return &DNSDelegation{
+			Nameservers:  icann.Nameservers,
+			Instructions: icann.Instructions,
+		}
+	}
+
 	return nil
 }
 

--- a/internal/api/dto/domain_test.go
+++ b/internal/api/dto/domain_test.go
@@ -1,0 +1,118 @@
+package dto
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	pluginDb "go.lumeweb.com/portal-plugin-ipfs/internal/db"
+	"gorm.io/datatypes"
+)
+
+// TestDomainResponse_FromModel_HNS verifies a full HNS DelegationBundle is
+// projected into the typed DNSDelegation shape with the DS promoted to a
+// first-class field.
+func TestDomainResponse_FromModel_HNS(t *testing.T) {
+	delegation := datatypes.JSONMap{
+		"mode": "delegated",
+		"parent_records": []map[string]any{
+			{"type": "NS", "value": "ns1.lumeweb,ns2.lumeweb"},
+			{"type": "GLUE4", "ns": "ns1.lumeweb.", "address": "185.189.155.208"},
+			{"type": "DS", "value": "lumeweb. 3600 IN DS 12345 13 2 <digest>"},
+		},
+		"authoritative_records": []map[string]any{
+			{"type": "NS", "value": "ns1.lumeweb\nns2.lumeweb"},
+			{"type": "TLSA", "value": "_443._tcp.lumeweb. 3600 IN TLSA 3 1 1 <hash>"},
+		},
+		"instructions": "Publish the parent_records in your HNS wallet. Configure the authoritative_records on your DNS server.",
+	}
+
+	model := &pluginDb.WebsiteDomain{
+		ID:             7,
+		Domain:         "lumeweb",
+		Namespace:      pluginDb.DomainNamespaceHNS,
+		Status:         pluginDb.DomainStatusRecordsGenerated,
+		ZoneName:       "lumeweb.",
+		GatewayHost:    "gateway.lumeweb.com",
+		DelegationData: delegation,
+	}
+
+	var resp DomainResponse
+	err := resp.FromModel(model)
+	require.NoError(t, err)
+
+	assert.Equal(t, uint(7), resp.ID)
+	assert.Equal(t, "lumeweb", resp.Domain)
+	assert.Equal(t, "hns", resp.Namespace)
+	assert.Equal(t, "records_generated", resp.Status)
+	assert.Equal(t, "lumeweb.", resp.ZoneName)
+	assert.Equal(t, "gateway.lumeweb.com", resp.GatewayHost)
+
+	require.NotNil(t, resp.Delegation, "delegation should be populated for HNS")
+	assert.Equal(t, "delegated", resp.Delegation.Mode)
+	assert.Equal(t, "Publish the parent_records in your HNS wallet. Configure the authoritative_records on your DNS server.", resp.Delegation.Instructions)
+
+	// DS promoted to first-class field.
+	assert.Equal(t, "lumeweb. 3600 IN DS 12345 13 2 <digest>", resp.Delegation.DS)
+
+	// Parent records preserved with type/ns/address.
+	require.Len(t, resp.Delegation.ParentRecords, 3)
+	assert.Equal(t, "NS", resp.Delegation.ParentRecords[0].Type)
+	assert.Equal(t, "GLUE4", resp.Delegation.ParentRecords[1].Type)
+	assert.Equal(t, "ns1.lumeweb.", resp.Delegation.ParentRecords[1].NS)
+	assert.Equal(t, "185.189.155.208", resp.Delegation.ParentRecords[1].Address)
+
+	// Authoritative records preserved.
+	require.Len(t, resp.Delegation.AuthoritativeRecords, 2)
+	assert.Equal(t, "TLSA", resp.Delegation.AuthoritativeRecords[1].Type)
+}
+
+// TestDomainResponse_FromModel_ICANN verifies the ICANN nameservers shortcut is
+// projected into the typed shape.
+func TestDomainResponse_FromModel_ICANN(t *testing.T) {
+	delegation := datatypes.JSONMap{
+		"nameservers":  []string{"ns1.example.com", "ns2.example.com"},
+		"instructions": "Configure these NS records at your registrar for example.com",
+	}
+
+	model := &pluginDb.WebsiteDomain{
+		ID:             3,
+		Domain:         "example.com",
+		Namespace:      pluginDb.DomainNamespaceICANN,
+		Status:         pluginDb.DomainStatusActive,
+		ZoneName:       "example.com.",
+		GatewayHost:    "gateway.example.com",
+		DelegationData: delegation,
+	}
+
+	var resp DomainResponse
+	err := resp.FromModel(model)
+	require.NoError(t, err)
+
+	require.NotNil(t, resp.Delegation)
+	assert.Equal(t, []string{"ns1.example.com", "ns2.example.com"}, resp.Delegation.Nameservers)
+	assert.Equal(t, "Configure these NS records at your registrar for example.com", resp.Delegation.Instructions)
+	assert.Empty(t, resp.Delegation.DS)
+	assert.Empty(t, resp.Delegation.ParentRecords)
+}
+
+// TestDomainResponse_FromModel_NoDelegation verifies core fields still populate
+// when DelegationData is empty and no gateway host is set.
+func TestDomainResponse_FromModel_NoDelegation(t *testing.T) {
+	model := &pluginDb.WebsiteDomain{
+		ID:        1,
+		Domain:    "example.com",
+		Namespace: pluginDb.DomainNamespaceICANN,
+		Status:    pluginDb.DomainStatusDraft,
+		ZoneName:  "example.com.",
+	}
+
+	var resp DomainResponse
+	err := resp.FromModel(model)
+	require.NoError(t, err)
+
+	assert.Equal(t, uint(1), resp.ID)
+	assert.Equal(t, "draft", resp.Status)
+	assert.Nil(t, resp.Delegation, "delegation should be nil when no DelegationData")
+	assert.Empty(t, resp.GatewayHost)
+}

--- a/internal/service/domain/delegated_domain_service.go
+++ b/internal/service/domain/delegated_domain_service.go
@@ -282,7 +282,14 @@ func (s *DelegatedDomainService) UpdateTLSAFromCert(ctx context.Context, namespa
 							zone = canonicalZoneName(domain)
 						}
 						auth[i].Value = formatFullTLSARecord(tlsa, zone)
-						wd.DelegationData["authoritative_records"], _ = json.Marshal(auth)
+						// Store the updated records as a real JSON structure, not the raw
+						// marshaled []byte. JSONMap encodes []byte as base64 on save, which
+						// silently breaks DTO projection (json.Unmarshal into []delegationRecord).
+						raw, _ := json.Marshal(auth)
+						var out any
+						if json.Unmarshal(raw, &out) == nil {
+							wd.DelegationData["authoritative_records"] = out
+						}
 						break
 					}
 				}


### PR DESCRIPTION
## Problem

DomainResponse offered no typed way to expose the DNS delegation records
computed at bind time. Namespace providers persisted heterogeneous payloads
into WebsiteDomain.DelegationData — HNS emits a DelegationBundle
(DS/NS/GLUE/TLSA authoritative + parent records plus instructions), ICANN
emits nameservers + instructions — but the API never returned them. Clients
had no typed field to render DNS/DNSSEC/DANE setup guidance and were forced
to interpret provider-specific JSON, or dropped it entirely.

## Changes

- dto/domain.go: add DNSDelegation / DNSDelegationRecord DTOs and extend
  DomainResponse with gateway\_host + delegation. FromModel projects the raw
  DelegationData into a provider-agnostic shape (HNS bundle with DS promoted
  to a first-class field; ICANN nameservers shortcut), so clients render the
  same contract regardless of namespace.
- api.go / api\_domains.go: add GET /websites/:id/domains/:domain\_id/dns-requirements
  which reuses DomainResponse — one renderer across bind / verify / dns-requirements.

## Tests

- dto/domain\_test.go: FromModel mapping for HNS bundle (DS promotion),
  ICANN nameservers, and empty DelegationData.
- api\_domains\_test.go: endpoint returns 200 with populated delegation, and
  404 for a missing domain.

## Verification

- DTO tests pass on this host: TestDomainResponse\_FromModel\_\* (3/3 PASS).
- go build -mod=mod ./internal/api/... passes. (Repo has pre-existing
  go.mod↔vendor drift requiring -mod=mod.)
- internal/api package tests cannot execute locally due to a pre-existing
  protobuf rpc.proto init panic that also breaks the existing
  TestAPI\_DeleteDomain — unrelated env issue, not introduced here.

* `develop` <!-- branch-stack -->
  - **feat(api): surface domain DNS delegation requirements in DomainResponse** :point\_left:

***

<!-- kody-pr-summary:start -->

## Summary

This pull request adds a new API endpoint that surfaces DNS delegation requirements for bound domains, enabling clients to render DNS/DNSSEC setup guidance after a domain binding.

## Changes

### New API Endpoint

- Added `GET /websites/:id/domains/:domain_id/dns-requirements` endpoint that returns the DNS records a user must publish to complete domain delegation for a bound domain
- The endpoint requires user authentication and validates that the domain belongs to the specified website and user
- Returns a typed `DomainResponse` with an enriched `Delegation` field

### Enhanced Domain Response DTO

- Extended `DomainResponse` with new fields: `GatewayHost` and `Delegation`
- Added `DNSDelegation` structure containing:
  - Mode (e.g., "delegated")
  - Human-readable instructions
  - Parent records (NS, GLUE, SYNTH, DS) to publish in the parent namespace (HNS wallet or ICANN registrar)
  - Authoritative records (NS, TLSA) to configure on the authoritative DNS server
  - Nameservers (ICANN shortcut)
  - First-class DS record field
- Added `DNSDelegationRecord` type representing individual DNS records with type, value, NS, and address fields

### Provider-Agnostic Data Mapping

- Implemented `mapDNSDelegation` function that converts provider-specific raw `DelegationData` JSON into a typed, generic structure
- Supports both HNS (`DelegationBundle` with parent/authoritative records) and ICANN (nameservers) shapes
- Gracefully handles missing or unparseable delegation data without failing the entire response

### Testing

- Added unit tests for DTO mapping covering HNS, ICANN, and no-delegation scenarios
- Added API integration tests verifying successful delegation data retrieval and 404 handling for missing domains

## Impact

This feature enables frontend clients to display accurate DNS/DNSSEC configuration instructions to users after binding a domain, with consistent rendering across different namespaces (HNS and ICANN).

<!-- kody-pr-summary:end -->
