### PR TITLE
fix(domain): emit DS record value as RDATA only

### DIFF
--- a/internal/service/domain/hns_provider.go
+++ b/internal/service/domain/hns_provider.go
@@ -272,7 +272,12 @@ func (p *HNSProvider) enableDNSSECAndDS(ctx context.Context, zoneID uint, zoneNa
 		return nil, fmt.Errorf("compute ds: %w", err)
 	}
 
-	dsStr := dane.FormatDSRecord(dnsname.TrimDot(zoneName), ds)
+	// The DS VALUE carries only the RDATA (key tag, algorithm, digest type,
+	// digest) per RFC 4034 §5.3 — the owner name and record-type token belong
+	// to the table's domain/type context, not the value. Use ds.String()
+	// (RDATA presentation) rather than dane.FormatDSRecord, which would
+	// prefix "<owner> DS " onto the value.
+	dsStr := ds.String()
 	return []Record{{
 		Type:  "DS",
 		Value: dsStr,

--- a/internal/service/domain/hns_provider_test.go
+++ b/internal/service/domain/hns_provider_test.go
@@ -4,10 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"net"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	dane "go.lumeweb.com/dane"
 	danehns "go.lumeweb.com/dane/hns"
 	pluginDb "go.lumeweb.com/portal-plugin-ipfs/internal/db"
@@ -179,4 +182,50 @@ func TestHNSProvider_SynthName_FromDaneLib(t *testing.T) {
 	name := danehns.SynthName(ip4)
 	assert.NotEmpty(t, name)
 	assert.Contains(t, name, "x") // current lib convention from dane/hns
+}
+
+// fakeDNSZoneService is a minimal DNSZoneService stub for enabling DNSSEC with
+// a fixed DNSKEY, so enableDNSSECAndDS can be exercised deterministically.
+type fakeDNSZoneService struct{ dnskey string }
+
+func (f *fakeDNSZoneService) CreateZone(ctx context.Context, domain string, userID uint) (*pluginDb.DNSZone, error) {
+	panic("unused")
+}
+func (f *fakeDNSZoneService) DeleteZone(ctx context.Context, zoneID uint) error { panic("unused") }
+func (f *fakeDNSZoneService) CreateDNSLinkRecord(ctx context.Context, zoneID uint, target string) error {
+	panic("unused")
+}
+func (f *fakeDNSZoneService) CreateALIASRecord(ctx context.Context, zoneID uint, gatewayHost string) error {
+	panic("unused")
+}
+func (f *fakeDNSZoneService) EnableDNSSEC(ctx context.Context, zoneID uint) (string, error) {
+	return f.dnskey, nil
+}
+
+func TestHNSProvider_enableDNSSECAndDS_ValueIsRDATAOnly(t *testing.T) {
+	// Regression: the DS parent record VALUE must carry only the RDATA
+	// (key tag, algorithm, digest type, digest) — never the owner name or the
+	// "DS" record-type token (RFC 4034 §5.3). Previously dane.FormatDSRecord
+	// was used, which prefixes "<owner> DS " onto the value.
+	p := NewHNSProvider("", []string{"ns1.example.com."}, TLSASource{})
+	p.SetDNSService(&fakeDNSZoneService{dnskey: "257 3 13 dGVzdA=="})
+
+	records, err := p.enableDNSSECAndDS(context.Background(), 1, "example")
+	require.NoError(t, err)
+	require.Len(t, records, 1)
+	assert.Equal(t, "DS", records[0].Type)
+
+	v := records[0].Value
+	fields := strings.Fields(v)
+	assert.Len(t, fields, 4, "DS value must have exactly 4 RDATA fields: keytag, alg, digesttype, digest")
+
+	// First three fields are numeric (key tag, algorithm, digest type).
+	for _, f := range fields[:3] {
+		_, err := strconv.ParseUint(f, 10, 16) // key tag fits in u16; alg/digesttype smaller
+		assert.NoError(t, err, "field %q should be a number", f)
+	}
+	// Digest field is non-empty hex (no owner/type tokens).
+	assert.NotEmpty(t, fields[3])
+	assert.NotContains(t, v, " DS ", "record-type token must not leak into the value")
+	assert.NotContains(t, v, "example", "owner name must not leak into the value")
 }


### PR DESCRIPTION
## Summary

The HNS delegation provider built a parent DS record's `Value` with `dane.FormatDSRecord(zoneName, ds)`, which returns a **full zone-file line** — `<owner> DS <key tag> <algorithm> <digest type> <digest>`, e.g. `lumeweb DS 44451 13 2 c359...`.

A DS record's value must carry only the **RDATA**: `key tag algorithm digest type digest` (RFC 4034 §5.3). The owner name and the `DS` record-type token are table/zone context, not part of the value — and were leaking into the value (and into the first-class `DS` field it's promoted into by `mapDNSDelegation`).

This changes it to use `ds.String()` (RDATA presentation), so the value is `44451 13 2 c359...`.

## Changes

- `internal/service/domain/hns_provider.go`: `enableDNSSECAndDS` now emits `ds.String()` instead of `dane.FormatDSRecord(...)`.
- `internal/service/domain/hns_provider_test.go`: regression test asserting the DS value is exactly 4 RDATA fields, the first three numeric, no `DS` token / owner-name leak.

## Verification

- `go build ./...` ✓
- `go vet ./internal/service/domain/` ✓
- `go test ./internal/service/domain/` ✓ (with `GOLANG_PROTOBUF_REGISTRATION_CONFLICT=warn`)

Note: `make test` reports pre-existing protobuf `rpc.proto` registration panics in unrelated packages (`internal/service/website`, `internal/protocol`, `internal/service/pin`, etc.) that reproduce on clean develop without this change — not caused by this PR.

- `develop` <!-- branch-stack -->
  - **fix(domain): emit DS record value as RDATA only** :point\_left:

---

<!-- kody-pr-summary:start -->
## Summary

This pull request fixes an issue in the HNS (Handshake) provider where DS record values were incorrectly formatted, causing them to include the owner name and record-type token instead of just the RDATA as required by RFC 4034 §5.3.

## Changes

### Bug Fix
In `internal/service/domain/hns_provider.go`, the DS record value generation was changed from using `dane.FormatDSRecord()` to `ds.String()`:
- **Before**: The value included the full record format (e.g., `example DS 12345 13 2 <digest>`)
- **After**: The value now contains only the RDATA fields (key tag, algorithm, digest type, digest) as specified by RFC 4034 §5.3

This ensures the DS record value is correctly formatted as pure RDATA without the owner name or "DS" type token, which belong in the table's domain/type context rather than the value field.

### Regression Test
A new test (`TestHNSProvider_enableDNSSECAndDS_ValueIsRDATAOnly`) was added in `internal/service/domain/hns_provider_test.go` that:
- Creates a fake DNS zone service to deterministically test DNSSEC enabling
- Verifies the DS record value contains exactly 4 fields (key tag, algorithm, digest type, digest)
- Confirms the first three fields are numeric
- Validates that neither the "DS" record-type token nor the owner name leaks into the value

This fix resolves the data integrity issue where DS records contained extraneous information in their value field, which could cause problems with DNS record handling downstream.
<!-- kody-pr-summary:end -->