### PR TITLE
fix(domain): stop emitting free-form instructions prose in delegation

### DIFF
--- a/internal/api/api_domains.go
+++ b/internal/api/api_domains.go
@@ -210,9 +210,9 @@ func (a *API) verifyDomain(c echo.Context) error {
 }
 
 // domainDNSRequirements returns the DNS delegation requirements (DS/NS/GLUE/TLSA
-// parent + authoritative records and instructions) for a bound domain so a
-// client can render DNS/DNSSEC setup guidance after binding. It reuses the same
-// typed DomainResponse as create/verify so clients share one renderer.
+// parent + authoritative records) for a bound domain so a client can render
+// DNS/DNSSEC setup guidance after binding. It reuses the same typed
+// DomainResponse as create/verify so clients share one renderer.
 func (a *API) domainDNSRequirements(c echo.Context) error {
 	ctx := httputil.Context(c)
 	reqCtx := ctx.Context.Request().Context()

--- a/internal/api/api_domains_test.go
+++ b/internal/api/api_domains_test.go
@@ -107,7 +107,6 @@ func TestAPI_DomainDNSRequirements(t *testing.T) {
 					"authoritative_records": []map[string]any{
 						{"type": "NS", "value": "ns1.lumeweb\nns2.lumeweb"},
 					},
-					"instructions": "Publish the parent_records in your HNS wallet.",
 				},
 			}
 			require.NoError(t, ctx.DB().Create(wd).Error)

--- a/internal/api/dto/domain.go
+++ b/internal/api/dto/domain.go
@@ -38,15 +38,16 @@ type DNSDelegationRecord struct {
 }
 
 // DNSDelegation carries the namespace-specific records a user must publish to
-// complete domain delegation, plus human-readable instructions.
+// complete domain delegation.
 //
 // Parent records (NS + optional GLUE/SYNTH + DS) are published in the parent
 // namespace — for HNS that is the HNS wallet/resource; for ICANN it is the
 // registrar. Authoritative records (NS + TLSA) are configured on the
-// authoritative DNS server. Nameservers is the ICANN shortcut.
+// authoritative DNS server. Nameservers is the ICANN shortcut. Clients render
+// their own guidance from the namespace, mode, and record data that the server
+// returns.
 type DNSDelegation struct {
 	Mode                 string                `json:"mode,omitempty"`
-	Instructions         string                `json:"instructions,omitempty"`
 	Nameservers          []string              `json:"nameservers,omitempty"`
 	DS                   string                `json:"ds,omitempty"`
 	ParentRecords        []DNSDelegationRecord `json:"parent_records,omitempty"`
@@ -85,9 +86,9 @@ func (r *DomainResponse) FromModel(m *db.WebsiteDomain) error {
 }
 
 // mapDNSDelegation converts the raw provider DelegationData (JSON) into the
-// typed DNSDelegation. HNS emits a DelegationBundle with parent_records,
-// authoritative_records and instructions; ICANN emits nameservers + instructions.
-// It returns nil when the payload cannot be interpreted.
+// typed DNSDelegation. HNS emits a DelegationBundle with parent_records and
+// authoritative_records; ICANN emits nameservers. It returns nil when the
+// payload cannot be interpreted.
 func mapDNSDelegation(raw []byte) *DNSDelegation {
 	if len(raw) == 0 {
 		return nil
@@ -96,7 +97,6 @@ func mapDNSDelegation(raw []byte) *DNSDelegation {
 	// Try the HNS DelegationBundle shape first.
 	var hns struct {
 		Mode                 string                `json:"mode"`
-		Instructions         string                `json:"instructions"`
 		ParentRecords        []DNSDelegationRecord `json:"parent_records"`
 		AuthoritativeRecords []DNSDelegationRecord `json:"authoritative_records"`
 	}
@@ -105,7 +105,6 @@ func mapDNSDelegation(raw []byte) *DNSDelegation {
 
 		d := &DNSDelegation{
 			Mode:                 hns.Mode,
-			Instructions:         hns.Instructions,
 			ParentRecords:        hns.ParentRecords,
 			AuthoritativeRecords: hns.AuthoritativeRecords,
 		}
@@ -121,13 +120,11 @@ func mapDNSDelegation(raw []byte) *DNSDelegation {
 
 	// Fall back to the ICANN shape.
 	var icann struct {
-		Nameservers  []string `json:"nameservers"`
-		Instructions string   `json:"instructions"`
+		Nameservers []string `json:"nameservers"`
 	}
 	if err := json.Unmarshal(raw, &icann); err == nil && len(icann.Nameservers) > 0 {
 		return &DNSDelegation{
-			Nameservers:  icann.Nameservers,
-			Instructions: icann.Instructions,
+			Nameservers: icann.Nameservers,
 		}
 	}
 

--- a/internal/api/dto/domain_test.go
+++ b/internal/api/dto/domain_test.go
@@ -24,7 +24,6 @@ func TestDomainResponse_FromModel_HNS(t *testing.T) {
 			{"type": "NS", "value": "ns1.lumeweb\nns2.lumeweb"},
 			{"type": "TLSA", "value": "_443._tcp.lumeweb. 3600 IN TLSA 3 1 1 <hash>"},
 		},
-		"instructions": "Publish the parent_records in your HNS wallet. Configure the authoritative_records on your DNS server.",
 	}
 
 	model := &pluginDb.WebsiteDomain{
@@ -50,7 +49,6 @@ func TestDomainResponse_FromModel_HNS(t *testing.T) {
 
 	require.NotNil(t, resp.Delegation, "delegation should be populated for HNS")
 	assert.Equal(t, "delegated", resp.Delegation.Mode)
-	assert.Equal(t, "Publish the parent_records in your HNS wallet. Configure the authoritative_records on your DNS server.", resp.Delegation.Instructions)
 
 	// DS promoted to first-class field.
 	assert.Equal(t, "lumeweb. 3600 IN DS 12345 13 2 <digest>", resp.Delegation.DS)
@@ -71,8 +69,7 @@ func TestDomainResponse_FromModel_HNS(t *testing.T) {
 // projected into the typed shape.
 func TestDomainResponse_FromModel_ICANN(t *testing.T) {
 	delegation := datatypes.JSONMap{
-		"nameservers":  []string{"ns1.example.com", "ns2.example.com"},
-		"instructions": "Configure these NS records at your registrar for example.com",
+		"nameservers": []string{"ns1.example.com", "ns2.example.com"},
 	}
 
 	model := &pluginDb.WebsiteDomain{
@@ -91,7 +88,6 @@ func TestDomainResponse_FromModel_ICANN(t *testing.T) {
 
 	require.NotNil(t, resp.Delegation)
 	assert.Equal(t, []string{"ns1.example.com", "ns2.example.com"}, resp.Delegation.Nameservers)
-	assert.Equal(t, "Configure these NS records at your registrar for example.com", resp.Delegation.Instructions)
 	assert.Empty(t, resp.Delegation.DS)
 	assert.Empty(t, resp.Delegation.ParentRecords)
 }

--- a/internal/service/domain/hns_provider.go
+++ b/internal/service/domain/hns_provider.go
@@ -106,7 +106,6 @@ type DelegationBundle struct {
 	Mode                 string   `json:"mode"`
 	ParentRecords        []Record `json:"parent_records"`
 	AuthoritativeRecords []Record `json:"authoritative_records"`
-	Instructions         string   `json:"instructions"`
 }
 
 // HNSProvider implements DomainProvider for the Handshake (HNS) namespace.
@@ -316,7 +315,6 @@ func (p *HNSProvider) buildDelegated(zoneName string, nsRecords []string, tlsa s
 		Mode:                 string(HNSModeDelegated),
 		ParentRecords:        parent,
 		AuthoritativeRecords: auth,
-		Instructions:         "Publish the parent_records (NS + optional GLUE) in your HNS wallet. Configure the authoritative_records on your DNS server.",
 	}
 }
 
@@ -363,7 +361,6 @@ func (p *HNSProvider) buildHNSInline(zoneName string, nsRecords []string, tlsa s
 		Mode:                 string(HNSModeInline),
 		ParentRecords:        parent,
 		AuthoritativeRecords: auth,
-		Instructions:         "Publish the SYNTH records in your HNS wallet. The authoritative side uses synthetic nameserver names derived from the IPs.",
 	}, nil
 }
 

--- a/internal/service/domain/icann_provider.go
+++ b/internal/service/domain/icann_provider.go
@@ -12,8 +12,7 @@ import (
 // ICANNDelegation is the typed result for ICANN BuildDelegation.
 // Replaces loose map[string]interface{}.
 type ICANNDelegation struct {
-	Nameservers  []string `json:"nameservers"`
-	Instructions string   `json:"instructions"`
+	Nameservers []string `json:"nameservers"`
 }
 type ICANNProvider struct {
 	nameservers []string
@@ -42,8 +41,7 @@ func (p *ICANNProvider) BuildDelegation(ctx context.Context, zoneID uint,
 	domain string, website *pluginDb.Website, config json.RawMessage) (any, error) {
 
 	return ICANNDelegation{
-		Nameservers:  p.nameservers,
-		Instructions: fmt.Sprintf("Configure these NS records at your registrar for %s", domain),
+		Nameservers: p.nameservers,
 	}, nil
 }
 


### PR DESCRIPTION
## Summary

The `DNSDelegation` API response and both namespace providers (HNS, ICANN) sent a hand-written `instructions` string that:

- leaked internal field names (`parent_records`, `authoritative_records`, `optional GLUE`)
- gave incorrect guidance for HNS — records are published **on-chain in the HNS wallet**, not "configured on your DNS server"

pinner-cli (pinner-cli#151) already renders delegation copy from structured data (namespace + mode + `dns_hosting_enabled`) and no longer reads `instructions`. This PR completes the server side by removing the field entirely.

## Changes

- Drop `Instructions` from `DelegationBundle` (`hns_provider.go`), `ICANNDelegation` (`icann_provider.go`), and `DNSDelegation` (`dto/domain.go`)
- Stop copying `instructions` through `mapDNSDelegation`
- Remove the `instructions` key from the ICANN DTO test fixture; HNS/ICANN DTO tests simply no longer assert on it (the field is gone — asserting its absence would be testing for nothing)
- Clean up now-stale doc comments

## Verification

- `go build ./...`, `go vet ./...` ✓
- `go test ./internal/api/dto/ ./internal/service/domain/` ✓ (packages touched)
- Note: other packages in this repo fail with a **pre-existing** protobuf `rpc.proto already registered` panic (libp2p-pubsub vs etcd) that also occurs on a clean `develop` checkout — unrelated to this change.

This pairs with pinner-cli#151 (`feat(websites): render dns-requirements copy from data, not server prose`). Next SDK regeneration (`ipfs-sdk`) will drop the `instructions` field from the generated response struct.

- `develop` <!-- branch-stack -->
  - **fix(domain): stop emitting free-form instructions prose in delegation** :point\_left:

***

<!-- kody-pr-summary:start -->

This pull request removes the free-form human-readable instructions text from the DNS delegation API responses across both HNS and ICANN providers. The changes:

1. **Removed `Instructions` field** from the `DNSDelegation` response type in the domain DTO
2. **Removed instruction generation** from both providers:
   - HNS provider no longer emits instructions like "Publish the parent\_records in your HNS wallet..."
   - ICANN provider no longer emits instructions like "Configure these NS records at your registrar for example.com"
3. **Simplified the ICANN delegation type** by removing the `Instructions` field
4. **Updated the API response contract** so clients derive their own human-readable instructions from the namespace/mode/record data rather than receiving server-generated prose
5. **Cleaned up documentation comments** to reflect that the API now focuses on delivering only the structured delegation records (NS, DS, GLUE, TLSA records) without instructional text
6. **Updated tests** to remove assertions on the now-removed `Instructions` field

The functional impact is that DNS delegation responses are now purely data-driven (records, nameservers, DS records, etc.) without opinionated instructional text, allowing clients to render their own guidance based on the data structure.

<!-- kody-pr-summary:end -->
