### PR TITLE
feat(dns): provider-driven apex record type for DNSSEC-signed alt-root zones

### DIFF
--- a/core/dns.go
+++ b/core/dns.go
@@ -59,8 +59,10 @@ type DNSService interface {
 	// CreateDNSLinkRecord creates a DNSLink _dnslink.<domain> TXT record
 	CreateDNSLinkRecord(ctx context.Context, zoneID uint, target string) error
 
-	// CreateALIASRecord creates an ALIAS / CNAME apex record pointing to gateway
-	CreateALIASRecord(ctx context.Context, zoneID uint, gatewayHost string) error
+	// CreateApexRecord creates an apex (root) record pointing to the gateway.
+	// recordType is e.g. RecordTypeA (IP content for DNSSEC-signed alt-root)
+	// or RecordTypeALIAS (gateway hostname content).
+	CreateApexRecord(ctx context.Context, zoneID uint, recordType RecordType, content string) error
 
 	// CreateRecord creates a new DNS record in PowerDNS via RRSet
 	// name: the record name (e.g., "www")

--- a/internal/config/dns.go
+++ b/internal/config/dns.go
@@ -37,6 +37,13 @@ type DnsConfig struct {
 	// Gateway domain for ALIAS records (auto-wiring)
 	GatewayDomain string `config:"gateway_domain"`
 
+	// GatewayIP is the IP address to publish as the apex A record for
+	// DNSSEC-signed alt-root (e.g. HNS) zones. Alt-root apexes must be real
+	// A records (not ALIAS) so they carry an RRSIG; PowerDNS cannot sign a
+	// synthetic ALIAS at the apex. This should match where GatewayDomain
+	// currently resolves. Keep it in sync when the gateway IP changes.
+	GatewayIP string `config:"gateway_ip"`
+
 	// Verification token key used as the subdomain label for validation TXT records
 	VerificationTokenKey string `config:"verification_token_key"`
 
@@ -58,6 +65,7 @@ func (c DnsConfig) Defaults() map[string]any {
 		"HNSNameservers":               []string{},
 		"HNSResolver":                  "",
 		"GatewayDomain":                "",
+		"GatewayIP":                    "",
 		"VerificationTokenKey":         "lumeweb-verify",
 		"DANEKeyEncryptionKey":         "",
 		"NameserverValidationInterval": 5 * time.Minute,

--- a/internal/service/dns/dns_service.go
+++ b/internal/service/dns/dns_service.go
@@ -153,9 +153,11 @@ func (s *DNSServiceDefault) CreateDNSLinkRecord(ctx context.Context, zoneID uint
 	return err
 }
 
-// CreateALIASRecord creates an ALIAS/CNAME apex record in a zone (adapter for domain.DNSZoneService)
-func (s *DNSServiceDefault) CreateALIASRecord(ctx context.Context, zoneID uint, gatewayHost string) error {
-	_, err := s.CreateRecord(ctx, zoneID, "", "ALIAS", gatewayHost, 300)
+// CreateApexRecord creates the apex (root) record in a zone (adapter for
+// domain.DNSZoneService). content is raw: an IP for A, a gateway hostname for
+// ALIAS/CNAME.
+func (s *DNSServiceDefault) CreateApexRecord(ctx context.Context, zoneID uint, recordType pluginCore.RecordType, content string) error {
+	_, err := s.CreateRecord(ctx, zoneID, "", string(recordType), content, 300)
 	return err
 }
 

--- a/internal/service/domain/delegated_domain_service.go
+++ b/internal/service/domain/delegated_domain_service.go
@@ -29,7 +29,10 @@ type DNSZoneService interface {
 	CreateZone(ctx context.Context, domain string, userID uint) (*pluginDb.DNSZone, error)
 	DeleteZone(ctx context.Context, zoneID uint) error
 	CreateDNSLinkRecord(ctx context.Context, zoneID uint, target string) error
-	CreateALIASRecord(ctx context.Context, zoneID uint, gatewayHost string) error
+	// CreateApexRecord creates the apex (root) record for a zone of the given
+	// record type (e.g. RecordTypeA or RecordTypeALIAS). content is the raw
+	// value: an IP address for A, a gateway hostname for ALIAS.
+	CreateApexRecord(ctx context.Context, zoneID uint, recordType pluginCore.RecordType, content string) error
 	// EnableDNSSEC enables DNSSEC on a zone and returns the DNSKEY.
 	EnableDNSSEC(ctx context.Context, zoneID uint) (dnskey string, err error)
 }
@@ -62,6 +65,19 @@ func (s *DelegatedDomainService) gatewayHost() string {
 		return ""
 	}
 	return dnsCfg.GatewayDomain
+}
+
+// gatewayIP returns the configured gateway IP published as the apex A
+// record for DNSSEC-signed alt-root zones, read from the DNS service config.
+func (s *DelegatedDomainService) gatewayIP() string {
+	if s.BaseComponent == nil {
+		return ""
+	}
+	dnsCfg := core.GetServiceConfig[*pluginConfig.DnsConfig](s.Context(), pluginCore.DNS_SERVICE)
+	if dnsCfg == nil {
+		return ""
+	}
+	return dnsCfg.GatewayIP
 }
 
 func (s *DelegatedDomainService) CreateDomain(ctx context.Context,
@@ -118,14 +134,29 @@ func (s *DelegatedDomainService) CreateDomain(ctx context.Context,
 		return nil, fmt.Errorf("dnslink creation failed: %w", err)
 	}
 
-	// Create apex ALIAS record pointing to the gateway host.
-	if gatewayHost := s.gatewayHost(); gatewayHost != "" {
-		if err := s.dnsSvc.CreateALIASRecord(ctx, zone.ID, gatewayHost); err != nil {
+	// Create apex record pointing to the gateway. DNSSEC-signed alt-root
+	// providers (e.g. HNS) need a real A record (gateway IP) so the apex
+	// carries an RRSIG; otherwise use an ALIAS to the gateway hostname.
+	apexType := provider.ApexRecordType()
+	var apexContent string
+	if apexType == pluginCore.RecordTypeA {
+		apexContent = s.gatewayIP()
+		if apexContent == "" {
 			s.DB().WithContext(ctx).Unscoped().Delete(wd)
 			_ = s.dnsSvc.DeleteZone(ctx, zone.ID)
-			return nil, fmt.Errorf("alias creation failed: %w", err)
+			return nil, fmt.Errorf("gateway_ip not configured: alt-root apex requires a real A record and cannot fall back to ALIAS (set dns.gateway_ip, e.g. to the gateway IP)")
 		}
-		wd.GatewayHost = gatewayHost
+	} else if gatewayHost := s.gatewayHost(); gatewayHost != "" {
+		apexContent = gatewayHost
+	}
+
+	if apexContent != "" {
+		if err := s.dnsSvc.CreateApexRecord(ctx, zone.ID, apexType, apexContent); err != nil {
+			s.DB().WithContext(ctx).Unscoped().Delete(wd)
+			_ = s.dnsSvc.DeleteZone(ctx, zone.ID)
+			return nil, fmt.Errorf("apex record creation failed: %w", err)
+		}
+		wd.GatewayHost = apexContent
 	}
 
 	// Build delegation after zone is created (needs zone ID).

--- a/internal/service/domain/hns_provider.go
+++ b/internal/service/domain/hns_provider.go
@@ -16,6 +16,7 @@ import (
 	dane "go.lumeweb.com/dane"
 	danehns "go.lumeweb.com/dane/hns"
 	"go.lumeweb.com/ipfs-sdk/dnsname"
+	pluginCore "go.lumeweb.com/portal-plugin-ipfs/core"
 	pluginDb "go.lumeweb.com/portal-plugin-ipfs/internal/db"
 
 	"github.com/miekg/dns"
@@ -146,6 +147,13 @@ func (p *HNSProvider) SetDNSService(dns DNSZoneService) {
 
 func (p *HNSProvider) Protocol() string {
 	return "hns"
+}
+
+// ApexRecordType returns RecordTypeA: HNS zones are DNSSEC-signed at the apex,
+// so the apex must be a real A record that carries an RRSIG. PowerDNS cannot
+// sign a synthetic ALIAS at the apex.
+func (p *HNSProvider) ApexRecordType() pluginCore.RecordType {
+	return pluginCore.RecordTypeA
 }
 
 var hnsDomainRe = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$`)

--- a/internal/service/domain/hns_provider_test.go
+++ b/internal/service/domain/hns_provider_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 	dane "go.lumeweb.com/dane"
 	danehns "go.lumeweb.com/dane/hns"
+	pluginCore "go.lumeweb.com/portal-plugin-ipfs/core"
 	pluginDb "go.lumeweb.com/portal-plugin-ipfs/internal/db"
 )
 
@@ -195,7 +196,7 @@ func (f *fakeDNSZoneService) DeleteZone(ctx context.Context, zoneID uint) error 
 func (f *fakeDNSZoneService) CreateDNSLinkRecord(ctx context.Context, zoneID uint, target string) error {
 	panic("unused")
 }
-func (f *fakeDNSZoneService) CreateALIASRecord(ctx context.Context, zoneID uint, gatewayHost string) error {
+func (f *fakeDNSZoneService) CreateApexRecord(ctx context.Context, zoneID uint, recordType pluginCore.RecordType, content string) error {
 	panic("unused")
 }
 func (f *fakeDNSZoneService) EnableDNSSEC(ctx context.Context, zoneID uint) (string, error) {

--- a/internal/service/domain/icann_provider.go
+++ b/internal/service/domain/icann_provider.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	pluginCore "go.lumeweb.com/portal-plugin-ipfs/core"
 	pluginDb "go.lumeweb.com/portal-plugin-ipfs/internal/db"
 )
 
@@ -24,6 +25,13 @@ func NewICANNProvider(nameservers []string) *ICANNProvider {
 
 func (p *ICANNProvider) Protocol() string {
 	return "icann"
+}
+
+// ApexRecordType returns RecordTypeALIAS: ICANN apex is served through the
+// gateway and is not separately DNSSEC-signed at the apex in our setup, so a
+// synthetic ALIAS is acceptable.
+func (p *ICANNProvider) ApexRecordType() pluginCore.RecordType {
+	return pluginCore.RecordTypeALIAS
 }
 
 func (p *ICANNProvider) Validate(domain string) error {

--- a/internal/service/domain/integration_test.go
+++ b/internal/service/domain/integration_test.go
@@ -24,6 +24,19 @@ func TestIntegration_CreateAndVerifyHNSDomain(t *testing.T) {
 		t.Skipf("dane.GenerateSelfSignedECDSA not usable: %v", certErr)
 	}
 
+	// Gateway IP is injected via env so the fixture does not hardcode a
+	// production address; defaults to a loopback-safe value for CI.
+	gatewayIP := os.Getenv("TEST_GATEWAY_IP")
+	if gatewayIP == "" {
+		gatewayIP = "127.0.0.1"
+	}
+
+	intOpts := coreTesting.CombineOptions(
+		TestOptions,
+		coreTesting.WithConfig("plugin.ipfs.service.dns.gateway_domain", "ipfs.pub"),
+		coreTesting.WithConfig("plugin.ipfs.service.dns.gateway_ip", gatewayIP),
+	)
+
 	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 		db := ctx.DB()
 
@@ -56,6 +69,7 @@ func TestIntegration_CreateAndVerifyHNSDomain(t *testing.T) {
 		mockDNS.EXPECT().CreateZone(mock.Anything, "example", uint(1)).
 			Return(&pluginDb.DNSZone{Model: gorm.Model{ID: 1}, Domain: "example"}, nil).Once()
 		mockDNS.EXPECT().CreateDNSLinkRecord(mock.Anything, uint(1), mock.Anything).Return(nil).Once()
+		mockDNS.EXPECT().CreateApexRecord(mock.Anything, uint(1), pluginCore.RecordTypeA, gatewayIP).Return(nil).Once()
 		mockDNS.EXPECT().EnableDNSSEC(mock.Anything, uint(1)).Return("257 3 13 dGVzdA==", nil).Maybe()
 
 		// Create domain
@@ -63,5 +77,5 @@ func TestIntegration_CreateAndVerifyHNSDomain(t *testing.T) {
 		require.NoError(tb, err)
 		require.NotNil(tb, wd)
 		assert.Equal(tb, pluginDb.DomainStatusRecordsGenerated, wd.Status)
-	}, TestOptions)
+	}, intOpts)
 }

--- a/internal/service/domain/provider.go
+++ b/internal/service/domain/provider.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 
 	"github.com/samber/lo"
+	pluginCore "go.lumeweb.com/portal-plugin-ipfs/core"
 	pluginDb "go.lumeweb.com/portal-plugin-ipfs/internal/db"
 )
 
@@ -23,6 +24,12 @@ type DomainProvider interface {
 	// differ from ICANN's; these are operator-provided, not user-provided.
 	// Returns the namespace's nameservers, or nil/empty when none are set.
 	Nameservers() []string
+	// ApexRecordType returns the DNS record type used for the zone apex.
+	// DNSSEC-signed alt-root providers (e.g. HNS) must return RecordTypeA so
+	// the apex is a real, signable RRset, which PowerDNS cannot provide for a
+	// synthetic ALIAS/CNAME record at the apex. Providers whose apex is not
+	// separately signed return RecordTypeALIAS.
+	ApexRecordType() pluginCore.RecordType
 }
 
 type Registry struct {

--- a/internal/service/domain/provider_test.go
+++ b/internal/service/domain/provider_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	pluginCore "go.lumeweb.com/portal-plugin-ipfs/core"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/testing/mocks"
 )
 
@@ -56,4 +57,14 @@ func TestNormalizeDomain(t *testing.T) {
 			assert.Equal(t, tt.expected, got)
 		})
 	}
+}
+
+func TestHNSProvider_ApexRecordType(t *testing.T) {
+	p := NewHNSProvider("", nil, TLSASource{})
+	assert.Equal(t, pluginCore.RecordTypeA, p.ApexRecordType())
+}
+
+func TestICANNProvider_ApexRecordType(t *testing.T) {
+	p := NewICANNProvider(nil)
+	assert.Equal(t, pluginCore.RecordTypeALIAS, p.ApexRecordType())
 }

--- a/internal/testing/mocks/MockDNSService.go
+++ b/internal/testing/mocks/MockDNSService.go
@@ -8,6 +8,7 @@ import (
 	"context"
 
 	mock "github.com/stretchr/testify/mock"
+	core0 "go.lumeweb.com/portal-plugin-ipfs/core"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/api/dto"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/db"
 	"go.lumeweb.com/portal/config"
@@ -221,37 +222,38 @@ func (_c *MockDNSService_Context_Call) RunAndReturn(run func() core.Context) *Mo
 	return _c
 }
 
-// CreateALIASRecord provides a mock function for the type MockDNSService
-func (_mock *MockDNSService) CreateALIASRecord(ctx context.Context, zoneID uint, gatewayHost string) error {
-	ret := _mock.Called(ctx, zoneID, gatewayHost)
+// CreateApexRecord provides a mock function for the type MockDNSService
+func (_mock *MockDNSService) CreateApexRecord(ctx context.Context, zoneID uint, recordType core0.RecordType, content string) error {
+	ret := _mock.Called(ctx, zoneID, recordType, content)
 
 	if len(ret) == 0 {
-		panic("no return value specified for CreateALIASRecord")
+		panic("no return value specified for CreateApexRecord")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, uint, string) error); ok {
-		r0 = returnFunc(ctx, zoneID, gatewayHost)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uint, core0.RecordType, string) error); ok {
+		r0 = returnFunc(ctx, zoneID, recordType, content)
 	} else {
 		r0 = ret.Error(0)
 	}
 	return r0
 }
 
-// MockDNSService_CreateALIASRecord_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CreateALIASRecord'
-type MockDNSService_CreateALIASRecord_Call struct {
+// MockDNSService_CreateApexRecord_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CreateApexRecord'
+type MockDNSService_CreateApexRecord_Call struct {
 	*mock.Call
 }
 
-// CreateALIASRecord is a helper method to define mock.On call
+// CreateApexRecord is a helper method to define mock.On call
 //   - ctx context.Context
 //   - zoneID uint
-//   - gatewayHost string
-func (_e *MockDNSService_Expecter) CreateALIASRecord(ctx any, zoneID any, gatewayHost any) *MockDNSService_CreateALIASRecord_Call {
-	return &MockDNSService_CreateALIASRecord_Call{Call: _e.mock.On("CreateALIASRecord", ctx, zoneID, gatewayHost)}
+//   - recordType core0.RecordType
+//   - content string
+func (_e *MockDNSService_Expecter) CreateApexRecord(ctx any, zoneID any, recordType any, content any) *MockDNSService_CreateApexRecord_Call {
+	return &MockDNSService_CreateApexRecord_Call{Call: _e.mock.On("CreateApexRecord", ctx, zoneID, recordType, content)}
 }
 
-func (_c *MockDNSService_CreateALIASRecord_Call) Run(run func(ctx context.Context, zoneID uint, gatewayHost string)) *MockDNSService_CreateALIASRecord_Call {
+func (_c *MockDNSService_CreateApexRecord_Call) Run(run func(ctx context.Context, zoneID uint, recordType core0.RecordType, content string)) *MockDNSService_CreateApexRecord_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -261,25 +263,30 @@ func (_c *MockDNSService_CreateALIASRecord_Call) Run(run func(ctx context.Contex
 		if args[1] != nil {
 			arg1 = args[1].(uint)
 		}
-		var arg2 string
+		var arg2 core0.RecordType
 		if args[2] != nil {
-			arg2 = args[2].(string)
+			arg2 = args[2].(core0.RecordType)
+		}
+		var arg3 string
+		if args[3] != nil {
+			arg3 = args[3].(string)
 		}
 		run(
 			arg0,
 			arg1,
 			arg2,
+			arg3,
 		)
 	})
 	return _c
 }
 
-func (_c *MockDNSService_CreateALIASRecord_Call) Return(err error) *MockDNSService_CreateALIASRecord_Call {
+func (_c *MockDNSService_CreateApexRecord_Call) Return(err error) *MockDNSService_CreateApexRecord_Call {
 	_c.Call.Return(err)
 	return _c
 }
 
-func (_c *MockDNSService_CreateALIASRecord_Call) RunAndReturn(run func(ctx context.Context, zoneID uint, gatewayHost string) error) *MockDNSService_CreateALIASRecord_Call {
+func (_c *MockDNSService_CreateApexRecord_Call) RunAndReturn(run func(ctx context.Context, zoneID uint, recordType core0.RecordType, content string) error) *MockDNSService_CreateApexRecord_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/testing/mocks/MockDNSZoneService.go
+++ b/internal/testing/mocks/MockDNSZoneService.go
@@ -8,6 +8,7 @@ import (
 	"context"
 
 	mock "github.com/stretchr/testify/mock"
+	"go.lumeweb.com/portal-plugin-ipfs/core"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/db"
 )
 
@@ -38,37 +39,38 @@ func (_m *MockDNSZoneService) EXPECT() *MockDNSZoneService_Expecter {
 	return &MockDNSZoneService_Expecter{mock: &_m.Mock}
 }
 
-// CreateALIASRecord provides a mock function for the type MockDNSZoneService
-func (_mock *MockDNSZoneService) CreateALIASRecord(ctx context.Context, zoneID uint, gatewayHost string) error {
-	ret := _mock.Called(ctx, zoneID, gatewayHost)
+// CreateApexRecord provides a mock function for the type MockDNSZoneService
+func (_mock *MockDNSZoneService) CreateApexRecord(ctx context.Context, zoneID uint, recordType core.RecordType, content string) error {
+	ret := _mock.Called(ctx, zoneID, recordType, content)
 
 	if len(ret) == 0 {
-		panic("no return value specified for CreateALIASRecord")
+		panic("no return value specified for CreateApexRecord")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, uint, string) error); ok {
-		r0 = returnFunc(ctx, zoneID, gatewayHost)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uint, core.RecordType, string) error); ok {
+		r0 = returnFunc(ctx, zoneID, recordType, content)
 	} else {
 		r0 = ret.Error(0)
 	}
 	return r0
 }
 
-// MockDNSZoneService_CreateALIASRecord_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CreateALIASRecord'
-type MockDNSZoneService_CreateALIASRecord_Call struct {
+// MockDNSZoneService_CreateApexRecord_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CreateApexRecord'
+type MockDNSZoneService_CreateApexRecord_Call struct {
 	*mock.Call
 }
 
-// CreateALIASRecord is a helper method to define mock.On call
+// CreateApexRecord is a helper method to define mock.On call
 //   - ctx context.Context
 //   - zoneID uint
-//   - gatewayHost string
-func (_e *MockDNSZoneService_Expecter) CreateALIASRecord(ctx any, zoneID any, gatewayHost any) *MockDNSZoneService_CreateALIASRecord_Call {
-	return &MockDNSZoneService_CreateALIASRecord_Call{Call: _e.mock.On("CreateALIASRecord", ctx, zoneID, gatewayHost)}
+//   - recordType core.RecordType
+//   - content string
+func (_e *MockDNSZoneService_Expecter) CreateApexRecord(ctx any, zoneID any, recordType any, content any) *MockDNSZoneService_CreateApexRecord_Call {
+	return &MockDNSZoneService_CreateApexRecord_Call{Call: _e.mock.On("CreateApexRecord", ctx, zoneID, recordType, content)}
 }
 
-func (_c *MockDNSZoneService_CreateALIASRecord_Call) Run(run func(ctx context.Context, zoneID uint, gatewayHost string)) *MockDNSZoneService_CreateALIASRecord_Call {
+func (_c *MockDNSZoneService_CreateApexRecord_Call) Run(run func(ctx context.Context, zoneID uint, recordType core.RecordType, content string)) *MockDNSZoneService_CreateApexRecord_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -78,25 +80,30 @@ func (_c *MockDNSZoneService_CreateALIASRecord_Call) Run(run func(ctx context.Co
 		if args[1] != nil {
 			arg1 = args[1].(uint)
 		}
-		var arg2 string
+		var arg2 core.RecordType
 		if args[2] != nil {
-			arg2 = args[2].(string)
+			arg2 = args[2].(core.RecordType)
+		}
+		var arg3 string
+		if args[3] != nil {
+			arg3 = args[3].(string)
 		}
 		run(
 			arg0,
 			arg1,
 			arg2,
+			arg3,
 		)
 	})
 	return _c
 }
 
-func (_c *MockDNSZoneService_CreateALIASRecord_Call) Return(err error) *MockDNSZoneService_CreateALIASRecord_Call {
+func (_c *MockDNSZoneService_CreateApexRecord_Call) Return(err error) *MockDNSZoneService_CreateApexRecord_Call {
 	_c.Call.Return(err)
 	return _c
 }
 
-func (_c *MockDNSZoneService_CreateALIASRecord_Call) RunAndReturn(run func(ctx context.Context, zoneID uint, gatewayHost string) error) *MockDNSZoneService_CreateALIASRecord_Call {
+func (_c *MockDNSZoneService_CreateApexRecord_Call) RunAndReturn(run func(ctx context.Context, zoneID uint, recordType core.RecordType, content string) error) *MockDNSZoneService_CreateApexRecord_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/testing/mocks/MockDomainProvider.go
+++ b/internal/testing/mocks/MockDomainProvider.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 
 	mock "github.com/stretchr/testify/mock"
+	"go.lumeweb.com/portal-plugin-ipfs/core"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/db"
 )
 
@@ -37,6 +38,50 @@ type MockDomainProvider_Expecter struct {
 
 func (_m *MockDomainProvider) EXPECT() *MockDomainProvider_Expecter {
 	return &MockDomainProvider_Expecter{mock: &_m.Mock}
+}
+
+// ApexRecordType provides a mock function for the type MockDomainProvider
+func (_mock *MockDomainProvider) ApexRecordType() core.RecordType {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for ApexRecordType")
+	}
+
+	var r0 core.RecordType
+	if returnFunc, ok := ret.Get(0).(func() core.RecordType); ok {
+		r0 = returnFunc()
+	} else {
+		r0 = ret.Get(0).(core.RecordType)
+	}
+	return r0
+}
+
+// MockDomainProvider_ApexRecordType_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ApexRecordType'
+type MockDomainProvider_ApexRecordType_Call struct {
+	*mock.Call
+}
+
+// ApexRecordType is a helper method to define mock.On call
+func (_e *MockDomainProvider_Expecter) ApexRecordType() *MockDomainProvider_ApexRecordType_Call {
+	return &MockDomainProvider_ApexRecordType_Call{Call: _e.mock.On("ApexRecordType")}
+}
+
+func (_c *MockDomainProvider_ApexRecordType_Call) Run(run func()) *MockDomainProvider_ApexRecordType_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockDomainProvider_ApexRecordType_Call) Return(recordType core.RecordType) *MockDomainProvider_ApexRecordType_Call {
+	_c.Call.Return(recordType)
+	return _c
+}
+
+func (_c *MockDomainProvider_ApexRecordType_Call) RunAndReturn(run func() core.RecordType) *MockDomainProvider_ApexRecordType_Call {
+	_c.Call.Return(run)
+	return _c
 }
 
 // BuildDelegation provides a mock function for the type MockDomainProvider
@@ -78,7 +123,7 @@ type MockDomainProvider_BuildDelegation_Call struct {
 //   - domain string
 //   - website *db.Website
 //   - config json.RawMessage
-func (_e *MockDomainProvider_Expecter) BuildDelegation(ctx interface{}, zoneID interface{}, domain interface{}, website interface{}, config interface{}) *MockDomainProvider_BuildDelegation_Call {
+func (_e *MockDomainProvider_Expecter) BuildDelegation(ctx any, zoneID any, domain any, website any, config any) *MockDomainProvider_BuildDelegation_Call {
 	return &MockDomainProvider_BuildDelegation_Call{Call: _e.mock.On("BuildDelegation", ctx, zoneID, domain, website, config)}
 }
 
@@ -197,7 +242,7 @@ type MockDomainProvider_OnCertAvailable_Call struct {
 //   - ctx context.Context
 //   - domain string
 //   - certPEM string
-func (_e *MockDomainProvider_Expecter) OnCertAvailable(ctx interface{}, domain interface{}, certPEM interface{}) *MockDomainProvider_OnCertAvailable_Call {
+func (_e *MockDomainProvider_Expecter) OnCertAvailable(ctx any, domain any, certPEM any) *MockDomainProvider_OnCertAvailable_Call {
 	return &MockDomainProvider_OnCertAvailable_Call{Call: _e.mock.On("OnCertAvailable", ctx, domain, certPEM)}
 }
 
@@ -302,7 +347,7 @@ type MockDomainProvider_Validate_Call struct {
 
 // Validate is a helper method to define mock.On call
 //   - domain string
-func (_e *MockDomainProvider_Expecter) Validate(domain interface{}) *MockDomainProvider_Validate_Call {
+func (_e *MockDomainProvider_Expecter) Validate(domain any) *MockDomainProvider_Validate_Call {
 	return &MockDomainProvider_Validate_Call{Call: _e.mock.On("Validate", domain)}
 }
 
@@ -364,7 +409,7 @@ type MockDomainProvider_VerifyDelegation_Call struct {
 //   - ctx context.Context
 //   - domain string
 //   - delegationData json.RawMessage
-func (_e *MockDomainProvider_Expecter) VerifyDelegation(ctx interface{}, domain interface{}, delegationData interface{}) *MockDomainProvider_VerifyDelegation_Call {
+func (_e *MockDomainProvider_Expecter) VerifyDelegation(ctx any, domain any, delegationData any) *MockDomainProvider_VerifyDelegation_Call {
 	return &MockDomainProvider_VerifyDelegation_Call{Call: _e.mock.On("VerifyDelegation", ctx, domain, delegationData)}
 }
 


### PR DESCRIPTION
## What

Alt-root (HNS) zones are DNSSEC-signed at the apex, but PowerDNS cannot sign a synthetic ALIAS record there, so `dig lumeweb A +dnssec` returns the apex A without an RRSIG. This makes the apex record type a per-provider capability instead of a namespace assumption.

## Changes

- Add `DomainProvider.ApexRecordType() core.RecordType`: `HNSProvider` returns `RecordTypeA`, `ICANNProvider` returns `RecordTypeALIAS`.
- `CreateDomain` publishes a real apex `A` record from the new `dns.gateway_ip` config for alt-root providers, and an `ALIAS` to the gateway hostname otherwise. Missing `gateway_ip` for an alt-root provider hard-fails domain creation (cannot silently create an unsigned apex).
- Generalize `CreateALIASRecord` → `CreateApexRecord(recordType, content)` across `DNSZoneService` and `core.DNSService`.
- Regenerate mocks (mockery v3).

## Verification

- `go build ./...` passes
- `go test ./internal/service/domain/... ./internal/service/dns/...` pass (incl. new `ApexRecordType` tests and updated integration test asserting the apex `A` content)
- Kodus review clean on the diff

* `develop` <!-- branch-stack -->
  - **feat(dns): provider-driven apex record type for DNSSEC-signed alt-root zones** :point\_left:

***

<!-- kody-pr-summary:start -->

This pull request introduces provider-driven apex record types for DNS zone creation, specifically addressing the needs of DNSSEC-signed alt-root zones like HNS.

## Summary

The changes refactor how apex (root) records are created when registering domains. Previously, all providers used a hardcoded ALIAS/CNAME record pointing to the gateway hostname. Now, each domain provider determines its own apex record type:

- **HNS (alt-root)**: Uses a real `A` record containing the gateway IP address, since HNS zones are DNSSEC-signed at the apex and PowerDNS cannot sign a synthetic ALIAS record at the apex.
- **ICANN**: Continues to use `ALIAS` records pointing to the gateway hostname.

## Key Implementation Details

1. **New `ApexRecordType()` interface method** on `DomainProvider` - Each provider returns either `RecordTypeA` or `RecordTypeALIAS`.

2. **New DNS configuration option** - `dns.gateway_ip` added to the config for the IP address used in `A` apex records for alt-root providers.

3. **API refactoring** - `CreateALIASRecord` renamed to `CreateApexRecord`, accepting both a record type and content value, so it can handle either IP addresses (for A records) or hostnames (for ALIAS records).

4. **Validation logic** - When creating a domain for a DNSSEC-signed alt-root provider, the service now requires `gateway_ip` to be configured. Since the apex must be a real `A` record for RRSIG signing, it cannot fall back to an ALIAS record. If `gateway_ip` is not set, domain creation fails and cleanup occurs.

5. **Tests** - Updated integration tests with new config values and mock expectations for `A` record creation, plus unit tests verifying each provider returns its correct apex record type.

## Impact

This fix enables proper DNSSEC signing of apex records for Handshake (HNS) domains by ensuring the apex is a real, signable `A` record. It also makes the system more flexible for future providers with different apex record requirements.

<!-- kody-pr-summary:end -->
