### PR TITLE
fix(dns): gate HNS delegation on served DS for platform-managed zones

### DIFF
--- a/internal/service/domain/hns_provider.go
+++ b/internal/service/domain/hns_provider.go
@@ -400,16 +400,26 @@ func (p *HNSProvider) Nameservers() []string {
 	return p.nsRecords
 }
 
-// VerifyDelegation checks if the expected NS records for a HNS name are visible
-// via the configured HNS resolver. HNS names are resolved against the Handshake
+// VerifyDelegation checks whether a HNS name's delegation is live via the
+// configured HNS resolver. HNS names are resolved against the Handshake
 // blockchain; this requires an HNS-aware resolver (not the system default).
-// For ICANN, verification is intentionally a no-op.
+//
+// For platform-managed zones the portal generated (and stored) the DS record
+// from the zone's PowerDNS DNSKEY. Such a zone is only considered live when
+// BOTH the expected NS delegation is visible AND the DS the portal generated
+// is actually served by the parent zone (i.e. the root has taken effect).
+// Requiring the DS prevents a domain from being marked Active before the
+// DNSSEC chain of trust is in place. Self-managed zones (no DS the portal
+// generated) are validated on NS visibility alone, since only the name owner
+// knows their own DNSKEY/DS.
 func (p *HNSProvider) VerifyDelegation(ctx context.Context, domain string,
 	delegationData json.RawMessage) (bool, error) {
 
 	if p.resolverAddr == "" {
 		return false, fmt.Errorf("HNS resolver not configured (DnsConfig.HNSResolver); standard resolvers cannot resolve HNS names")
 	}
+
+	expectedNS := p.Nameservers()
 
 	nss, err := queryNS(ctx, p.resolverAddr, dnsname.EnsureFQDN(domain))
 	if err != nil {
@@ -422,16 +432,79 @@ func (p *HNSProvider) VerifyDelegation(ctx context.Context, domain string,
 		return false, fmt.Errorf("HNS resolver query failed (resolver %q): %w", p.resolverAddr, err)
 	}
 
-	expectedNS := p.Nameservers()
+	nsVisible := false
 	for _, ns := range nss {
 		for _, expected := range expectedNS {
 			if dnsname.Equal(ns, expected) {
-				return true, nil
+				nsVisible = true
+				break
 			}
 		}
+		if nsVisible {
+			break
+		}
+	}
+	if !nsVisible {
+		return false, nil
 	}
 
+	// Platform-generated DS: if the stored delegation carries a DS record the
+	// portal computed (managed/PowerDNS-signed zone), require that exact DS to
+	// be served by the parent zone before considering the delegation live.
+	expectedDS := delegationExpectedDS(delegationData)
+	if expectedDS == "" {
+		// Self-managed zone: the name owner publishes a DS from their own
+		// DNSKEY, which the portal cannot know. NS visibility is sufficient.
+		return true, nil
+	}
+
+	servedDS, err := queryDS(ctx, p.resolverAddr, dnsname.EnsureFQDN(domain))
+	if err != nil {
+		// A failed DS query means the DS is not yet resolvable from the parent
+		// zone; treat the delegation as not-yet-live (DNSSEC chain not in
+		// place) rather than an error the caller surfaces as a soft failure.
+		return false, nil
+	}
+	for _, served := range servedDS {
+		if dsEqual(served, expectedDS) {
+			return true, nil
+		}
+	}
 	return false, nil
+}
+
+// delegationExpectedDS extracts the platform-generated DS value (RDATA, e.g.
+// "44451 13 2 c359...") from a stored delegation bundle, or "" when the
+// portal did not generate a DS (self-managed zone).
+func delegationExpectedDS(delegationData json.RawMessage) string {
+	var bundle DelegationBundle
+	if len(delegationData) > 0 {
+		_ = json.Unmarshal(delegationData, &bundle)
+	}
+	for _, rec := range bundle.ParentRecords {
+		if rec.Type == "DS" && rec.Value != "" {
+			// DS values may carry a leading owner/token from older persisted
+			// data ("<owner> DS <rdata>"); normalize to RDATA.
+			if idx := strings.Index(rec.Value, " DS "); idx >= 0 {
+				return rec.Value[idx+len(" DS "):]
+			}
+			return rec.Value
+		}
+	}
+	return ""
+}
+
+// dsEqual compares two DS RDATA presentation strings ignoring the leading
+// owner-name/token prefix and collapsing whitespace.
+func dsEqual(a, b string) bool {
+	return canonicalDS(a) == canonicalDS(b)
+}
+
+func canonicalDS(s string) string {
+	if idx := strings.Index(s, " DS "); idx >= 0 {
+		s = s[idx+len(" DS "):]
+	}
+	return strings.Join(strings.Fields(s), " ")
 }
 
 // queryNS performs an NS query for the absolute FQDN `name` against the DNS
@@ -444,19 +517,69 @@ func (p *HNSProvider) VerifyDelegation(ctx context.Context, domain string,
 // exists. miekg/dns reads both sections, so this returns the delegation
 // correctly. It tries UDP first, then TCP on failure or truncation (RFC 5966).
 func queryNS(ctx context.Context, addr, name string) ([]string, error) {
+	r, err := queryResolver(ctx, addr, name, dns.TypeNS)
+	if err != nil {
+		return nil, err
+	}
+	var nss []string
+	for _, rr := range r.Answer {
+		if ns, ok := rr.(*dns.NS); ok {
+			nss = append(nss, ns.Ns)
+		}
+	}
+	// NS records may also appear in the authority section for non-authoritative
+	// responses; include them rather than only the answer section.
+	for _, rr := range r.Ns {
+		if ns, ok := rr.(*dns.NS); ok {
+			nss = append(nss, ns.Ns)
+		}
+	}
+	return nss, nil
+}
+
+// queryDS performs a DS query for the absolute FQDN `name` against the DNS
+// server at `addr` using raw miekg/dns, returning the DS RDATA strings served
+// by the parent zone (answer and authority sections). This is how
+// VerifyDelegation confirms the platform-generated DS has propagated: a DS
+// only appears once the parent zone (HSD root for HNS) actually serves it.
+func queryDS(ctx context.Context, addr, name string) ([]string, error) {
+	r, err := queryResolver(ctx, addr, name, dns.TypeDS)
+	if err != nil {
+		return nil, err
+	}
+	var dss []string
+	for _, rr := range append(append([]dns.RR{}, r.Answer...), r.Ns...) {
+		if ds, ok := rr.(*dns.DS); ok {
+			// RDATA presentation (RFC 4034 §5.3): key tag, algorithm, digest
+			// type, digest. Built from the structured fields so it matches the
+			// persisted dane-computed DS RDATA, with a lowercased digest so the
+			// comparison is not tripped by miekg's uppercase String() hex.
+			dss = append(dss, strings.Join([]string{
+				strconv.Itoa(int(ds.KeyTag)),
+				strconv.Itoa(int(ds.Algorithm)),
+				strconv.Itoa(int(ds.DigestType)),
+				strings.ToLower(ds.Digest),
+			}, " "))
+		}
+	}
+	return dss, nil
+}
+
+// queryResolver issues a single DNS query of the given record type against the
+// server at `addr` and returns the full reply, handling the UDP-then-TCP
+// fallback on failure or truncation (RFC 5966) shared by all resolver queries.
+// If the TCP retry fails we must not fall through to a truncated UDP response,
+// which would silently drop records that didn't fit in the UDP packet.
+func queryResolver(ctx context.Context, addr, name string, qtype uint16) (*dns.Msg, error) {
 	c := &dns.Client{
 		Net:     "udp",
 		Timeout: 5 * time.Second,
 	}
 	m := new(dns.Msg)
-	m.SetQuestion(name, dns.TypeNS)
+	m.SetQuestion(name, qtype)
 
 	r, _, err := c.ExchangeContext(ctx, m, addr)
 	if err == nil && r.Truncated {
-		// Retry over TCP on truncation (RFC 5966). If the TCP retry fails, we
-		// must not fall through to the truncated UDP response — returning it
-		// silently drops nameservers that didn't fit in the UDP packet and makes
-		// VerifyDelegation return false for a valid delegation.
 		tc := &dns.Client{Net: "tcp", Timeout: 5 * time.Second}
 		tr, _, terr := tc.ExchangeContext(ctx, m, addr)
 		if terr != nil {
@@ -475,21 +598,7 @@ func queryNS(ctx context.Context, addr, name string) ([]string, error) {
 			IsNotFound: r.Rcode == dns.RcodeNameError,
 		}
 	}
-
-	var nss []string
-	for _, rr := range r.Answer {
-		if ns, ok := rr.(*dns.NS); ok {
-			nss = append(nss, ns.Ns)
-		}
-	}
-	// NS records may also appear in the authority section for non-authoritative
-	// responses; include them rather than only the answer section.
-	for _, rr := range r.Ns {
-		if ns, ok := rr.(*dns.NS); ok {
-			nss = append(nss, ns.Ns)
-		}
-	}
-	return nss, nil
+	return r, nil
 }
 
 // OnCertAvailable updates the TLSA source when a cert is pushed from the

--- a/internal/service/domain/hns_provider.go
+++ b/internal/service/domain/hns_provider.go
@@ -504,7 +504,7 @@ func canonicalDS(s string) string {
 	if idx := strings.Index(s, " DS "); idx >= 0 {
 		s = s[idx+len(" DS "):]
 	}
-	return strings.Join(strings.Fields(s), " ")
+	return strings.ToLower(strings.Join(strings.Fields(s), " "))
 }
 
 // queryNS performs an NS query for the absolute FQDN `name` against the DNS

--- a/internal/service/domain/hns_resolver_integration_test.go
+++ b/internal/service/domain/hns_resolver_integration_test.go
@@ -407,3 +407,17 @@ func TestDelegationExpectedDS(t *testing.T) {
 	assert.Equal(t, "", delegationExpectedDS(json.RawMessage(`{}`)))
 	assert.Equal(t, "", delegationExpectedDS(json.RawMessage(`{"parent_records":[]}`)))
 }
+
+// dsEqual must normalize case on both sides: the served digest is lowercased
+// (queryDS), but the persisted dane.computed DS RDATA may carry an uppercase
+// digest. Without normalizing the expected side, a valid managed zone would be
+// left in WaitingDelegation forever.
+func TestDSEqualCaseInsensitive(t *testing.T) {
+	lower := "44451 13 2 cb6c0f5bbf0ca4391b008cfe56f8e072d3f3f21d4b3bfb40b46f5c5b35a0b1e1"
+	upper := "44451 13 2 CB6C0F5BBF0CA4391B008CFE56F8E072D3F3F21D4B3BFB40B46F5C5B35A0B1E1"
+
+	assert.True(t, dsEqual(upper, lower), "dsEqual must ignore digest case")
+	assert.True(t, dsEqual(lower, upper), "dsEqual must ignore digest case")
+	assert.True(t, dsEqual(lower, lower))
+	assert.False(t, dsEqual(lower, "44451 13 2 0000000000000000000000000000000000000000000000000000000000000000"))
+}

--- a/internal/service/domain/hns_resolver_integration_test.go
+++ b/internal/service/domain/hns_resolver_integration_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -35,8 +36,14 @@ import (
 // ephemeral port on loopback. The handler answers NS queries for `name` with
 // the given nameservers and increments a counter so the test can assert the
 // query actually reached this server.
-func startCustomPortDNSServer(t *testing.T, name string, nsRecords []string) (addr string, served *atomicCounter) {
+func startCustomPortDNSServer(t *testing.T, name string, nsRecords []string, dsRecord ...string) (addr string, served *atomicCounter) {
 	t.Helper()
+
+	// The single DS record the server serves, if any.
+	var servedDS string
+	if len(dsRecord) > 0 {
+		servedDS = dsRecord[0]
+	}
 
 	served = &atomicCounter{}
 	handler := dns.HandlerFunc(func(w dns.ResponseWriter, req *dns.Msg) {
@@ -44,13 +51,33 @@ func startCustomPortDNSServer(t *testing.T, name string, nsRecords []string) (ad
 		m := new(dns.Msg)
 		m.SetReply(req)
 		m.Authoritative = true
-		if len(req.Question) > 0 && req.Question[0].Qtype == dns.TypeNS {
-			for _, ns := range nsRecords {
-				rr := &dns.NS{
-					Hdr: dns.RR_Header{Name: name, Rrtype: dns.TypeNS, Class: dns.ClassINET, Ttl: 300},
-					Ns:  ns,
+		if len(req.Question) > 0 {
+			qtype := req.Question[0].Qtype
+			switch qtype {
+			case dns.TypeNS:
+				for _, ns := range nsRecords {
+					rr := &dns.NS{
+						Hdr: dns.RR_Header{Name: name, Rrtype: dns.TypeNS, Class: dns.ClassINET, Ttl: 300},
+						Ns:  ns,
+					}
+					m.Answer = append(m.Answer, rr)
 				}
-				m.Answer = append(m.Answer, rr)
+			case dns.TypeDS:
+				if servedDS != "" {
+					// Parse "keytag alg digesttype digest" into a DS record.
+					parts := strings.Fields(servedDS)
+					keyTag, _ := strconv.Atoi(parts[0])
+					alg, _ := strconv.Atoi(parts[1])
+					digType, _ := strconv.Atoi(parts[2])
+					rr := &dns.DS{
+						Hdr:        dns.RR_Header{Name: name, Rrtype: dns.TypeDS, Class: dns.ClassINET, Ttl: 300},
+						KeyTag:     uint16(keyTag),
+						Algorithm:  uint8(alg),
+						DigestType: uint8(digType),
+						Digest:     parts[3],
+					}
+					m.Answer = append(m.Answer, rr)
+				}
 			}
 		}
 		_ = w.WriteMsg(m)
@@ -286,4 +313,97 @@ func TestHNSProvider_VerifyDelegation_ErrorSurfacesActualResolverAddr(t *testing
 	assert.Contains(t, err.Error(), "HNS resolver query failed",
 		"error must retain the operation context")
 	t.Logf("resolver error surfaces actual dial target: %v", err)
+}
+
+// A platform-managed zone carries the DS the portal generated from its
+// PowerDNS DNSKEY. It must NOT be marked verified until that exact DS is
+// served by the parent zone (the "root takes effect" step). When the parent
+// does not yet serve the DS, VerifyDelegation must return false even though
+// the NS delegation is already visible.
+func TestHNSProvider_VerifyDelegation_Managed_RequiresServedDS(t *testing.T) {
+	const domain = "lumeweb."
+	const dsRdata = "44451 13 2 cb6c0f5bbf0ca4391b008cfe56f8e072d3f3f21d4b3bfb40b46f5c5b35a0b1e1"
+
+	// Server serves the NS delegation but NOT the DS (pre-propagation state).
+	addr, _ := startCustomPortDNSServer(t, domain, []string{"ns1.lumeweb.", "ns2.lumeweb."})
+
+	p := NewHNSProvider(addr, []string{"ns1.lumeweb.", "ns2.lumeweb."}, TLSASource{})
+
+	// Delegation data is the platform-generated bundle: it carries the DS the
+	// portal computed (managed zone).
+	managedDelegation := json.RawMessage(`{
+		"mode": "delegated",
+		"parent_records": [
+			{"type": "NS", "value": "ns1.lumeweb.,ns2.lumeweb."},
+			{"type": "DS", "value": "` + dsRdata + `"}
+		]
+	}`)
+
+	verified, err := p.VerifyDelegation(context.Background(), "lumeweb", managedDelegation)
+	require.NoError(t, err)
+	assert.False(t, verified,
+		"managed zone must not verify before the portal's DS is served by the parent zone")
+}
+
+// Once the parent zone actually serves the portal's generated DS, a managed
+// zone becomes verified: NS delegation visible AND the DS has taken effect.
+func TestHNSProvider_VerifyDelegation_Managed_VerifiedWhenDSServed(t *testing.T) {
+	const domain = "lumeweb."
+	const dsRdata = "44451 13 2 cb6c0f5bbf0ca4391b008cfe56f8e072d3f3f21d4b3bfb40b46f5c5b35a0b1e1"
+
+	// Server serves both the NS delegation and the matching DS.
+	addr, served := startCustomPortDNSServer(t, domain, []string{"ns1.lumeweb.", "ns2.lumeweb."}, dsRdata)
+
+	p := NewHNSProvider(addr, []string{"ns1.lumeweb.", "ns2.lumeweb."}, TLSASource{})
+
+	managedDelegation := json.RawMessage(`{
+		"mode": "delegated",
+		"parent_records": [
+			{"type": "NS", "value": "ns1.lumeweb.,ns2.lumeweb."},
+			{"type": "DS", "value": "` + dsRdata + `"}
+		]
+	}`)
+
+	verified, err := p.VerifyDelegation(context.Background(), "lumeweb", managedDelegation)
+	require.NoError(t, err)
+	assert.True(t, verified,
+		"managed zone must verify once NS delegation is visible AND the portal's DS is served")
+	assert.Greater(t, served.value(), 0, "resolver must have received the DS query")
+}
+
+// A self-managed zone has no DS the portal generated, so validation stays on
+// NS visibility alone (only the name owner knows their own DNSKEY/DS).
+func TestHNSProvider_VerifyDelegation_SelfManaged_NSOnly(t *testing.T) {
+	const domain = "lumeweb."
+
+	addr, _ := startCustomPortDNSServer(t, domain, []string{"ns1.lumeweb.", "ns2.lumeweb."})
+	p := NewHNSProvider(addr, []string{"ns1.lumeweb.", "ns2.lumeweb."}, TLSASource{})
+
+	// No parent DS record -> self-managed.
+	verified, err := p.VerifyDelegation(context.Background(), "lumeweb", json.RawMessage(`{
+		"mode": "delegated",
+		"parent_records": [{"type": "NS", "value": "ns1.lumeweb.,ns2.lumeweb."}]
+	}`))
+	require.NoError(t, err)
+	assert.True(t, verified, "self-managed zone validates on NS visibility alone")
+}
+
+// delegationExpectedDS normalizes both plain RDATA and legacy
+// "<owner> DS <rdata>" persisted values down to the DS RDATA.
+func TestDelegationExpectedDS(t *testing.T) {
+	raw := json.RawMessage(`{
+		"parent_records": [
+			{"type": "NS", "value": "ns1.lumeweb."},
+			{"type": "DS", "value": "44451 13 2 cb6c0f5b"}
+		]
+	}`)
+	assert.Equal(t, "44451 13 2 cb6c0f5b", delegationExpectedDS(raw))
+
+	legacy := json.RawMessage(`{
+		"parent_records": [{"type": "DS", "value": "lumeweb. 3600 IN DS 44451 13 2 cb6c0f5b"}]
+	}`)
+	assert.Equal(t, "44451 13 2 cb6c0f5b", delegationExpectedDS(legacy))
+
+	assert.Equal(t, "", delegationExpectedDS(json.RawMessage(`{}`)))
+	assert.Equal(t, "", delegationExpectedDS(json.RawMessage(`{"parent_records":[]}`)))
 }


### PR DESCRIPTION
## What

`HNSProvider.VerifyDelegation` only checked that the expected NS records were visible via the HNS resolver. That let a platform-managed (PowerDNS-signed) zone be marked **Active** as soon as its NS delegation appeared, before the DS record the portal generated from the zone's DNSKEY had taken effect at the parent/root. A domain could therefore be validated while the DNSSEC chain of trust was not yet in place.

## Changes

- When the stored delegation bundle carries a DS the portal generated (managed zone), `VerifyDelegation` now also requires that exact DS to be **served by the parent zone** before reporting the delegation live. If the DS hasn't propagated yet, verification returns false (zone stays in a waiting state) instead of going Active.
- Self-managed zones (no portal-generated DS) still validate on NS visibility alone, since only the name owner knows their own DNSKEY/DS.
- Adds `queryDS` alongside `queryNS`, both built on a shared `queryResolver` (UDP→TCP fallback, answer + authority sections).
- Normalizes legacy `"<owner> DS <rdata>"` persisted values down to RDATA for comparison.

## Verification

- New real-resolver integration tests: managed zone not verified before DS served, verified once DS served, self-managed NS-only, and `delegationExpectedDS` normalization.
- Existing `VerifyDelegation` tests (custom port, NS mismatch, no resolver, truncation, error surface) all still pass.
- `go build ./...` and `go test ./internal/service/domain/...` green; gofmt clean.

* `develop` <!-- branch-stack -->
  - **fix(dns): gate HNS delegation on served DS for platform-managed zones** :point\_left:

***

<!-- kody-pr-summary:start -->

## Summary

This pull request fixes the HNS (Handshake) domain delegation verification logic for platform-managed zones. The change ensures that a domain is only marked as Active when the DNSSEC chain of trust is fully in place, not just when the NS records are visible.

## What Changed

### Stricter Delegation Verification for Managed Zones

Previously, `VerifyDelegation` only checked whether the expected NS records were visible via the HNS resolver. This could result in a domain being marked as **Active** before the DNSSEC chain of trust was properly established.

Now, for **platform-managed zones** (where the portal generated and stored a DS record from the zone's PowerDNS DNSKEY), the verification process requires **both**:

1. The expected NS delegation is visible
2. The exact DS record the portal generated is actually served by the parent zone (meaning the root has taken effect)

### Behavior by Zone Type

- **Platform-managed zones** (with a portal-generated DS): Verification fails until the exact DS record is served, preventing premature activation before DNSSEC is live.
- **Self-managed zones** (no portal-generated DS): Validation remains based on NS visibility alone, since only the name owner knows their own DNSKEY/DS.

## Technical Implementation

- Added a DS query function that retrieves DS records from the parent zone via the HNS resolver
- Extracted the expected DS value from the stored delegation bundle, with normalization for legacy data formats
- Added DS record comparison logic that handles case differences and legacy owner-name prefixes
- Refactored the DNS query code to share a common UDP-then-TCP fallback mechanism between NS and DS queries
- Updated the integration test DNS server to support serving DS records in addition to NS records
- Added comprehensive tests covering:
  - Managed zones that must not verify when DS is not yet served
  - Managed zones that verify once both NS and DS are present
  - Self-managed zones that verify on NS visibility alone
  - DS value extraction and normalization from various delegation data formats

<!-- kody-pr-summary:end -->
