### PR TITLE
fix(dns): move SSL status to per-domain WebsiteDomain

### DIFF
--- a/core/website.go
+++ b/core/website.go
@@ -68,8 +68,15 @@ type WebsiteService interface {
 	// CheckStatus checks the status of a website by validating its target
 	CheckStatus(ctx context.Context, website *pluginDb.Website) (pluginDb.WebsiteStatus, error)
 
-	// UpdateSSLStatus updates the SSL certificate status for a website domain
-	UpdateSSLStatus(ctx context.Context, domain string, status pluginDb.SSLStatus, sslError string, timestamp *time.Time) (*pluginDb.Website, error)
+	// UpdateSSLStatus updates the SSL certificate status for a domain binding.
+	// SSL state is a per-domain property, so it returns the updated
+	// WebsiteDomain (the source of truth for certificate status).
+	UpdateSSLStatus(ctx context.Context, domain string, status pluginDb.SSLStatus, sslError string, timestamp *time.Time) (*pluginDb.WebsiteDomain, error)
+
+	// GetApexDomainBinding returns the website's primary/apex domain binding,
+	// whose SSL state is presented at the website level for backward-compatible
+	// site-level SSL synthesis.
+	GetApexDomainBinding(ctx context.Context, websiteID uint) (*pluginDb.WebsiteDomain, error)
 
 	// WaitForPublishes blocks until all in-flight async publish operations complete
 	WaitForPublishes()

--- a/internal/api/api_websites.go
+++ b/internal/api/api_websites.go
@@ -499,6 +499,10 @@ func (a *API) updateSSLStatus(c echo.Context) error {
 		apiErr := NewError(ErrKeyFileProcessingFailed, err)
 		return ctx.Error(apiErr, apiErr.HttpStatus())
 	}
+	if website == nil {
+		apiErr := NewError(pluginEvents.ErrWebsiteNotFound, fmt.Errorf("website not found: %s", domain))
+		return ctx.Error(apiErr, http.StatusNotFound)
+	}
 
 	resp := &dto.WebsiteResponse{}
 	resp.GatewayDomain = a.gatewayDomain()

--- a/internal/api/api_websites.go
+++ b/internal/api/api_websites.go
@@ -422,7 +422,39 @@ func (a *API) getSSLStatus(c echo.Context) error {
 	resp.SetSubdomainInfo(a.zoneDomain(reqCtx, website.DNSZoneID))
 	resp.SetValidationRecordInfo(a.verificationTokenKey())
 	resp.EnrichActiveCID(ipnsKeyCIDResolver{svc: a.ipnsKeyService, ctx: reqCtx}, website.UserID, website)
+	a.applyApexSSLStatus(reqCtx, resp, website)
 	return httputil.EncodeResponse(ctx, website, resp)
+}
+
+// applyApexSSLStatus synthesizes the website-level SSL status from the apex
+// (primary) domain binding, preserving backward-compatible site-level SSL
+// presentation now that the source of truth lives per-domain on WebsiteDomain.
+func (a *API) applyApexSSLStatus(ctx context.Context, resp *dto.WebsiteResponse, website *pluginDb.Website) {
+	if website == nil {
+		return
+	}
+	apex, err := a.websiteService.GetApexDomainBinding(ctx, website.ID)
+	if err != nil || apex == nil || apex.SSLStatus == "" {
+		return
+	}
+	resp.SSL = sslStatusInfoFromDomain(apex)
+}
+
+// sslStatusInfoFromDomain converts a domain binding's SSL state to the DTO.
+func sslStatusInfoFromDomain(wd *pluginDb.WebsiteDomain) *dto.SSLStatusInfo {
+	info := &dto.SSLStatusInfo{
+		Status: wd.SSLStatus,
+		Error:  wd.SSLError,
+	}
+	if wd.SSLIssuedAt != nil {
+		v := *wd.SSLIssuedAt
+		info.IssuedAt = &v
+	}
+	if wd.SSLLastUpdatedAt != nil {
+		v := *wd.SSLLastUpdatedAt
+		info.LastUpdatedAt = &v
+	}
+	return info
 }
 
 func (a *API) updateSSLStatus(c echo.Context) error {
@@ -450,7 +482,7 @@ func (a *API) updateSSLStatus(c echo.Context) error {
 		timestamp = &parsed
 	}
 
-	website, err := a.websiteService.UpdateSSLStatus(reqCtx, domain, req.Status, req.Error, timestamp)
+	wd, err := a.websiteService.UpdateSSLStatus(reqCtx, domain, req.Status, req.Error, timestamp)
 	if err != nil {
 		if strings.Contains(err.Error(), "website not found") {
 			apiErr := NewError(pluginEvents.ErrWebsiteNotFound, err)
@@ -461,10 +493,18 @@ func (a *API) updateSSLStatus(c echo.Context) error {
 		return ctx.Error(apiErr, apiErr.HttpStatus())
 	}
 
+	website, err := a.websiteService.GetWebsite(reqCtx, wd.UserID, wd.WebsiteID)
+	if err != nil {
+		a.Logger().Error("Failed to load website for SSL response", zap.Error(err), zap.String("domain", domain))
+		apiErr := NewError(ErrKeyFileProcessingFailed, err)
+		return ctx.Error(apiErr, apiErr.HttpStatus())
+	}
+
 	resp := &dto.WebsiteResponse{}
 	resp.GatewayDomain = a.gatewayDomain()
 	resp.SetSubdomainInfo(a.zoneDomain(reqCtx, website.DNSZoneID))
 	resp.SetValidationRecordInfo(a.verificationTokenKey())
 	resp.EnrichActiveCID(ipnsKeyCIDResolver{svc: a.ipnsKeyService, ctx: reqCtx}, website.UserID, website)
+	a.applyApexSSLStatus(reqCtx, resp, website)
 	return httputil.EncodeResponse(ctx, website, resp)
 }

--- a/internal/api/api_websites_test.go
+++ b/internal/api/api_websites_test.go
@@ -13,12 +13,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	pluginCore "go.lumeweb.com/portal-plugin-ipfs/core"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/api/dto"
 	pluginDb "go.lumeweb.com/portal-plugin-ipfs/internal/db"
 	mocks "go.lumeweb.com/portal-plugin-ipfs/internal/testing/mocks"
-	pluginCore "go.lumeweb.com/portal-plugin-ipfs/core"
-	coreTesting "go.lumeweb.com/portal/core/testing"
 	"go.lumeweb.com/portal/core"
+	coreTesting "go.lumeweb.com/portal/core/testing"
 	"gorm.io/gorm"
 )
 
@@ -219,18 +219,23 @@ func TestAPI_GetSSLStatus(t *testing.T) {
 
 			mockWebsiteService := core.GetService[*mocks.MockWebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
 
-			timestamp := time.Now().UTC()
 			mockWebsite := &pluginDb.Website{
-				ID:              1,
-				UserID:          userID,
-				Domain:          TestDomain,
-				TargetType:      string(pluginDb.WebsiteTargetTypeIPFS),
-				Status:          string(pluginDb.WebsiteStatusActive),
-				SSLStatus:       string(pluginDb.SSLStatusReady),
-				SSLLastUpdatedAt: &timestamp,
+				ID:         1,
+				UserID:     userID,
+				Domain:     TestDomain,
+				TargetType: string(pluginDb.WebsiteTargetTypeIPFS),
+				Status:     string(pluginDb.WebsiteStatusActive),
+			}
+			mockApex := &pluginDb.WebsiteDomain{
+				ID:               1,
+				WebsiteID:        1,
+				Domain:           TestDomain,
+				SSLStatus:        string(pluginDb.SSLStatusReady),
+				SSLLastUpdatedAt: func() *time.Time { v := time.Now().UTC(); return &v }(),
 			}
 
 			mockWebsiteService.EXPECT().GetWebsiteByDomain(mock.Anything, TestDomain).Return(mockWebsite, pluginDb.DomainNamespaceICANN, nil)
+			mockWebsiteService.EXPECT().GetApexDomainBinding(mock.Anything, uint(1)).Return(mockApex, nil)
 
 			rec := helper.makeRequest(http.MethodGet, "/api/websites/"+TestDomain+"/ssl-status", nil)
 
@@ -252,18 +257,23 @@ func TestAPI_GetSSLStatus(t *testing.T) {
 
 			mockWebsiteService := core.GetService[*mocks.MockWebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
 
-			timestamp := time.Now().UTC()
 			mockWebsite := &pluginDb.Website{
-				ID:              1,
-				UserID:          userID,
-				Domain:          TestDomain,
-				TargetType:      string(pluginDb.WebsiteTargetTypeIPFS),
-				Status:          string(pluginDb.WebsiteStatusActive),
-				SSLStatus:       string(pluginDb.SSLStatusPending),
-				SSLLastUpdatedAt: &timestamp,
+				ID:         1,
+				UserID:     userID,
+				Domain:     TestDomain,
+				TargetType: string(pluginDb.WebsiteTargetTypeIPFS),
+				Status:     string(pluginDb.WebsiteStatusActive),
+			}
+			mockApex := &pluginDb.WebsiteDomain{
+				ID:               1,
+				WebsiteID:        1,
+				Domain:           TestDomain,
+				SSLStatus:        string(pluginDb.SSLStatusPending),
+				SSLLastUpdatedAt: func() *time.Time { v := time.Now().UTC(); return &v }(),
 			}
 
 			mockWebsiteService.EXPECT().GetWebsiteByDomain(mock.Anything, TestDomain).Return(mockWebsite, pluginDb.DomainNamespaceICANN, nil)
+			mockWebsiteService.EXPECT().GetApexDomainBinding(mock.Anything, uint(1)).Return(mockApex, nil)
 
 			rec := helper.makeRequest(http.MethodGet, "/api/websites/"+TestDomain+"/ssl-status", nil)
 
@@ -299,29 +309,39 @@ func TestAPI_GetSSLStatus(t *testing.T) {
 	})
 }
 
-// Webhook SSL Status Integration Tests
-// These tests verify the webhook endpoint for SSL status updates from Caddy
-
 func TestAPI_UpdateSSLStatus_Webhook(t *testing.T) {
+	// setUpWebhookMocks sets up the UpdateSSLStatus / GetWebsite / GetApexDomainBinding
+	// mocks shared by the success cases. It returns the website and apex binding used.
+	setUpWebhookMocks := func(tb coreTesting.TB, mockWebsiteService *mocks.MockWebsiteService, status pluginDb.SSLStatus, sslError string, ts time.Time) (*pluginDb.Website, *pluginDb.WebsiteDomain) {
+		mockWebsite := &pluginDb.Website{
+			ID:         1,
+			UserID:     uint(1),
+			Domain:     TestDomain,
+			TargetType: string(pluginDb.WebsiteTargetTypeIPFS),
+			Status:     string(pluginDb.WebsiteStatusActive),
+		}
+		mockApex := &pluginDb.WebsiteDomain{
+			ID:               1,
+			WebsiteID:        1,
+			Domain:           TestDomain,
+			SSLStatus:        string(status),
+			SSLError:         sslError,
+			SSLLastUpdatedAt: &ts,
+		}
+		mockWebsiteService.EXPECT().UpdateSSLStatus(mock.Anything, TestDomain, status, sslError, mock.AnythingOfType("*time.Time")).Return(mockApex, nil)
+		mockWebsiteService.EXPECT().GetWebsite(mock.Anything, uint(1), uint(1)).Return(mockWebsite, nil)
+		mockWebsiteService.EXPECT().GetApexDomainBinding(mock.Anything, uint(1)).Return(mockApex, nil)
+		return mockWebsite, mockApex
+	}
+
 	t.Run("success_status_ready", func(t *testing.T) {
 		coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 			helper := newMockHelper(t, ctx)
-			userID := uint(1)
 
 			mockWebsiteService := core.GetService[*mocks.MockWebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
 
 			timestamp := time.Now().UTC()
-			mockWebsite := &pluginDb.Website{
-				ID:              1,
-				UserID:          userID,
-				Domain:          TestDomain,
-				TargetType:      string(pluginDb.WebsiteTargetTypeIPFS),
-				Status:          string(pluginDb.WebsiteStatusActive),
-				SSLStatus:       string(pluginDb.SSLStatusReady),
-				SSLLastUpdatedAt: &timestamp,
-			}
-
-			mockWebsiteService.EXPECT().UpdateSSLStatus(mock.Anything, TestDomain, pluginDb.SSLStatusReady, "", mock.AnythingOfType("*time.Time")).Return(mockWebsite, nil)
+			setUpWebhookMocks(tb, mockWebsiteService, pluginDb.SSLStatusReady, "", timestamp)
 
 			reqBody := fmt.Sprintf(`{"status":"ready","timestamp":"%s"}`, timestamp.Format(time.RFC3339))
 			rec := helper.makeGatewayAuthenticatedRequest(http.MethodPost, "/internal/websites/"+TestDomain+"/ssl-status", testGatewaySecret(), []byte(reqBody))
@@ -340,23 +360,11 @@ func TestAPI_UpdateSSLStatus_Webhook(t *testing.T) {
 	t.Run("success_status_failed_with_error", func(t *testing.T) {
 		coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 			helper := newMockHelper(t, ctx)
-			userID := uint(1)
 
 			mockWebsiteService := core.GetService[*mocks.MockWebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
 
 			timestamp := time.Now().UTC()
-			mockWebsite := &pluginDb.Website{
-				ID:              1,
-				UserID:          userID,
-				Domain:          TestDomain,
-				TargetType:      string(pluginDb.WebsiteTargetTypeIPFS),
-				Status:          string(pluginDb.WebsiteStatusActive),
-				SSLStatus:       string(pluginDb.SSLStatusFailed),
-				SSLError:        "certificate validation failed",
-				SSLLastUpdatedAt: &timestamp,
-			}
-
-			mockWebsiteService.EXPECT().UpdateSSLStatus(mock.Anything, TestDomain, pluginDb.SSLStatusFailed, "certificate validation failed", mock.AnythingOfType("*time.Time")).Return(mockWebsite, nil)
+			setUpWebhookMocks(tb, mockWebsiteService, pluginDb.SSLStatusFailed, "certificate validation failed", timestamp)
 
 			reqBody := fmt.Sprintf(`{"status":"failed","error":"certificate validation failed","timestamp":"%s"}`, timestamp.Format(time.RFC3339))
 			rec := helper.makeGatewayAuthenticatedRequest(http.MethodPost, "/internal/websites/"+TestDomain+"/ssl-status", testGatewaySecret(), []byte(reqBody))
@@ -376,22 +384,11 @@ func TestAPI_UpdateSSLStatus_Webhook(t *testing.T) {
 	t.Run("success_status_pending", func(t *testing.T) {
 		coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 			helper := newMockHelper(t, ctx)
-			userID := uint(1)
 
 			mockWebsiteService := core.GetService[*mocks.MockWebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
 
 			timestamp := time.Now().UTC()
-			mockWebsite := &pluginDb.Website{
-				ID:              1,
-				UserID:          userID,
-				Domain:          TestDomain,
-				TargetType:      string(pluginDb.WebsiteTargetTypeIPFS),
-				Status:          string(pluginDb.WebsiteStatusActive),
-				SSLStatus:       string(pluginDb.SSLStatusPending),
-				SSLLastUpdatedAt: &timestamp,
-			}
-
-			mockWebsiteService.EXPECT().UpdateSSLStatus(mock.Anything, TestDomain, pluginDb.SSLStatusPending, "", mock.AnythingOfType("*time.Time")).Return(mockWebsite, nil)
+			setUpWebhookMocks(tb, mockWebsiteService, pluginDb.SSLStatusPending, "", timestamp)
 
 			reqBody := fmt.Sprintf(`{"status":"pending","timestamp":"%s"}`, timestamp.Format(time.RFC3339))
 			rec := helper.makeGatewayAuthenticatedRequest(http.MethodPost, "/internal/websites/"+TestDomain+"/ssl-status", testGatewaySecret(), []byte(reqBody))
@@ -410,22 +407,11 @@ func TestAPI_UpdateSSLStatus_Webhook(t *testing.T) {
 	t.Run("success_status_issuing", func(t *testing.T) {
 		coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 			helper := newMockHelper(t, ctx)
-			userID := uint(1)
 
 			mockWebsiteService := core.GetService[*mocks.MockWebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
 
 			timestamp := time.Now().UTC()
-			mockWebsite := &pluginDb.Website{
-				ID:              1,
-				UserID:          userID,
-				Domain:          TestDomain,
-				TargetType:      string(pluginDb.WebsiteTargetTypeIPFS),
-				Status:          string(pluginDb.WebsiteStatusActive),
-				SSLStatus:       string(pluginDb.SSLStatusIssuing),
-				SSLLastUpdatedAt: &timestamp,
-			}
-
-			mockWebsiteService.EXPECT().UpdateSSLStatus(mock.Anything, TestDomain, pluginDb.SSLStatusIssuing, "", mock.AnythingOfType("*time.Time")).Return(mockWebsite, nil)
+			setUpWebhookMocks(tb, mockWebsiteService, pluginDb.SSLStatusIssuing, "", timestamp)
 
 			reqBody := fmt.Sprintf(`{"status":"issuing","timestamp":"%s"}`, timestamp.Format(time.RFC3339))
 			rec := helper.makeGatewayAuthenticatedRequest(http.MethodPost, "/internal/websites/"+TestDomain+"/ssl-status", testGatewaySecret(), []byte(reqBody))
@@ -525,36 +511,6 @@ func TestAPI_UpdateSSLStatus_Webhook(t *testing.T) {
 		}, TestOptions)
 	})
 
-	t.Run("idempotent_duplicate_requests", func(t *testing.T) {
-		coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
-			helper := newMockHelper(t, ctx)
-			userID := uint(1)
-
-			mockWebsiteService := core.GetService[*mocks.MockWebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
-
-			timestamp := time.Now().UTC()
-			mockWebsite := &pluginDb.Website{
-				ID:              1,
-				UserID:          userID,
-				Domain:          TestDomain,
-				TargetType:      string(pluginDb.WebsiteTargetTypeIPFS),
-				Status:          string(pluginDb.WebsiteStatusActive),
-				SSLStatus:       string(pluginDb.SSLStatusReady),
-				SSLLastUpdatedAt: &timestamp,
-			}
-
-			mockWebsiteService.EXPECT().UpdateSSLStatus(mock.Anything, TestDomain, pluginDb.SSLStatusReady, "", mock.AnythingOfType("*time.Time")).Return(mockWebsite, nil).Times(2)
-
-			reqBody := fmt.Sprintf(`{"status":"ready","timestamp":"%s"}`, timestamp.Format(time.RFC3339))
-
-			rec1 := helper.makeGatewayAuthenticatedRequest(http.MethodPost, "/internal/websites/"+TestDomain+"/ssl-status", testGatewaySecret(), []byte(reqBody))
-			assert.Equal(t, http.StatusOK, rec1.Code)
-
-			rec2 := helper.makeGatewayAuthenticatedRequest(http.MethodPost, "/internal/websites/"+TestDomain+"/ssl-status", testGatewaySecret(), []byte(reqBody))
-			assert.Equal(t, http.StatusOK, rec2.Code)
-		}, TestOptions)
-	})
-
 	t.Run("status_transition_pending_to_issuing_to_ready", func(t *testing.T) {
 		coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 			helper := newMockHelper(t, ctx)
@@ -566,44 +522,29 @@ func TestAPI_UpdateSSLStatus_Webhook(t *testing.T) {
 			timestamp2 := timestamp1.Add(time.Minute)
 			timestamp3 := timestamp2.Add(time.Hour)
 
-			mockWebsitePending := &pluginDb.Website{
-				ID:              1,
-				UserID:          userID,
-				Domain:          TestDomain,
-				TargetType:      string(pluginDb.WebsiteTargetTypeIPFS),
-				Status:          string(pluginDb.WebsiteStatusActive),
-				SSLStatus:       string(pluginDb.SSLStatusPending),
-				SSLLastUpdatedAt: &timestamp1,
+			mockWebsite := &pluginDb.Website{
+				ID:         1,
+				UserID:     userID,
+				Domain:     TestDomain,
+				TargetType: string(pluginDb.WebsiteTargetTypeIPFS),
+				Status:     string(pluginDb.WebsiteStatusActive),
 			}
 
-			mockWebsiteIssuing := &pluginDb.Website{
-				ID:              1,
-				UserID:          userID,
-				Domain:          TestDomain,
-				TargetType:      string(pluginDb.WebsiteTargetTypeIPFS),
-				Status:          string(pluginDb.WebsiteStatusActive),
-				SSLStatus:       string(pluginDb.SSLStatusIssuing),
-				SSLLastUpdatedAt: &timestamp2,
-			}
+			mockApexPending := &pluginDb.WebsiteDomain{ID: 1, WebsiteID: 1, Domain: TestDomain, SSLStatus: string(pluginDb.SSLStatusPending), SSLLastUpdatedAt: &timestamp1}
+			mockApexIssuing := &pluginDb.WebsiteDomain{ID: 1, WebsiteID: 1, Domain: TestDomain, SSLStatus: string(pluginDb.SSLStatusIssuing), SSLLastUpdatedAt: &timestamp2}
+			mockApexReady := &pluginDb.WebsiteDomain{ID: 1, WebsiteID: 1, Domain: TestDomain, SSLStatus: string(pluginDb.SSLStatusReady), SSLLastUpdatedAt: &timestamp3}
 
-			mockWebsiteReady := &pluginDb.Website{
-				ID:              1,
-				UserID:          userID,
-				Domain:          TestDomain,
-				TargetType:      string(pluginDb.WebsiteTargetTypeIPFS),
-				Status:          string(pluginDb.WebsiteStatusActive),
-				SSLStatus:       string(pluginDb.SSLStatusReady),
-				SSLLastUpdatedAt: &timestamp3,
-			}
-
-			mockWebsiteService.EXPECT().UpdateSSLStatus(mock.Anything, TestDomain, pluginDb.SSLStatusPending, "", mock.AnythingOfType("*time.Time")).Return(mockWebsitePending, nil)
-			mockWebsiteService.EXPECT().UpdateSSLStatus(mock.Anything, TestDomain, pluginDb.SSLStatusIssuing, "", mock.AnythingOfType("*time.Time")).Return(mockWebsiteIssuing, nil)
-			mockWebsiteService.EXPECT().UpdateSSLStatus(mock.Anything, TestDomain, pluginDb.SSLStatusReady, "", mock.AnythingOfType("*time.Time")).Return(mockWebsiteReady, nil)
+			mockWebsiteService.EXPECT().UpdateSSLStatus(mock.Anything, TestDomain, pluginDb.SSLStatusPending, "", mock.AnythingOfType("*time.Time")).Return(mockApexPending, nil)
+			mockWebsiteService.EXPECT().UpdateSSLStatus(mock.Anything, TestDomain, pluginDb.SSLStatusIssuing, "", mock.AnythingOfType("*time.Time")).Return(mockApexIssuing, nil)
+			mockWebsiteService.EXPECT().UpdateSSLStatus(mock.Anything, TestDomain, pluginDb.SSLStatusReady, "", mock.AnythingOfType("*time.Time")).Return(mockApexReady, nil)
+			mockWebsiteService.EXPECT().GetWebsite(mock.Anything, userID, uint(1)).Return(mockWebsite, nil).Times(3)
+			mockWebsiteService.EXPECT().GetApexDomainBinding(mock.Anything, uint(1)).Return(mockApexPending, nil).Once()
+			mockWebsiteService.EXPECT().GetApexDomainBinding(mock.Anything, uint(1)).Return(mockApexIssuing, nil).Once()
+			mockWebsiteService.EXPECT().GetApexDomainBinding(mock.Anything, uint(1)).Return(mockApexReady, nil).Once()
 
 			reqBody1 := fmt.Sprintf(`{"status":"pending","timestamp":"%s"}`, timestamp1.Format(time.RFC3339))
 			rec1 := helper.makeGatewayAuthenticatedRequest(http.MethodPost, "/internal/websites/"+TestDomain+"/ssl-status", testGatewaySecret(), []byte(reqBody1))
 			assert.Equal(t, http.StatusOK, rec1.Code)
-
 			var response1 dto.WebsiteResponse
 			err := json.Unmarshal(rec1.Body.Bytes(), &response1)
 			require.NoError(t, err)
@@ -612,7 +553,6 @@ func TestAPI_UpdateSSLStatus_Webhook(t *testing.T) {
 			reqBody2 := fmt.Sprintf(`{"status":"issuing","timestamp":"%s"}`, timestamp2.Format(time.RFC3339))
 			rec2 := helper.makeGatewayAuthenticatedRequest(http.MethodPost, "/internal/websites/"+TestDomain+"/ssl-status", testGatewaySecret(), []byte(reqBody2))
 			assert.Equal(t, http.StatusOK, rec2.Code)
-
 			var response2 dto.WebsiteResponse
 			err = json.Unmarshal(rec2.Body.Bytes(), &response2)
 			require.NoError(t, err)
@@ -621,7 +561,6 @@ func TestAPI_UpdateSSLStatus_Webhook(t *testing.T) {
 			reqBody3 := fmt.Sprintf(`{"status":"ready","timestamp":"%s"}`, timestamp3.Format(time.RFC3339))
 			rec3 := helper.makeGatewayAuthenticatedRequest(http.MethodPost, "/internal/websites/"+TestDomain+"/ssl-status", testGatewaySecret(), []byte(reqBody3))
 			assert.Equal(t, http.StatusOK, rec3.Code)
-
 			var response3 dto.WebsiteResponse
 			err = json.Unmarshal(rec3.Body.Bytes(), &response3)
 			require.NoError(t, err)
@@ -629,8 +568,6 @@ func TestAPI_UpdateSSLStatus_Webhook(t *testing.T) {
 		}, TestOptions)
 	})
 }
-
-
 
 func TestAPI_ListWebsites(t *testing.T) {
 	t.Run("success", func(t *testing.T) {

--- a/internal/api/dto/domain.go
+++ b/internal/api/dto/domain.go
@@ -63,6 +63,9 @@ type DomainResponse struct {
 	ZoneName    string         `json:"zone_name,omitempty"`
 	GatewayHost string         `json:"gateway_host,omitempty"`
 	Delegation  *DNSDelegation `json:"delegation,omitempty"`
+	// Per-domain SSL certificate state. SSL is a per-domain property, so it is
+	// exposed on the domain record (not the website).
+	SSL *SSLStatusInfo `json:"ssl,omitempty"`
 }
 
 func (r *DomainResponse) FromModel(m *db.WebsiteDomain) error {
@@ -72,6 +75,21 @@ func (r *DomainResponse) FromModel(m *db.WebsiteDomain) error {
 	r.Status = string(m.Status)
 	r.ZoneName = m.ZoneName
 	r.GatewayHost = m.GatewayHost
+
+	if m.SSLStatus != "" {
+		r.SSL = &SSLStatusInfo{
+			Status: m.SSLStatus,
+			Error:  m.SSLError,
+		}
+		if m.SSLIssuedAt != nil {
+			v := *m.SSLIssuedAt
+			r.SSL.IssuedAt = &v
+		}
+		if m.SSLLastUpdatedAt != nil {
+			v := *m.SSLLastUpdatedAt
+			r.SSL.LastUpdatedAt = &v
+		}
+	}
 
 	// Project the heterogeneous, provider-emitted DelegationData into the typed,
 	// provider-agnostic shape. If it fails to map, leave Delegation nil rather

--- a/internal/api/dto/website.go
+++ b/internal/api/dto/website.go
@@ -48,13 +48,13 @@ func (r *IPNSKeyRequest) ToModel() (*db.IPFSIPNSKey, error) {
 
 // IPNSKeyResponse represents an IPNS key response
 type IPNSKeyResponse struct {
-	ID               uint       `json:"id"`
-	Name             string     `json:"name"`
-	IPNSName         string     `json:"ipns_name"`
-	PeerID           string     `json:"peer_id"`
-	Value            string     `json:"value,omitempty"`
-	LastPublishedAt  *time.Time `json:"last_published_at,omitempty"`
-	Created          time.Time  `json:"created"`
+	ID              uint       `json:"id"`
+	Name            string     `json:"name"`
+	IPNSName        string     `json:"ipns_name"`
+	PeerID          string     `json:"peer_id"`
+	Value           string     `json:"value,omitempty"`
+	LastPublishedAt *time.Time `json:"last_published_at,omitempty"`
+	Created         time.Time  `json:"created"`
 }
 
 func (r *IPNSKeyResponse) FromModel(model *db.IPFSIPNSKey) error {
@@ -70,13 +70,13 @@ func (r *IPNSKeyResponse) FromModel(model *db.IPFSIPNSKey) error {
 
 // IPNSKeyListResponse represents an IPNS key in a list response
 type IPNSKeyListResponse struct {
-	ID               uint       `json:"id"`
-	Name             string     `json:"name"`
-	IPNSName         string     `json:"ipns_name"`
-	PeerID           string     `json:"peer_id"`
-	Value            string     `json:"value,omitempty"`
-	LastPublishedAt  *time.Time `json:"last_published_at,omitempty"`
-	Created          time.Time  `json:"created"`
+	ID              uint       `json:"id"`
+	Name            string     `json:"name"`
+	IPNSName        string     `json:"ipns_name"`
+	PeerID          string     `json:"peer_id"`
+	Value           string     `json:"value,omitempty"`
+	LastPublishedAt *time.Time `json:"last_published_at,omitempty"`
+	Created         time.Time  `json:"created"`
 }
 
 func (r *IPNSKeyListResponse) FromModel(model *db.IPFSIPNSKey) error {
@@ -177,10 +177,10 @@ func (r *IPNSRepublishResponse) FromModel(any) error {
 
 // WebsiteRequest represents a request to create a website
 type WebsiteRequest struct {
-	Domain          string              `json:"domain"`
-	TargetType      db.WebsiteTargetType `json:"target_type"` // db.WebsiteTargetTypeIPFS or db.WebsiteTargetTypeIPNS
-	TargetHash      string              `json:"target_hash"` // CID or IPNS peer ID
-	DNSEnabled      *bool               `json:"dns_hosting_enabled,omitempty"` // Whether DNS hosting is enabled for this website (defaults to true if not specified)
+	Domain     string               `json:"domain"`
+	TargetType db.WebsiteTargetType `json:"target_type"`                   // db.WebsiteTargetTypeIPFS or db.WebsiteTargetTypeIPNS
+	TargetHash string               `json:"target_hash"`                   // CID or IPNS peer ID
+	DNSEnabled *bool                `json:"dns_hosting_enabled,omitempty"` // Whether DNS hosting is enabled for this website (defaults to true if not specified)
 }
 
 func (r WebsiteRequest) Schema() *zog.StructSchema {
@@ -274,10 +274,10 @@ func (r *WebsiteRequest) ToModel() (*db.Website, error) {
 // WebsiteUpdateRequest represents a request to update a website
 // All fields are optional — only provided fields will be updated
 type WebsiteUpdateRequest struct {
-	Domain     *string              `json:"domain,omitempty"`
+	Domain     *string               `json:"domain,omitempty"`
 	TargetType *db.WebsiteTargetType `json:"target_type,omitempty"`
-	TargetHash *string              `json:"target_hash,omitempty"`
-	DNSEnabled *bool                `json:"dns_hosting_enabled,omitempty"`
+	TargetHash *string               `json:"target_hash,omitempty"`
+	DNSEnabled *bool                 `json:"dns_hosting_enabled,omitempty"`
 }
 
 // HasUpdates returns true if at least one field is set
@@ -361,46 +361,46 @@ func (r *WebsiteUpdateRequest) ToModel() (*db.Website, error) {
 
 // SSLStatusInfo represents SSL certificate status information
 type SSLStatusInfo struct {
-	Status         string     `json:"status"`
-	Error          string     `json:"error,omitempty"`
-	IssuedAt       *time.Time `json:"issued_at,omitempty"`
-	LastUpdatedAt  *time.Time `json:"last_updated_at,omitempty"`
+	Status        string     `json:"status"`
+	Error         string     `json:"error,omitempty"`
+	IssuedAt      *time.Time `json:"issued_at,omitempty"`
+	LastUpdatedAt *time.Time `json:"last_updated_at,omitempty"`
 }
 
 // WebsiteResponse represents a website response
 type WebsiteResponse struct {
-	ID                  uint           `json:"id"`
-	Domain              string         `json:"domain"`
+	ID     uint   `json:"id"`
+	Domain string `json:"domain"`
 	// IPFS or IPNS
-	TargetType          string         `json:"target_type"`
+	TargetType string `json:"target_type"`
 	// CID (IPFS) or peer ID (IPNS)
-	TargetHash          string         `json:"target_hash"`
+	TargetHash string `json:"target_hash"`
 	// FK to the linked IPNS key (set when DNS hosting auto-creates a key)
-	IPNSKeyID           *uint          `json:"ipns_key_id,omitempty"`
+	IPNSKeyID *uint `json:"ipns_key_id,omitempty"`
 	// The currently-published IPFS content CID (distinct from target_hash when target is IPNS)
-	ActiveCID           string         `json:"active_cid,omitempty"`
-	Status              string         `json:"status"`
+	ActiveCID string `json:"active_cid,omitempty"`
+	Status    string `json:"status"`
 	// The full TXT record value (e.g. "lumeweb-verify=abc123...")
-	ValidationToken       string     `json:"validation_token"`
+	ValidationToken string `json:"validation_token"`
 	// The DNS hostname for the TXT record (e.g. "lumeweb-verify.example.com")
-	ValidationRecordHost  string     `json:"validation_record_host,omitempty"`
-	ValidationExpiresAt *time.Time     `json:"validation_expires_at,omitempty"`
-	LastCheckedAt       *time.Time     `json:"last_checked_at,omitempty"`
+	ValidationRecordHost string     `json:"validation_record_host,omitempty"`
+	ValidationExpiresAt  *time.Time `json:"validation_expires_at,omitempty"`
+	LastCheckedAt        *time.Time `json:"last_checked_at,omitempty"`
 	// FK to the DNS zone hosting this website's records
-	DNSZoneID           *uint          `json:"dns_zone_id,omitempty"`
+	DNSZoneID *uint `json:"dns_zone_id,omitempty"`
 	// Whether DNS hosting (zone + records) is enabled for this website
-	Enabled             bool           `json:"dns_hosting_enabled"`
+	Enabled bool `json:"dns_hosting_enabled"`
 	// True if domain is a subdomain of a shared DNS zone
-	IsSubdomain         bool           `json:"is_subdomain"`
+	IsSubdomain bool `json:"is_subdomain"`
 	// Gateway domain for constructing public URLs (e.g. ipfs.example.com)
-	GatewayDomain       string         `json:"gateway_domain,omitempty"`
-	Created             time.Time      `json:"created"`
-	Updated             time.Time      `json:"updated"`
+	GatewayDomain string    `json:"gateway_domain,omitempty"`
+	Created       time.Time `json:"created"`
+	Updated       time.Time `json:"updated"`
 	// Whether validation token has expired
-	Expired             bool            `json:"expired"`
-	SSL                 *SSLStatusInfo  `json:"ssl,omitempty"`
+	Expired bool           `json:"expired"`
+	SSL     *SSLStatusInfo `json:"ssl,omitempty"`
 	// Set by SetValidationRecordInfo; consumed by FromModel to format ValidationToken/ValidationRecordHost
-	tokenKey            string
+	tokenKey string
 }
 
 func (r *WebsiteResponse) FromModel(model *db.Website) error {
@@ -423,25 +423,6 @@ func (r *WebsiteResponse) FromModel(model *db.Website) error {
 		r.ValidationRecordHost = r.tokenKey + "." + model.Domain
 	} else {
 		r.ValidationToken = model.ValidationToken
-	}
-
-	if model.SSLStatus != "" {
-		var lastUpdated *time.Time
-		if model.SSLLastUpdatedAt != nil {
-			v := *model.SSLLastUpdatedAt
-			lastUpdated = &v
-		}
-		var issuedAt *time.Time
-		if model.SSLIssuedAt != nil {
-			v := *model.SSLIssuedAt
-			issuedAt = &v
-		}
-		r.SSL = &SSLStatusInfo{
-			Status:        model.SSLStatus,
-			Error:         model.SSLError,
-			IssuedAt:      issuedAt,
-			LastUpdatedAt: lastUpdated,
-		}
 	}
 
 	return nil
@@ -501,9 +482,9 @@ type WebsiteItemResponse struct {
 
 // WebsiteFilter represents filtering options for website listings
 type WebsiteFilter struct {
-	Domain     *string              `json:"domain,omitempty" query:"domain"`
+	Domain     *string               `json:"domain,omitempty" query:"domain"`
 	TargetType *db.WebsiteTargetType `json:"target_type,omitempty" query:"target_type"`
-	Status     *db.WebsiteStatus    `json:"status,omitempty" query:"status"`
+	Status     *db.WebsiteStatus     `json:"status,omitempty" query:"status"`
 }
 
 func (f WebsiteFilter) Schema() *zog.StructSchema {
@@ -561,7 +542,7 @@ func (r SSLStatusUpdateRequest) Schema() *zog.StructSchema {
 			db.SSLStatusReady,
 			db.SSLStatusFailed,
 		}).Required(),
-		"Error":     zog.String().Optional().Max(1000),
+		"Error": zog.String().Optional().Max(1000),
 		"Timestamp": zog.String().Optional().Transform(func(val *string, ctx zog.Ctx) error {
 			if *val == "" {
 				return fmt.Errorf("timestamp cannot be an empty string")

--- a/internal/api/dto/website_test.go
+++ b/internal/api/dto/website_test.go
@@ -17,7 +17,7 @@ func TestSSLStatusUpdateRequest_Schema(t *testing.T) {
 	t.Run("schema returns non-nil struct schema", func(t *testing.T) {
 		req := SSLStatusUpdateRequest{}
 		schema := req.Schema()
-		
+
 		require.NotNil(t, schema, "Schema() should return non-nil schema")
 		assert.IsType(t, &zog.StructSchema{}, schema, "Schema() should return *zog.StructSchema")
 	})
@@ -72,7 +72,7 @@ func TestSSLStatusUpdateRequest_StatusValidation(t *testing.T) {
 
 		schema := req.Schema()
 		require.NotNil(t, schema)
-		
+
 		// Verify the schema is properly configured
 		// The actual validation logic is in the Schema() method
 	})
@@ -167,7 +167,7 @@ func TestSSLStatusUpdateRequest_InvalidStatusValues(t *testing.T) {
 
 		schema := req.Schema()
 		require.NotNil(t, schema)
-		
+
 		// The Schema() method uses config.ZogStringLike[db.SSLStatus]().OneOf()
 		// which validates that status is one of the allowed values
 		assert.Equal(t, db.SSLStatusReady, req.Status)
@@ -180,7 +180,7 @@ func TestSSLStatusUpdateRequest_InvalidStatusValues(t *testing.T) {
 
 		schema := req.Schema()
 		require.NotNil(t, schema)
-		
+
 		// Verify the schema is configured with OneOf validation
 		// The actual validation happens at runtime via httputil.DecodeAndValidateRequest
 	})
@@ -192,7 +192,7 @@ func TestSSLStatusUpdateRequest_InvalidStatusValues(t *testing.T) {
 
 		schema := req.Schema()
 		require.NotNil(t, schema)
-		
+
 		// Status field is marked as Required() in the schema
 		assert.Equal(t, db.SSLStatusReady, req.Status)
 	})
@@ -207,7 +207,7 @@ func TestSSLStatusUpdateRequest_InvalidTimestampFormat(t *testing.T) {
 
 		schema := req.Schema()
 		require.NotNil(t, schema)
-		
+
 		// The Schema() method includes a Transform() that validates RFC3339 format
 		assert.Equal(t, "2024-02-24T12:00:00Z", req.Timestamp)
 	})
@@ -220,7 +220,7 @@ func TestSSLStatusUpdateRequest_InvalidTimestampFormat(t *testing.T) {
 
 		schema := req.Schema()
 		require.NotNil(t, schema)
-		
+
 		// Transform function validates RFC3339 format in the schema
 		assert.Equal(t, "2024-02-24T12:00:00-08:00", req.Timestamp)
 	})
@@ -233,7 +233,7 @@ func TestSSLStatusUpdateRequest_InvalidTimestampFormat(t *testing.T) {
 
 		schema := req.Schema()
 		require.NotNil(t, schema)
-		
+
 		// Timestamp is Optional() and Transform() allows empty string
 		assert.Equal(t, "", req.Timestamp)
 	})
@@ -245,7 +245,7 @@ func TestSSLStatusUpdateRequest_InvalidTimestampFormat(t *testing.T) {
 
 		schema := req.Schema()
 		require.NotNil(t, schema)
-		
+
 		// Timestamp field is marked as Optional() in the schema
 		assert.Equal(t, "", req.Timestamp)
 	})
@@ -260,7 +260,7 @@ func TestSSLStatusUpdateRequest_OptionalFields(t *testing.T) {
 
 		schema := req.Schema()
 		require.NotNil(t, schema)
-		
+
 		// Error field is marked as Optional() in the schema
 		assert.Equal(t, "", req.Error)
 	})
@@ -272,7 +272,7 @@ func TestSSLStatusUpdateRequest_OptionalFields(t *testing.T) {
 
 		schema := req.Schema()
 		require.NotNil(t, schema)
-		
+
 		assert.Equal(t, "", req.Error)
 	})
 
@@ -284,7 +284,7 @@ func TestSSLStatusUpdateRequest_OptionalFields(t *testing.T) {
 
 		schema := req.Schema()
 		require.NotNil(t, schema)
-		
+
 		// Error field has Max(1000) validation
 		assert.Equal(t, "Certificate issuance failed: timeout waiting for ACME challenge", req.Error)
 	})
@@ -298,7 +298,7 @@ func TestSSLStatusUpdateRequest_OptionalFields(t *testing.T) {
 
 		schema := req.Schema()
 		require.NotNil(t, schema)
-		
+
 		// All fields are properly configured
 		assert.Equal(t, db.SSLStatusFailed, req.Status)
 		assert.Equal(t, "Certificate issuance failed: timeout", req.Error)
@@ -312,7 +312,7 @@ func TestSSLStatusUpdateRequest_OptionalFields(t *testing.T) {
 
 		schema := req.Schema()
 		require.NotNil(t, schema)
-		
+
 		assert.Equal(t, db.SSLStatusReady, req.Status)
 		assert.Equal(t, "", req.Error)
 		assert.Equal(t, "", req.Timestamp)
@@ -326,7 +326,7 @@ func TestSSLStatusUpdateRequest_OptionalFields(t *testing.T) {
 
 		schema := req.Schema()
 		require.NotNil(t, schema)
-		
+
 		assert.Equal(t, db.SSLStatusFailed, req.Status)
 		assert.Equal(t, "Certificate issuance failed", req.Error)
 		assert.Equal(t, "", req.Timestamp)
@@ -340,7 +340,7 @@ func TestSSLStatusUpdateRequest_OptionalFields(t *testing.T) {
 
 		schema := req.Schema()
 		require.NotNil(t, schema)
-		
+
 		assert.Equal(t, db.SSLStatusReady, req.Status)
 		assert.Equal(t, "", req.Error)
 		assert.Equal(t, "2024-02-24T12:00:00Z", req.Timestamp)
@@ -350,7 +350,7 @@ func TestSSLStatusUpdateRequest_OptionalFields(t *testing.T) {
 func TestSSLStatusUpdateRequest_StructFields(t *testing.T) {
 	t.Run("struct has required fields", func(t *testing.T) {
 		req := SSLStatusUpdateRequest{}
-		
+
 		// Verify the struct has the expected fields
 		assert.IsType(t, db.SSLStatus(""), req.Status, "Status should be SSLStatus type")
 		assert.IsType(t, "", req.Error, "Error should be string")
@@ -363,7 +363,7 @@ func TestSSLStatusUpdateRequest_StructFields(t *testing.T) {
 			Error:     "error",
 			Timestamp: "2024-01-01T00:00:00Z",
 		}
-		
+
 		// Verify the struct can be used for JSON marshaling
 		// The actual JSON tags are defined in the struct definition
 		assert.Equal(t, db.SSLStatusReady, req.Status)
@@ -374,126 +374,25 @@ func TestSSLStatusUpdateRequest_StructFields(t *testing.T) {
 
 // Test WebsiteResponse SSL field population
 
-func TestWebsiteResponse_FromModel_SSL_Populated(t *testing.T) {
-	t.Run("populates SSL field when SSL status is set", func(t *testing.T) {
+func TestWebsiteResponse_FromModel_DoesNotSetSSL(t *testing.T) {
+	// SSL presentation moved to the API layer (applyApexSSLStatus), which reads
+	// the apex WebsiteDomain binding. FromModel no longer synthesizes SSL on the
+	// website response itself.
+	t.Run("leaves SSL nil", func(t *testing.T) {
 		now := time.Now()
-		issuedAt := now.Add(-24 * time.Hour)
-		lastUpdated := now.Add(-1 * time.Hour)
-
 		model := &db.Website{
-			ID:                  1,
-			Domain:              "example.com",
-			TargetType:          string(db.WebsiteTargetTypeIPFS),
-			Status:              string(db.WebsiteStatusActive),
-			ValidationToken:     "token123",
-			ValidationExpiresAt: nil,
-			LastCheckedAt:       &now,
-			CreatedAt:           now,
-			UpdatedAt:           now,
-			SSLStatus:           string(db.SSLStatusReady),
-			SSLError:            "",
-			SSLIssuedAt:         &issuedAt,
-			SSLLastUpdatedAt:    &lastUpdated,
+			ID:              1,
+			Domain:          "example.com",
+			TargetType:      string(db.WebsiteTargetTypeIPFS),
+			Status:          string(db.WebsiteStatusActive),
+			ValidationToken: "token123",
+			CreatedAt:       now,
+			UpdatedAt:       now,
 		}
-
 		var resp WebsiteResponse
 		err := resp.FromModel(model)
-
 		require.NoError(t, err)
-		assert.NotNil(t, resp.SSL, "SSL field should be populated")
-		assert.Equal(t, string(db.SSLStatusReady), resp.SSL.Status)
-		assert.Equal(t, "", resp.SSL.Error)
-		assert.Equal(t, issuedAt, *resp.SSL.IssuedAt)
-		assert.Equal(t, &lastUpdated, resp.SSL.LastUpdatedAt)
-	})
-
-	t.Run("populates SSL field with error when SSL failed", func(t *testing.T) {
-		now := time.Now()
-		lastUpdated := now.Add(-1 * time.Hour)
-
-		model := &db.Website{
-			ID:                  1,
-			Domain:              "example.com",
-			TargetType:          string(db.WebsiteTargetTypeIPFS),
-			Status:              string(db.WebsiteStatusActive),
-			ValidationToken:     "token123",
-			ValidationExpiresAt: nil,
-			LastCheckedAt:       &now,
-			CreatedAt:           now,
-			UpdatedAt:           now,
-			SSLStatus:           string(db.SSLStatusFailed),
-			SSLError:            "Certificate issuance failed: timeout",
-			SSLIssuedAt:         nil,
-			SSLLastUpdatedAt:    &lastUpdated,
-		}
-
-		var resp WebsiteResponse
-		err := resp.FromModel(model)
-
-		require.NoError(t, err)
-		assert.NotNil(t, resp.SSL, "SSL field should be populated")
-		assert.Equal(t, string(db.SSLStatusFailed), resp.SSL.Status)
-		assert.Equal(t, "Certificate issuance failed: timeout", resp.SSL.Error)
-		assert.Nil(t, resp.SSL.IssuedAt, "IssuedAt should be nil when SSL failed")
-		assert.Equal(t, &lastUpdated, resp.SSL.LastUpdatedAt)
-	})
-
-	t.Run("populates SSL field for issuing status", func(t *testing.T) {
-		now := time.Now()
-		lastUpdated := now.Add(-30 * time.Minute)
-
-		model := &db.Website{
-			ID:                  1,
-			Domain:              "example.com",
-			TargetType:          string(db.WebsiteTargetTypeIPFS),
-			Status:              string(db.WebsiteStatusActive),
-			ValidationToken:     "token123",
-			ValidationExpiresAt: nil,
-			LastCheckedAt:       &now,
-			CreatedAt:           now,
-			UpdatedAt:           now,
-			SSLStatus:           string(db.SSLStatusIssuing),
-			SSLError:            "",
-			SSLIssuedAt:         nil,
-			SSLLastUpdatedAt:    &lastUpdated,
-		}
-
-		var resp WebsiteResponse
-		err := resp.FromModel(model)
-
-		require.NoError(t, err)
-		assert.NotNil(t, resp.SSL, "SSL field should be populated")
-		assert.Equal(t, string(db.SSLStatusIssuing), resp.SSL.Status)
-		assert.Equal(t, "", resp.SSL.Error)
-		assert.Nil(t, resp.SSL.IssuedAt, "IssuedAt should be nil when SSL is issuing")
-		assert.Equal(t, &lastUpdated, resp.SSL.LastUpdatedAt)
-	})
-
-	t.Run("handles nil SSLLastUpdatedAt when SSL status is set", func(t *testing.T) {
-		now := time.Now()
-
-		model := &db.Website{
-			ID:                  1,
-			Domain:              "example.com",
-			TargetType:          string(db.WebsiteTargetTypeIPFS),
-			Status:              string(db.WebsiteStatusActive),
-			ValidationToken:     "token123",
-			ValidationExpiresAt: nil,
-			LastCheckedAt:       &now,
-			CreatedAt:           now,
-			UpdatedAt:           now,
-			SSLStatus:           string(db.SSLStatusIssuing),
-			SSLError:            "",
-			SSLIssuedAt:         nil,
-			SSLLastUpdatedAt:    nil,
-		}
-
-		var resp WebsiteResponse
-		err := resp.FromModel(model)
-
-		require.NoError(t, err)
-		assert.NotNil(t, resp.SSL, "SSL field should be populated")
-		assert.Nil(t, resp.SSL.LastUpdatedAt, "LastUpdatedAt should be nil when model field is nil")
+		assert.Nil(t, resp.SSL, "FromModel should not synthesize SSL; it is applied by the API layer")
 	})
 }
 
@@ -605,63 +504,6 @@ func TestWebsiteUpdateRequest_ToModel_IPNS_WithValidPeerID(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, string(db.WebsiteTargetTypeIPNS), model.TargetType)
 	assert.Nil(t, model.CIDVersion, "CIDVersion should be nil for valid IPNS target")
-}
-
-func TestWebsiteResponse_FromModel_SSL_NotPopulated(t *testing.T) {
-	t.Run("does not populate SSL field when SSL status is empty", func(t *testing.T) {
-		now := time.Now()
-
-		model := &db.Website{
-			ID:                  1,
-			Domain:              "example.com",
-			TargetType:          string(db.WebsiteTargetTypeIPFS),
-			Status:              string(db.WebsiteStatusActive),
-			ValidationToken:     "token123",
-			ValidationExpiresAt: nil,
-			LastCheckedAt:       &now,
-			CreatedAt:           now,
-			UpdatedAt:           now,
-			SSLStatus:           "", // Empty SSL status
-			SSLError:            "",
-			SSLIssuedAt:         nil,
-			SSLLastUpdatedAt:    nil,
-		}
-
-		var resp WebsiteResponse
-		err := resp.FromModel(model)
-
-		require.NoError(t, err)
-		assert.Nil(t, resp.SSL, "SSL field should be nil when SSL status is empty")
-	})
-
-	t.Run("populates all other fields when SSL is not populated", func(t *testing.T) {
-		now := time.Now()
-
-		model := &db.Website{
-			ID:                  1,
-			Domain:              "example.com",
-			TargetType:          string(db.WebsiteTargetTypeIPFS),
-			Status:              string(db.WebsiteStatusActive),
-			ValidationToken:     "token123",
-			ValidationExpiresAt: nil,
-			LastCheckedAt:       &now,
-			CreatedAt:           now,
-			UpdatedAt:           now,
-			SSLStatus:           "",
-		}
-
-		var resp WebsiteResponse
-		err := resp.FromModel(model)
-
-		require.NoError(t, err)
-		assert.Equal(t, uint(1), resp.ID)
-		assert.Equal(t, "example.com", resp.Domain)
-		assert.Equal(t, string(db.WebsiteTargetTypeIPFS), resp.TargetType)
-		assert.Equal(t, string(db.WebsiteStatusActive), resp.Status)
-		assert.Equal(t, "token123", resp.ValidationToken)
-		assert.Equal(t, now, resp.Created)
-		assert.Equal(t, now, resp.Updated)
-	})
 }
 
 func TestWebsiteResponse_SetValidationRecordInfo(t *testing.T) {

--- a/internal/db/migrations/mysql/20260805120000_move_ssl_status_to_website_domains.sql
+++ b/internal/db/migrations/mysql/20260805120000_move_ssl_status_to_website_domains.sql
@@ -1,0 +1,83 @@
+-- +goose Up
+-- Move SSL certificate state from ipfs_websites (one row per website) to
+-- website_domains (one row per bound hostname). SSL is a per-domain property:
+-- each bound domain may carry its own certificate/issuance lifecycle, so the
+-- granularity belongs on the domain binding. Caddy already reports SSL events
+-- per-domain, so this aligns the storage grain with the data arriving.
+
+-- 1. Add per-domain SSL columns to website_domains.
+-- +goose StatementBegin
+ALTER TABLE website_domains
+    ADD COLUMN ssl_status VARCHAR(50) NOT NULL DEFAULT 'pending',
+    ADD COLUMN ssl_error TEXT NULL,
+    ADD COLUMN ssl_issued_at TIMESTAMP NULL DEFAULT NULL,
+    ADD COLUMN ssl_last_updated_at TIMESTAMP NULL DEFAULT NULL;
+-- +goose StatementEnd
+
+CREATE INDEX idx_website_domains_ssl_status ON website_domains(ssl_status);
+CREATE INDEX idx_website_domains_ssl_issued_at ON website_domains(ssl_issued_at);
+CREATE INDEX idx_website_domains_ssl_last_updated_at ON website_domains(ssl_last_updated_at);
+
+-- +goose StatementBegin
+-- 2. Backfill the apex (primary) domain binding from its owning website's SSL
+--    state, preserving the existing website-level cert state. Only the binding
+--    whose domain matches the website's primary domain inherits it; additional
+--    domain bindings stay 'pending' (they had no prior per-domain cert state).
+UPDATE website_domains wd
+JOIN ipfs_websites w ON w.id = wd.website_id AND w.domain = wd.domain
+SET wd.ssl_status = w.ssl_status,
+    wd.ssl_error = w.ssl_error,
+    wd.ssl_issued_at = w.ssl_issued_at,
+    wd.ssl_last_updated_at = w.ssl_last_updated_at;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+-- 3. Remove the now-migrated SSL columns from ipfs_websites (split into two
+--    ALTERs: drop the indexes first, then the columns, for MySQL ordering.
+-- +goose StatementEnd
+ALTER TABLE ipfs_websites
+    DROP INDEX idx_ipfs_websites_ssl_status,
+    DROP INDEX idx_ipfs_websites_ssl_issued_at,
+    DROP INDEX idx_ipfs_websites_ssl_last_updated_at;
+
+ALTER TABLE ipfs_websites
+    DROP COLUMN ssl_status,
+    DROP COLUMN ssl_error,
+    DROP COLUMN ssl_issued_at,
+    DROP COLUMN ssl_last_updated_at;
+
+-- +goose Down
+-- +goose StatementBegin
+-- 1. Re-add the SSL columns to ipfs_websites.
+ALTER TABLE ipfs_websites
+    ADD COLUMN ssl_status VARCHAR(50) NOT NULL DEFAULT 'pending',
+    ADD COLUMN ssl_error TEXT NULL,
+    ADD COLUMN ssl_issued_at TIMESTAMP NULL DEFAULT NULL,
+    ADD COLUMN ssl_last_updated_at TIMESTAMP NULL DEFAULT NULL,
+    ADD KEY idx_ipfs_websites_ssl_status (ssl_status),
+    ADD KEY idx_ipfs_websites_ssl_issued_at (ssl_issued_at),
+    ADD KEY idx_ipfs_websites_ssl_last_updated_at (ssl_last_updated_at);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+-- 2. Restore website SSL state from the apex domain binding.
+UPDATE ipfs_websites w
+JOIN website_domains wd ON wd.website_id = w.id AND wd.domain = w.domain
+SET w.ssl_status = wd.ssl_status,
+    w.ssl_error = wd.ssl_error,
+    w.ssl_issued_at = wd.ssl_issued_at,
+    w.ssl_last_updated_at = wd.ssl_last_updated_at;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+-- 3. Drop the per-domain SSL columns from website_domains.
+DROP INDEX IF EXISTS idx_website_domains_ssl_status ON website_domains;
+DROP INDEX IF EXISTS idx_website_domains_ssl_issued_at ON website_domains;
+DROP INDEX IF EXISTS idx_website_domains_ssl_last_updated_at ON website_domains;
+-- +goose StatementEnd
+
+ALTER TABLE website_domains
+    DROP COLUMN ssl_status,
+    DROP COLUMN ssl_error,
+    DROP COLUMN ssl_issued_at,
+    DROP COLUMN ssl_last_updated_at;

--- a/internal/db/migrations/sqlite/20260805120000_move_ssl_status_to_website_domains.sql
+++ b/internal/db/migrations/sqlite/20260805120000_move_ssl_status_to_website_domains.sql
@@ -1,0 +1,72 @@
+-- +goose Up
+-- Move SSL certificate state from ipfs_websites (one row per website) to
+-- website_domains (one row per bound hostname). SSL is a per-domain property:
+-- each bound domain may carry its own certificate/issuance lifecycle, so the
+-- granularity belongs on the domain binding.
+
+-- 1. Add per-domain SSL columns to website_domains.
+ALTER TABLE website_domains ADD COLUMN ssl_status TEXT NOT NULL DEFAULT 'pending';
+ALTER TABLE website_domains ADD COLUMN ssl_error TEXT NULL;
+ALTER TABLE website_domains ADD COLUMN ssl_issued_at TIMESTAMP NULL DEFAULT NULL;
+ALTER TABLE website_domains ADD COLUMN ssl_last_updated_at TIMESTAMP NULL DEFAULT NULL;
+
+CREATE INDEX idx_website_domains_ssl_status ON website_domains(ssl_status);
+CREATE INDEX idx_website_domains_ssl_issued_at ON website_domains(ssl_issued_at);
+CREATE INDEX idx_website_domains_ssl_last_updated_at ON website_domains(ssl_last_updated_at);
+
+-- +goose StatementBegin
+-- 2. Backfill the apex (primary) domain binding from its owning website's SSL
+--    state, preserving the existing website-level cert state. SQLite has no
+--    UPDATE ... JOIN, so use a correlated subquery keyed on the primary domain.
+UPDATE website_domains
+SET ssl_status = (SELECT w.ssl_status FROM ipfs_websites w WHERE w.id = website_domains.website_id AND w.domain = website_domains.domain),
+    ssl_error = (SELECT w.ssl_error FROM ipfs_websites w WHERE w.id = website_domains.website_id AND w.domain = website_domains.domain),
+    ssl_issued_at = (SELECT w.ssl_issued_at FROM ipfs_websites w WHERE w.id = website_domains.website_id AND w.domain = website_domains.domain),
+    ssl_last_updated_at = (SELECT w.ssl_last_updated_at FROM ipfs_websites w WHERE w.id = website_domains.website_id AND w.domain = website_domains.domain)
+WHERE EXISTS (
+    SELECT 1 FROM ipfs_websites w WHERE w.id = website_domains.website_id AND w.domain = website_domains.domain
+);
+-- +goose StatementEnd
+
+-- 3. Remove the now-migrated SSL columns from ipfs_websites.
+DROP INDEX IF EXISTS idx_ipfs_websites_ssl_status;
+DROP INDEX IF EXISTS idx_ipfs_websites_ssl_issued_at;
+DROP INDEX IF EXISTS idx_ipfs_websites_ssl_last_updated_at;
+
+ALTER TABLE ipfs_websites DROP COLUMN ssl_status;
+ALTER TABLE ipfs_websites DROP COLUMN ssl_error;
+ALTER TABLE ipfs_websites DROP COLUMN ssl_issued_at;
+ALTER TABLE ipfs_websites DROP COLUMN ssl_last_updated_at;
+
+-- +goose Down
+-- 1. Re-add the SSL columns to ipfs_websites.
+ALTER TABLE ipfs_websites ADD COLUMN ssl_status TEXT NOT NULL DEFAULT 'pending';
+ALTER TABLE ipfs_websites ADD COLUMN ssl_error TEXT NULL;
+ALTER TABLE ipfs_websites ADD COLUMN ssl_issued_at TIMESTAMP NULL DEFAULT NULL;
+ALTER TABLE ipfs_websites ADD COLUMN ssl_last_updated_at TIMESTAMP NULL DEFAULT NULL;
+
+CREATE INDEX idx_ipfs_websites_ssl_status ON ipfs_websites(ssl_status);
+CREATE INDEX idx_ipfs_websites_ssl_issued_at ON ipfs_websites(ssl_issued_at);
+CREATE INDEX idx_ipfs_websites_ssl_last_updated_at ON ipfs_websites(ssl_last_updated_at);
+
+-- +goose StatementBegin
+-- 2. Restore website SSL state from the apex domain binding.
+UPDATE ipfs_websites
+SET ssl_status = (SELECT wd.ssl_status FROM website_domains wd WHERE wd.website_id = ipfs_websites.id AND wd.domain = ipfs_websites.domain),
+    ssl_error = (SELECT wd.ssl_error FROM website_domains wd WHERE wd.website_id = ipfs_websites.id AND wd.domain = ipfs_websites.domain),
+    ssl_issued_at = (SELECT wd.ssl_issued_at FROM website_domains wd WHERE wd.website_id = ipfs_websites.id AND wd.domain = ipfs_websites.domain),
+    ssl_last_updated_at = (SELECT wd.ssl_last_updated_at FROM website_domains wd WHERE wd.website_id = ipfs_websites.id AND wd.domain = ipfs_websites.domain)
+WHERE EXISTS (
+    SELECT 1 FROM website_domains wd WHERE wd.website_id = ipfs_websites.id AND wd.domain = ipfs_websites.domain
+);
+-- +goose StatementEnd
+
+-- 3. Drop the per-domain SSL columns from website_domains.
+DROP INDEX IF EXISTS idx_website_domains_ssl_status;
+DROP INDEX IF EXISTS idx_website_domains_ssl_issued_at;
+DROP INDEX IF EXISTS idx_website_domains_ssl_last_updated_at;
+
+ALTER TABLE website_domains DROP COLUMN ssl_status;
+ALTER TABLE website_domains DROP COLUMN ssl_error;
+ALTER TABLE website_domains DROP COLUMN ssl_issued_at;
+ALTER TABLE website_domains DROP COLUMN ssl_last_updated_at;

--- a/internal/db/website.go
+++ b/internal/db/website.go
@@ -101,19 +101,15 @@ type Website struct {
 	Domain              string         `gorm:"type:varchar(255);index:idx_ipfs_websites_domain;not null"`
 	TargetType          string         `gorm:"type:varchar(50);index:idx_ipfs_websites_status;not null"` // WebsiteTargetTypeIPFS or WebsiteTargetTypeIPNS
 	TargetMultihash     mh.Multihash   `gorm:"type:varbinary(64);not null"`                              // CID multihash (IPFS) or peer ID multihash (IPNS)
-	CIDVersion          *uint8         `gorm:"column:cid_version;type:tinyint unsigned"`                // 0 = CIDv0, 1 = CIDv1; NULL for IPNS
-	CIDType             *uint8         `gorm:"column:cid_type;type:tinyint unsigned"`                  // CID codec type (e.g., 85=Raw, 113=DagCBOR); NULL for IPNS or v0
+	CIDVersion          *uint8         `gorm:"column:cid_version;type:tinyint unsigned"`                 // 0 = CIDv0, 1 = CIDv1; NULL for IPNS
+	CIDType             *uint8         `gorm:"column:cid_type;type:tinyint unsigned"`                    // CID codec type (e.g., 85=Raw, 113=DagCBOR); NULL for IPNS or v0
 	Status              string         `gorm:"type:varchar(50);index:idx_ipfs_websites_status;not null"` // pending_validation, active, broken
 	ValidationToken     string         `gorm:"type:varchar(255);not null"`
 	ValidationExpiresAt *time.Time     `gorm:"index"`
 	LastCheckedAt       *time.Time     `gorm:"index:idx_ipfs_websites_last_checked_at"`
-	DNSZoneID           *uint          `gorm:"column:dns_zone_id;index:idx_ipfs_websites_dns_zone_id"`    // Foreign key to DNS zone (if DNS hosting enabled)
-	IPNSKeyID           *uint          `gorm:"column:ipns_key_id;index:idx_ipfs_websites_ipns_key_id"`     // Foreign key to IPNS key (if auto-created for managed DNS)
-	Enabled             bool           `gorm:"column:dns_enabled;default:false"`                // Whether DNS hosting is enabled
-	SSLStatus           string         `gorm:"column:ssl_status;type:varchar(50);index:idx_ipfs_websites_ssl_status;default:'pending'"`
-	SSLError            string         `gorm:"column:ssl_error;type:text"`
-	SSLIssuedAt         *time.Time     `gorm:"column:ssl_issued_at;index:idx_ipfs_websites_ssl_issued_at"`
-	SSLLastUpdatedAt    *time.Time     `gorm:"column:ssl_last_updated_at;index:idx_ipfs_websites_ssl_last_updated_at"`
+	DNSZoneID           *uint          `gorm:"column:dns_zone_id;index:idx_ipfs_websites_dns_zone_id"` // Foreign key to DNS zone (if DNS hosting enabled)
+	IPNSKeyID           *uint          `gorm:"column:ipns_key_id;index:idx_ipfs_websites_ipns_key_id"` // Foreign key to IPNS key (if auto-created for managed DNS)
+	Enabled             bool           `gorm:"column:dns_enabled;default:false"`                       // Whether DNS hosting is enabled
 	CreatedAt           time.Time      `gorm:"autoCreateTime"`
 	UpdatedAt           time.Time      `gorm:"autoUpdateTime"`
 	DeletedAt           gorm.DeletedAt `gorm:"index:idx_ipfs_websites_deleted_at"`
@@ -140,14 +136,6 @@ func (w *Website) BeforeSave(_ *gorm.DB) error {
 	// Validate status
 	if _, ok := validWebsiteStatuses[WebsiteStatus(w.Status)]; !ok {
 		return fmt.Errorf("%s: %s", errors.ErrInvalidWebsiteStatus, w.Status)
-	}
-
-	// Validate SSL status
-	if w.SSLStatus == "" {
-		w.SSLStatus = string(SSLStatusPending)
-	}
-	if _, ok := validSSLStatuses[SSLStatus(w.SSLStatus)]; !ok {
-		return fmt.Errorf("%s: %s", errors.ErrInvalidSSLStatus, w.SSLStatus)
 	}
 
 	// Validate multihash is set

--- a/internal/db/website_domain.go
+++ b/internal/db/website_domain.go
@@ -28,10 +28,10 @@ const (
 
 // WebsiteDomain binds a domain (by namespace) to a website.
 type WebsiteDomain struct {
-	ID             uint              `gorm:"primaryKey"`
+	ID             uint `gorm:"primaryKey"`
 	WebsiteID      uint
 	UserID         uint
-	Domain         string `gorm:"index:idx_domain_namespace,unique"`
+	Domain         string          `gorm:"index:idx_domain_namespace,unique"`
 	Namespace      DomainNamespace `gorm:"index:idx_domain_namespace,unique"`
 	ZoneName       string
 	GatewayHost    string
@@ -39,6 +39,14 @@ type WebsiteDomain struct {
 	Status         DomainStatus
 	DelegationData datatypes.JSONMap `gorm:"type:json"`
 	ProtocolData   datatypes.JSONMap `gorm:"type:json"`
+
+	// SSL certificate state for this specific domain binding. SSL is a
+	// per-hostname property (each bound domain may hold its own cert), so it
+	// lives here rather than on the owning Website.
+	SSLStatus        string     `gorm:"column:ssl_status;type:varchar(50);index:idx_website_domains_ssl_status;default:'pending'"`
+	SSLError         string     `gorm:"column:ssl_error;type:text"`
+	SSLIssuedAt      *time.Time `gorm:"column:ssl_issued_at;index:idx_website_domains_ssl_issued_at"`
+	SSLLastUpdatedAt *time.Time `gorm:"column:ssl_last_updated_at;index:idx_website_domains_ssl_last_updated_at"`
 
 	CreatedAt time.Time
 	UpdatedAt time.Time
@@ -53,5 +61,8 @@ func (WebsiteDomain) TableName() string {
 // write so a www.-prefixed hostname can never be persisted.
 func (wd *WebsiteDomain) BeforeSave(_ *gorm.DB) error {
 	wd.Domain = NormalizeDomain(wd.Domain)
+	if wd.SSLStatus == "" {
+		wd.SSLStatus = string(SSLStatusPending)
+	}
 	return nil
 }

--- a/internal/db/website_test.go
+++ b/internal/db/website_test.go
@@ -8,9 +8,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestWebsiteSSLFields(t *testing.T) {
-	t.Run("Website struct has SSL status fields", func(t *testing.T) {
-		w := Website{}
+func TestWebsiteDomainSSLFields(t *testing.T) {
+	t.Run("WebsiteDomain struct has SSL status fields", func(t *testing.T) {
+		w := WebsiteDomain{}
 		assert.IsType(t, "", w.SSLStatus)
 		assert.IsType(t, "", w.SSLError)
 		assert.IsType(t, (*time.Time)(nil), w.SSLIssuedAt)
@@ -18,7 +18,7 @@ func TestWebsiteSSLFields(t *testing.T) {
 	})
 
 	t.Run("SSLStatus field can be set to valid values", func(t *testing.T) {
-		w := Website{
+		w := WebsiteDomain{
 			SSLStatus: string(SSLStatusPending),
 		}
 		assert.Equal(t, string(SSLStatusPending), w.SSLStatus)
@@ -34,7 +34,7 @@ func TestWebsiteSSLFields(t *testing.T) {
 	})
 
 	t.Run("SSLError field can store error messages", func(t *testing.T) {
-		w := Website{
+		w := WebsiteDomain{
 			SSLError: "certificate validation failed",
 		}
 		assert.Equal(t, "certificate validation failed", w.SSLError)
@@ -45,7 +45,7 @@ func TestWebsiteSSLFields(t *testing.T) {
 
 	t.Run("SSLIssuedAt field can store timestamp", func(t *testing.T) {
 		now := time.Now()
-		w := Website{
+		w := WebsiteDomain{
 			SSLIssuedAt: &now,
 		}
 		assert.NotNil(t, w.SSLIssuedAt)
@@ -57,7 +57,7 @@ func TestWebsiteSSLFields(t *testing.T) {
 
 	t.Run("SSLLastUpdatedAt field can store timestamp", func(t *testing.T) {
 		now := time.Now()
-		w := Website{
+		w := WebsiteDomain{
 			SSLLastUpdatedAt: &now,
 		}
 		assert.NotNil(t, w.SSLLastUpdatedAt)
@@ -70,7 +70,7 @@ func TestWebsiteSSLFields(t *testing.T) {
 	t.Run("SSL fields work together", func(t *testing.T) {
 		issuedAt := time.Now().Add(-24 * time.Hour)
 		updatedAt := time.Now()
-		w := Website{
+		w := WebsiteDomain{
 			SSLStatus:        string(SSLStatusReady),
 			SSLError:         "",
 			SSLIssuedAt:      &issuedAt,
@@ -148,16 +148,12 @@ func TestSSLStatus(t *testing.T) {
 	})
 }
 
-func TestWebsiteBeforeSaveSSLValidation(t *testing.T) {
+func TestWebsiteDomainBeforeSaveSSLValidation(t *testing.T) {
 	t.Run("BeforeSave accepts empty SSL status", func(t *testing.T) {
-		w := &Website{
-			UserID:          1,
-			Domain:          "example.com",
-			TargetType:      string(WebsiteTargetTypeIPFS),
-			TargetMultihash: []byte("test"),
-			CIDVersion:      uint8Ptr(1),
-			Status:          string(WebsiteStatusPendingValidation),
-			SSLStatus:       "",
+		w := &WebsiteDomain{
+			Domain:    "lumeweb",
+			Namespace: DomainNamespaceHNS,
+			SSLStatus: "",
 		}
 
 		err := w.BeforeSave(nil)
@@ -166,84 +162,15 @@ func TestWebsiteBeforeSaveSSLValidation(t *testing.T) {
 		assert.Equal(t, string(SSLStatusPending), w.SSLStatus)
 	})
 
-	t.Run("BeforeSave rejects invalid SSL status", func(t *testing.T) {
-		w := &Website{
-			UserID:          1,
-			Domain:          "example.com",
-			TargetType:      string(WebsiteTargetTypeIPFS),
-			TargetMultihash: []byte("test"),
-			CIDVersion:      uint8Ptr(1),
-			Status:          string(WebsiteStatusPendingValidation),
-			SSLStatus:       "invalid_status",
-		}
-
-		err := w.BeforeSave(nil)
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "INVALID_SSL_STATUS")
-	})
-
-	t.Run("BeforeSave accepts valid SSL status 'pending'", func(t *testing.T) {
-		w := &Website{
-			UserID:          1,
-			Domain:          "example.com",
-			TargetType:      string(WebsiteTargetTypeIPFS),
-			TargetMultihash: []byte("test"),
-			CIDVersion:      uint8Ptr(1),
-			Status:          string(WebsiteStatusPendingValidation),
-			SSLStatus:       string(SSLStatusPending),
+	t.Run("BeforeSave preserves an explicit non-pending SSL status", func(t *testing.T) {
+		w := &WebsiteDomain{
+			Domain:    "lumeweb",
+			Namespace: DomainNamespaceHNS,
+			SSLStatus: string(SSLStatusReady),
 		}
 
 		err := w.BeforeSave(nil)
 		assert.NoError(t, err)
+		assert.Equal(t, string(SSLStatusReady), w.SSLStatus)
 	})
-
-	t.Run("BeforeSave accepts valid SSL status 'issuing'", func(t *testing.T) {
-		w := &Website{
-			UserID:          1,
-			Domain:          "example.com",
-			TargetType:      string(WebsiteTargetTypeIPFS),
-			TargetMultihash: []byte("test"),
-			CIDVersion:      uint8Ptr(1),
-			Status:          string(WebsiteStatusPendingValidation),
-			SSLStatus:       string(SSLStatusIssuing),
-		}
-
-		err := w.BeforeSave(nil)
-		assert.NoError(t, err)
-	})
-
-	t.Run("BeforeSave accepts valid SSL status 'ready'", func(t *testing.T) {
-		w := &Website{
-			UserID:          1,
-			Domain:          "example.com",
-			TargetType:      string(WebsiteTargetTypeIPFS),
-			TargetMultihash: []byte("test"),
-			CIDVersion:      uint8Ptr(1),
-			Status:          string(WebsiteStatusPendingValidation),
-			SSLStatus:       string(SSLStatusReady),
-		}
-
-		err := w.BeforeSave(nil)
-		assert.NoError(t, err)
-	})
-
-	t.Run("BeforeSave accepts valid SSL status 'failed'", func(t *testing.T) {
-		w := &Website{
-			UserID:          1,
-			Domain:          "example.com",
-			TargetType:      string(WebsiteTargetTypeIPFS),
-			TargetMultihash: []byte("test"),
-			CIDVersion:      uint8Ptr(1),
-			Status:          string(WebsiteStatusPendingValidation),
-			SSLStatus:       string(SSLStatusFailed),
-		}
-
-		err := w.BeforeSave(nil)
-		assert.NoError(t, err)
-	})
-}
-
-// Helper function to get a pointer to uint8
-func uint8Ptr(v uint8) *uint8 {
-	return &v
 }

--- a/internal/service/website/website.go
+++ b/internal/service/website/website.go
@@ -13,7 +13,6 @@ import (
 
 	dnslink "github.com/dnslink-std/go"
 	"github.com/ipfs/go-cid"
-	"golang.org/x/sync/errgroup"
 	"github.com/libp2p/go-libp2p/core/peer"
 	pluginCore "go.lumeweb.com/portal-plugin-ipfs/core"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/api/dto"
@@ -21,6 +20,7 @@ import (
 	pluginDb "go.lumeweb.com/portal-plugin-ipfs/internal/db"
 	pluginEvent "go.lumeweb.com/portal-plugin-ipfs/internal/event"
 	domsvc "go.lumeweb.com/portal-plugin-ipfs/internal/service/domain"
+	"golang.org/x/sync/errgroup"
 
 	"go.lumeweb.com/ipfs-sdk/dnsname"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/protocol/encoding"
@@ -34,8 +34,6 @@ import (
 	"gorm.io/gorm/clause"
 )
 
-const sslCertValidity = 90 * 24 * time.Hour
-
 func (s *WebsiteServiceDefault) verificationTokenKey() string {
 	if s.dnsConfig != nil && s.dnsConfig.VerificationTokenKey != "" {
 		return s.dnsConfig.VerificationTokenKey
@@ -44,11 +42,11 @@ func (s *WebsiteServiceDefault) verificationTokenKey() string {
 }
 
 const (
-	msgTokenExpired = "Validation token expired for %s — a new token has been generated. Please add the updated TXT record at %s.%s to your DNS configuration"
-	msgDNSMissing   = "No DNS records found for %s. Please add the required TXT records to your DNS configuration"
-	msgDNSMismatch  = "DNS validation failed: missing or incorrect dnslink record (expected: %s, found: %s)"
-	msgTokenMissing = "DNS validation failed: missing validation token at %s.%s for %s"
-	msgValidated    = "DNS validation successful for %s"
+	msgTokenExpired      = "Validation token expired for %s — a new token has been generated. Please add the updated TXT record at %s.%s to your DNS configuration"
+	msgDNSMissing        = "No DNS records found for %s. Please add the required TXT records to your DNS configuration"
+	msgDNSMismatch       = "DNS validation failed: missing or incorrect dnslink record (expected: %s, found: %s)"
+	msgTokenMissing      = "DNS validation failed: missing validation token at %s.%s for %s"
+	msgValidated         = "DNS validation successful for %s"
 	msgDelegationPending = "Domain delegation not yet published"
 )
 
@@ -96,6 +94,7 @@ type delegatedDomainService interface {
 	GetWebsiteDomainByName(ctx context.Context, domain string) (*pluginDb.WebsiteDomain, error)
 	GetPendingWebsiteDomainsPaginated(ctx context.Context, status pluginDb.DomainStatus, limit, offset int) ([]pluginDb.WebsiteDomain, error)
 }
+
 // resolverForDomain returns the appropriate DNSResolver for the given domain.
 // Different roots (ICANN vs HNS etc.) may require different DNS resolvers
 // because alt-root records are not visible to the system default resolver.
@@ -119,7 +118,6 @@ func (s *WebsiteServiceDefault) resolverForDomain(domain string) DNSResolver {
 	return NewLiveResolver("")
 }
 
-
 // NewWebsiteService creates a new website service
 func NewWebsiteService() (core.Service, []core.ContextBuilderOption, error) {
 	svc := &WebsiteServiceDefault{}
@@ -131,9 +129,9 @@ func NewWebsiteService() (core.Service, []core.ContextBuilderOption, error) {
 			svc.mailerSvc = core.GetService[core.MailerService](ctx, core.MAILER_SERVICE)
 			svc.dnsSvc = core.GetService[pluginCore.DNSService](ctx, pluginCore.DNS_SERVICE)
 			var dds *domsvc.DelegatedDomainService = core.GetServiceOptional[*domsvc.DelegatedDomainService](ctx, pluginCore.DELEGATED_DOMAIN_SERVICE)
-		if dds != nil {
-			svc.delegatedDomainSvc = dds
-		}
+			if dds != nil {
+				svc.delegatedDomainSvc = dds
+			}
 
 			// Load configuration from service config
 			svc.config = core.GetServiceConfig[*pluginConfig.WebsiteConfig](ctx, pluginCore.WEBSITE_SERVICE)
@@ -202,23 +200,6 @@ func (s *WebsiteServiceDefault) CreateWebsite(ctx context.Context, website *plug
 			}
 			if existing != nil {
 				return nil, fmt.Errorf("domain already exists: %s", website.Domain)
-			}
-
-			// Inherit SSL state from soft-deleted website if cert is still valid
-			var deletedWebsite pluginDb.Website
-			err = db.RetryableComponentTransaction(s, ctx, func(tx *gorm.DB) *gorm.DB {
-				return tx.Unscoped().
-					Where("domain = ? AND deleted_at IS NOT NULL", website.Domain).
-					Where("ssl_status = ?", string(pluginDb.SSLStatusReady)).
-					Order("deleted_at DESC").
-					First(&deletedWebsite)
-			})
-			if err == nil && deletedWebsite.SSLIssuedAt != nil {
-				if time.Since(*deletedWebsite.SSLIssuedAt) < sslCertValidity {
-					website.SSLStatus = string(pluginDb.SSLStatusReady)
-					website.SSLIssuedAt = deletedWebsite.SSLIssuedAt
-					website.SSLLastUpdatedAt = deletedWebsite.SSLLastUpdatedAt
-				}
 			}
 
 			// Generate validation token
@@ -1779,8 +1760,12 @@ func (s *WebsiteServiceDefault) notifyUserStatusChanged(ctx context.Context, web
 	return nil
 }
 
-// UpdateSSLStatus updates the SSL certificate status for a website domain
-func (s *WebsiteServiceDefault) UpdateSSLStatus(ctx context.Context, domain string, status pluginDb.SSLStatus, sslError string, timestamp *time.Time) (*pluginDb.Website, error) {
+// UpdateSSLStatus updates the SSL certificate status for a domain. SSL state is
+// a per-domain property, so the update resolves the domain binding (handling
+// both the primary and additional-domain records on a website) and persists the
+// state on the WebsiteDomain row. The updated binding is returned as the source
+// of truth for certificate status.
+func (s *WebsiteServiceDefault) UpdateSSLStatus(ctx context.Context, domain string, status pluginDb.SSLStatus, sslError string, timestamp *time.Time) (*pluginDb.WebsiteDomain, error) {
 	ctx, span := core.TraceMethod(ctx, "WebsiteServiceDefault.UpdateSSLStatus")
 	defer span.End()
 
@@ -1788,17 +1773,19 @@ func (s *WebsiteServiceDefault) UpdateSSLStatus(ctx context.Context, domain stri
 	// hostname) resolves to the stored apex domain record.
 	domain = domsvc.NormalizeDomain(domain)
 
-	var website pluginDb.Website
+	var wd pluginDb.WebsiteDomain
+
 	err := db.RetryableComponentTransaction(s, ctx, func(tx *gorm.DB) *gorm.DB {
-		// Lock row for update
+		// Lock the domain binding row for update. The binding is the SSL context:
+		// each bound hostname carries its own certificate lifecycle.
 		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
 			Where("domain = ?", domain).
-			First(&website).Error; err != nil {
+			First(&wd).Error; err != nil {
 			if err == gorm.ErrRecordNotFound {
 				_ = tx.AddError(fmt.Errorf("website not found"))
 				return tx
 			}
-			_ = tx.AddError(fmt.Errorf("failed to get website: %w", err))
+			_ = tx.AddError(fmt.Errorf("failed to get website domain: %w", err))
 			return tx
 		}
 
@@ -1815,12 +1802,12 @@ func (s *WebsiteServiceDefault) UpdateSSLStatus(ctx context.Context, domain stri
 		}
 
 		// Set issued_at only when transitioning to ready
-		if status == pluginDb.SSLStatusReady && website.SSLStatus != string(pluginDb.SSLStatusReady) {
+		if status == pluginDb.SSLStatusReady && wd.SSLStatus != string(pluginDb.SSLStatusReady) {
 			updates["SSLIssuedAt"] = &updateTime
 		}
 
 		// Clear issued_at when transitioning away from ready
-		if status != pluginDb.SSLStatusReady && website.SSLStatus == string(pluginDb.SSLStatusReady) {
+		if status != pluginDb.SSLStatusReady && wd.SSLStatus == string(pluginDb.SSLStatusReady) {
 			updates["SSLIssuedAt"] = nil
 		}
 
@@ -1831,15 +1818,15 @@ func (s *WebsiteServiceDefault) UpdateSSLStatus(ctx context.Context, domain stri
 			updates["SSLError"] = ""
 		}
 
-		// Update website
-		if err := tx.Model(&website).Updates(updates).Error; err != nil {
+		// Update the domain binding (source of truth for per-domain SSL).
+		if err := tx.Model(&wd).Updates(updates).Error; err != nil {
 			_ = tx.AddError(fmt.Errorf("failed to update SSL status: %w", err))
 			return tx
 		}
 
-		// Reload the website to get updated values
-		if err := tx.First(&website, website.ID).Error; err != nil {
-			_ = tx.AddError(fmt.Errorf("failed to reload website after update: %w", err))
+		// Reload the binding to get updated values.
+		if err := tx.First(&wd, wd.ID).Error; err != nil {
+			_ = tx.AddError(fmt.Errorf("failed to reload website domain after update: %w", err))
 			return tx
 		}
 
@@ -1854,5 +1841,28 @@ func (s *WebsiteServiceDefault) UpdateSSLStatus(ctx context.Context, domain stri
 		return nil, fmt.Errorf("failed to update SSL status: %w", err)
 	}
 
-	return &website, nil
+	return &wd, nil
+}
+
+// GetApexDomainBinding returns the website's primary/apex domain binding. The
+// apex binding is the one whose domain matches the website's primary domain; its
+// SSL state is synthesized onto the website-level response for backward
+// compatibility. If the delegated domain service is unavailable or no binding
+// matches, it returns gorm.ErrRecordNotFound.
+func (s *WebsiteServiceDefault) GetApexDomainBinding(ctx context.Context, websiteID uint) (*pluginDb.WebsiteDomain, error) {
+	var website pluginDb.Website
+	if err := s.DB().WithContext(ctx).Where("id = ?", websiteID).First(&website).Error; err != nil {
+		return nil, err
+	}
+	if s.delegatedDomainSvc == nil {
+		return nil, gorm.ErrRecordNotFound
+	}
+	apex, err := s.delegatedDomainSvc.GetWebsiteDomainByName(ctx, website.Domain)
+	if err != nil {
+		return nil, err
+	}
+	if apex.DeletedAt.Valid {
+		return nil, gorm.ErrRecordNotFound
+	}
+	return apex, nil
 }

--- a/internal/service/website/website_test.go
+++ b/internal/service/website/website_test.go
@@ -72,21 +72,21 @@ func setupIPNSAutoCreationMocks(t *testing.T, mockIPNS *mocks.MockIPNSKeyService
 	testPeerIDStr := "k51qzi5uqu5dlts3p5vfpw8kneqp5ye1ttb2jlt8qkt5mq9f2gvgmet6sec29r"
 	testPeerID, _ := parsePeerID(testPeerIDStr)
 	testPeerIDMultihash := mh.Multihash(testPeerID)
-	
+
 	testIPNSKey := &pluginDb.IPFSIPNSKey{
 		ID:              testKeyID,
 		UserID:          userID,
 		Name:            expectedKeyName,
 		PeerIDMultihash: testPeerIDMultihash,
 	}
-	
+
 	// Mock key listing (returns empty for new website)
 	mockIPNS.EXPECT().ListKeys(mock.Anything, userID).Return([]pluginDb.IPFSIPNSKey{}, nil).Once()
 	// Mock key creation
 	mockIPNS.EXPECT().CreateKey(mock.Anything, userID, expectedKeyName, 1).Return(testIPNSKey, nil).Once()
 	// Mock CID publishing
 	mockIPNS.EXPECT().PublishCID(mock.Anything, mock.Anything, mock.Anything, mock.AnythingOfType("time.Duration")).Return(nil).Once()
-	
+
 	return testIPNSKey
 }
 
@@ -129,7 +129,6 @@ func createTestIPFSWebsite(userID uint, domain string, cidStr string) *pluginDb.
 		TargetMultihash: c.Hash(),
 		CIDVersion:      &version,
 		CIDType:         &codec,
-		SSLStatus:       string(pluginDb.SSLStatusPending),
 	}
 }
 
@@ -144,7 +143,19 @@ func createTestIPNSWebsite(userID uint, domain string, ipnsStr string) *pluginDb
 		TargetType:      string(pluginDb.WebsiteTargetTypeIPNS),
 		TargetMultihash: target.ToMultihash(),
 		CIDVersion:      nil,
-		SSLStatus:       string(pluginDb.SSLStatusPending),
+	}
+}
+
+// createTestWebsiteDomain creates a domain binding for a website. SSL state is
+// stored per-domain on WebsiteDomain, so tests that exercise SSL updates must
+// create a binding first.
+func createTestWebsiteDomain(websiteID uint, domain string) *pluginDb.WebsiteDomain {
+	return &pluginDb.WebsiteDomain{
+		WebsiteID: websiteID,
+		UserID:    testUserID1,
+		Domain:    domain,
+		Namespace: pluginDb.DomainNamespaceICANN,
+		Status:    pluginDb.DomainStatusDraft,
 	}
 }
 
@@ -232,6 +243,9 @@ func TestWebsiteService_SSLStatusDoesNotAffectWebsiteStatus(t *testing.T) {
 		createdWebsite, err := websiteService.CreateWebsite(context.Background(), website)
 		require.NoError(tb, err)
 
+		// Create a domain binding (per-domain SSL source of truth).
+		require.NoError(tb, ctx.DB().Create(createTestWebsiteDomain(createdWebsite.ID, createdWebsite.Domain)).Error)
+
 		// Get initial website status before SSL update
 		initialStatus := createdWebsite.Status
 
@@ -239,13 +253,15 @@ func TestWebsiteService_SSLStatusDoesNotAffectWebsiteStatus(t *testing.T) {
 		_, err = websiteService.UpdateSSLStatus(context.Background(), createdWebsite.Domain, pluginDb.SSLStatusFailed, "cert validation failed", nil)
 		require.NoError(tb, err)
 
-		// Act & Assert - Verify SSL status is failed and website status is unchanged
+		// Act & Assert - binding SSL is failed and website status is unchanged
+		var binding pluginDb.WebsiteDomain
+		require.NoError(tb, ctx.DB().Where("domain = ?", createdWebsite.Domain).First(&binding).Error)
+		assert.Equal(tb, string(pluginDb.SSLStatusFailed), binding.SSLStatus)
+		assert.Equal(tb, "cert validation failed", binding.SSLError)
+
 		finalWebsite, err := websiteService.GetWebsite(context.Background(), testUserID1, createdWebsite.ID)
 		require.NoError(tb, err)
-
 		assert.Equal(tb, initialStatus, finalWebsite.Status, "website status should not be affected by SSL transitions")
-		assert.Equal(tb, string(pluginDb.SSLStatusFailed), finalWebsite.SSLStatus)
-		assert.Equal(tb, "cert validation failed", finalWebsite.SSLError)
 	}, TestOptions)
 }
 
@@ -262,29 +278,32 @@ func TestWebsiteService_SSLStatusTransitionsIndependently(t *testing.T) {
 		createdWebsite, err := websiteService.CreateWebsite(context.Background(), website)
 		require.NoError(tb, err)
 
+		// Create a domain binding for the website.
+		require.NoError(tb, ctx.DB().Create(createTestWebsiteDomain(createdWebsite.ID, createdWebsite.Domain)).Error)
+
 		// Act - Simulate SSL status transitions
 		now := time.Now()
 
 		// pending -> issuing
-		updatedWebsite, err := websiteService.UpdateSSLStatus(context.Background(), createdWebsite.Domain, pluginDb.SSLStatusIssuing, "", &now)
+		wd, err := websiteService.UpdateSSLStatus(context.Background(), createdWebsite.Domain, pluginDb.SSLStatusIssuing, "", &now)
 		require.NoError(tb, err)
-		assert.Equal(tb, string(pluginDb.SSLStatusIssuing), updatedWebsite.SSLStatus)
-		assert.Nil(tb, updatedWebsite.SSLIssuedAt)
+		assert.Equal(tb, string(pluginDb.SSLStatusIssuing), wd.SSLStatus)
+		assert.Nil(tb, wd.SSLIssuedAt)
 
 		// issuing -> ready
 		now2 := time.Now().Add(time.Minute)
-		updatedWebsite, err = websiteService.UpdateSSLStatus(context.Background(), createdWebsite.Domain, pluginDb.SSLStatusReady, "", &now2)
+		wd, err = websiteService.UpdateSSLStatus(context.Background(), createdWebsite.Domain, pluginDb.SSLStatusReady, "", &now2)
 		require.NoError(tb, err)
-		assert.Equal(tb, string(pluginDb.SSLStatusReady), updatedWebsite.SSLStatus)
-		assert.NotNil(tb, updatedWebsite.SSLIssuedAt)
-		assert.Equal(tb, "", updatedWebsite.SSLError)
+		assert.Equal(tb, string(pluginDb.SSLStatusReady), wd.SSLStatus)
+		assert.NotNil(tb, wd.SSLIssuedAt)
+		assert.Equal(tb, "", wd.SSLError)
 
 		// ready -> failed (simulating certificate expiration)
 		now3 := time.Now().Add(2 * time.Minute)
-		updatedWebsite, err = websiteService.UpdateSSLStatus(context.Background(), createdWebsite.Domain, pluginDb.SSLStatusFailed, "certificate expired", &now3)
+		wd, err = websiteService.UpdateSSLStatus(context.Background(), createdWebsite.Domain, pluginDb.SSLStatusFailed, "certificate expired", &now3)
 		require.NoError(tb, err)
-		assert.Equal(tb, string(pluginDb.SSLStatusFailed), updatedWebsite.SSLStatus)
-		assert.Equal(tb, "certificate expired", updatedWebsite.SSLError)
+		assert.Equal(tb, string(pluginDb.SSLStatusFailed), wd.SSLStatus)
+		assert.Equal(tb, "certificate expired", wd.SSLError)
 
 		// Assert - Website status should not have changed
 		finalWebsite, err := websiteService.GetWebsite(context.Background(), testUserID1, createdWebsite.ID)
@@ -306,24 +325,30 @@ func TestWebsiteService_WebsiteCanBeBrokenRegardlessOfSSLStatus(t *testing.T) {
 		createdWebsite, err := websiteService.CreateWebsite(context.Background(), website)
 		require.NoError(tb, err)
 
+		// Create a domain binding for the website.
+		require.NoError(tb, ctx.DB().Create(createTestWebsiteDomain(createdWebsite.ID, createdWebsite.Domain)).Error)
+
 		// Set SSL status to ready
 		_, err = websiteService.UpdateSSLStatus(context.Background(), createdWebsite.Domain, pluginDb.SSLStatusReady, "", nil)
 		require.NoError(tb, err)
 
-		// Verify SSL is ready
-		websiteWithSSL, err := websiteService.GetWebsite(context.Background(), testUserID1, createdWebsite.ID)
-		require.NoError(tb, err)
-		assert.Equal(tb, string(pluginDb.SSLStatusReady), websiteWithSSL.SSLStatus)
+		// Verify SSL is ready on the binding
+		var binding pluginDb.WebsiteDomain
+		require.NoError(tb, ctx.DB().Where("domain = ?", createdWebsite.Domain).First(&binding).Error)
+		assert.Equal(tb, string(pluginDb.SSLStatusReady), binding.SSLStatus)
 
 		// Act - Update website status to broken
 		updates := map[string]interface{}{"status": string(pluginDb.WebsiteStatusBroken)}
 		_, err = websiteService.UpdateWebsite(context.Background(), testUserID1, createdWebsite.ID, updates)
 		require.NoError(tb, err)
 
-		// Assert - SSL status remains ready, website status is now broken
+		// Assert - SSL status remains ready on the binding, website status is now broken
+		var finalBinding pluginDb.WebsiteDomain
+		require.NoError(tb, ctx.DB().Where("domain = ?", createdWebsite.Domain).First(&finalBinding).Error)
+		assert.Equal(t, string(pluginDb.SSLStatusReady), finalBinding.SSLStatus, "SSL status should not be affected by website status change")
+
 		finalWebsite, err := websiteService.GetWebsite(context.Background(), testUserID1, createdWebsite.ID)
 		require.NoError(tb, err)
-		assert.Equal(t, string(pluginDb.SSLStatusReady), finalWebsite.SSLStatus, "SSL status should not be affected by website status change")
 		assert.Equal(t, string(pluginDb.WebsiteStatusBroken), finalWebsite.Status, "Website status should be broken")
 	}, TestOptions)
 }
@@ -378,7 +403,6 @@ func TestWebsiteService_CreateWebsite_IPNSTargetWithPlainCID_AutoConvert(t *test
 			TargetMultihash: c.Hash(),
 			CIDVersion:      &version,
 			CIDType:         &codec,
-			SSLStatus:       string(pluginDb.SSLStatusPending),
 		}
 
 		// Set up IPNS key mocks for auto-conversion
@@ -386,7 +410,7 @@ func TestWebsiteService_CreateWebsite_IPNSTargetWithPlainCID_AutoConvert(t *test
 
 		// Act
 		createdWebsite, err := websiteService.CreateWebsite(context.Background(), website)
-  websiteService.WaitForPublishes()
+		websiteService.WaitForPublishes()
 
 		// Assert
 		require.NoError(tb, err)
@@ -1069,11 +1093,11 @@ func TestWebsiteService_UpdateSSLStatus_WebsiteNotFound(t *testing.T) {
 		require.NotNil(tb, websiteService)
 
 		// Act - Try to update SSL status for non-existent domain
-		updatedWebsite, err := websiteService.UpdateSSLStatus(context.Background(), "nonexistent.com", pluginDb.SSLStatusReady, "", nil)
+		wd, err := websiteService.UpdateSSLStatus(context.Background(), "nonexistent.com", pluginDb.SSLStatusReady, "", nil)
 
 		// Assert
 		assert.Error(tb, err)
-		assert.Nil(tb, updatedWebsite)
+		assert.Nil(tb, wd)
 		assert.Contains(tb, err.Error(), "website not found")
 	}, TestOptions)
 }
@@ -1089,36 +1113,33 @@ func TestWebsiteService_UpdateSSLStatus_IssuedAtSetOnlyOnReadyTransition(t *test
 		website := createTestIPFSWebsite(testUserID1, "ssl-issuedat-test.com", testCID.String())
 		createdWebsite, err := websiteService.CreateWebsite(context.Background(), website)
 		require.NoError(tb, err)
+		require.NoError(tb, ctx.DB().Create(createTestWebsiteDomain(createdWebsite.ID, createdWebsite.Domain)).Error)
+
+		lookupBinding := func(tb coreTesting.TB) pluginDb.WebsiteDomain {
+			var wd pluginDb.WebsiteDomain
+			require.NoError(tb, ctx.DB().Where("domain = ?", createdWebsite.Domain).First(&wd).Error)
+			return wd
+		}
 
 		// Act - Update to issuing (should not set issued_at)
 		_, err = websiteService.UpdateSSLStatus(context.Background(), createdWebsite.Domain, pluginDb.SSLStatusIssuing, "", nil)
 		require.NoError(tb, err)
-
-		// Check website after first update
-		websiteAfterIssuing, _, err := websiteService.GetWebsiteByDomain(context.Background(), createdWebsite.Domain)
-		require.NoError(tb, err)
-		assert.Nil(tb, websiteAfterIssuing.SSLIssuedAt)
+		assert.Nil(tb, lookupBinding(tb).SSLIssuedAt)
 
 		// Act - Update to ready (should set issued_at)
 		_, err = websiteService.UpdateSSLStatus(context.Background(), createdWebsite.Domain, pluginDb.SSLStatusReady, "", nil)
 		require.NoError(tb, err)
-
-		// Check website after ready transition
-		websiteAfterReady, _, err := websiteService.GetWebsiteByDomain(context.Background(), createdWebsite.Domain)
-		require.NoError(tb, err)
-		assert.NotNil(tb, websiteAfterReady.SSLIssuedAt)
+		afterReady := lookupBinding(tb)
+		assert.NotNil(tb, afterReady.SSLIssuedAt)
 
 		// Act - Update to ready again (should not change issued_at)
-		originalIssuedAt := websiteAfterReady.SSLIssuedAt
+		originalIssuedAt := afterReady.SSLIssuedAt
 		time.Sleep(10 * time.Millisecond)
 		_, err = websiteService.UpdateSSLStatus(context.Background(), createdWebsite.Domain, pluginDb.SSLStatusReady, "", nil)
 		require.NoError(tb, err)
-
-		// Check website after second ready update
-		websiteAfterSecondReady, _, err := websiteService.GetWebsiteByDomain(context.Background(), createdWebsite.Domain)
-		require.NoError(tb, err)
-		assert.NotNil(tb, websiteAfterSecondReady.SSLIssuedAt)
-		assert.Equal(tb, originalIssuedAt.Unix(), websiteAfterSecondReady.SSLIssuedAt.Unix(), "issued_at should not change when already ready")
+		afterSecondReady := lookupBinding(tb)
+		assert.NotNil(tb, afterSecondReady.SSLIssuedAt)
+		assert.Equal(tb, originalIssuedAt.Unix(), afterSecondReady.SSLIssuedAt.Unix(), "issued_at should not change when already ready")
 	}, TestOptions)
 }
 
@@ -1133,17 +1154,18 @@ func TestWebsiteService_UpdateSSLStatus_ErrorSetOnFailed(t *testing.T) {
 		website := createTestIPFSWebsite(testUserID1, "ssl-error-test.com", testCID.String())
 		createdWebsite, err := websiteService.CreateWebsite(context.Background(), website)
 		require.NoError(tb, err)
+		require.NoError(tb, ctx.DB().Create(createTestWebsiteDomain(createdWebsite.ID, createdWebsite.Domain)).Error)
 
 		testErrorMsg := "certificate validation failed"
 
 		// Act - Update SSL status to failed with error message
-		updatedWebsite, err := websiteService.UpdateSSLStatus(context.Background(), createdWebsite.Domain, pluginDb.SSLStatusFailed, testErrorMsg, nil)
+		wd, err := websiteService.UpdateSSLStatus(context.Background(), createdWebsite.Domain, pluginDb.SSLStatusFailed, testErrorMsg, nil)
 
 		// Assert
 		require.NoError(tb, err)
-		assert.NotNil(tb, updatedWebsite)
-		assert.Equal(tb, string(pluginDb.SSLStatusFailed), updatedWebsite.SSLStatus)
-		assert.Equal(tb, testErrorMsg, updatedWebsite.SSLError)
+		assert.NotNil(tb, wd)
+		assert.Equal(tb, string(pluginDb.SSLStatusFailed), wd.SSLStatus)
+		assert.Equal(tb, testErrorMsg, wd.SSLError)
 	}, TestOptions)
 }
 
@@ -1158,25 +1180,26 @@ func TestWebsiteService_UpdateSSLStatus_ErrorClearedOnStatusChange(t *testing.T)
 		website := createTestIPFSWebsite(testUserID1, "ssl-clear-error-test.com", testCID.String())
 		createdWebsite, err := websiteService.CreateWebsite(context.Background(), website)
 		require.NoError(tb, err)
+		require.NoError(tb, ctx.DB().Create(createTestWebsiteDomain(createdWebsite.ID, createdWebsite.Domain)).Error)
 
 		// Set status to failed with error
 		testErrorMsg := "certificate validation failed"
 		_, err = websiteService.UpdateSSLStatus(context.Background(), createdWebsite.Domain, pluginDb.SSLStatusFailed, testErrorMsg, nil)
 		require.NoError(tb, err)
 
-		// Verify error is set
-		websiteAfterFailed, _, err := websiteService.GetWebsiteByDomain(context.Background(), createdWebsite.Domain)
-		require.NoError(tb, err)
-		assert.Equal(tb, testErrorMsg, websiteAfterFailed.SSLError)
+		// Verify error is set on the binding
+		var binding pluginDb.WebsiteDomain
+		require.NoError(tb, ctx.DB().Where("domain = ?", createdWebsite.Domain).First(&binding).Error)
+		assert.Equal(tb, testErrorMsg, binding.SSLError)
 
 		// Act - Update to pending (should clear error)
-		updatedWebsite, err := websiteService.UpdateSSLStatus(context.Background(), createdWebsite.Domain, pluginDb.SSLStatusPending, "", nil)
+		wd, err := websiteService.UpdateSSLStatus(context.Background(), createdWebsite.Domain, pluginDb.SSLStatusPending, "", nil)
 
 		// Assert
 		require.NoError(tb, err)
-		assert.NotNil(tb, updatedWebsite)
-		assert.Equal(tb, string(pluginDb.SSLStatusPending), updatedWebsite.SSLStatus)
-		assert.Empty(tb, updatedWebsite.SSLError, "Error should be cleared when status changes away from failed")
+		assert.NotNil(tb, wd)
+		assert.Equal(tb, string(pluginDb.SSLStatusPending), wd.SSLStatus)
+		assert.Empty(tb, wd.SSLError, "Error should be cleared when status changes away from failed")
 	}, TestOptions)
 }
 
@@ -1196,64 +1219,55 @@ func TestWebsiteService_UpdateSSLStatus_AtomicUpdates(t *testing.T) {
 		website := createTestIPFSWebsite(testUserID1, "ssl-atomic-test.com", testCID.String())
 		createdWebsite, err := websiteService.CreateWebsite(context.Background(), website)
 		require.NoError(tb, err)
+		require.NoError(tb, ctx.DB().Create(createTestWebsiteDomain(createdWebsite.ID, createdWebsite.Domain)).Error)
 
 		// Act - Perform concurrent updates to test atomicity
 		numGoroutines := 3
 		errChan := make(chan error, numGoroutines)
 
-		// Launch multiple goroutines updating SSL status concurrently
 		for i := 0; i < numGoroutines; i++ {
 			go func(index int) {
 				var status pluginDb.SSLStatus
 				var errorMsg string
-
 				switch index % 4 {
 				case 0:
 					status = pluginDb.SSLStatusIssuing
-					errorMsg = ""
 				case 1:
 					status = pluginDb.SSLStatusReady
-					errorMsg = ""
 				case 2:
 					status = pluginDb.SSLStatusFailed
 					errorMsg = "concurrent test error"
 				case 3:
 					status = pluginDb.SSLStatusPending
-					errorMsg = ""
 				}
-
 				_, err := websiteService.UpdateSSLStatus(context.Background(), createdWebsite.Domain, status, errorMsg, nil)
 				errChan <- err
 			}(i)
 		}
 
-		// Wait for all goroutines to complete
 		for i := 0; i < numGoroutines; i++ {
 			err := <-errChan
 			require.NoError(tb, err, "concurrent update should not fail")
 		}
 
 		// Assert - Final state should be consistent (no data corruption)
-		finalWebsite, _, err := websiteService.GetWebsiteByDomain(context.Background(), createdWebsite.Domain)
-		require.NoError(tb, err)
-		assert.NotNil(tb, finalWebsite)
+		var finalBinding pluginDb.WebsiteDomain
+		require.NoError(tb, ctx.DB().Where("domain = ?", createdWebsite.Domain).First(&finalBinding).Error)
 
-		// Verify final state is consistent and adheres to state transition rules
-		switch pluginDb.SSLStatus(finalWebsite.SSLStatus) {
+		switch pluginDb.SSLStatus(finalBinding.SSLStatus) {
 		case pluginDb.SSLStatusReady:
-			assert.NotNil(tb, finalWebsite.SSLIssuedAt, "SSLIssuedAt should be set for Ready status")
-			assert.Empty(tb, finalWebsite.SSLError, "SSLError should be empty for Ready status")
+			assert.NotNil(tb, finalBinding.SSLIssuedAt, "SSLIssuedAt should be set for Ready status")
+			assert.Empty(tb, finalBinding.SSLError, "SSLError should be empty for Ready status")
 		case pluginDb.SSLStatusFailed:
-			assert.NotEmpty(tb, finalWebsite.SSLError, "SSLError should be set for Failed status")
+			assert.NotEmpty(tb, finalBinding.SSLError, "SSLError should be set for Failed status")
 		case pluginDb.SSLStatusPending, pluginDb.SSLStatusIssuing:
-			assert.Empty(tb, finalWebsite.SSLError, "SSLError should be empty for non-failed status")
-			assert.Nil(tb, finalWebsite.SSLIssuedAt, "SSLIssuedAt should be nil for non-ready status")
+			assert.Empty(tb, finalBinding.SSLError, "SSLError should be empty for non-failed status")
+			assert.Nil(tb, finalBinding.SSLIssuedAt, "SSLIssuedAt should be nil for non-ready status")
 		default:
-			tb.Fatalf("unexpected final SSL status: %s", finalWebsite.SSLStatus)
+			tb.Fatalf("unexpected final SSL status: %s", finalBinding.SSLStatus)
 		}
 
-		// Verify last_updated_at was set
-		assert.NotNil(tb, finalWebsite.SSLLastUpdatedAt)
+		assert.NotNil(tb, finalBinding.SSLLastUpdatedAt)
 	}, TestOptions)
 }
 
@@ -1285,7 +1299,7 @@ func TestWebsiteService_CreateWebsite_DNSZoneCreatedWhenEnabled(t *testing.T) {
 		).Return(nil).Once()
 
 		createdWebsite, err := websiteService.CreateWebsite(context.Background(), website)
-  websiteService.WaitForPublishes()
+		websiteService.WaitForPublishes()
 
 		// Assert
 		require.NoError(tb, err)
@@ -1345,7 +1359,7 @@ func TestWebsiteService_CreateWebsite_DNSRecordsCreated(t *testing.T) {
 		).Return(nil).Once()
 
 		createdWebsite, err := websiteService.CreateWebsite(context.Background(), website)
-  websiteService.WaitForPublishes()
+		websiteService.WaitForPublishes()
 
 		// Assert
 		require.NoError(tb, err)
@@ -1424,7 +1438,7 @@ func TestWebsiteService_DeleteWebsite_DNSRecordsCleanedUp(t *testing.T) {
 		).Return(nil).Once()
 
 		createdWebsite, err := websiteService.CreateWebsite(context.Background(), website)
-  websiteService.WaitForPublishes()
+		websiteService.WaitForPublishes()
 		require.NoError(tb, err)
 		require.NotNil(tb, createdWebsite)
 
@@ -1471,7 +1485,7 @@ func TestWebsiteService_DeleteWebsite_DNSCleanupFailureDoesNotPreventDeletion(t 
 		).Return(nil).Once()
 
 		createdWebsite, err := websiteService.CreateWebsite(context.Background(), website)
-  websiteService.WaitForPublishes()
+		websiteService.WaitForPublishes()
 		require.NoError(tb, err)
 		require.NotNil(tb, createdWebsite)
 
@@ -1586,7 +1600,7 @@ func TestWebsiteService_CreateWebsite_DNSHostingEnabled_CreatesZoneAndRecords(t 
 
 		// Act
 		createdWebsite, err := websiteService.CreateWebsite(context.Background(), website)
-  websiteService.WaitForPublishes()
+		websiteService.WaitForPublishes()
 
 		// Assert
 		require.NoError(tb, err)
@@ -1628,7 +1642,7 @@ func TestWebsiteService_UpdateWebsite_DNSHostingEnabled_NoDNSUpdateWhenTargetUnc
 		).Return(nil).Once()
 
 		createdWebsite, err := websiteService.CreateWebsite(context.Background(), website)
-  websiteService.WaitForPublishes()
+		websiteService.WaitForPublishes()
 		require.NoError(tb, err)
 
 		// Act - Update website without changing target (should NOT update DNS records)
@@ -1675,7 +1689,7 @@ func TestWebsiteService_DeleteWebsite_DNSHostingEnabled_ZoneRemainsAfterDeletion
 		).Return(nil).Once()
 
 		createdWebsite, err := websiteService.CreateWebsite(context.Background(), website)
-  websiteService.WaitForPublishes()
+		websiteService.WaitForPublishes()
 		require.NoError(tb, err)
 
 		// Mock DNS records deletion
@@ -1829,7 +1843,7 @@ func TestWebsiteService_CreateWebsite_DNSZoneCreationFailure_ContinuesWithoutDNS
 
 		// Act - Create website with DNS zone creation failure
 		createdWebsite, err := websiteService.CreateWebsite(context.Background(), website)
-  websiteService.WaitForPublishes()
+		websiteService.WaitForPublishes()
 
 		// Assert - Website should still be created despite DNS failure
 		require.NoError(tb, err)
@@ -1876,7 +1890,7 @@ func TestWebsiteService_CreateWebsite_DNSRecordsCreationFailure_ContinuesWithout
 
 		// Act - Create website with DNS records creation failure
 		createdWebsite, err := websiteService.CreateWebsite(context.Background(), website)
-  websiteService.WaitForPublishes()
+		websiteService.WaitForPublishes()
 
 		// Assert - Website should still be created with zone ID set
 		require.NoError(tb, err)
@@ -1939,7 +1953,7 @@ func TestWebsiteService_CreateWebsite_IPNSKeyAutoCreation_NoDuplicate(t *testing
 		website1 := createTestIPFSWebsite(testUserID1, domain, testCID.String())
 		website1.Enabled = true // Enable DNS hosting
 		createdWebsite1, err := websiteService.CreateWebsite(context.Background(), website1)
-  websiteService.WaitForPublishes()
+		websiteService.WaitForPublishes()
 		require.NoError(tb, err)
 
 		// Assert - IPNS key was created
@@ -2087,12 +2101,12 @@ func TestWebsiteService_UpdateWebsite_DisableDNSHostingTransition(t *testing.T) 
 
 		// Set up IPNS key mocks for auto-creation
 		setupIPNSAutoCreationMocks(t, mockIPNSKey, testUserID1, domain, testCID)
-		
+
 		// Mock DNS operations for initial website creation with DNS enabled
 		setupDNSZoneCreationMocks(t, mockDNS, testZoneID, domain, testUserID1)
 
 		createdWebsite, err := websiteService.CreateWebsite(context.Background(), website)
-  websiteService.WaitForPublishes()
+		websiteService.WaitForPublishes()
 		require.NoError(tb, err)
 		require.NotNil(tb, createdWebsite)
 		assert.True(t, createdWebsite.Enabled)
@@ -2211,7 +2225,7 @@ func TestWebsiteService_UpdateWebsite_DNSEnableToggleOffOn(t *testing.T) {
 		setupDNSZoneCreationMocks(t, mockDNS, testZoneID, domain, testUserID1)
 
 		createdWebsite, err := websiteService.CreateWebsite(context.Background(), website)
-  websiteService.WaitForPublishes()
+		websiteService.WaitForPublishes()
 		require.NoError(tb, err)
 		require.NotNil(tb, createdWebsite)
 		assert.True(t, createdWebsite.Enabled)
@@ -2263,7 +2277,7 @@ func TestWebsiteService_UpdateWebsite_DisableDNSHostingDeleteZoneFails(t *testin
 		setupDNSZoneCreationMocks(t, mockDNS, testZoneID, domain, testUserID1)
 
 		createdWebsite, err := websiteService.CreateWebsite(context.Background(), website)
-  websiteService.WaitForPublishes()
+		websiteService.WaitForPublishes()
 		require.NoError(tb, err)
 		require.NotNil(tb, createdWebsite)
 		assert.NotNil(t, createdWebsite.DNSZoneID)
@@ -2281,109 +2295,6 @@ func TestWebsiteService_UpdateWebsite_DisableDNSHostingDeleteZoneFails(t *testin
 		assert.False(t, updatedWebsite.Enabled)
 		assert.NotNil(t, updatedWebsite.DNSZoneID, "dns_zone_id should be preserved when DeleteZone fails")
 		assert.Equal(t, *createdWebsite.DNSZoneID, *updatedWebsite.DNSZoneID)
-	}, TestOptions)
-}
-
-func TestWebsiteService_CreateWebsite_InheritsSSLFromSoftDeletedWebsite(t *testing.T) {
-	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
-		websiteService := core.GetService[pluginCore.WebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
-		require.NotNil(tb, websiteService)
-
-		testCID := util.GenerateTestCID(t, "test data")
-		domain := "ssl-inherit-test.com"
-
-		website := createTestIPFSWebsite(testUserID1, domain, testCID.String())
-		createdWebsite, err := websiteService.CreateWebsite(context.Background(), website)
-		require.NoError(tb, err)
-
-		now := time.Now()
-		_, err = websiteService.UpdateSSLStatus(context.Background(), domain, pluginDb.SSLStatusReady, "", &now)
-		require.NoError(tb, err)
-
-		err = websiteService.DeleteWebsite(context.Background(), testUserID1, createdWebsite.ID)
-		require.NoError(tb, err)
-
-		_, _, err = websiteService.GetWebsiteByDomain(context.Background(), domain)
-		require.NoError(tb, err)
-
-		newWebsite := createTestIPFSWebsite(testUserID1, domain, testCID.String())
-		recreatedWebsite, err := websiteService.CreateWebsite(context.Background(), newWebsite)
-		require.NoError(tb, err)
-
-		assert.Equal(tb, string(pluginDb.SSLStatusReady), recreatedWebsite.SSLStatus)
-		assert.NotNil(tb, recreatedWebsite.SSLIssuedAt)
-		assert.NotNil(tb, recreatedWebsite.SSLLastUpdatedAt)
-	}, TestOptions)
-}
-
-func TestWebsiteService_CreateWebsite_DoesNotInheritExpiredSSLCert(t *testing.T) {
-	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
-		websiteService := core.GetService[pluginCore.WebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
-		require.NotNil(tb, websiteService)
-
-		testCID := util.GenerateTestCID(t, "test data")
-		domain := "ssl-expired-inherit-test.com"
-
-		website := createTestIPFSWebsite(testUserID1, domain, testCID.String())
-		createdWebsite, err := websiteService.CreateWebsite(context.Background(), website)
-		require.NoError(tb, err)
-
-		oldIssuedAt := time.Now().Add(-91 * 24 * time.Hour)
-		_, err = websiteService.UpdateSSLStatus(context.Background(), domain, pluginDb.SSLStatusReady, "", &oldIssuedAt)
-		require.NoError(tb, err)
-
-		err = websiteService.DeleteWebsite(context.Background(), testUserID1, createdWebsite.ID)
-		require.NoError(tb, err)
-
-		newWebsite := createTestIPFSWebsite(testUserID1, domain, testCID.String())
-		recreatedWebsite, err := websiteService.CreateWebsite(context.Background(), newWebsite)
-		require.NoError(tb, err)
-
-		assert.Equal(tb, string(pluginDb.SSLStatusPending), recreatedWebsite.SSLStatus)
-		assert.Nil(tb, recreatedWebsite.SSLIssuedAt)
-	}, TestOptions)
-}
-
-func TestWebsiteService_CreateWebsite_DoesNotInheritFailedSSL(t *testing.T) {
-	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
-		websiteService := core.GetService[pluginCore.WebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
-		require.NotNil(tb, websiteService)
-
-		testCID := util.GenerateTestCID(t, "test data")
-		domain := "ssl-failed-inherit-test.com"
-
-		website := createTestIPFSWebsite(testUserID1, domain, testCID.String())
-		createdWebsite, err := websiteService.CreateWebsite(context.Background(), website)
-		require.NoError(tb, err)
-
-		_, err = websiteService.UpdateSSLStatus(context.Background(), domain, pluginDb.SSLStatusFailed, "cert failed", nil)
-		require.NoError(tb, err)
-
-		err = websiteService.DeleteWebsite(context.Background(), testUserID1, createdWebsite.ID)
-		require.NoError(tb, err)
-
-		newWebsite := createTestIPFSWebsite(testUserID1, domain, testCID.String())
-		recreatedWebsite, err := websiteService.CreateWebsite(context.Background(), newWebsite)
-		require.NoError(tb, err)
-
-		assert.Equal(tb, string(pluginDb.SSLStatusPending), recreatedWebsite.SSLStatus)
-	}, TestOptions)
-}
-
-func TestWebsiteService_CreateWebsite_NoInheritWithoutSoftDeletedWebsite(t *testing.T) {
-	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
-		websiteService := core.GetService[pluginCore.WebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
-		require.NotNil(tb, websiteService)
-
-		testCID := util.GenerateTestCID(t, "test data")
-		domain := "ssl-no-inherit-test.com"
-
-		website := createTestIPFSWebsite(testUserID1, domain, testCID.String())
-		createdWebsite, err := websiteService.CreateWebsite(context.Background(), website)
-		require.NoError(tb, err)
-
-		assert.Equal(tb, string(pluginDb.SSLStatusPending), createdWebsite.SSLStatus)
-		assert.Nil(tb, createdWebsite.SSLIssuedAt)
 	}, TestOptions)
 }
 
@@ -2419,7 +2330,7 @@ func TestWebsiteService_UpdateWebsite_ConvertIPNSToIPFS_UpdatesDNSRecords(t *tes
 		).Return(nil).Once()
 
 		createdWebsite, err := websiteService.CreateWebsite(context.Background(), website)
-  websiteService.WaitForPublishes()
+		websiteService.WaitForPublishes()
 		require.NoError(tb, err)
 		require.NotNil(tb, createdWebsite)
 		assert.Equal(tb, string(pluginDb.WebsiteTargetTypeIPNS), createdWebsite.TargetType)
@@ -2492,7 +2403,7 @@ func TestWebsiteService_UpdateWebsite_IPNSToIPNS_NoDNSUpdate(t *testing.T) {
 		).Return(nil).Once()
 
 		createdWebsite, err := websiteService.CreateWebsite(context.Background(), website)
-  websiteService.WaitForPublishes()
+		websiteService.WaitForPublishes()
 		require.NoError(tb, err)
 		require.NotNil(tb, createdWebsite)
 
@@ -2554,7 +2465,7 @@ func TestWebsiteService_UpdateWebsite_ConvertIPFSToIPNS_UpdatesDNSRecords(t *tes
 		).Return(nil).Once()
 
 		createdWebsite, err := websiteService.CreateWebsite(context.Background(), website)
-  websiteService.WaitForPublishes()
+		websiteService.WaitForPublishes()
 		require.NoError(tb, err)
 		require.NotNil(tb, createdWebsite)
 		require.NotNil(tb, createdWebsite.DNSZoneID)
@@ -2649,7 +2560,7 @@ func TestWebsiteService_UpdateWebsite_TargetTypeIPNSAlone(t *testing.T) {
 		}
 
 		updatedWebsite, err := websiteService.UpdateWebsite(context.Background(), testUserID1, createdWebsite.ID, updates)
-  websiteService.WaitForPublishes()
+		websiteService.WaitForPublishes()
 
 		require.NoError(tb, err)
 		require.NotNil(tb, updatedWebsite)
@@ -2700,7 +2611,7 @@ func TestWebsiteService_UpdateWebsite_TargetTypeIPNSAlone_DNSRecordsUpdated(t *t
 		).Return(nil).Once()
 
 		updatedWebsite, err := websiteService.UpdateWebsite(context.Background(), testUserID1, createdWebsite.ID, updates)
-  websiteService.WaitForPublishes()
+		websiteService.WaitForPublishes()
 
 		require.NoError(tb, err)
 		require.NotNil(tb, updatedWebsite)
@@ -2738,7 +2649,7 @@ func TestWebsiteService_UpdateWebsite_IPNSTargetTypeWithCID(t *testing.T) {
 		}
 
 		updatedWebsite, err := websiteService.UpdateWebsite(context.Background(), testUserID1, createdWebsite.ID, updates)
-  websiteService.WaitForPublishes()
+		websiteService.WaitForPublishes()
 
 		require.NoError(tb, err)
 		require.NotNil(tb, updatedWebsite)
@@ -2773,7 +2684,7 @@ func TestWebsiteService_UpdateWebsite_IPNSToIPFSWithoutCID(t *testing.T) {
 		).Return(nil).Once()
 
 		createdWebsite, err := websiteService.CreateWebsite(context.Background(), website)
-  websiteService.WaitForPublishes()
+		websiteService.WaitForPublishes()
 		require.NoError(tb, err)
 		assert.Equal(tb, string(pluginDb.WebsiteTargetTypeIPNS), createdWebsite.TargetType)
 

--- a/internal/testing/mocks/MockWebsiteService.go
+++ b/internal/testing/mocks/MockWebsiteService.go
@@ -437,6 +437,74 @@ func (_c *MockWebsiteService_DeleteWebsite_Call) RunAndReturn(run func(ctx conte
 	return _c
 }
 
+// GetApexDomainBinding provides a mock function for the type MockWebsiteService
+func (_mock *MockWebsiteService) GetApexDomainBinding(ctx context.Context, websiteID uint) (*db.WebsiteDomain, error) {
+	ret := _mock.Called(ctx, websiteID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetApexDomainBinding")
+	}
+
+	var r0 *db.WebsiteDomain
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uint) (*db.WebsiteDomain, error)); ok {
+		return returnFunc(ctx, websiteID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uint) *db.WebsiteDomain); ok {
+		r0 = returnFunc(ctx, websiteID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*db.WebsiteDomain)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, uint) error); ok {
+		r1 = returnFunc(ctx, websiteID)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockWebsiteService_GetApexDomainBinding_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetApexDomainBinding'
+type MockWebsiteService_GetApexDomainBinding_Call struct {
+	*mock.Call
+}
+
+// GetApexDomainBinding is a helper method to define mock.On call
+//   - ctx context.Context
+//   - websiteID uint
+func (_e *MockWebsiteService_Expecter) GetApexDomainBinding(ctx any, websiteID any) *MockWebsiteService_GetApexDomainBinding_Call {
+	return &MockWebsiteService_GetApexDomainBinding_Call{Call: _e.mock.On("GetApexDomainBinding", ctx, websiteID)}
+}
+
+func (_c *MockWebsiteService_GetApexDomainBinding_Call) Run(run func(ctx context.Context, websiteID uint)) *MockWebsiteService_GetApexDomainBinding_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 uint
+		if args[1] != nil {
+			arg1 = args[1].(uint)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockWebsiteService_GetApexDomainBinding_Call) Return(websiteDomain *db.WebsiteDomain, err error) *MockWebsiteService_GetApexDomainBinding_Call {
+	_c.Call.Return(websiteDomain, err)
+	return _c
+}
+
+func (_c *MockWebsiteService_GetApexDomainBinding_Call) RunAndReturn(run func(ctx context.Context, websiteID uint) (*db.WebsiteDomain, error)) *MockWebsiteService_GetApexDomainBinding_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetConfig provides a mock function for the type MockWebsiteService
 func (_mock *MockWebsiteService) GetConfig() (any, error) {
 	ret := _mock.Called()
@@ -1040,23 +1108,23 @@ func (_c *MockWebsiteService_UnblockWebsite_Call) RunAndReturn(run func(ctx cont
 }
 
 // UpdateSSLStatus provides a mock function for the type MockWebsiteService
-func (_mock *MockWebsiteService) UpdateSSLStatus(ctx context.Context, domain string, status db.SSLStatus, sslError string, timestamp *time.Time) (*db.Website, error) {
+func (_mock *MockWebsiteService) UpdateSSLStatus(ctx context.Context, domain string, status db.SSLStatus, sslError string, timestamp *time.Time) (*db.WebsiteDomain, error) {
 	ret := _mock.Called(ctx, domain, status, sslError, timestamp)
 
 	if len(ret) == 0 {
 		panic("no return value specified for UpdateSSLStatus")
 	}
 
-	var r0 *db.Website
+	var r0 *db.WebsiteDomain
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, db.SSLStatus, string, *time.Time) (*db.Website, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, db.SSLStatus, string, *time.Time) (*db.WebsiteDomain, error)); ok {
 		return returnFunc(ctx, domain, status, sslError, timestamp)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, db.SSLStatus, string, *time.Time) *db.Website); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, db.SSLStatus, string, *time.Time) *db.WebsiteDomain); ok {
 		r0 = returnFunc(ctx, domain, status, sslError, timestamp)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*db.Website)
+			r0 = ret.Get(0).(*db.WebsiteDomain)
 		}
 	}
 	if returnFunc, ok := ret.Get(1).(func(context.Context, string, db.SSLStatus, string, *time.Time) error); ok {
@@ -1115,12 +1183,12 @@ func (_c *MockWebsiteService_UpdateSSLStatus_Call) Run(run func(ctx context.Cont
 	return _c
 }
 
-func (_c *MockWebsiteService_UpdateSSLStatus_Call) Return(website *db.Website, err error) *MockWebsiteService_UpdateSSLStatus_Call {
-	_c.Call.Return(website, err)
+func (_c *MockWebsiteService_UpdateSSLStatus_Call) Return(websiteDomain *db.WebsiteDomain, err error) *MockWebsiteService_UpdateSSLStatus_Call {
+	_c.Call.Return(websiteDomain, err)
 	return _c
 }
 
-func (_c *MockWebsiteService_UpdateSSLStatus_Call) RunAndReturn(run func(ctx context.Context, domain string, status db.SSLStatus, sslError string, timestamp *time.Time) (*db.Website, error)) *MockWebsiteService_UpdateSSLStatus_Call {
+func (_c *MockWebsiteService_UpdateSSLStatus_Call) RunAndReturn(run func(ctx context.Context, domain string, status db.SSLStatus, sslError string, timestamp *time.Time) (*db.WebsiteDomain, error)) *MockWebsiteService_UpdateSSLStatus_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
## Summary

SSL certificate state is a per-domain property: each bound hostname on a website carries its own cert/issuance lifecycle. It was mis-modeled on the `Website` row (one status per website), which broke Caddy's DANE cert webhook for **additional domain records** — a cert event for an extra hostname like `lumeweb` 404'd with "website not found", leaving Caddy with no cert and hanging the TLS handshake.

This moves SSL state onto the domain binding so additional-domain records are handled transparently.

## Changes

- Move `ssl_status` / `ssl_error` / `ssl_issued_at` / `ssl_last_updated_at` from `ipfs_websites` onto `website_domains`
- `UpdateSSLStatus` now resolves and persists the domain binding (handles primary + additional domains); returns the updated `WebsiteDomain`
- Synthesize website-level `ssl` from the apex binding for backward-compatible responses; expose per-domain `ssl` on `DomainResponse`
- Goose migration (sqlite + mysql): backfill each apex binding from its owning website, then drop the columns from `ipfs_websites`

## Verification

`go build ./...`, `go vet ./...`, and gofmt pass. Server-side schema restructure; SDK/CLI follow-up happens after the server deploys.

- `develop` <!-- branch-stack -->
  - **fix(dns): move SSL status to per-domain WebsiteDomain** :point\_left:

***

<!-- kody-pr-summary:start -->

This pull request refactors SSL certificate status tracking to be per-domain rather than per-website. Previously, SSL state (status, error, issued date, last updated date) was stored on the `Website` model, but this change moves it to the `WebsiteDomain` model, since SSL certificates are issued per hostname.

Key changes include:

- **Database schema migration**: A new migration adds SSL columns (`ssl_status`, `ssl_error`, `ssl_issued_at`, `ssl_last_updated_at`) to the `website_domains` table and removes them from the `ipfs_websites` table. Existing website SSL data is backfilled to the apex (primary) domain binding for each website.

- **Service layer**: The `UpdateSSLStatus` method now operates on the `WebsiteDomain` record for a given domain instead of updating the `Website` directly. A new `GetApexDomainBinding` method retrieves the website's primary domain binding to support site-level status presentation.

- **API layer**: SSL status is now exposed per-domain on `DomainResponse` objects with a new `ssl` field. For backward compatibility, website-level responses (`WebsiteResponse`) still include SSL info, synthesized from the apex domain binding via the new `applyApexSSLStatus` helper.

- **Model changes**: The `Website` model no longer contains SSL fields, while `WebsiteDomain` now includes them with appropriate validation and default values in its save hook.

- **Removed logic**: Domain SSL state is no longer inherited from soft-deleted websites during creation since the state is now tied to specific domain bindings rather than the website itself.

<!-- kody-pr-summary:end -->
