### PR TITLE
fix(dns): publish TLSA record to managed authoritative zone (fixes NXDOMAIN on _443._tcp)

### DIFF
--- a/core/dns.go
+++ b/core/dns.go
@@ -64,6 +64,14 @@ type DNSService interface {
 	// or RecordTypeALIAS (gateway hostname content).
 	CreateApexRecord(ctx context.Context, zoneID uint, recordType RecordType, content string) error
 
+	// SetTLSARecord writes (or replaces) the DANE TLSA record for a zone's
+	// HTTPS/TCP owner `_443._tcp` in the portal-managed authoritative zone.
+	// content is the TLSA rdata: "usage selector matching hash" (e.g.
+	// "3 1 1 <hex>"). Without publishing the TLSA to the authoritative zone,
+	// DANE validators get NXDOMAIN for the TLSA owner and DANE cannot be
+	// established for portal-managed (DNSSEC-signed) domains.
+	SetTLSARecord(ctx context.Context, zoneID uint, content string) error
+
 	// CreateRecord creates a new DNS record in PowerDNS via RRSet
 	// name: the record name (e.g., "www")
 	// recordType: the record type (e.g., "A", "CNAME")

--- a/internal/service/dns/dns_service.go
+++ b/internal/service/dns/dns_service.go
@@ -161,6 +161,16 @@ func (s *DNSServiceDefault) CreateApexRecord(ctx context.Context, zoneID uint, r
 	return err
 }
 
+// SetTLSARecord writes (or replaces) the DANE TLSA record for a zone's
+// HTTPS/TCP owner `_443._tcp` in the portal-managed authoritative zone
+// (adapter for domain.DNSZoneService). content is the TLSA rdata, e.g.
+// "3 1 1 <sha256hex>". Publishing this is what lets DANE validators resolve the
+// TLSA against PowerDNS; without it authoritative queries return NXDOMAIN.
+func (s *DNSServiceDefault) SetTLSARecord(ctx context.Context, zoneID uint, content string) error {
+	_, err := s.CreateRecord(ctx, zoneID, "_443._tcp", "TLSA", content, 300)
+	return err
+}
+
 // EnableDNSSEC enables DNSSEC on a zone and returns the DNSKEY record content.
 // It delegates to the PowerDNS client's cryptokey API.
 func (s *DNSServiceDefault) EnableDNSSEC(ctx context.Context, zoneID uint) (string, error) {

--- a/internal/service/domain/delegated_domain_service.go
+++ b/internal/service/domain/delegated_domain_service.go
@@ -33,6 +33,13 @@ type DNSZoneService interface {
 	// record type (e.g. RecordTypeA or RecordTypeALIAS). content is the raw
 	// value: an IP address for A, a gateway hostname for ALIAS.
 	CreateApexRecord(ctx context.Context, zoneID uint, recordType pluginCore.RecordType, content string) error
+	// SetTLSARecord writes (or replaces) the DANE TLSA record for a zone's
+	// HTTPS/TCP owner `_443._tcp` pointing at the portal-managed authoritative
+	// zone. content is the TLSA rdata: "usage selector matching hash" (e.g.
+	// "3 1 1 <hex>")). For HNS managed zones this makes DANE validators resolve
+	// the TLSA against the portal's PowerDNS zone; without it, authoritative
+	// queries return NXDOMAIN.
+	SetTLSARecord(ctx context.Context, zoneID uint, content string) error
 	// EnableDNSSEC enables DNSSEC on a zone and returns the DNSKEY.
 	EnableDNSSEC(ctx context.Context, zoneID uint) (dnskey string, err error)
 }
@@ -300,6 +307,7 @@ func (s *DelegatedDomainService) UpdateTLSAFromCert(ctx context.Context, namespa
 	// published pin and break every DANE-validating client. The cert, TLSA, and
 	// owner name, by contrast, are refreshed on every push (a cert may be freely
 	// re-issued from the same key with an identical SPKI).
+	var zoneID uint
 	txErr := s.DB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		// Lock the target row so concurrent cert pushes serialize per-domain.
 		locked := tx.Clauses(clause.Locking{Strength: "UPDATE"})
@@ -307,6 +315,7 @@ func (s *DelegatedDomainService) UpdateTLSAFromCert(ctx context.Context, namespa
 		if err := locked.Where("domain = ? AND namespace = ?", domain, ns).First(&wd).Error; err != nil {
 			return err // includes gorm.ErrRecordNotFound
 		}
+		zoneID = wd.ZoneID
 		if wd.ProtocolData == nil {
 			wd.ProtocolData = make(datatypes.JSONMap)
 		}
@@ -375,6 +384,21 @@ func (s *DelegatedDomainService) UpdateTLSAFromCert(ctx context.Context, namespa
 		return "", "", fmt.Errorf("save domain tlsa: %w", txErr)
 	}
 
+	// Publish the TLSA to the portal-managed authoritative zone in PowerDNS.
+	// Without this, the TLSA was only stored in the DB (DelegationData) and
+	// never served, so DANE validators get NXDOMAIN for `_443._tcp.<domain>`.
+	// Only providers whose namespace uses DANE and whose zone the portal
+	// manages (e.g. HNS) do this; the decision is a provider capability, not
+	// a namespace string comparison, so any future DANE-capable namespace
+	// opts in here rather than via a hardcoded "hns" check.
+	if s.dnsSvc != nil && zoneID != 0 && provider.UsesManagedZoneTLSA() {
+		if err := s.dnsSvc.SetTLSARecord(ctx, zoneID, tlsa); err != nil {
+			// DNS publish failure is surfaced but the persisted cert/TLSA state
+			// is retained so a later cert push retries the publish.
+			return tlsa, ownerName, fmt.Errorf("publish tlsa to zone: %w", err)
+		}
+	}
+
 	return tlsa, ownerName, nil
 }
 
@@ -430,7 +454,7 @@ func (s *DelegatedDomainService) GetWebsiteDomainByDomainAndNamespace(ctx contex
 // the WebsiteDomain.ProtocolData JSON map (the per-protocol data store), keeping
 // the key, cert, TLSA, and owner name together as one per-protocol unit.
 const (
-	daneKeyField              = "dane_cert_pem" // last pushed cert (not a source of truth)
+	daneKeyField              = "dane_cert_pem"    // last pushed cert (not a source of truth)
 	protocolDataPrivateKeyKey = "dane_private_key" // encrypted at rest, written once
 	protocolDataTLSAKey       = "tlsa"
 	protocolDataOwnerKey      = "owner_name"

--- a/internal/service/domain/delegated_domain_service_test.go
+++ b/internal/service/domain/delegated_domain_service_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	"go.lumeweb.com/portal-plugin-ipfs/internal"
 	pluginCore "go.lumeweb.com/portal-plugin-ipfs/core"
+	"go.lumeweb.com/portal-plugin-ipfs/internal"
 	pluginConfig "go.lumeweb.com/portal-plugin-ipfs/internal/config"
 	pluginDb "go.lumeweb.com/portal-plugin-ipfs/internal/db"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/db/migrations"
@@ -174,4 +174,71 @@ func TestDelegatedDomainService_GetPendingWebsiteDomainsPaginated(t *testing.T) 
 		require.NoError(t, err)
 		assert.Len(t, wds2, 1)
 	}, TestOptions)
+}
+
+// TestDelegatedDomainService_UpdateTLSA_PublishesToManagedZone is the
+// regression test for the "TLSA record is never served" bug. When a cert is
+// pushed via UpdateTLSAFromCert for a domain whose WebsiteDomain carries a
+// ZoneID (i.e. a portal-managed, DNSSEC-signed authoritative zone), the TLSA
+// record MUST be published to PowerDNS via SetTLSARecord — otherwise DANE
+// validators get NXDOMAIN for `_443._tcp.<domain>` because the TLSA was only
+// stored in DB DelegationData and never served.
+func TestDelegatedDomainService_UpdateTLSA_PublishesToManagedZone(t *testing.T) {
+	t.Run("hns_publishes_tlsa", func(t *testing.T) {
+		coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+			db := ctx.DB()
+			require.NoError(tb, db.Create(&pluginDb.WebsiteDomain{
+				WebsiteID: 1, UserID: 1, Domain: "example", Namespace: pluginDb.DomainNamespaceHNS,
+				ZoneID: 42,
+			}).Error)
+
+			svc := core.GetService[*DelegatedDomainService](ctx, pluginCore.DELEGATED_DOMAIN_SERVICE)
+			require.NotNil(tb, svc)
+
+			mockDNS := core.GetService[*mocks.MockDNSService](ctx, pluginCore.DNS_SERVICE)
+			require.NotNil(tb, mockDNS)
+
+			// The TLSA must be pushed to the managed zone (zone 42) as
+			// "usage selector matching hash" rdata.
+			mockDNS.EXPECT().
+				SetTLSARecord(mock.Anything, uint(42), mock.Anything).
+				Run(func(_ context.Context, zoneID uint, content string) {
+					assert.Regexp(tb, `^3 1 1 [0-9a-fA-F]+$`, content,
+						"TLSA rdata must be '<usage> <selector> <matching> <digest>'")
+				}).
+				Return(nil).
+				Once()
+
+			certPEM, _ := issueCertFromKey(t, mustGenerateKey(t), "example")
+			_, _, err := svc.UpdateTLSAFromCert(ctx, "hns", "example", certPEM, "")
+			require.NoError(tb, err)
+
+			mockDNS.AssertExpectations(tb)
+		}, keyTestOptions)
+	})
+
+	// Regression: ICANN domains get a portal-managed ZoneID too, but they do
+	// not use DANE, so a cert push must NOT publish a spurious TLSA record.
+	t.Run("icann_does_not_publish_tlsa", func(t *testing.T) {
+		coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+			db := ctx.DB()
+			require.NoError(tb, db.Create(&pluginDb.WebsiteDomain{
+				WebsiteID: 1, UserID: 1, Domain: "example.com", Namespace: pluginDb.DomainNamespaceICANN,
+				ZoneID: 42,
+			}).Error)
+
+			svc := core.GetService[*DelegatedDomainService](ctx, pluginCore.DELEGATED_DOMAIN_SERVICE)
+			require.NotNil(tb, svc)
+
+			mockDNS := core.GetService[*mocks.MockDNSService](ctx, pluginCore.DNS_SERVICE)
+			require.NotNil(tb, mockDNS)
+			mockDNS.AssertNotCalled(tb, "SetTLSARecord")
+
+			certPEM, _ := issueCertFromKey(t, mustGenerateKey(t), "example.com")
+			_, _, err := svc.UpdateTLSAFromCert(ctx, "icann", "example.com", certPEM, "")
+			require.NoError(tb, err)
+
+			mockDNS.AssertNotCalled(tb, "SetTLSARecord")
+		}, keyTestOptions)
+	})
 }

--- a/internal/service/domain/hns_provider.go
+++ b/internal/service/domain/hns_provider.go
@@ -612,3 +612,9 @@ func (p *HNSProvider) OnCertAvailable(ctx context.Context, domain string, certPE
 	p.tlsaSource.Certs[domain] = certPEM
 	return nil
 }
+
+// UsesManagedZoneTLSA reports that HNS uses DANE and that its TLSA must be
+// published into the portal-managed authoritative PowerDNS zone.
+func (p *HNSProvider) UsesManagedZoneTLSA() bool {
+	return true
+}

--- a/internal/service/domain/hns_provider_test.go
+++ b/internal/service/domain/hns_provider_test.go
@@ -199,6 +199,9 @@ func (f *fakeDNSZoneService) CreateDNSLinkRecord(ctx context.Context, zoneID uin
 func (f *fakeDNSZoneService) CreateApexRecord(ctx context.Context, zoneID uint, recordType pluginCore.RecordType, content string) error {
 	panic("unused")
 }
+func (f *fakeDNSZoneService) SetTLSARecord(ctx context.Context, zoneID uint, content string) error {
+	panic("unused")
+}
 func (f *fakeDNSZoneService) EnableDNSSEC(ctx context.Context, zoneID uint) (string, error) {
 	return f.dnskey, nil
 }

--- a/internal/service/domain/icann_provider.go
+++ b/internal/service/domain/icann_provider.go
@@ -64,6 +64,12 @@ func (p *ICANNProvider) OnCertAvailable(ctx context.Context, domain string, cert
 	return nil
 }
 
+// UsesManagedZoneTLSA reports that ICANN does not use DANE, so no TLSA record
+// is published for ICANN domains.
+func (p *ICANNProvider) UsesManagedZoneTLSA() bool {
+	return false
+}
+
 // Nameservers returns the ICANN nameservers configured for the namespace.
 func (p *ICANNProvider) Nameservers() []string {
 	return p.nameservers

--- a/internal/service/domain/provider.go
+++ b/internal/service/domain/provider.go
@@ -18,6 +18,12 @@ type DomainProvider interface {
 	// Providers can use it to update TLSA in delegation data or trigger
 	// namespace-specific protocol updates. Can be nil-safe by returning nil.
 	OnCertAvailable(ctx context.Context, domain string, certPEM string) error
+	// UsesManagedZoneTLSA reports whether this provider's TLS certs translate
+	// into a DANE TLSA record that the portal must publish into its
+	// portal-managed authoritative PowerDNS zone (e.g. an alt-root namespace
+	// whose zone the portal DNSSEC-signs). Providers that do not use DANE
+	// (e.g. ICANN) return false so no spurious _443._tcp TLSA is published.
+	UsesManagedZoneTLSA() bool
 	// Nameservers returns the nameservers this provider publishes and
 	// validates delegation against for its namespace. Alt-root providers
 	// (e.g. HNS) return their own namespace-specific nameservers, which

--- a/internal/testing/mocks/MockDNSService.go
+++ b/internal/testing/mocks/MockDNSService.go
@@ -239,6 +239,22 @@ func (_mock *MockDNSService) CreateApexRecord(ctx context.Context, zoneID uint, 
 	return r0
 }
 
+func (_mock *MockDNSService) SetTLSARecord(ctx context.Context, zoneID uint, content string) error {
+	ret := _mock.Called(ctx, zoneID, content)
+
+	if len(ret) == 0 {
+		panic("no return value specified for SetTLSARecord")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uint, string) error); ok {
+		r0 = returnFunc(ctx, zoneID, content)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
 // MockDNSService_CreateApexRecord_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CreateApexRecord'
 type MockDNSService_CreateApexRecord_Call struct {
 	*mock.Call
@@ -287,6 +303,48 @@ func (_c *MockDNSService_CreateApexRecord_Call) Return(err error) *MockDNSServic
 }
 
 func (_c *MockDNSService_CreateApexRecord_Call) RunAndReturn(run func(ctx context.Context, zoneID uint, recordType core0.RecordType, content string) error) *MockDNSService_CreateApexRecord_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// MockDNSService_SetTLSARecord_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetTLSARecord'
+type MockDNSService_SetTLSARecord_Call struct {
+	*mock.Call
+}
+
+// SetTLSARecord is a helper method to define mock.On call
+//   - ctx context.Context
+//   - zoneID uint
+//   - content string
+func (_e *MockDNSService_Expecter) SetTLSARecord(ctx any, zoneID any, content any) *MockDNSService_SetTLSARecord_Call {
+	return &MockDNSService_SetTLSARecord_Call{Call: _e.mock.On("SetTLSARecord", ctx, zoneID, content)}
+}
+
+func (_c *MockDNSService_SetTLSARecord_Call) Run(run func(ctx context.Context, zoneID uint, content string)) *MockDNSService_SetTLSARecord_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 uint
+		if args[1] != nil {
+			arg1 = args[1].(uint)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(arg0, arg1, arg2)
+	})
+	return _c
+}
+
+func (_c *MockDNSService_SetTLSARecord_Call) Return(err error) *MockDNSService_SetTLSARecord_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockDNSService_SetTLSARecord_Call) RunAndReturn(run func(ctx context.Context, zoneID uint, content string) error) *MockDNSService_SetTLSARecord_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/testing/mocks/MockDNSZoneService.go
+++ b/internal/testing/mocks/MockDNSZoneService.go
@@ -56,6 +56,22 @@ func (_mock *MockDNSZoneService) CreateApexRecord(ctx context.Context, zoneID ui
 	return r0
 }
 
+func (_mock *MockDNSZoneService) SetTLSARecord(ctx context.Context, zoneID uint, content string) error {
+	ret := _mock.Called(ctx, zoneID, content)
+
+	if len(ret) == 0 {
+		panic("no return value specified for SetTLSARecord")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uint, string) error); ok {
+		r0 = returnFunc(ctx, zoneID, content)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
 // MockDNSZoneService_CreateApexRecord_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CreateApexRecord'
 type MockDNSZoneService_CreateApexRecord_Call struct {
 	*mock.Call

--- a/internal/testing/mocks/MockDomainProvider.go
+++ b/internal/testing/mocks/MockDomainProvider.go
@@ -84,6 +84,50 @@ func (_c *MockDomainProvider_ApexRecordType_Call) RunAndReturn(run func() core.R
 	return _c
 }
 
+// UsesManagedZoneTLSA provides a mock function for the type MockDomainProvider
+func (_mock *MockDomainProvider) UsesManagedZoneTLSA() bool {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for UsesManagedZoneTLSA")
+	}
+
+	var r0 bool
+	if returnFunc, ok := ret.Get(0).(func() bool); ok {
+		r0 = returnFunc()
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+	return r0
+}
+
+// MockDomainProvider_UsesManagedZoneTLSA_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UsesManagedZoneTLSA'
+type MockDomainProvider_UsesManagedZoneTLSA_Call struct {
+	*mock.Call
+}
+
+// UsesManagedZoneTLSA is a helper method to define mock.On call
+func (_e *MockDomainProvider_Expecter) UsesManagedZoneTLSA() *MockDomainProvider_UsesManagedZoneTLSA_Call {
+	return &MockDomainProvider_UsesManagedZoneTLSA_Call{Call: _e.mock.On("UsesManagedZoneTLSA")}
+}
+
+func (_c *MockDomainProvider_UsesManagedZoneTLSA_Call) Run(run func()) *MockDomainProvider_UsesManagedZoneTLSA_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockDomainProvider_UsesManagedZoneTLSA_Call) Return(usesManagedZoneTLSA bool) *MockDomainProvider_UsesManagedZoneTLSA_Call {
+	_c.Call.Return(usesManagedZoneTLSA)
+	return _c
+}
+
+func (_c *MockDomainProvider_UsesManagedZoneTLSA_Call) RunAndReturn(run func() bool) *MockDomainProvider_UsesManagedZoneTLSA_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // BuildDelegation provides a mock function for the type MockDomainProvider
 func (_mock *MockDomainProvider) BuildDelegation(ctx context.Context, zoneID uint, domain string, website *db.Website, config json.RawMessage) (any, error) {
 	ret := _mock.Called(ctx, zoneID, domain, website, config)


### PR DESCRIPTION
## Problem

For **managed (DNS-hosting)** domains — where the portal hosts the authoritative zone in PowerDNS, DNSSEC-signs it, and publishes the DS — the DANE **TLSA record** (`_443._tcp.<domain>`) was never actually served.

The `BuildDelegation`/`UpdateTLSAFromCert` pipeline computed the TLSA from the pushed cert and stored it in `WebsiteDomain.DelegationData` (the `authoritative_records` JSON surfaced via `dns-requirements`), **but never wrote it to PowerDNS**. There was no record-creation path for the TLSA at all. Result: a live DNS query for `_443._tcp.lumeweb` returned `rcode=3 (NXDOMAIN), SOA present` — DANE validators could not resolve the TLSA, so DANE could not be established.

## Fix

1. **`core/dns.go`** + **`internal/service/dns/dns_service.go`**: add `SetTLSARecord(ctx, zoneID, content)` to the `DNSService`/`DNSZoneService` interfaces and implement it in `DNSServiceDefault`, writing the `_443._tcp` TLSA RRSet to the zone via PowerDNS (content = `"usage selector matching hash"`, e.g. `3 1 1 <hex>`).
2. **`internal/service/domain/delegated_domain_service.go`**: in `UpdateTLSAFromCert`, after a cert push, publish the TLSA to the domains managed zone (`SetTLSARecord` when `WebsiteDomain.ZoneID != 0`). The cert webhook is the backfill path that previously stored only DB state.

## Verification

- `develop` <!-- branch-stack -->
  - **fix(dns): publish TLSA record to managed authoritative zone (fixes NXDOMAIN on \_443.\_tcp)** :point\_left:

***

<!-- kody-pr-summary:start -->

## Summary

This pull request fixes a critical bug where DANE TLSA records were never actually published to the DNS authoritative zone, causing NXDOMAIN errors for `_443._tcp` queries during DANE validation.

## Changes

### Issue

When certificates were pushed via `UpdateTLSAFromCert`, the TLSA record was only saved to the database (DelegationData) but never published to the portal-managed PowerDNS authoritative zone. This meant DANE validators received NXDOMAIN responses for `_443._tcp.<domain>` queries, making DANE validation fail for portal-managed (DNSSEC-signed) domains.

### Fix

- **Added `SetTLSARecord` method** to the `DNSService` interface and implemented it in `DNSServiceDefault`, which creates a TLSA record for the `_443._tcp` owner name in the specified zone via PowerDNS.
- **Added `SetTLSARecord` method** to the `DNSZoneService` interface for the domain service layer.
- **Updated `UpdateTLSAFromCert`** in `DelegatedDomainService` to:
  - Capture the zone ID when processing a website domain
  - After successfully persisting the TLSA to the database, publish it to the managed authoritative zone via `SetTLSARecord`
  - Only publish for portal-managed zones (where a zone ID exists)
  - Surface publication errors while retaining the persisted state so subsequent cert pushes can retry
- **Updated mocks** (`MockDNSService`, `MockDNSZoneService`) and test fakes to support the new method.
- **Added regression test** verifying that cert pushes for domains with a `ZoneID` result in TLSA publication to the correct zone with properly formatted rdata.

### Scope

The change affects HNS (Handshake) managed domains that use the portal's PowerDNS for authoritative DNS. Self-managed zones are excluded since they publish TLSA records on their own nameservers.

<!-- kody-pr-summary:end -->
