### PR TITLE
fix(tests): repair SSL-status tests broken by per-domain migration

### DIFF
--- a/internal/api/api_websites_test.go
+++ b/internal/api/api_websites_test.go
@@ -323,6 +323,7 @@ func TestAPI_UpdateSSLStatus_Webhook(t *testing.T) {
 		mockApex := &pluginDb.WebsiteDomain{
 			ID:               1,
 			WebsiteID:        1,
+			UserID:           1,
 			Domain:           TestDomain,
 			SSLStatus:        string(status),
 			SSLError:         sslError,
@@ -530,9 +531,9 @@ func TestAPI_UpdateSSLStatus_Webhook(t *testing.T) {
 				Status:     string(pluginDb.WebsiteStatusActive),
 			}
 
-			mockApexPending := &pluginDb.WebsiteDomain{ID: 1, WebsiteID: 1, Domain: TestDomain, SSLStatus: string(pluginDb.SSLStatusPending), SSLLastUpdatedAt: &timestamp1}
-			mockApexIssuing := &pluginDb.WebsiteDomain{ID: 1, WebsiteID: 1, Domain: TestDomain, SSLStatus: string(pluginDb.SSLStatusIssuing), SSLLastUpdatedAt: &timestamp2}
-			mockApexReady := &pluginDb.WebsiteDomain{ID: 1, WebsiteID: 1, Domain: TestDomain, SSLStatus: string(pluginDb.SSLStatusReady), SSLLastUpdatedAt: &timestamp3}
+			mockApexPending := &pluginDb.WebsiteDomain{ID: 1, WebsiteID: 1, UserID: userID, Domain: TestDomain, SSLStatus: string(pluginDb.SSLStatusPending), SSLLastUpdatedAt: &timestamp1}
+			mockApexIssuing := &pluginDb.WebsiteDomain{ID: 1, WebsiteID: 1, UserID: userID, Domain: TestDomain, SSLStatus: string(pluginDb.SSLStatusIssuing), SSLLastUpdatedAt: &timestamp2}
+			mockApexReady := &pluginDb.WebsiteDomain{ID: 1, WebsiteID: 1, UserID: userID, Domain: TestDomain, SSLStatus: string(pluginDb.SSLStatusReady), SSLLastUpdatedAt: &timestamp3}
 
 			mockWebsiteService.EXPECT().UpdateSSLStatus(mock.Anything, TestDomain, pluginDb.SSLStatusPending, "", mock.AnythingOfType("*time.Time")).Return(mockApexPending, nil)
 			mockWebsiteService.EXPECT().UpdateSSLStatus(mock.Anything, TestDomain, pluginDb.SSLStatusIssuing, "", mock.AnythingOfType("*time.Time")).Return(mockApexIssuing, nil)

--- a/internal/service/website/website_test.go
+++ b/internal/service/website/website_test.go
@@ -1074,6 +1074,10 @@ func TestWebsiteService_UpdateSSLStatus_SuccessfulUpdate(t *testing.T) {
 		createdWebsite, err := websiteService.CreateWebsite(context.Background(), website)
 		require.NoError(tb, err)
 
+		// SSL state lives per-domain on WebsiteDomain, so a binding must exist
+		// before UpdateSSLStatus can find and update it.
+		require.NoError(tb, ctx.DB().Create(createTestWebsiteDomain(createdWebsite.ID, createdWebsite.Domain)).Error)
+
 		// Act - Update SSL status to issuing
 		updatedWebsite, err := websiteService.UpdateSSLStatus(context.Background(), createdWebsite.Domain, pluginDb.SSLStatusIssuing, "", nil)
 


### PR DESCRIPTION
## Problem

The `move_ssl_status_to_website_domains` migration relocated SSL state from the `Website` table to per-domain `WebsiteDomain` bindings, but two test setups did not keep up, producing spurious CI failures:

1. **`TestWebsiteService_UpdateSSLStatus_SuccessfulUpdate`** — created a `Website` but no `WebsiteDomain` binding. `UpdateSSLStatus` queries `website_domains` by domain, so it returned "website not found".
2. **API webhook subtests** — mocked `WebsiteDomain` apexes without a `UserID`. The handler calls `GetWebsite(wd.UserID, wd.WebsiteID)`, which invoked `GetWebsite(0, 1)` while the mock expected `(1, 1)`, failing the response path (`(uint=0) != (uint=1)`).

## Fix (test-only, no production change)

- `website_test.go`: create the `WebsiteDomain` binding via the existing `createTestWebsiteDomain` helper before `UpdateSSLStatus`, matching the passing sibling SSL tests.
- `api_websites_test.go`: set `UserID` on the mock apex `WebsiteDomain`s in both `setUpWebhookMocks` and the `status_transition_pending_to_issuing_to_ready` subtest.

## Verification

- `TestWebsiteService_UpdateSSLStatus*` — pass
- `TestAPI_UpdateSSLStatus_Webhook` (all subtests incl. status transitions) — pass
- Full `internal/service/website`, `internal/api`, `internal/service/domain`, `internal/service/dns` suites — pass
- Pre-existing unrelated failures in `internal/protocol/tests` (CAR/block-queue + file-path stress) fail identically on clean develop and were not touched.

* `develop` <!-- branch-stack -->
  - **fix(tests): repair SSL-status tests broken by per-domain migration** :point\_left:

---

<!-- kody-pr-summary:start -->
## Summary

This pull request fixes SSL-status tests that were broken by the recent migration to per-domain SSL state management.

## Changes

### Test Data Updates
- Added the required `UserID` field to mock `WebsiteDomain` objects in API tests, aligning test data with the new per-domain data model.
- Updated multiple test fixtures to include the `userID` when constructing domain objects in SSL status update test scenarios.

### Test Setup Fix
- In the website service tests, added a step to explicitly create a `WebsiteDomain` binding record before calling `UpdateSSLStatus`. This is necessary because SSL state now lives on the `WebsiteDomain` entity rather than the website itself—without an associated domain record, the update operation cannot find the target to modify.

## Impact
These changes ensure the SSL-status tests accurately reflect the current data model where SSL status is tracked per-domain, restoring test reliability that was broken by the per-domain migration.
<!-- kody-pr-summary:end -->