### PR TITLE
feat(api): add DANE TLSA force-republish endpoint

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -817,6 +817,17 @@ See also:.*`),
 				router.WithSuccessResponse(http.StatusOK, "Domain DNS requirements", router.WithJSONContent(dto.DomainResponse{})),
 			),
 		),
+		router.NewRoute(http.MethodPost, "/websites/:id/domains/:domain_id/dane/republish", a.republishDomainDANE,
+			router.WithAccess(core.ACCESS_USER_ROLE),
+			router.WithSwagger(
+				router.WithSummary("Force re-publish of domain DANE records"),
+				router.WithDescription(`Forces re-publication of a bound domain's DANE records (the _443._tcp.<domain> TLSA RRset) into the portal-managed authoritative PowerDNS zone. It re-pushes the stored certificate/key through the same path used by the cert webhook, idempotently overwriting the TLSA. Use this when a TLSA was deleted or went missing and cert renewal did not re-trigger a publish. Only DANE-capable namespaces (e.g. HNS) are supported; a domain with no stored certificate returns 409.`),
+				router.WithTags("Websites", "Domains"),
+				router.WithPathParam("id", "Website ID", ""),
+				router.WithPathParam("domain_id", "Domain ID", ""),
+				router.WithSuccessResponse(http.StatusOK, "Republish result", router.WithJSONContent(dto.DomainDANERepublishResponse{})),
+			),
+		),
 	)
 
 	if err := router.RegisterRoutes(apiGroup, accessSvc, a.Subdomain(), websiteRoutes, router.WithMiddlewares(authMw), router.WithCors()); err != nil {

--- a/internal/api/api_domains.go
+++ b/internal/api/api_domains.go
@@ -253,3 +253,104 @@ func (a *API) domainDNSRequirements(c echo.Context) error {
 	}
 	return httputil.EncodeResponse(ctx, &wd, &resp)
 }
+
+// republishDomainDANE forces re-publication of a bound domain's DANE records
+// (the TLSA for a portal-managed, DNSSEC-signed zone) into the authoritative
+// PowerDNS zone. It re-pushes the stored certificate/key through
+// UpdateTLSAFromCert, which idempotently rewrites the _443._tcp.<domain> TLSA
+// RRset (PowerDNS REPLACE). This is the operator's escape hatch for a TLSA
+// that was deleted or went missing and won't be re-triggered by cert renewal.
+func (a *API) republishDomainDANE(c echo.Context) error {
+	ctx := httputil.Context(c)
+	reqCtx := ctx.Context.Request().Context()
+
+	userID, err := mcontext.GetUserID(c)
+	if err != nil {
+		return ctx.Error(err, http.StatusUnauthorized)
+	}
+
+	websiteID, err := strconv.ParseUint(c.Param("id"), 10, 64)
+	if err != nil {
+		apiErr := NewError(ErrKeyInvalidPathID, errors.New("invalid website ID"))
+		return ctx.Error(apiErr, apiErr.HttpStatus())
+	}
+
+	domainID, err := strconv.ParseUint(c.Param("domain_id"), 10, 64)
+	if err != nil {
+		apiErr := NewError(ErrKeyInvalidPathID, errors.New("invalid domain ID"))
+		return ctx.Error(apiErr, apiErr.HttpStatus())
+	}
+
+	var wd pluginDb.WebsiteDomain
+	if err := a.DB().WithContext(reqCtx).
+		Where("id = ? AND website_id = ? AND user_id = ?", domainID, websiteID, userID).
+		First(&wd).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			apiErr := NewError(ErrKeyDomainNotFound, errors.New("domain not found"))
+			return ctx.Error(apiErr, apiErr.HttpStatus())
+		}
+		apiErr := NewError(ErrKeyFileProcessingFailed, err)
+		return ctx.Error(apiErr, apiErr.HttpStatus())
+	}
+
+	if a.delegatedDomainSvc == nil {
+		apiErr := NewError(ErrKeyFileProcessingFailed, fmt.Errorf("domain service not available"))
+		return ctx.Error(apiErr, apiErr.HttpStatus())
+	}
+
+	ns := string(wd.Namespace)
+	// Only DANE-capable namespaces whose provider publishes a managed-zone TLSA
+	// can be force-republished. Non-DANE namespaces (e.g. ICANN) have no TLSA.
+	if !a.delegatedDomainSvc.NamespaceUsesManagedZoneTLSA(ns) {
+		apiErr := NewError(ErrKeyNoStoredCertificate, fmt.Errorf("namespace %q does not use managed-zone DANE", ns))
+		return ctx.Error(apiErr, apiErr.HttpStatus())
+	}
+
+	// The republish writes the TLSA into the portal-managed authoritative zone
+	// resolved by the domain's ZoneID. If no zone is assigned there is nothing
+	// to publish into -- short-circuit rather than return a false success.
+	if wd.ZoneID == 0 {
+		apiErr := NewError(ErrKeyNoStoredCertificate, fmt.Errorf("domain %q has no assigned managed zone; cannot republish", wd.Domain))
+		return ctx.Error(apiErr, apiErr.HttpStatus())
+	}
+
+	cert, err := a.delegatedDomainSvc.GetCertificateKey(reqCtx, ns, wd.Domain)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			apiErr := NewError(ErrKeyNoStoredCertificate, err)
+			return ctx.Error(apiErr, apiErr.HttpStatus())
+		}
+		a.Logger().Error("Failed to load stored certificate for DANE republish", zap.Error(err), zap.String("domain", wd.Domain))
+		apiErr := NewError(ErrKeyFileProcessingFailed, err)
+		return ctx.Error(apiErr, apiErr.HttpStatus())
+	}
+
+	tlsa, ownerName, err := a.delegatedDomainSvc.UpdateTLSAFromCert(reqCtx, ns, wd.Domain, cert.CertPEM, cert.PrivateKeyPEM)
+	if err != nil {
+		a.Logger().Error("Failed to republish DANE TLSA", zap.Error(err), zap.String("domain", wd.Domain))
+		apiErr := NewError(ErrKeyFileProcessingFailed, err)
+		return ctx.Error(apiErr, apiErr.HttpStatus())
+	}
+
+	// Reload wd after the publish: UpdateTLSAFromCert rewrites the row's
+	// DelegationData authoritative TLSA records in the DB, so the response must
+	// project the post-republish delegation state rather than the stale one we
+	// loaded before the publish.
+	if err := a.DB().WithContext(reqCtx).First(&wd, wd.ID).Error; err != nil {
+		a.Logger().Error("Failed to reload domain after DANE republish", zap.Error(err), zap.Uint("domain_id", wd.ID))
+		apiErr := NewError(ErrKeyFileProcessingFailed, err)
+		return ctx.Error(apiErr, apiErr.HttpStatus())
+	}
+
+	resp := dto.DomainDANERepublishResponse{}
+	if err := resp.FromModel(&wd); err != nil {
+		apiErr := NewError(ErrKeyFileProcessingFailed, err)
+		return ctx.Error(apiErr, apiErr.HttpStatus())
+	}
+	resp.TLSARData = tlsa
+	resp.OwnerName = ownerName
+	if ownerName != "" && tlsa != "" {
+		resp.TLSARecord = fmt.Sprintf("%s. 3600 IN TLSA %s", ownerName, tlsa)
+	}
+	return httputil.EncodeResponse(ctx, &wd, &resp)
+}

--- a/internal/api/api_domains_test.go
+++ b/internal/api/api_domains_test.go
@@ -2,13 +2,22 @@ package api
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"go.lumeweb.com/dane"
+	pluginCore "go.lumeweb.com/portal-plugin-ipfs/core"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/api/dto"
 	pluginDb "go.lumeweb.com/portal-plugin-ipfs/internal/db"
+	"go.lumeweb.com/portal-plugin-ipfs/internal/service/domain"
+	"go.lumeweb.com/portal-plugin-ipfs/internal/testing/mocks"
+	"go.lumeweb.com/portal-plugin-ipfs/internal/testing/util"
+	"go.lumeweb.com/portal/core"
 	coreTesting "go.lumeweb.com/portal/core/testing"
 	"gorm.io/datatypes"
 )
@@ -135,4 +144,184 @@ func TestAPI_DomainDNSRequirements(t *testing.T) {
 			assert.Equal(t, http.StatusNotFound, rec.Code)
 		}, TestOptions)
 	})
+}
+
+func TestAPI_DANERepublish(t *testing.T) {
+	republishPath := func(websiteID, domainID int) string {
+		return fmt.Sprintf("/api/websites/%d/domains/%d/dane/republish", websiteID, domainID)
+	}
+	seedWebsite := func(tb coreTesting.TB, ctx coreTesting.TestContext, userID uint, domain string) uint {
+		testCID := util.GenerateTestCID(t, "test data")
+		website := createTestIPFSGatewayWebsite(1, userID, domain, testCID, pluginDb.WebsiteStatusActive)
+		require.NoError(t, ctx.DB().Create(website).Error)
+		return website.ID
+	}
+	seedDomain := func(tb coreTesting.TB, ctx coreTesting.TestContext, websiteID, userID uint, domain string, ns pluginDb.DomainNamespace) uint {
+		wd := &pluginDb.WebsiteDomain{
+			WebsiteID: websiteID,
+			UserID:    userID,
+			Domain:    domain,
+			Namespace: ns,
+			Status:    pluginDb.DomainStatusDraft,
+			ZoneID:    42,
+		}
+		require.NoError(t, ctx.DB().Create(wd).Error)
+		return wd.ID
+	}
+
+	t.Run("missing_domain_returns_404", func(t *testing.T) {
+		coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+			helper := newMockHelper(t, ctx)
+			token, _, _, _ := helper.SetupAuthenticatedTest()
+
+			rec := helper.makeAuthenticatedRequest(http.MethodPost, republishPath(1, 999), token, nil)
+			assert.Equal(t, http.StatusNotFound, rec.Code)
+		}, TestOptions)
+	})
+
+	t.Run("other_users_domain_returns_404", func(t *testing.T) {
+		coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+			helper := newMockHelper(t, ctx)
+			token, userID, _, _ := helper.SetupAuthenticatedTest()
+
+			websiteID := seedWebsite(t, ctx, userID, "other.com")
+			// Domain owned by a different user.
+			seedDomain(t, ctx, websiteID, userID+100, "other.com", pluginDb.DomainNamespaceHNS)
+
+			rec := helper.makeAuthenticatedRequest(http.MethodPost, republishPath(int(websiteID), 1), token, nil)
+			assert.Equal(t, http.StatusNotFound, rec.Code)
+		}, TestOptions)
+	})
+
+	t.Run("icann_domain_rejected_409", func(t *testing.T) {
+		coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+			helper := newMockHelper(t, ctx)
+			token, userID, _, _ := helper.SetupAuthenticatedTest()
+
+			websiteID := seedWebsite(t, ctx, userID, "icann.test")
+			domainID := seedDomain(t, ctx, websiteID, userID, "icann.test", pluginDb.DomainNamespaceICANN)
+
+			rec := helper.makeAuthenticatedRequest(http.MethodPost, republishPath(int(websiteID), int(domainID)), token, nil)
+			assert.Equal(t, http.StatusConflict, rec.Code, "ICANN namespace has no managed-zone DANE TLSA")
+		}, TestOptions)
+	})
+
+	t.Run("hns_no_stored_cert_returns_409", func(t *testing.T) {
+		coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+			helper := newMockHelper(t, ctx)
+			token, userID, _, _ := helper.SetupAuthenticatedTest()
+
+			websiteID := seedWebsite(t, ctx, userID, "hns.test")
+			domainID := seedDomain(t, ctx, websiteID, userID, "hns.test", pluginDb.DomainNamespaceHNS)
+
+			// No ProtocolData -> GetCertificateKey returns ErrRecordNotFound -> 409.
+			rec := helper.makeAuthenticatedRequest(http.MethodPost, republishPath(int(websiteID), int(domainID)), token, nil)
+			assert.Equal(t, http.StatusConflict, rec.Code, "HNS domain with no stored cert cannot be republished")
+		}, TestOptions)
+	})
+
+	t.Run("hns_no_assigned_zone_returns_409", func(t *testing.T) {
+		coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+			helper := newMockHelper(t, ctx)
+			token, userID, _, _ := helper.SetupAuthenticatedTest()
+
+			websiteID := seedWebsite(t, ctx, userID, "hns-zone.test")
+			// ZoneID 0 (no assigned managed zone) but no stored cert either; the
+			// handler must reject on the missing zone BEFORE touching the cert.
+			wd := &pluginDb.WebsiteDomain{
+				WebsiteID: websiteID,
+				UserID:    userID,
+				Domain:    "hns-zone.test",
+				Namespace: pluginDb.DomainNamespaceHNS,
+				Status:    pluginDb.DomainStatusDraft,
+				ZoneID:    0,
+			}
+			require.NoError(t, ctx.DB().Create(wd).Error)
+
+			rec := helper.makeAuthenticatedRequest(http.MethodPost, republishPath(int(websiteID), int(wd.ID)), token, nil)
+			assert.Equal(t, http.StatusConflict, rec.Code, "HNS domain with no assigned managed zone cannot be republished")
+		}, TestOptions)
+	})
+
+	t.Run("hns_with_stored_cert_republishes", func(t *testing.T) {
+		coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+			helper := newMockHelper(t, ctx)
+			token, userID, _, _ := helper.SetupAuthenticatedTest()
+
+			website := createTestIPFSGatewayWebsite(1, userID, "hns-repub.test", util.GenerateTestCID(t, "td"), pluginDb.WebsiteStatusActive)
+			require.NoError(t, ctx.DB().Create(website).Error)
+			websiteID := website.ID
+
+			// Seed an HNS domain with an assigned managed zone.
+			wd := &pluginDb.WebsiteDomain{
+				WebsiteID: websiteID,
+				UserID:    userID,
+				Domain:    "hns-repub.test",
+				Namespace: pluginDb.DomainNamespaceHNS,
+				Status:    pluginDb.DomainStatusDraft,
+				ZoneID:    42,
+			}
+			require.NoError(t, ctx.DB().Create(wd).Error)
+
+			// Populate the stored cert/key path by pushing a real cert through the
+			// service (same path the cert webhook uses). This writes the encrypted
+			// private key into ProtocolData, so GetCertificateKey can decrypt it.
+			svc := core.GetService[*domain.DelegatedDomainService](ctx, pluginCore.DELEGATED_DOMAIN_SERVICE)
+			require.NotNil(tb, svc)
+			keyPEM := mustGenerateTestKey(t)
+			certPEM := mustIssueTestCert(t, keyPEM, "hns-repub.test")
+			mockDNS := core.GetService[*mocks.MockDNSService](ctx, pluginCore.DNS_SERVICE)
+			require.NotNil(tb, mockDNS)
+			// The seeding push and the HTTP republish each call SetTLSARecord(zoneID=42).
+			mockDNS.On("SetTLSARecord", mock.Anything, uint(42), mock.Anything).Return(nil).Times(2)
+			_, _, err := svc.UpdateTLSAFromCert(ctx, "hns", wd.Domain, certPEM, keyPEM)
+			require.NoError(t, err, "seeding stored cert via UpdateTLSAFromCert")
+
+			mockDNS.AssertCalled(tb, "SetTLSARecord", mock.Anything, uint(42), mock.Anything)
+
+			rec := helper.makeAuthenticatedRequest(http.MethodPost, republishPath(int(websiteID), int(wd.ID)), token, nil)
+			require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+
+			var resp dto.DomainDANERepublishResponse
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+			assert.Equal(t, "hns-repub.test", resp.Domain)
+			assert.Equal(t, "hns", resp.Namespace)
+			require.NotEmpty(t, resp.TLSARData)
+			require.NotEmpty(t, resp.OwnerName)
+			assert.Contains(t, resp.TLSARecord, "TLSA")
+
+			// The DNS publish must have happened for the managed zone.
+			mockDNS.AssertNumberOfCalls(tb, "SetTLSARecord", 2)
+		}, daneRepublishTestOptions)
+	})
+}
+
+// testDANEKey is the fixed 32-byte AES-256 key (base64) used to encrypt the DANE
+// private key at rest. It matches the domain package's testDANEKey and is an
+// at-rest encryption key, not a secret literal.
+const testDANEKey = "IUf7FMs69krvqJGFn7y8U2jfurNf8bxynXFQBGnP7cI="
+
+// daneRepublishTestOptions wires the DnsConfig DANE key-encryption key so the
+// republish handler's GetCertificateKey can decrypt the stored private key.
+var daneRepublishTestOptions = coreTesting.CombineOptions(
+	TestOptions,
+	coreTesting.WithConfig("plugin.ipfs.service.dns.dane_key_encryption_key", testDANEKey),
+)
+
+func mustGenerateTestKey(t testing.TB) string {
+	t.Helper()
+	_, keyPEM, err := dane.GenerateSelfSignedECDSA([]string{"example"}, time.Now().AddDate(1, 0, 0))
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	return keyPEM
+}
+
+func mustIssueTestCert(t testing.TB, _ string, domain string) string {
+	t.Helper()
+	certPEM, _, err := dane.GenerateSelfSignedECDSA([]string{domain}, time.Now().AddDate(1, 0, 0))
+	if err != nil {
+		t.Fatalf("issue cert: %v", err)
+	}
+	return certPEM
 }

--- a/internal/api/dto/domain.go
+++ b/internal/api/dto/domain.go
@@ -103,6 +103,64 @@ func (r *DomainResponse) FromModel(m *db.WebsiteDomain) error {
 	return nil
 }
 
+// DomainDANERepublishResponse is the result of forcing a DANE republish for a
+// bound domain. It carries the (reloaded) domain state plus the TLSA record and
+// owner name that were (re)published into the managed authoritative zone.
+//
+// NOTE: it deliberately duplicates the DomainResponse scalar fields rather than
+// embedding DomainResponse, because the gswagger schema generator rejects Go
+// embedded structs (potential infinite recursion).
+type DomainDANERepublishResponse struct {
+	ID          uint           `json:"id"`
+	Domain      string         `json:"domain"`
+	Namespace   string         `json:"namespace"`
+	Status      string         `json:"status,omitempty"`
+	ZoneName    string         `json:"zone_name,omitempty"`
+	GatewayHost string         `json:"gateway_host,omitempty"`
+	Delegation  *DNSDelegation `json:"delegation,omitempty"`
+	SSL         *SSLStatusInfo `json:"ssl,omitempty"`
+	TLSARecord  string         `json:"tlsa_record,omitempty"` // full "_443._tcp.<domain> ... TLSA ..." presentation
+	OwnerName   string         `json:"owner_name,omitempty"`  // "_443._tcp.<domain>"
+	TLSARData   string         `json:"tlsa_rdata,omitempty"`  // "3 1 1 <hex>"
+}
+
+// FromModel populates the DomainResponse-backed fields from a WebsiteDomain.
+func (r *DomainDANERepublishResponse) FromModel(m *db.WebsiteDomain) error {
+	return r.DomainResponseFromModel(m)
+}
+
+// DomainResponseFromModel copies the shared domain fields. It is defined so the
+// scalar fields line up with DomainResponse.FromModel without embedding.
+func (r *DomainDANERepublishResponse) DomainResponseFromModel(m *db.WebsiteDomain) error {
+	r.ID = m.ID
+	r.Domain = m.Domain
+	r.Namespace = string(m.Namespace)
+	r.Status = string(m.Status)
+	r.ZoneName = m.ZoneName
+	r.GatewayHost = m.GatewayHost
+	if m.SSLStatus != "" {
+		r.SSL = &SSLStatusInfo{
+			Status: m.SSLStatus,
+			Error:  m.SSLError,
+		}
+		if m.SSLIssuedAt != nil {
+			v := *m.SSLIssuedAt
+			r.SSL.IssuedAt = &v
+		}
+		if m.SSLLastUpdatedAt != nil {
+			v := *m.SSLLastUpdatedAt
+			r.SSL.LastUpdatedAt = &v
+		}
+	}
+	if len(m.DelegationData) > 0 {
+		raw, _ := json.Marshal(m.DelegationData)
+		if len(raw) > 0 {
+			r.Delegation = mapDNSDelegation(raw)
+		}
+	}
+	return nil
+}
+
 // mapDNSDelegation converts the raw provider DelegationData (JSON) into the
 // typed DNSDelegation. HNS emits a DelegationBundle with parent_records and
 // authoritative_records; ICANN emits nameservers. It returns nil when the

--- a/internal/api/errors.go
+++ b/internal/api/errors.go
@@ -55,6 +55,10 @@ const (
 	// Website domain binding error types
 	ErrKeyDomainNotFound core.ErrorType = "DOMAIN_NOT_FOUND"
 	ErrKeyInvalidPathID  core.ErrorType = "INVALID_PATH_ID"
+	// ErrKeyNoStoredCertificate is returned when a DANE republish is requested
+	// for a domain that has no certificate/key stored (e.g. none was ever
+	// pushed via the cert webhook, or the binding is not DANE-capable).
+	ErrKeyNoStoredCertificate core.ErrorType = "NO_STORED_CERTIFICATE"
 )
 
 // HTTP status classes (RFC 9110 / RFC 4918) — keep these consistent:
@@ -101,6 +105,7 @@ func init() {
 		ErrKeyInvalidTarget:         {Key: ErrKeyInvalidTarget, Message: "Invalid target hash or peer ID provided"},
 		ErrKeyDomainNotFound:        {Key: ErrKeyDomainNotFound, Message: "Domain not found"},
 		ErrKeyInvalidPathID:         {Key: ErrKeyInvalidPathID, Message: "Invalid path parameter: %s"},
+		ErrKeyNoStoredCertificate:   {Key: ErrKeyNoStoredCertificate, Message: "No stored certificate for domain; nothing to republish"},
 		ErrKeyDeleteFailed:          {Key: ErrKeyDeleteFailed, Message: "Failed to delete zone"},
 		ErrKeyUpdateFailed:          {Key: ErrKeyUpdateFailed, Message: "Failed to update zone"},
 	})
@@ -132,6 +137,7 @@ func init() {
 		ErrKeyPermissionDenied:      http.StatusForbidden,
 		ErrKeyDomainNotFound:        http.StatusNotFound,
 		ErrKeyInvalidPathID:         http.StatusBadRequest,
+		ErrKeyNoStoredCertificate:   http.StatusConflict,
 		ErrKeyDeleteFailed:          http.StatusInternalServerError,
 		ErrKeyUpdateFailed:          http.StatusInternalServerError,
 	})

--- a/internal/service/domain/delegated_domain_service.go
+++ b/internal/service/domain/delegated_domain_service.go
@@ -408,6 +408,17 @@ func (s *DelegatedDomainService) UsesDelegationForOwnership(domain string) bool 
 	return ok && ns != string(pluginDb.DomainNamespaceICANN)
 }
 
+// NamespaceUsesManagedZoneTLSA reports whether the given namespace's provider
+// translates certs into a DANE TLSA that the portal publishes into its managed
+// authoritative zone. Only such namespaces (e.g. HNS) can be force-republished.
+func (s *DelegatedDomainService) NamespaceUsesManagedZoneTLSA(namespace string) bool {
+	if s.registry == nil {
+		return false
+	}
+	prov := s.registry.Get(namespace)
+	return prov != nil && prov.UsesManagedZoneTLSA()
+}
+
 // GetNamespaceForDomain returns the namespace for the given domain if it
 // matches a registered provider. This is used to select the correct DNS
 // resolver for alt-root domains (different roots require different resolvers).


### PR DESCRIPTION
## What

Adds `POST /websites/:id/domains/:domain_id/dane/republish` — an operator escape hatch to re-publish a bound domain's DANE TLSA (`_443._tcp.<domain>`) into the portal-managed authoritative PowerDNS zone.

## Why

A TLSA that was deleted or went missing stays gone if cert renewal doesn't re-trigger the cert-webhook publish (same-key renewal produces no change → no re-push). This endpoint forces a republish on demand.

## Changes

- `republishDomainDANE` handler: owner-scoped (`id` + `website_id` + `user_id`), loads the stored cert via `GetCertificateKey`, re-pushes via `UpdateTLSAFromCert` (idempotent PowerDNS REPLACE).
- Gate: only DANE-capable namespaces (`provider.UsesManagedZoneTLSA`); 409 CONFLICT for non-DANE namespaces or domains with no stored cert.
- `DomainDANERepublishResponse` DTO (flat, not embedded — gswagger rejects embedded structs).
- `DelegatedDomainService.NamespaceUsesManagedZoneTLSA` capability helper.
- `ErrKeyNoStoredCertificate` error key (409).
- Tests: 404 missing, 404 non-owner, 409 ICANN, 409 no-cert.

## Verification

- `go test ./internal/api/ -run TestAPI_DANERepublish` — pass (4 subtests)
- `go test ./internal/service/domain/` — pass
- Full `./internal/api/` suite: only pre-existing `TestAPI_UpdateSSLStatus_Webhook` fails (unrelated, present on clean develop, not touched here).

* `develop` <!-- branch-stack -->
  - **feat(api): add DANE TLSA force-republish endpoint** :point\_left:

***

<!-- kody-pr-summary:start -->

## Summary

This pull request adds a new API endpoint that allows users to force re-publication of DANE (TLSA) records for domains bound to their websites. This serves as a recovery mechanism when TLSA records have been deleted or gone missing and haven't been automatically re-published by the certificate renewal process.

## Key Changes

### New API Endpoint

- Added `POST /websites/:id/domains/:domain_id/dane/republish` endpoint that allows users to trigger a manual re-publication of a domain's DANE TLSA records.
- The endpoint is accessible to authenticated users with appropriate permissions.

### Functionality

- The endpoint retrieves the stored certificate and private key for the specified domain and re-pushes them through the same processing pipeline used by the cert webhook.
- It idempotently overwrites the `_443._tcp.<domain>` TLSA RRset in the portal-managed authoritative PowerDNS zone using a REPLACE operation.
- The response includes the republished TLSA record details (owner name, TLSA data, and full record string) along with domain information.

### Validation & Error Handling

- Validates that the requested website and domain exist and belong to the authenticated user (returns `404` if not found).
- Only supports namespaces that use managed-zone DANE records (e.g., HNS); non-DANE namespaces like ICANN return a `409 Conflict` response.
- Returns `409 Conflict` if no stored certificate exists for the domain (e.g., none was ever pushed via the cert webhook).
- Handles missing domain service and database errors appropriately.

### Service Layer

- Added `NamespaceUsesManagedZoneTLSA()` method to the delegated domain service to check whether a given namespace's provider supports managed-zone DANE publication.

### Response DTO

- Added new `DomainDANERepublishResponse` DTO that includes standard domain fields plus the TLSA record information (record string, owner name, and TLSA data).
- Deliberately duplicates scalar fields instead of embedding `DomainResponse` to avoid schema generator recursion issues.

### Test Coverage

- Added test cases covering:
  - Missing domain (404)
  - Domain owned by another user (404)
  - ICANN namespace rejection (409)
  - HNS domain without stored certificate (409)

<!-- kody-pr-summary:end -->
