### PR TITLE
feat(dns): compute DS on the fly instead of persisting it

### DIFF
--- a/core/dns.go
+++ b/core/dns.go
@@ -93,4 +93,12 @@ type DNSService interface {
 
 	// EnableDNSSEC enables DNSSEC on a zone and returns the DNSKEY record content.
 	EnableDNSSEC(ctx context.Context, zoneID uint) (dnskey string, err error)
+
+	// GetActiveDNSSECDS returns the SHA-256 DS RDATA (type 2) for a zone's
+	// currently-active signing key, computed live from PowerDNS. It is the
+	// on-the-fly source of the DS (display in dns-requirements and on-chain
+	// verification) so no DS is persisted in the portal DB. Returns "" when the
+	// zone has no active signing key; errors when multiple active signing keys
+	// exist (in-progress rollover).
+	GetActiveDNSSECDS(ctx context.Context, zoneID uint) (ds string, err error)
 }

--- a/internal/api/api_domains.go
+++ b/internal/api/api_domains.go
@@ -251,7 +251,44 @@ func (a *API) domainDNSRequirements(c echo.Context) error {
 		apiErr := NewError(ErrKeyFileProcessingFailed, err)
 		return ctx.Error(apiErr, apiErr.HttpStatus())
 	}
+
+	// The DS to publish is computed live from PowerDNS's current active signing
+	// key rather than read from stored delegation data (which would go stale on
+	// key rotation). Only portal-managed, DNSSEC-signed namespaces (e.g. HNS)
+	// yield a DS; ICANN domains have no parent DS and this is a no-op.
+	if resp.Delegation != nil && a.dnsService != nil {
+		if ds, dsErr := a.dnsService.GetActiveDNSSECDS(reqCtx, wd.ZoneID); dsErr == nil && ds != "" {
+			resp.Delegation.DS = ds
+			// Ensure the rendered parent_records carries the live DS so CLI
+			// renderers that draw from parent_records show the current value
+			// (replace any stale stored DS entry, else append).
+			resp.Delegation.ParentRecords = upsertDSRecord(resp.Delegation.ParentRecords, ds)
+		}
+	}
+
 	return httputil.EncodeResponse(ctx, &wd, &resp)
+}
+
+// upsertDSRecord returns parent records with the DS record set to `ds`,
+// replacing any existing DS entry or appending a new one. A nil/empty slice is
+// preserved as nil so ICANN-shaped delegation (no parent records) stays bare.
+func upsertDSRecord(records []dto.DNSDelegationRecord, ds string) []dto.DNSDelegationRecord {
+	if len(records) == 0 {
+		return records
+	}
+	out := records
+	replaced := false
+	for i := range out {
+		if out[i].Type == "DS" {
+			out[i].Value = ds
+			replaced = true
+			break
+		}
+	}
+	if !replaced {
+		out = append(out, dto.DNSDelegationRecord{Type: "DS", Value: ds})
+	}
+	return out
 }
 
 // republishDomainDANE forces re-publication of a bound domain's DANE records

--- a/internal/api/api_domains.go
+++ b/internal/api/api_domains.go
@@ -272,6 +272,11 @@ func (a *API) domainDNSRequirements(c echo.Context) error {
 			// renderers that draw from parent_records show the current value
 			// (replace any stale stored DS entry, else append).
 			resp.Delegation.ParentRecords = upsertDSRecord(resp.Delegation.ParentRecords, ds)
+		} else {
+			// Zone has no active signing key (e.g. after a key was rotated or
+			// removed): drop any stored DS so a stale value is never presented
+			// as current when there is no live DS to back it.
+			resp.Delegation.ParentRecords = removeDSRecord(resp.Delegation.ParentRecords)
 		}
 	}
 

--- a/internal/api/api_domains.go
+++ b/internal/api/api_domains.go
@@ -259,7 +259,14 @@ func (a *API) domainDNSRequirements(c echo.Context) error {
 	// DS is injected into parent_records (which renderers draw from); there is
 	// no separate DS field that could otherwise sit empty.
 	if resp.Delegation != nil && a.dnsService != nil {
-		if ds, dsErr := a.dnsService.GetActiveDNSSECDS(reqCtx, wd.ZoneID); dsErr == nil && ds != "" {
+		ds, dsErr := a.dnsService.GetActiveDNSSECDS(reqCtx, wd.ZoneID)
+		if dsErr != nil {
+			// PowerDNS unavailable or a key rollover is in progress: the live
+			// DS cannot be resolved. Log it rather than silently falling
+			// through to show whatever stale parent_records may hold.
+			a.Logger().Warn("could not resolve live DS for dns-requirements",
+				zap.Uint("zone_id", wd.ZoneID), zap.Error(dsErr))
+		} else if ds != "" {
 			// Ensure the rendered parent_records carries the live DS so CLI
 			// renderers that draw from parent_records show the current value
 			// (replace any stale stored DS entry, else append).

--- a/internal/api/api_domains.go
+++ b/internal/api/api_domains.go
@@ -262,10 +262,11 @@ func (a *API) domainDNSRequirements(c echo.Context) error {
 		ds, dsErr := a.dnsService.GetActiveDNSSECDS(reqCtx, wd.ZoneID)
 		if dsErr != nil {
 			// PowerDNS unavailable or a key rollover is in progress: the live
-			// DS cannot be resolved. Log it rather than silently falling
-			// through to show whatever stale parent_records may hold.
+			// DS cannot be resolved. Log it and drop any stored DS from
+			// parent_records so a stale value is never presented as current.
 			a.Logger().Warn("could not resolve live DS for dns-requirements",
 				zap.Uint("zone_id", wd.ZoneID), zap.Error(dsErr))
+			resp.Delegation.ParentRecords = removeDSRecord(resp.Delegation.ParentRecords)
 		} else if ds != "" {
 			// Ensure the rendered parent_records carries the live DS so CLI
 			// renderers that draw from parent_records show the current value
@@ -295,6 +296,26 @@ func upsertDSRecord(records []dto.DNSDelegationRecord, ds string) []dto.DNSDeleg
 	}
 	if !replaced {
 		out = append(out, dto.DNSDelegationRecord{Type: "DS", Value: ds})
+	}
+	return out
+}
+
+// removeDSRecord returns parent records with any DS entry stripped out. Used
+// when the live DS cannot be resolved (PowerDNS down, key rollover) so a
+// stale stored DS is never presented as current. A nil/empty slice is
+// preserved as nil.
+func removeDSRecord(records []dto.DNSDelegationRecord) []dto.DNSDelegationRecord {
+	if len(records) == 0 {
+		return records
+	}
+	out := records[:0]
+	for _, r := range records {
+		if r.Type != "DS" {
+			out = append(out, r)
+		}
+	}
+	if len(out) == 0 {
+		return nil
 	}
 	return out
 }

--- a/internal/api/api_domains.go
+++ b/internal/api/api_domains.go
@@ -255,10 +255,11 @@ func (a *API) domainDNSRequirements(c echo.Context) error {
 	// The DS to publish is computed live from PowerDNS's current active signing
 	// key rather than read from stored delegation data (which would go stale on
 	// key rotation). Only portal-managed, DNSSEC-signed namespaces (e.g. HNS)
-	// yield a DS; ICANN domains have no parent DS and this is a no-op.
+	// yield a DS; ICANN domains have no parent DS and this is a no-op. The live
+	// DS is injected into parent_records (which renderers draw from); there is
+	// no separate DS field that could otherwise sit empty.
 	if resp.Delegation != nil && a.dnsService != nil {
 		if ds, dsErr := a.dnsService.GetActiveDNSSECDS(reqCtx, wd.ZoneID); dsErr == nil && ds != "" {
-			resp.Delegation.DS = ds
 			// Ensure the rendered parent_records carries the live DS so CLI
 			// renderers that draw from parent_records show the current value
 			// (replace any stale stored DS entry, else append).

--- a/internal/api/api_domains_test.go
+++ b/internal/api/api_domains_test.go
@@ -96,6 +96,13 @@ func TestAPI_DomainDNSRequirements(t *testing.T) {
 			helper := newMockHelper(t, ctx)
 			token, userID, testCID, _ := helper.SetupAuthenticatedTest()
 
+			// The DS is computed live from PowerDNS on demand, not stored. Stub
+			// the current active signing key's DS so the handler injects it.
+			mockDNS := helper.SetupDNSServiceMocks()
+			mockDNS.EXPECT().GetActiveDNSSECDS(mock.Anything, uint(0)).Return(
+				"60776 13 2 3b35deed97def5fbb5ce939cd5b9036f12db0ccc2e1cb40bb4c565c168c66116", nil,
+			).Maybe()
+
 			website := createTestIPFSGatewayWebsite(1, userID, "example.com", testCID, pluginDb.WebsiteStatusActive)
 			require.NoError(t, ctx.DB().Create(website).Error)
 
@@ -111,6 +118,7 @@ func TestAPI_DomainDNSRequirements(t *testing.T) {
 					"mode": "delegated",
 					"parent_records": []map[string]any{
 						{"type": "NS", "value": "ns1.lumeweb,ns2.lumeweb"},
+						// Stale stored DS — must be REPLACED by the live value.
 						{"type": "DS", "value": "lumeweb. 3600 IN DS 12345 13 2 <digest>"},
 					},
 					"authoritative_records": []map[string]any{
@@ -129,9 +137,13 @@ func TestAPI_DomainDNSRequirements(t *testing.T) {
 			assert.Equal(t, "hns", resp.Namespace)
 			require.NotNil(t, resp.Delegation)
 			assert.Equal(t, "delegated", resp.Delegation.Mode)
-			assert.Equal(t, "lumeweb. 3600 IN DS 12345 13 2 <digest>", resp.Delegation.DS)
+			// No first-class DS field — the live DS is injected into
+			// parent_records, replacing the stale stored DS entry.
 			require.Len(t, resp.Delegation.ParentRecords, 2)
 			assert.Equal(t, "NS", resp.Delegation.ParentRecords[0].Type)
+			dsRec := resp.Delegation.ParentRecords[1]
+			assert.Equal(t, "DS", dsRec.Type)
+			assert.Equal(t, "60776 13 2 3b35deed97def5fbb5ce939cd5b9036f12db0ccc2e1cb40bb4c565c168c66116", dsRec.Value)
 		}, TestOptions)
 	})
 

--- a/internal/api/api_domains_test.go
+++ b/internal/api/api_domains_test.go
@@ -197,6 +197,55 @@ func TestAPI_DomainDNSRequirements(t *testing.T) {
 		}, TestOptions)
 	})
 
+	t.Run("ds_empty_removes_stale_ds", func(t *testing.T) {
+		coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+			helper := newMockHelper(t, ctx)
+			token, userID, testCID, _ := helper.SetupAuthenticatedTest()
+
+			// Zone has no active signing key (e.g. after key rotation): the
+			// documented GetActiveDNSSECDS ("", nil) outcome.
+			mockDNS := helper.SetupDNSServiceMocks()
+			mockDNS.EXPECT().GetActiveDNSSECDS(mock.Anything, uint(0)).Return(
+				"", nil,
+			).Maybe()
+
+			website := createTestIPFSGatewayWebsite(1, userID, "example.com", testCID, pluginDb.WebsiteStatusActive)
+			require.NoError(t, ctx.DB().Create(website).Error)
+
+			wd := &pluginDb.WebsiteDomain{
+				WebsiteID:   1,
+				UserID:      userID,
+				Domain:      "lumeweb",
+				Namespace:   pluginDb.DomainNamespaceHNS,
+				Status:      pluginDb.DomainStatusRecordsGenerated,
+				ZoneName:    "lumeweb.",
+				GatewayHost: "gateway.lumeweb.com",
+				DelegationData: datatypes.JSONMap{
+					"mode": "delegated",
+					"parent_records": []map[string]any{
+						{"type": "NS", "value": "ns1.lumeweb,ns2.lumeweb"},
+						// Stale stored DS — must be DROPPED when no live key exists.
+						{"type": "DS", "value": "lumeweb. 3600 IN DS 12345 13 2 <digest>"},
+					},
+					"authoritative_records": []map[string]any{
+						{"type": "NS", "value": "ns1.lumeweb\nns2.lumeweb"},
+					},
+				},
+			}
+			require.NoError(t, ctx.DB().Create(wd).Error)
+
+			rec := helper.makeAuthenticatedRequest(http.MethodGet, "/api/websites/1/domains/1/dns-requirements", token, nil)
+			require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+
+			var resp dto.DomainResponse
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+			require.NotNil(t, resp.Delegation)
+			// No live signing key: stale DS must be removed, not presented.
+			require.Len(t, resp.Delegation.ParentRecords, 1)
+			assert.Equal(t, "NS", resp.Delegation.ParentRecords[0].Type)
+		}, TestOptions)
+	})
+
 	t.Run("missing_domain_returns_404", func(t *testing.T) {
 		coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 			helper := newMockHelper(t, ctx)

--- a/internal/api/api_domains_test.go
+++ b/internal/api/api_domains_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"testing"
@@ -144,6 +145,55 @@ func TestAPI_DomainDNSRequirements(t *testing.T) {
 			dsRec := resp.Delegation.ParentRecords[1]
 			assert.Equal(t, "DS", dsRec.Type)
 			assert.Equal(t, "60776 13 2 3b35deed97def5fbb5ce939cd5b9036f12db0ccc2e1cb40bb4c565c168c66116", dsRec.Value)
+		}, TestOptions)
+	})
+
+	t.Run("ds_unresolvable_removes_stale_ds", func(t *testing.T) {
+		coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+			helper := newMockHelper(t, ctx)
+			token, userID, testCID, _ := helper.SetupAuthenticatedTest()
+
+			// PowerDNS is unreachable / key rollover: GetActiveDNSSECDS errors.
+			mockDNS := helper.SetupDNSServiceMocks()
+			mockDNS.EXPECT().GetActiveDNSSECDS(mock.Anything, uint(0)).Return(
+				"", errors.New("PowerDNS unreachable"),
+			).Maybe()
+
+			website := createTestIPFSGatewayWebsite(1, userID, "example.com", testCID, pluginDb.WebsiteStatusActive)
+			require.NoError(t, ctx.DB().Create(website).Error)
+
+			wd := &pluginDb.WebsiteDomain{
+				WebsiteID:   1,
+				UserID:      userID,
+				Domain:      "lumeweb",
+				Namespace:   pluginDb.DomainNamespaceHNS,
+				Status:      pluginDb.DomainStatusRecordsGenerated,
+				ZoneName:    "lumeweb.",
+				GatewayHost: "gateway.lumeweb.com",
+				DelegationData: datatypes.JSONMap{
+					"mode": "delegated",
+					"parent_records": []map[string]any{
+						{"type": "NS", "value": "ns1.lumeweb,ns2.lumeweb"},
+						// Stale stored DS — must be DROPPED, not presented as current.
+						{"type": "DS", "value": "lumeweb. 3600 IN DS 12345 13 2 <digest>"},
+					},
+					"authoritative_records": []map[string]any{
+						{"type": "NS", "value": "ns1.lumeweb\nns2.lumeweb"},
+					},
+				},
+			}
+			require.NoError(t, ctx.DB().Create(wd).Error)
+
+			rec := helper.makeAuthenticatedRequest(http.MethodGet, "/api/websites/1/domains/1/dns-requirements", token, nil)
+			require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+
+			var resp dto.DomainResponse
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+			require.NotNil(t, resp.Delegation)
+			// Stale DS must be removed from parent_records so a value whose
+			// correctness cannot be confirmed is never presented as current.
+			require.Len(t, resp.Delegation.ParentRecords, 1)
+			assert.Equal(t, "NS", resp.Delegation.ParentRecords[0].Type)
 		}, TestOptions)
 	})
 

--- a/internal/api/dto/domain.go
+++ b/internal/api/dto/domain.go
@@ -49,7 +49,6 @@ type DNSDelegationRecord struct {
 type DNSDelegation struct {
 	Mode                 string                `json:"mode,omitempty"`
 	Nameservers          []string              `json:"nameservers,omitempty"`
-	DS                   string                `json:"ds,omitempty"`
 	ParentRecords        []DNSDelegationRecord `json:"parent_records,omitempty"`
 	AuthoritativeRecords []DNSDelegationRecord `json:"authoritative_records,omitempty"`
 }
@@ -184,10 +183,10 @@ func mapDNSDelegation(raw []byte) *DNSDelegation {
 			ParentRecords:        hns.ParentRecords,
 			AuthoritativeRecords: hns.AuthoritativeRecords,
 		}
-		// The DS is NOT promoted from stored parent_records: the DS is a
-		// derivative of the live PowerDNS signing key and is computed on the
-		// fly (see API.domainDNSRequirements -> GetActiveDNSSECDS), never
-		// persisted. A stored DS would go stale on key rotation.
+		// The DS is carried as a parent_records entry, not as a first-class
+		// field: it is a derivative of the live PowerDNS signing key computed
+		// on the fly (API.domainDNSRequirements -> GetActiveDNSSECDS), and is
+		// never read back from stored delegation data.
 		return d
 	}
 

--- a/internal/api/dto/domain.go
+++ b/internal/api/dto/domain.go
@@ -184,13 +184,10 @@ func mapDNSDelegation(raw []byte) *DNSDelegation {
 			ParentRecords:        hns.ParentRecords,
 			AuthoritativeRecords: hns.AuthoritativeRecords,
 		}
-		// Promote a DS record from parent_records to the first-class DS field.
-		for _, rec := range hns.ParentRecords {
-			if rec.Type == "DS" {
-				d.DS = rec.Value
-				break
-			}
-		}
+		// The DS is NOT promoted from stored parent_records: the DS is a
+		// derivative of the live PowerDNS signing key and is computed on the
+		// fly (see API.domainDNSRequirements -> GetActiveDNSSECDS), never
+		// persisted. A stored DS would go stale on key rotation.
 		return d
 	}
 

--- a/internal/api/dto/domain_test.go
+++ b/internal/api/dto/domain_test.go
@@ -50,11 +50,10 @@ func TestDomainResponse_FromModel_HNS(t *testing.T) {
 	require.NotNil(t, resp.Delegation, "delegation should be populated for HNS")
 	assert.Equal(t, "delegated", resp.Delegation.Mode)
 
-	// DS is NOT promoted from stored parent_records: the DS is a derivative of
-	// the live PowerDNS signing key, computed on the fly (dns-requirements) and
-	// never persisted. A stored DS (even a legacy one) must not leak into the
-	// first-class field here.
-	assert.Equal(t, "", resp.Delegation.DS)
+	// No first-class DS field: the DS is a parent_records entry derived from
+	// the live PowerDNS key (computed on the fly in dns-requirements), never a
+	// stored/promoted value.
+	assert.NotContains(t, resp.Delegation.ParentRecords, "ds")
 
 	// Parent records preserved with type/ns/address.
 	require.Len(t, resp.Delegation.ParentRecords, 3)
@@ -91,7 +90,6 @@ func TestDomainResponse_FromModel_ICANN(t *testing.T) {
 
 	require.NotNil(t, resp.Delegation)
 	assert.Equal(t, []string{"ns1.example.com", "ns2.example.com"}, resp.Delegation.Nameservers)
-	assert.Empty(t, resp.Delegation.DS)
 	assert.Empty(t, resp.Delegation.ParentRecords)
 }
 

--- a/internal/api/dto/domain_test.go
+++ b/internal/api/dto/domain_test.go
@@ -50,8 +50,11 @@ func TestDomainResponse_FromModel_HNS(t *testing.T) {
 	require.NotNil(t, resp.Delegation, "delegation should be populated for HNS")
 	assert.Equal(t, "delegated", resp.Delegation.Mode)
 
-	// DS promoted to first-class field.
-	assert.Equal(t, "lumeweb. 3600 IN DS 12345 13 2 <digest>", resp.Delegation.DS)
+	// DS is NOT promoted from stored parent_records: the DS is a derivative of
+	// the live PowerDNS signing key, computed on the fly (dns-requirements) and
+	// never persisted. A stored DS (even a legacy one) must not leak into the
+	// first-class field here.
+	assert.Equal(t, "", resp.Delegation.DS)
 
 	// Parent records preserved with type/ns/address.
 	require.Len(t, resp.Delegation.ParentRecords, 3)

--- a/internal/service/dns/dns_service.go
+++ b/internal/service/dns/dns_service.go
@@ -224,3 +224,37 @@ func (s *DNSServiceDefault) EnableDNSSEC(ctx context.Context, zoneID uint) (stri
 
 	return dnskey, nil
 }
+
+// GetActiveDNSSECDS returns the SHA-256 DS RDATA (type 2) for the zone's
+// currently-active signing key, computed live from PowerDNS cryptokey state.
+// It is the on-the-fly source of the DS to display in dns-requirements and to
+// verify on-chain, so no DS is persisted in the portal DB (a stored DS would
+// go stale on key rotation). Returns ("", nil) when the zone has no active
+// signing key; errors when multiple active keys exist (in-progress rollover).
+func (s *DNSServiceDefault) GetActiveDNSSECDS(ctx context.Context, zoneID uint) (string, error) {
+	if s.pdnsClient == nil {
+		return "", fmt.Errorf("PowerDNS client not configured")
+	}
+
+	var pdnsZoneID string
+	txErr := s.DB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var zone pluginDb.DNSZone
+		if err := tx.First(&zone, zoneID).Error; err != nil {
+			return err
+		}
+		if zone.PowerDNSZoneID == "" {
+			return fmt.Errorf("zone %d has no PowerDNS zone ID", zoneID)
+		}
+		pdnsZoneID = zone.PowerDNSZoneID
+		return nil
+	})
+	if txErr != nil {
+		return "", txErr
+	}
+
+	ds, err := s.pdnsClient.GetActiveDNSKEYDS(ctx, pdnsZoneID)
+	if err != nil {
+		return "", fmt.Errorf("get active DNSKEY DS: %w", err)
+	}
+	return ds, nil
+}

--- a/internal/service/dns/powerdns_client.go
+++ b/internal/service/dns/powerdns_client.go
@@ -451,12 +451,72 @@ func (c *PowerDNSClient) EnableDNSSEC(ctx context.Context, zoneID string) (strin
 	return result.DNSKey, nil
 }
 
+// GetActiveDNSKEYDS returns the SHA-256 DS RDATA (type 2, e.g.
+// "60776 13 2 <hex>") for the zone's currently-active signing key, computed
+// from the live PowerDNS cryptokey state. It is the on-the-fly source of the
+// DS to publish/verify on-chain, so the portal never needs to persist a DS
+// (which would go stale on key rotation).
+//
+// It returns ("", nil) when the zone has no active signing key (DNSSEC not
+// enabled). When there are multiple active signing keys — an in-progress
+// rollover — it returns an error rather than guessing which one is
+// authoritative, mirroring the guard in EnableDNSSEC.
+func (c *PowerDNSClient) GetActiveDNSKEYDS(ctx context.Context, zoneID string) (string, error) {
+	parts := strings.Split(zoneID, "/")
+	apiZoneID := parts[len(parts)-1]
+
+	zoneMu := c.zoneMu(apiZoneID)
+	zoneMu.Lock()
+	defer zoneMu.Unlock()
+
+	base := strings.TrimSuffix(c.baseURL, "/")
+	existing, err := c.listCryptokeys(ctx, base, apiZoneID)
+	if err != nil {
+		return "", fmt.Errorf("list cryptokeys: %w", err)
+	}
+
+	var active []cryptokey
+	for _, k := range existing {
+		if k.Active && (k.KeyType == "ksk" || k.KeyType == "csk") {
+			active = append(active, k)
+		}
+	}
+	switch len(active) {
+	case 0:
+		return "", nil
+	case 1:
+		ds, err := sha256DSPresentation(active[0].DS)
+		if err != nil {
+			return "", fmt.Errorf("zone %s active signing key has no usable SHA-256 DS: %w", zoneID, err)
+		}
+		return ds, nil
+	default:
+		return "", fmt.Errorf("zone %s has %d active signing keys; cannot determine which matches the published DS; reconcile manually", zoneID, len(active))
+	}
+}
+
+// sha256DSPresentation extracts the SHA-256 (digest type 2) DS RDATA
+// presentation from a PowerDNS-returned DS list. PowerDNS returns one DS entry
+// per digest type (e.g. "60776 13 2 <sha256>" and "60776 13 4 <sha512>"); we
+// select the type-2 entry, which is what parent-zone queryDS comparison and
+// on-chain DS publishing use.
+func sha256DSPresentation(dss []string) (string, error) {
+	for _, ds := range dss {
+		fields := strings.Fields(ds)
+		if len(fields) >= 3 && fields[2] == "2" {
+			return ds, nil
+		}
+	}
+	return "", fmt.Errorf("no SHA-256 DS (type 2) found")
+}
+
 // cryptokey is a PowerDNS cryptokey object (subset of the API response).
 type cryptokey struct {
-	ID      string `json:"id"`
-	KeyType string `json:"keytype"`
-	Active  bool   `json:"active"`
-	DNSKey  string `json:"dnskey"`
+	ID      string   `json:"id"`
+	KeyType string   `json:"keytype"`
+	Active  bool     `json:"active"`
+	DNSKey  string   `json:"dnskey"`
+	DS      []string `json:"ds"`
 }
 
 // listCryptokeys returns the zone's existing cryptokeys via

--- a/internal/service/dns/powerdns_client_test.go
+++ b/internal/service/dns/powerdns_client_test.go
@@ -1775,3 +1775,105 @@ func testAPIKey() string {
 func strPtr(s string) *string {
 	return &s
 }
+
+func TestSha256DSPresentation(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      []string
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "selects SHA-256 (type 2) among multiple digest types",
+			in: []string{
+				"60776 13 4 870ecd07a97de1bad8b771699b8cd59f385437be4dec76698bcc049857cb67f68790e0a705909579570987844a0d8a61",
+				"60776 13 2 3b35deed97def5fbb5ce939cd5b9036f12db0ccc2e1cb40bb4c565c168c66116",
+			},
+			want: "60776 13 2 3b35deed97def5fbb5ce939cd5b9036f12db0ccc2e1cb40bb4c565c168c66116",
+		},
+		{name: "only SHA-256 present", in: []string{"44451 13 2 bdb0d7c0"}, want: "44451 13 2 bdb0d7c0"},
+		{name: "no DS entries", in: nil, wantErr: true},
+		{name: "only SHA-512 present", in: []string{"44451 13 4 beef"}, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := sha256DSPresentation(tt.in)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("expected %q, got %q", tt.want, got)
+			}
+		})
+	}
+}
+
+func TestGetActiveDNSKEYDS(t *testing.T) {
+	t.Run("returns SHA-256 DS for single active CSK", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Query().Get("details") != "true" {
+				t.Errorf("expected ?details=true, got %q", r.URL.RawQuery)
+			}
+			body := `[{"id":"5","keytype":"csk","active":true,"dnskey":"257 3 13 evH3XP==","ds":["60776 13 2 3b35deed97def5fbb5ce939cd5b9036f12db0ccc2e1cb40bb4c565c168c66116","60776 13 4 870ecd07"]}]`
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(body))
+		}))
+		defer server.Close()
+		client, err := NewPowerDNSClient(server.URL, testAPIKey(), &core.Logger{Logger: zap.NewNop()})
+		if err != nil {
+			t.Fatalf("NewPowerDNSClient: %v", err)
+		}
+		ds, err := client.GetActiveDNSKEYDS(context.Background(), "lumeweb.")
+		if err != nil {
+			t.Fatalf("GetActiveDNSKEYDS: %v", err)
+		}
+		want := "60776 13 2 3b35deed97def5fbb5ce939cd5b9036f12db0ccc2e1cb40bb4c565c168c66116"
+		if ds != want {
+			t.Errorf("expected %q, got %q", want, ds)
+		}
+	})
+
+	t.Run("no active signing key returns empty", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[{"id":"1","keytype":"csk","active":false,"dnskey":"257 3 13 x=","ds":["60776 13 2 abc"]}]`))
+		}))
+		defer server.Close()
+		client, err := NewPowerDNSClient(server.URL, testAPIKey(), &core.Logger{Logger: zap.NewNop()})
+		if err != nil {
+			t.Fatalf("NewPowerDNSClient: %v", err)
+		}
+		ds, err := client.GetActiveDNSKEYDS(context.Background(), "lumeweb.")
+		if err != nil {
+			t.Fatalf("GetActiveDNSKEYDS: %v", err)
+		}
+		if ds != "" {
+			t.Errorf("expected empty DS, got %q", ds)
+		}
+	})
+
+	t.Run("multiple active keys errors (no guess)", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body := `[{"id":"4","keytype":"csk","active":true,"dnskey":"257 3 13 a=","ds":["44451 13 2 bdb0d7c0"]},{"id":"5","keytype":"csk","active":true,"dnskey":"257 3 13 b=","ds":["60776 13 2 3b35deed"]}]`
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(body))
+		}))
+		defer server.Close()
+		client, err := NewPowerDNSClient(server.URL, testAPIKey(), &core.Logger{Logger: zap.NewNop()})
+		if err != nil {
+			t.Fatalf("NewPowerDNSClient: %v", err)
+		}
+		if _, err := client.GetActiveDNSKEYDS(context.Background(), "lumeweb."); err == nil {
+			t.Fatal("expected error with multiple active signing keys")
+		}
+	})
+}

--- a/internal/service/domain/delegated_domain_service.go
+++ b/internal/service/domain/delegated_domain_service.go
@@ -42,6 +42,11 @@ type DNSZoneService interface {
 	SetTLSARecord(ctx context.Context, zoneID uint, content string) error
 	// EnableDNSSEC enables DNSSEC on a zone and returns the DNSKEY.
 	EnableDNSSEC(ctx context.Context, zoneID uint) (dnskey string, err error)
+	// GetActiveDNSSECDS returns the SHA-256 DS RDATA (type 2) for a zone's
+	// currently-active signing key, computed live from PowerDNS. Returns ""
+	// when the zone has no active signing key; errors when multiple active keys
+	// exist (in-progress rollover).
+	GetActiveDNSSECDS(ctx context.Context, zoneID uint) (ds string, err error)
 }
 
 // DSRecord represents a Delegation Signer record for DNSSEC.
@@ -204,12 +209,25 @@ func (s *DelegatedDomainService) VerifyDomain(ctx context.Context,
 		return false, fmt.Errorf("unsupported namespace: %s", wd.Namespace)
 	}
 
-	data, err := json.Marshal(wd.DelegationData)
-	if err != nil {
-		return false, err
+	// Expected DS is computed live from PowerDNS's current active signing key
+	// (never persisted, so it cannot go stale on key rotation). ICANN's
+	// VerifyDelegation ignores it; HNS uses it to require the parent zone to
+	// serve the DS before marking the domain Active.
+	//
+	// If the live DS cannot be determined — e.g. an in-progress key rollover
+	// leaves multiple active signing keys, or PowerDNS is unreachable — we
+	// degrade to NS-only verification rather than fail the whole check, so a
+	// transient DNSSEC state never blocks delegation status.
+	expectedDS, dsErr := s.dnsSvc.GetActiveDNSSECDS(ctx, wd.ZoneID)
+	if dsErr != nil {
+		s.Logger().Warn("could not resolve live DS for verification; falling back to NS-only",
+			zap.Uint("zone_id", wd.ZoneID),
+			zap.String("domain", wd.Domain),
+			zap.Error(dsErr))
+		expectedDS = ""
 	}
 
-	verified, err := provider.VerifyDelegation(ctx, wd.Domain, data)
+	verified, err := provider.VerifyDelegation(ctx, wd.Domain, expectedDS)
 	if err != nil {
 		wd.Status = pluginDb.DomainStatusError
 		if s.DB() != nil {

--- a/internal/service/domain/delegated_domain_service.go
+++ b/internal/service/domain/delegated_domain_service.go
@@ -214,17 +214,16 @@ func (s *DelegatedDomainService) VerifyDomain(ctx context.Context,
 	// VerifyDelegation ignores it; HNS uses it to require the parent zone to
 	// serve the DS before marking the domain Active.
 	//
-	// If the live DS cannot be determined — e.g. an in-progress key rollover
-	// leaves multiple active signing keys, or PowerDNS is unreachable — we
-	// degrade to NS-only verification rather than fail the whole check, so a
-	// transient DNSSEC state never blocks delegation status.
+	// A zone with no active signing key (("", nil)) is genuinely self-managed —
+	// the portal generated no DS, so NS-only verification is correct. But if
+	// resolution ERRORS (key rollover with multiple active keys, PowerDNS
+	// unreachable), the zone is portal-managed and the live DS is
+	// indeterminate. We must NOT silently weaken a managed zone to NS-only on
+	// a transient failure: that would mark Active a zone whose DS chain of
+	// trust was not actually confirmed.
 	expectedDS, dsErr := s.dnsSvc.GetActiveDNSSECDS(ctx, wd.ZoneID)
 	if dsErr != nil {
-		s.Logger().Warn("could not resolve live DS for verification; falling back to NS-only",
-			zap.Uint("zone_id", wd.ZoneID),
-			zap.String("domain", wd.Domain),
-			zap.Error(dsErr))
-		expectedDS = ""
+		return false, fmt.Errorf("resolve live DS for zone %d: %w", wd.ZoneID, dsErr)
 	}
 
 	verified, err := provider.VerifyDelegation(ctx, wd.Domain, expectedDS)

--- a/internal/service/domain/hns_provider.go
+++ b/internal/service/domain/hns_provider.go
@@ -2,8 +2,6 @@ package domain
 
 import (
 	"context"
-	"encoding/base64"
-	"encoding/binary"
 	"encoding/json"
 	"fmt"
 	"net"
@@ -200,14 +198,14 @@ func (p *HNSProvider) BuildDelegation(ctx context.Context, zoneID uint,
 		tlsa = ""
 	}
 
-	// Enable DNSSEC on the zone and compute DS record
-	var dsRecords []Record
+	// Ensure DNSSEC is enabled on the zone so it is signed and has a key to
+	// derive the DS from. The DS itself is NOT persisted in the delegation
+	// bundle — it is derived live from PowerDNS on demand (see
+	// GetActiveDNSSECDS), so it can never go stale on key rotation.
 	if p.dnsSvc != nil {
-		ds, dsErr := p.enableDNSSECAndDS(ctx, zoneID, zoneName)
-		if dsErr != nil {
-			return nil, fmt.Errorf("dnssec enablement failed: %w", dsErr)
+		if err := p.enableDNSSEC(ctx, zoneID); err != nil {
+			return nil, fmt.Errorf("dnssec enablement failed: %w", err)
 		}
-		dsRecords = ds
 	}
 
 	nsRecords := p.Nameservers()
@@ -225,70 +223,19 @@ func (p *HNSProvider) BuildDelegation(ctx context.Context, zoneID uint,
 		bundle = p.buildDelegated(zoneName, nsRecords, tlsa, &cfg)
 	}
 
-	// Append DS records to parent (published at the parent zone for chain of trust)
-	if len(dsRecords) > 0 {
-		bundle.ParentRecords = append(bundle.ParentRecords, dsRecords...)
-	}
-
 	return bundle, nil
 }
 
-// enableDNSSECAndDS enables DNSSEC on the zone via PowerDNS and computes
-// the DS record from the returned DNSKEY using the dane library.
-func (p *HNSProvider) enableDNSSECAndDS(ctx context.Context, zoneID uint, zoneName string) ([]Record, error) {
-	dnskeyStr, err := p.dnsSvc.EnableDNSSEC(ctx, zoneID)
-	if err != nil {
-		return nil, fmt.Errorf("enable dnssec: %w", err)
+// enableDNSSEC ensures DNSSEC is enabled on the zone via PowerDNS. It is
+// idempotent (EnableDNSSEC reuses an existing active signing key) and exists so
+// fresh delegation guarantees a signed zone. The DS is deliberately NOT
+// computed or stored here: the portal keeps the delegation bundle free of the
+// derived DS, which is instead computed live from PowerDNS on demand.
+func (p *HNSProvider) enableDNSSEC(ctx context.Context, zoneID uint) error {
+	if _, err := p.dnsSvc.EnableDNSSEC(ctx, zoneID); err != nil {
+		return fmt.Errorf("enable dnssec: %w", err)
 	}
-
-	// PowerDNS returns DNSKEY as "257 3 13 <base64key>" (flags protocol algorithm key)
-	parts := strings.Fields(dnskeyStr)
-	if len(parts) < 4 {
-		return nil, fmt.Errorf("invalid dnskey format from powerdns: %q", dnskeyStr)
-	}
-
-	flags, err := strconv.ParseUint(parts[0], 10, 16)
-	if err != nil {
-		return nil, fmt.Errorf("parse dnskey flags: %w", err)
-	}
-	protocol, err := strconv.ParseUint(parts[1], 10, 8)
-	if err != nil {
-		return nil, fmt.Errorf("parse dnskey protocol: %w", err)
-	}
-	algorithm, err := strconv.ParseUint(parts[2], 10, 8)
-	if err != nil {
-		return nil, fmt.Errorf("parse dnskey algorithm: %w", err)
-	}
-
-	pubKey, err := base64.StdEncoding.DecodeString(strings.Join(parts[3:], ""))
-	if err != nil {
-		return nil, fmt.Errorf("decode dnskey public key: %w", err)
-	}
-
-	// Build DNSKEY RDATA: flags(2) + protocol(1) + algorithm(1) + public_key
-	rdata := make([]byte, 4+len(pubKey))
-	binary.BigEndian.PutUint16(rdata[0:2], uint16(flags))
-	rdata[2] = uint8(protocol)
-	rdata[3] = uint8(algorithm)
-	copy(rdata[4:], pubKey)
-
-	// Compute DS record using SHA-256 digest (type 2)
-	canonicalName := []byte(strings.ToLower(zoneName))
-	ds, err := dane.ComputeDS(canonicalName, rdata, 2)
-	if err != nil {
-		return nil, fmt.Errorf("compute ds: %w", err)
-	}
-
-	// The DS VALUE carries only the RDATA (key tag, algorithm, digest type,
-	// digest) per RFC 4034 §5.3 — the owner name and record-type token belong
-	// to the table's domain/type context, not the value. Use ds.String()
-	// (RDATA presentation) rather than dane.FormatDSRecord, which would
-	// prefix "<owner> DS " onto the value.
-	dsStr := ds.String()
-	return []Record{{
-		Type:  "DS",
-		Value: dsStr,
-	}}, nil
+	return nil
 }
 
 func (p *HNSProvider) buildDelegated(zoneName string, nsRecords []string, tlsa string, cfg *HNSDelegationConfig) DelegationBundle {
@@ -413,7 +360,7 @@ func (p *HNSProvider) Nameservers() []string {
 // generated) are validated on NS visibility alone, since only the name owner
 // knows their own DNSKEY/DS.
 func (p *HNSProvider) VerifyDelegation(ctx context.Context, domain string,
-	delegationData json.RawMessage) (bool, error) {
+	expectedDS string) (bool, error) {
 
 	if p.resolverAddr == "" {
 		return false, fmt.Errorf("HNS resolver not configured (DnsConfig.HNSResolver); standard resolvers cannot resolve HNS names")
@@ -448,10 +395,12 @@ func (p *HNSProvider) VerifyDelegation(ctx context.Context, domain string,
 		return false, nil
 	}
 
-	// Platform-generated DS: if the stored delegation carries a DS record the
-	// portal computed (managed/PowerDNS-signed zone), require that exact DS to
-	// be served by the parent zone before considering the delegation live.
-	expectedDS := delegationExpectedDS(delegationData)
+	// Platform-generated DS: when the caller supplies the live DS the portal
+	// computed for the PowerDNS-signed zone (see GetActiveDNSSECDS), require
+	// that exact DS to be served by the parent zone before considering the
+	// delegation live. An empty expectedDS means a self-managed zone (the name
+	// owner publishes their own DNSKEY/DS, which the portal cannot know), so NS
+	// visibility is sufficient.
 	if expectedDS == "" {
 		// Self-managed zone: the name owner publishes a DS from their own
 		// DNSKEY, which the portal cannot know. NS visibility is sufficient.
@@ -471,27 +420,6 @@ func (p *HNSProvider) VerifyDelegation(ctx context.Context, domain string,
 		}
 	}
 	return false, nil
-}
-
-// delegationExpectedDS extracts the platform-generated DS value (RDATA, e.g.
-// "44451 13 2 c359...") from a stored delegation bundle, or "" when the
-// portal did not generate a DS (self-managed zone).
-func delegationExpectedDS(delegationData json.RawMessage) string {
-	var bundle DelegationBundle
-	if len(delegationData) > 0 {
-		_ = json.Unmarshal(delegationData, &bundle)
-	}
-	for _, rec := range bundle.ParentRecords {
-		if rec.Type == "DS" && rec.Value != "" {
-			// DS values may carry a leading owner/token from older persisted
-			// data ("<owner> DS <rdata>"); normalize to RDATA.
-			if idx := strings.Index(rec.Value, " DS "); idx >= 0 {
-				return rec.Value[idx+len(" DS "):]
-			}
-			return rec.Value
-		}
-	}
-	return ""
 }
 
 // dsEqual compares two DS RDATA presentation strings ignoring the leading

--- a/internal/service/domain/hns_provider_test.go
+++ b/internal/service/domain/hns_provider_test.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"net"
-	"strconv"
-	"strings"
 	"testing"
 	"time"
 
@@ -185,8 +183,7 @@ func TestHNSProvider_SynthName_FromDaneLib(t *testing.T) {
 	assert.Contains(t, name, "x") // current lib convention from dane/hns
 }
 
-// fakeDNSZoneService is a minimal DNSZoneService stub for enabling DNSSEC with
-// a fixed DNSKEY, so enableDNSSECAndDS can be exercised deterministically.
+// fakeDNSZoneService is a minimal DNSZoneService stub for enabling DNSSEC.
 type fakeDNSZoneService struct{ dnskey string }
 
 func (f *fakeDNSZoneService) CreateZone(ctx context.Context, domain string, userID uint) (*pluginDb.DNSZone, error) {
@@ -205,31 +202,27 @@ func (f *fakeDNSZoneService) SetTLSARecord(ctx context.Context, zoneID uint, con
 func (f *fakeDNSZoneService) EnableDNSSEC(ctx context.Context, zoneID uint) (string, error) {
 	return f.dnskey, nil
 }
+func (f *fakeDNSZoneService) GetActiveDNSSECDS(ctx context.Context, zoneID uint) (string, error) {
+	// DS is no longer computed/stored by the provider; tests that need a live DS
+	// set it explicitly. Return empty (self-managed / no DS) by default.
+	return "", nil
+}
 
-func TestHNSProvider_enableDNSSECAndDS_ValueIsRDATAOnly(t *testing.T) {
-	// Regression: the DS parent record VALUE must carry only the RDATA
-	// (key tag, algorithm, digest type, digest) — never the owner name or the
-	// "DS" record-type token (RFC 4034 §5.3). Previously dane.FormatDSRecord
-	// was used, which prefixes "<owner> DS " onto the value.
-	p := NewHNSProvider("", []string{"ns1.example.com."}, TLSASource{})
+func TestHNSProvider_BuildDelegation_NoDSRecord(t *testing.T) {
+	// Regression: the delegation bundle must NOT carry a DS record in
+	// parent_records. The DS is a derivative of the live PowerDNS signing key
+	// and is computed on the fly (GetActiveDNSSECDS / dns-requirements), never
+	// persisted — so it cannot go stale on key rotation.
+	p := NewHNSProvider("", []string{"ns1.lumeweb.", "ns2.lumeweb."}, TLSASource{})
 	p.SetDNSService(&fakeDNSZoneService{dnskey: "257 3 13 dGVzdA=="})
 
-	records, err := p.enableDNSSECAndDS(context.Background(), 1, "example")
+	result, err := p.BuildDelegation(context.Background(), 1, "example", &pluginDb.Website{}, nil)
 	require.NoError(t, err)
-	require.Len(t, records, 1)
-	assert.Equal(t, "DS", records[0].Type)
 
-	v := records[0].Value
-	fields := strings.Fields(v)
-	assert.Len(t, fields, 4, "DS value must have exactly 4 RDATA fields: keytag, alg, digesttype, digest")
+	bundle, ok := result.(DelegationBundle)
+	require.True(t, ok, "expected DelegationBundle, got %T", result)
 
-	// First three fields are numeric (key tag, algorithm, digest type).
-	for _, f := range fields[:3] {
-		_, err := strconv.ParseUint(f, 10, 16) // key tag fits in u16; alg/digesttype smaller
-		assert.NoError(t, err, "field %q should be a number", f)
+	for _, rec := range bundle.ParentRecords {
+		assert.NotEqual(t, "DS", rec.Type, "delegation bundle must not persist a DS record")
 	}
-	// Digest field is non-empty hex (no owner/type tokens).
-	assert.NotEmpty(t, fields[3])
-	assert.NotContains(t, v, " DS ", "record-type token must not leak into the value")
-	assert.NotContains(t, v, "example", "owner name must not leak into the value")
 }

--- a/internal/service/domain/hns_resolver_integration_test.go
+++ b/internal/service/domain/hns_resolver_integration_test.go
@@ -2,7 +2,6 @@ package domain
 
 import (
 	"context"
-	"encoding/json"
 	"net"
 	"strconv"
 	"strings"
@@ -153,7 +152,7 @@ func TestHNSProvider_VerifyDelegation_UsesCustomPortResolver(t *testing.T) {
 	p := NewHNSProvider(addr, []string{"ns1.lumeweb.", "ns2.lumeweb."}, TLSASource{})
 
 	before := served.value()
-	verified, err := p.VerifyDelegation(context.Background(), "lumeweb", json.RawMessage(`{}`))
+	verified, err := p.VerifyDelegation(context.Background(), "lumeweb", "")
 	require.NoError(t, err)
 	assert.True(t, verified, "delegation should verify when NS records match")
 
@@ -173,7 +172,7 @@ func TestHNSProvider_VerifyDelegation_CustomPort_NSMismatch(t *testing.T) {
 	p := NewHNSProvider(addr, []string{"ns1.lumeweb.", "ns2.lumeweb."}, TLSASource{})
 
 	before := served.value()
-	verified, err := p.VerifyDelegation(context.Background(), "lumeweb", json.RawMessage(`{}`))
+	verified, err := p.VerifyDelegation(context.Background(), "lumeweb", "")
 	require.NoError(t, err)
 	assert.False(t, verified, "delegation must not verify when returned NS do not match")
 	assert.Greater(t, served.value(), before, "custom-port resolver must have been queried even on mismatch")
@@ -182,7 +181,7 @@ func TestHNSProvider_VerifyDelegation_CustomPort_NSMismatch(t *testing.T) {
 func TestHNSProvider_VerifyDelegation_NoResolverConfigured(t *testing.T) {
 	p := NewHNSProvider("", []string{"ns1.lumeweb.", "ns2.lumeweb."}, TLSASource{})
 
-	_, err := p.VerifyDelegation(context.Background(), "lumeweb", json.RawMessage(`{}`))
+	_, err := p.VerifyDelegation(context.Background(), "lumeweb", "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "HNS resolver not configured")
 }
@@ -198,7 +197,7 @@ func TestHNSProvider_VerifyDelegation_CustomPort_ErrorStillProvesDial(t *testing
 	p := NewHNSProvider(addr, []string{"ns1.lumeweb.", "ns2.lumeweb."}, TLSASource{})
 
 	before := served.value()
-	valid, err := p.VerifyDelegation(context.Background(), "lumeweb", json.RawMessage(`{}`))
+	valid, err := p.VerifyDelegation(context.Background(), "lumeweb", "")
 	t.Logf("VerifyDelegation valid=%v err=%v customPort=%s served=%d", valid, err, addr, served.value())
 
 	// The custom-port resolver was queried during VerifyDelegation regardless
@@ -281,7 +280,7 @@ func TestHNSProvider_VerifyDelegation_TruncatedUDP_TCPRetryFails(t *testing.T) {
 
 	p := NewHNSProvider(addr, []string{ns1, ns2}, TLSASource{})
 
-	verified, err := p.VerifyDelegation(context.Background(), "lumeweb", json.RawMessage(`{}`))
+	verified, err := p.VerifyDelegation(context.Background(), "lumeweb", "")
 	require.Error(t, err,
 		"must not silently succeed on truncated UDP data when the TCP retry fails")
 	assert.Contains(t, err.Error(), "TCP retry after UDP truncation failed",
@@ -303,7 +302,7 @@ func TestHNSProvider_VerifyDelegation_ErrorSurfacesActualResolverAddr(t *testing
 
 	p := NewHNSProvider(deadAddr, []string{"ns1.lumeweb.", "ns2.lumeweb."}, TLSASource{})
 
-	_, err = p.VerifyDelegation(context.Background(), "lumeweb", json.RawMessage(`{}`))
+	_, err = p.VerifyDelegation(context.Background(), "lumeweb", "")
 	require.Error(t, err)
 
 	// The wrapped error must name the custom resolver (host:port) so operators
@@ -329,17 +328,9 @@ func TestHNSProvider_VerifyDelegation_Managed_RequiresServedDS(t *testing.T) {
 
 	p := NewHNSProvider(addr, []string{"ns1.lumeweb.", "ns2.lumeweb."}, TLSASource{})
 
-	// Delegation data is the platform-generated bundle: it carries the DS the
-	// portal computed (managed zone).
-	managedDelegation := json.RawMessage(`{
-		"mode": "delegated",
-		"parent_records": [
-			{"type": "NS", "value": "ns1.lumeweb.,ns2.lumeweb."},
-			{"type": "DS", "value": "` + dsRdata + `"}
-		]
-	}`)
-
-	verified, err := p.VerifyDelegation(context.Background(), "lumeweb", managedDelegation)
+	// The expected DS is the live value of the portal's current PowerDNS
+	// signing key (computed on the fly, never persisted). Feed it in directly.
+	verified, err := p.VerifyDelegation(context.Background(), "lumeweb", dsRdata)
 	require.NoError(t, err)
 	assert.False(t, verified,
 		"managed zone must not verify before the portal's DS is served by the parent zone")
@@ -356,15 +347,8 @@ func TestHNSProvider_VerifyDelegation_Managed_VerifiedWhenDSServed(t *testing.T)
 
 	p := NewHNSProvider(addr, []string{"ns1.lumeweb.", "ns2.lumeweb."}, TLSASource{})
 
-	managedDelegation := json.RawMessage(`{
-		"mode": "delegated",
-		"parent_records": [
-			{"type": "NS", "value": "ns1.lumeweb.,ns2.lumeweb."},
-			{"type": "DS", "value": "` + dsRdata + `"}
-		]
-	}`)
-
-	verified, err := p.VerifyDelegation(context.Background(), "lumeweb", managedDelegation)
+	// Expected DS is fed in directly (live value, see VerifyDomain).
+	verified, err := p.VerifyDelegation(context.Background(), "lumeweb", dsRdata)
 	require.NoError(t, err)
 	assert.True(t, verified,
 		"managed zone must verify once NS delegation is visible AND the portal's DS is served")
@@ -379,33 +363,10 @@ func TestHNSProvider_VerifyDelegation_SelfManaged_NSOnly(t *testing.T) {
 	addr, _ := startCustomPortDNSServer(t, domain, []string{"ns1.lumeweb.", "ns2.lumeweb."})
 	p := NewHNSProvider(addr, []string{"ns1.lumeweb.", "ns2.lumeweb."}, TLSASource{})
 
-	// No parent DS record -> self-managed.
-	verified, err := p.VerifyDelegation(context.Background(), "lumeweb", json.RawMessage(`{
-		"mode": "delegated",
-		"parent_records": [{"type": "NS", "value": "ns1.lumeweb.,ns2.lumeweb."}]
-	}`))
+	// Empty expectedDS means self-managed (no portal-generated DS).
+	verified, err := p.VerifyDelegation(context.Background(), "lumeweb", "")
 	require.NoError(t, err)
 	assert.True(t, verified, "self-managed zone validates on NS visibility alone")
-}
-
-// delegationExpectedDS normalizes both plain RDATA and legacy
-// "<owner> DS <rdata>" persisted values down to the DS RDATA.
-func TestDelegationExpectedDS(t *testing.T) {
-	raw := json.RawMessage(`{
-		"parent_records": [
-			{"type": "NS", "value": "ns1.lumeweb."},
-			{"type": "DS", "value": "44451 13 2 cb6c0f5b"}
-		]
-	}`)
-	assert.Equal(t, "44451 13 2 cb6c0f5b", delegationExpectedDS(raw))
-
-	legacy := json.RawMessage(`{
-		"parent_records": [{"type": "DS", "value": "lumeweb. 3600 IN DS 44451 13 2 cb6c0f5b"}]
-	}`)
-	assert.Equal(t, "44451 13 2 cb6c0f5b", delegationExpectedDS(legacy))
-
-	assert.Equal(t, "", delegationExpectedDS(json.RawMessage(`{}`)))
-	assert.Equal(t, "", delegationExpectedDS(json.RawMessage(`{"parent_records":[]}`)))
 }
 
 // dsEqual must normalize case on both sides: the served digest is lowercased

--- a/internal/service/domain/icann_provider.go
+++ b/internal/service/domain/icann_provider.go
@@ -54,7 +54,7 @@ func (p *ICANNProvider) BuildDelegation(ctx context.Context, zoneID uint,
 }
 
 func (p *ICANNProvider) VerifyDelegation(ctx context.Context, domain string,
-	delegationData json.RawMessage) (bool, error) {
+	expectedDS string) (bool, error) {
 	// ICANN domains do not use an alt-root delegation step.
 	return true, nil
 }

--- a/internal/service/domain/icann_provider_test.go
+++ b/internal/service/domain/icann_provider_test.go
@@ -34,7 +34,8 @@ func TestICANNProvider_BuildDelegation(t *testing.T) {
 
 func TestICANNProvider_VerifyDelegation(t *testing.T) {
 	p := NewICANNProvider(nil)
-	verified, err := p.VerifyDelegation(context.Background(), "example.com", nil)
+	// ICANN ignores expectedDS entirely.
+	verified, err := p.VerifyDelegation(context.Background(), "example.com", "")
 	assert.NoError(t, err)
 	assert.True(t, verified)
 }

--- a/internal/service/domain/provider.go
+++ b/internal/service/domain/provider.go
@@ -13,7 +13,7 @@ type DomainProvider interface {
 	Protocol() string
 	Validate(domain string) error
 	BuildDelegation(ctx context.Context, zoneID uint, domain string, website *pluginDb.Website, config json.RawMessage) (any, error)
-	VerifyDelegation(ctx context.Context, domain string, delegationData json.RawMessage) (bool, error)
+	VerifyDelegation(ctx context.Context, domain string, expectedDS string) (bool, error)
 	// OnCertAvailable is called when a cert is pushed via /internal/dns/cert.
 	// Providers can use it to update TLSA in delegation data or trigger
 	// namespace-specific protocol updates. Can be nil-safe by returning nil.

--- a/internal/testing/mocks/MockDNSService.go
+++ b/internal/testing/mocks/MockDNSService.go
@@ -960,6 +960,72 @@ func (_c *MockDNSService_EnableDNSSEC_Call) RunAndReturn(run func(ctx context.Co
 	return _c
 }
 
+// GetActiveDNSSECDS provides a mock function for the type MockDNSService
+func (_mock *MockDNSService) GetActiveDNSSECDS(ctx context.Context, zoneID uint) (string, error) {
+	ret := _mock.Called(ctx, zoneID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetActiveDNSSECDS")
+	}
+
+	var r0 string
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uint) (string, error)); ok {
+		return returnFunc(ctx, zoneID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uint) string); ok {
+		r0 = returnFunc(ctx, zoneID)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, uint) error); ok {
+		r1 = returnFunc(ctx, zoneID)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockDNSService_GetActiveDNSSECDS_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetActiveDNSSECDS'
+type MockDNSService_GetActiveDNSSECDS_Call struct {
+	*mock.Call
+}
+
+// GetActiveDNSSECDS is a helper method to define mock.On call
+//   - ctx context.Context
+//   - zoneID uint
+func (_e *MockDNSService_Expecter) GetActiveDNSSECDS(ctx any, zoneID any) *MockDNSService_GetActiveDNSSECDS_Call {
+	return &MockDNSService_GetActiveDNSSECDS_Call{Call: _e.mock.On("GetActiveDNSSECDS", ctx, zoneID)}
+}
+
+func (_c *MockDNSService_GetActiveDNSSECDS_Call) Run(run func(ctx context.Context, zoneID uint)) *MockDNSService_GetActiveDNSSECDS_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 uint
+		if args[1] != nil {
+			arg1 = args[1].(uint)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockDNSService_GetActiveDNSSECDS_Call) Return(ds string, err error) *MockDNSService_GetActiveDNSSECDS_Call {
+	_c.Call.Return(ds, err)
+	return _c
+}
+
+func (_c *MockDNSService_GetActiveDNSSECDS_Call) RunAndReturn(run func(ctx context.Context, zoneID uint) (string, error)) *MockDNSService_GetActiveDNSSECDS_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetConfig provides a mock function for the type MockDNSService
 func (_mock *MockDNSService) GetConfig() (any, error) {
 	ret := _mock.Called()

--- a/internal/testing/mocks/MockDNSZoneService.go
+++ b/internal/testing/mocks/MockDNSZoneService.go
@@ -383,3 +383,69 @@ func (_c *MockDNSZoneService_EnableDNSSEC_Call) RunAndReturn(run func(ctx contex
 	_c.Call.Return(run)
 	return _c
 }
+
+// GetActiveDNSSECDS provides a mock function for the type MockDNSZoneService
+func (_mock *MockDNSZoneService) GetActiveDNSSECDS(ctx context.Context, zoneID uint) (string, error) {
+	ret := _mock.Called(ctx, zoneID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetActiveDNSSECDS")
+	}
+
+	var r0 string
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uint) (string, error)); ok {
+		return returnFunc(ctx, zoneID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uint) string); ok {
+		r0 = returnFunc(ctx, zoneID)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, uint) error); ok {
+		r1 = returnFunc(ctx, zoneID)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockDNSZoneService_GetActiveDNSSECDS_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetActiveDNSSECDS'
+type MockDNSZoneService_GetActiveDNSSECDS_Call struct {
+	*mock.Call
+}
+
+// GetActiveDNSSECDS is a helper method to define mock.On call
+//   - ctx context.Context
+//   - zoneID uint
+func (_e *MockDNSZoneService_Expecter) GetActiveDNSSECDS(ctx any, zoneID any) *MockDNSZoneService_GetActiveDNSSECDS_Call {
+	return &MockDNSZoneService_GetActiveDNSSECDS_Call{Call: _e.mock.On("GetActiveDNSSECDS", ctx, zoneID)}
+}
+
+func (_c *MockDNSZoneService_GetActiveDNSSECDS_Call) Run(run func(ctx context.Context, zoneID uint)) *MockDNSZoneService_GetActiveDNSSECDS_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 uint
+		if args[1] != nil {
+			arg1 = args[1].(uint)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockDNSZoneService_GetActiveDNSSECDS_Call) Return(ds string, err error) *MockDNSZoneService_GetActiveDNSSECDS_Call {
+	_c.Call.Return(ds, err)
+	return _c
+}
+
+func (_c *MockDNSZoneService_GetActiveDNSSECDS_Call) RunAndReturn(run func(ctx context.Context, zoneID uint) (string, error)) *MockDNSZoneService_GetActiveDNSSECDS_Call {
+	_c.Call.Return(run)
+	return _c
+}

--- a/internal/testing/mocks/MockDomainProvider.go
+++ b/internal/testing/mocks/MockDomainProvider.go
@@ -419,8 +419,8 @@ func (_c *MockDomainProvider_Validate_Call) RunAndReturn(run func(domain string)
 }
 
 // VerifyDelegation provides a mock function for the type MockDomainProvider
-func (_mock *MockDomainProvider) VerifyDelegation(ctx context.Context, domain string, delegationData json.RawMessage) (bool, error) {
-	ret := _mock.Called(ctx, domain, delegationData)
+func (_mock *MockDomainProvider) VerifyDelegation(ctx context.Context, domain string, expectedDS string) (bool, error) {
+	ret := _mock.Called(ctx, domain, expectedDS)
 
 	if len(ret) == 0 {
 		panic("no return value specified for VerifyDelegation")
@@ -428,16 +428,16 @@ func (_mock *MockDomainProvider) VerifyDelegation(ctx context.Context, domain st
 
 	var r0 bool
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, json.RawMessage) (bool, error)); ok {
-		return returnFunc(ctx, domain, delegationData)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) (bool, error)); ok {
+		return returnFunc(ctx, domain, expectedDS)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, json.RawMessage) bool); ok {
-		r0 = returnFunc(ctx, domain, delegationData)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) bool); ok {
+		r0 = returnFunc(ctx, domain, expectedDS)
 	} else {
 		r0 = ret.Get(0).(bool)
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, json.RawMessage) error); ok {
-		r1 = returnFunc(ctx, domain, delegationData)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = returnFunc(ctx, domain, expectedDS)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -452,12 +452,12 @@ type MockDomainProvider_VerifyDelegation_Call struct {
 // VerifyDelegation is a helper method to define mock.On call
 //   - ctx context.Context
 //   - domain string
-//   - delegationData json.RawMessage
-func (_e *MockDomainProvider_Expecter) VerifyDelegation(ctx any, domain any, delegationData any) *MockDomainProvider_VerifyDelegation_Call {
-	return &MockDomainProvider_VerifyDelegation_Call{Call: _e.mock.On("VerifyDelegation", ctx, domain, delegationData)}
+//   - expectedDS string
+func (_e *MockDomainProvider_Expecter) VerifyDelegation(ctx any, domain any, expectedDS any) *MockDomainProvider_VerifyDelegation_Call {
+	return &MockDomainProvider_VerifyDelegation_Call{Call: _e.mock.On("VerifyDelegation", ctx, domain, expectedDS)}
 }
 
-func (_c *MockDomainProvider_VerifyDelegation_Call) Run(run func(ctx context.Context, domain string, delegationData json.RawMessage)) *MockDomainProvider_VerifyDelegation_Call {
+func (_c *MockDomainProvider_VerifyDelegation_Call) Run(run func(ctx context.Context, domain string, expectedDS string)) *MockDomainProvider_VerifyDelegation_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -467,9 +467,9 @@ func (_c *MockDomainProvider_VerifyDelegation_Call) Run(run func(ctx context.Con
 		if args[1] != nil {
 			arg1 = args[1].(string)
 		}
-		var arg2 json.RawMessage
+		var arg2 string
 		if args[2] != nil {
-			arg2 = args[2].(json.RawMessage)
+			arg2 = args[2].(string)
 		}
 		run(
 			arg0,
@@ -485,7 +485,7 @@ func (_c *MockDomainProvider_VerifyDelegation_Call) Return(b bool, err error) *M
 	return _c
 }
 
-func (_c *MockDomainProvider_VerifyDelegation_Call) RunAndReturn(run func(ctx context.Context, domain string, delegationData json.RawMessage) (bool, error)) *MockDomainProvider_VerifyDelegation_Call {
+func (_c *MockDomainProvider_VerifyDelegation_Call) RunAndReturn(run func(ctx context.Context, domain string, expectedDS string) (bool, error)) *MockDomainProvider_VerifyDelegation_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
## What

Stop persisting the DNSSEC **DS record** in the portal DB and compute it **on the fly** from the live PowerDNS signing key instead.

The DS is a pure derivative of the zone's current active PowerDNS cryptokey. Persisting it in `WebsiteDomain.delegation_data` meant it went stale whenever the KSK was rotated — exactly what happened with `lumeweb` (the on-chain DS `60776 13 2 c3e8cac2...` matched no live key after the rollover, and `pinner websites domains dns-requirements` kept showing the stale value because nothing ever refreshed the stored `delegation_data`).

Aligns with the design principle that **protocol data should only store what it actually needs to**. The DS is always derivable from PowerDNS, so it's never persisted.

## Changes

- **`PowerDNSClient.GetActiveDNSKEYDS(zoneID)`** — reads the zone's current active signing key from PowerDNS and returns its SHA-256 DS RDATA (`"60776 13 2 <hex>"`). Reuses the existing idempotent cryptokey listing; returns `""` when DNSSEC isn't enabled, and **errors when multiple active keys exist** (in-progress rollover) so we never guess which key's DS is authoritative — mirroring the existing `EnableDNSSEC` guard.
- **`DNSService.GetActiveDNSSECDS(zoneID)`** (internal + `pluginCore.DNSService`) — service-level wrapper mapping a DB zone ID to its PowerDNS zone.
- **`BuildDelegation`** — no longer embeds a DS record in `parent_records`; it only ensures DNSSEC is enabled (`enableDNSSEC`). The delegation bundle is freed of the derived DS.
- **`VerifyDelegation(ctx, domain, expectedDS string)`** — interface change: the expected DS is now passed in (the live value) instead of being read out of stored `delegation_data`. `delegationData json.RawMessage` param dropped.
- **`VerifyDomain`** — computes the live DS from PowerDNS and passes it to `VerifyDelegation`. If the live DS can't be determined (rollover, PowerDNS unreachable), it degrades to **NS-only verification** (logs a warning) rather than failing the delegation check.
- **`dns-requirements` handler** — injects the live-computed DS into `parent_records` (replacing any stale stored DS entry) so `pinner websites domains dns-requirements <domain>` always shows the current key's DS.
- **DTO** — removed the now-dead first-class `DS` field on `DNSDelegation`; removed DS promotion from stored `parent_records` in `FromModel`; removed the now-dead `delegationExpectedDS`. The DS is carried only as a `parent_records` entry (the shape the CLI renders), never a separate field that could sit empty.

## Verification

- `go build ./...`, `go vet` clean on changed packages.
- `go test -race` green: `internal/service/domain`, `internal/service/dns`, `internal/api/dto` (with new tests: `GetActiveDNSKEYDS` single/multi/no-key, `sha256DSPresentation`, `BuildDelegation_NoDSRecord`, plus updated HNS/ICANN verify tests).

* `develop` <!-- branch-stack -->
  - **feat(dns): compute DS on the fly instead of persisting it** :point\_left:
