### PR TITLE
fix(domain): never serve a stored DS from delegation data

### DIFF
--- a/internal/api/dto/domain.go
+++ b/internal/api/dto/domain.go
@@ -37,6 +37,27 @@ type DNSDelegationRecord struct {
 	Address string `json:"address,omitempty"`
 }
 
+// removeStoredDS returns the records with any DS entry stripped out. A DS is
+// a derivative of the live PowerDNS signing key, never something that should
+// be served from persisted delegation data (stored DS goes stale on key
+// rotation). It is stripped at read time so no endpoint ever surfaces a
+// leftover/stale DS from the DB; dns-requirements injects the live one.
+func removeStoredDS(records []DNSDelegationRecord) []DNSDelegationRecord {
+	if len(records) == 0 {
+		return records
+	}
+	out := records[:0]
+	for _, r := range records {
+		if r.Type != "DS" {
+			out = append(out, r)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
 // DNSDelegation carries the namespace-specific records a user must publish to
 // complete domain delegation.
 //
@@ -180,13 +201,15 @@ func mapDNSDelegation(raw []byte) *DNSDelegation {
 
 		d := &DNSDelegation{
 			Mode:                 hns.Mode,
-			ParentRecords:        hns.ParentRecords,
+			ParentRecords:        removeStoredDS(hns.ParentRecords),
 			AuthoritativeRecords: hns.AuthoritativeRecords,
 		}
 		// The DS is carried as a parent_records entry, not as a first-class
 		// field: it is a derivative of the live PowerDNS signing key computed
-		// on the fly (API.domainDNSRequirements -> GetActiveDNSSECDS), and is
-		// never read back from stored delegation data.
+		// on the fly (API.domainDNSRequirements -> GetActiveDNSSECDS). Any DS
+		// persisted in the stored delegation data is a stale snapshot that went
+		// out of sync on key rotation, so it is stripped here and never served
+		// from storage — the live DS is injected fresh by dns-requirements.
 		return d
 	}
 

--- a/internal/api/dto/domain_test.go
+++ b/internal/api/dto/domain_test.go
@@ -10,8 +10,8 @@ import (
 )
 
 // TestDomainResponse_FromModel_HNS verifies a full HNS DelegationBundle is
-// projected into the typed DNSDelegation shape with the DS promoted to a
-// first-class field.
+// projected into the typed DNSDelegation shape with any stored DS entry
+// stripped (the DS is derived live, not served from persisted data).
 func TestDomainResponse_FromModel_HNS(t *testing.T) {
 	delegation := datatypes.JSONMap{
 		"mode": "delegated",
@@ -52,11 +52,12 @@ func TestDomainResponse_FromModel_HNS(t *testing.T) {
 
 	// No first-class DS field: the DS is a parent_records entry derived from
 	// the live PowerDNS key (computed on the fly in dns-requirements), never a
-	// stored/promoted value.
+	// stored/promoted value. A DS present in the stored delegation data is
+	// stale/leftover and is stripped at read time.
 	assert.NotContains(t, resp.Delegation.ParentRecords, "ds")
 
-	// Parent records preserved with type/ns/address.
-	require.Len(t, resp.Delegation.ParentRecords, 3)
+	// Parent records preserved (stored DS entry stripped); type/ns/address kept.
+	require.Len(t, resp.Delegation.ParentRecords, 2)
 	assert.Equal(t, "NS", resp.Delegation.ParentRecords[0].Type)
 	assert.Equal(t, "GLUE4", resp.Delegation.ParentRecords[1].Type)
 	assert.Equal(t, "ns1.lumeweb.", resp.Delegation.ParentRecords[1].NS)


### PR DESCRIPTION
## What

Follow-up to #883 (compute DS on the fly). The DS is a derivative of the live PowerDNS signing key and is injected fresh by `dns-requirements` — it has **no reason to be read back from persisted delegation data**. But `mapDNSDelegation` copied `parent_records` verbatim from the stored `DelegationData`, so a stale/leftover DS persisted in the DB (e.g. from before the earlier key rotation, or any historical sync) was surfaced by **every** domain endpoint (`get`/`list`/`verify`) that runs `FromModel` — not just `dns-requirements`.

That's the leftover-stale-data path: the DB already holds a DS that's wrong, and we were serving it because nothing stripped it at read time.

## Change

Strip any `DS` entry from `parent_records` in `FromModel` (new `removeStoredDS`) so *no endpoint* ever serves a stored DS from the DB. `dns-requirements` remains the single source that injects the **live** DS into the response on demand.

- `internal/api/dto/domain.go` — `mapDNSDelegation` now runs `removeStoredDS` over stored `parent_records`.
- `internal/api/dto/domain_test.go` — HNS test updated to assert the stored DS entry is stripped (parent\_records now 2, not 3).

## Why not just fix `dns-requirements`

The stale DS was leaking through `FromModel`, which is shared by get/list/verify. Patching only the `dns-requirements` handler left every other endpoint serving the wrong stored DS.

## Test

- `go build ./...`, `go vet ./internal/api/...` clean.
- `go test ./internal/api/dto/...` green (runs locally).
- `internal/api` package compiles; runtime blocked by pre-existing `rpc.proto` proto-registration panic (unrelated, CI exercises it).

* `develop` <!-- branch-stack -->
  - **fix(domain): never serve a stored DS from delegation data** :point\_left:

---

<!-- kody-pr-summary:start -->
## Summary

This pull request fixes a bug where stale DS (Delegation Signer) records stored in persisted delegation data could be served to users.

## Changes

### Problem
When a domain's PowerDNS signing key rotates, any DS record that was previously persisted in the delegation data becomes stale and out of sync with the live key. Previously, these stored DS records could be surfaced through API responses, potentially serving incorrect DNS delegation information.

### Fix
The changes introduce a `removeStoredDS` helper function that strips DS entries from parent records at read time. This ensures that:

1. **Never serve stale DS from storage**: Any DS record persisted in the delegation data is removed from API responses before being returned
2. **Live DS injection**: The correct, current DS record is always computed on-the-fly by the `dns-requirements` endpoint using the active PowerDNS signing key
3. **Consistent behavior**: The DS is no longer treated as stored data but as a live derivative of the current signing key

### Implementation Details
- Added the `removeStoredDS` function to filter out DS-type records from delegation responses
- Applied the filter to parent records during the mapping of delegation data in API responses
- Updated tests to verify that stored DS entries are stripped while preserving all other record types (NS, GLUE4, etc.)
<!-- kody-pr-summary:end -->