### PR TITLE
fix(dns): route zone nameserver provisioning/validation by namespace via interface

### DIFF
--- a/core/dns_nameserver.go
+++ b/core/dns_nameserver.go
@@ -1,6 +1,16 @@
 package core
 
-import "context"
+import (
+	"context"
+	"errors"
+)
+
+// ErrNoProviderForDomain is returned by a NameserverResolver.LiveNameservers
+// when no registered provider validates the given domain. Callers that fall
+// back to a default resolution path for unmatched domains (mirroring
+// NameserversFor's false return) can match this sentinel with errors.Is to
+// continue their fallback.
+var ErrNoProviderForDomain = errors.New("no provider validates domain")
 
 // NameserverResolver resolves per-namespace nameserver and delegation
 // behavior for a domain, so namespace-agnostic services (DNS zone
@@ -21,7 +31,9 @@ type NameserverResolver interface {
 
 	// LiveNameservers returns the live NS records currently served for the
 	// domain, resolved against the namespace-appropriate resolver (the HNS
-	// resolver for HNS domains, the system resolver otherwise). The caller
-	// compares these against NameserversFor to confirm delegation.
+	// resolver for HNS domains, the system resolver otherwise). It returns
+	// ErrNoProviderForDomain when no registered provider validates the
+	// domain. The caller compares these against NameserversFor to confirm
+	// delegation.
 	LiveNameservers(ctx context.Context, domain string) ([]string, error)
 }

--- a/core/dns_nameserver.go
+++ b/core/dns_nameserver.go
@@ -1,0 +1,27 @@
+package core
+
+import "context"
+
+// NameserverResolver resolves per-namespace nameserver and delegation
+// behavior for a domain, so namespace-agnostic services (DNS zone
+// provisioning and validation) can consult the right provider without
+// namespace branching. It is implemented by the domain provider registry,
+// which already distinguishes namespaces via their providers.
+//
+// Alt-root namespaces (e.g. HNS) resolve/validate their NS delegation
+// against an HNS-aware resolver and publish their own namespace
+// nameservers, which differ from ICANN's. Routing this through an interface
+// keeps the DNS zone service free of `if namespace == hns` style logic.
+type NameserverResolver interface {
+	// NameserversFor returns the nameservers to publish for the given
+	// domain's namespace (ICANN list for ICANN domains, HNS list for HNS
+	// domains). The second return is false when no provider matches the
+	// domain.
+	NameserversFor(domain string) ([]string, bool)
+
+	// LiveNameservers returns the live NS records currently served for the
+	// domain, resolved against the namespace-appropriate resolver (the HNS
+	// resolver for HNS domains, the system resolver otherwise). The caller
+	// compares these against NameserversFor to confirm delegation.
+	LiveNameservers(ctx context.Context, domain string) ([]string, error)
+}

--- a/internal/service/dns/dns_nameserver_resolver_test.go
+++ b/internal/service/dns/dns_nameserver_resolver_test.go
@@ -1,0 +1,86 @@
+package dns
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	pluginCore "go.lumeweb.com/portal-plugin-ipfs/core"
+	pluginConfig "go.lumeweb.com/portal-plugin-ipfs/internal/config"
+)
+
+// stubNameserverResolver records which domain it was asked about, so tests
+// can assert the DNS service delegates per-namespace routing to it.
+type stubNameserverResolver struct {
+	nsByDomain      map[string][]string
+	liveByDomain    map[string][]string
+	liveErrByDomain map[string]error
+}
+
+func (s *stubNameserverResolver) NameserversFor(domain string) ([]string, bool) {
+	ns, ok := s.nsByDomain[domain]
+	return ns, ok
+}
+
+func (s *stubNameserverResolver) LiveNameservers(ctx context.Context, domain string) ([]string, error) {
+	if err := s.liveErrByDomain[domain]; err != nil {
+		return nil, err
+	}
+	return s.liveByDomain[domain], nil
+}
+
+var _ pluginCore.NameserverResolver = (*stubNameserverResolver)(nil)
+
+func TestNameserversForDomain_UsesResolver(t *testing.T) {
+	resolver := &stubNameserverResolver{
+		nsByDomain: map[string][]string{
+			"example.com": {"ns1.icann.example.", "ns2.icann.example."},
+			"lumeweb":     {"ns1.lumeweb.", "ns2.lumeweb."},
+		},
+	}
+	svc := &DNSServiceDefault{nameserverResolver: resolver}
+
+	// HNS domain resolves to the HNS nameservers via the interface.
+	ns, err := svc.nameserversForDomain("lumeweb")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"ns1.lumeweb.", "ns2.lumeweb."}, ns)
+
+	// ICANN domain resolves to the ICANN nameservers via the interface.
+	ns, err = svc.nameserversForDomain("example.com")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"ns1.icann.example.", "ns2.icann.example."}, ns)
+}
+
+func TestNameserversForDomain_FallsBackToConfig(t *testing.T) {
+	// Without an injected resolver the DNS service falls back to the ICANN
+	// config nameservers, preserving prior behavior for deployments without
+	// the provider registry wired up.
+	svc := &DNSServiceDefault{
+		config: &pluginConfig.DnsConfig{Nameservers: []string{"ns1.icann.example."}},
+	}
+
+	ns, err := svc.nameserversForDomain("example.com")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"ns1.icann.example."}, ns)
+
+	svc.config.Nameservers = nil
+	_, err = svc.nameserversForDomain("example.com")
+	assert.ErrorContains(t, err, "no approved nameservers configured")
+}
+
+func TestLiveNameservers_DelegatesToResolver(t *testing.T) {
+	resolver := &stubNameserverResolver{
+		liveByDomain:    map[string][]string{"lumeweb": {"ns1.lumeweb."}},
+		liveErrByDomain: map[string]error{"broken": errors.New("resolver failed")},
+	}
+	svc := &DNSServiceDefault{nameserverResolver: resolver}
+
+	live, err := svc.liveNameservers(context.Background(), "lumeweb")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"ns1.lumeweb."}, live)
+
+	_, err = svc.liveNameservers(context.Background(), "broken")
+	assert.ErrorContains(t, err, "resolver failed")
+}

--- a/internal/service/dns/dns_nameserver_resolver_test.go
+++ b/internal/service/dns/dns_nameserver_resolver_test.go
@@ -3,12 +3,14 @@ package dns
 import (
 	"context"
 	"errors"
+	"net"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	pluginCore "go.lumeweb.com/portal-plugin-ipfs/core"
 	pluginConfig "go.lumeweb.com/portal-plugin-ipfs/internal/config"
+	"go.lumeweb.com/portal-plugin-ipfs/internal/testing/mocks"
 )
 
 // stubNameserverResolver records which domain it was asked about, so tests
@@ -83,4 +85,26 @@ func TestLiveNameservers_DelegatesToResolver(t *testing.T) {
 
 	_, err = svc.liveNameservers(context.Background(), "broken")
 	assert.ErrorContains(t, err, "resolver failed")
+}
+
+func TestLiveNameservers_FallsBackToLookup_OnNoProvider(t *testing.T) {
+	// When the resolver reports no provider for the domain
+	// (ErrNoProviderForDomain), liveNameservers must fall back to the default
+	// lookup so it stays consistent with nameserversForDomain (which also
+	// falls back to config nameservers for unmatched domains).
+	resolver := &stubNameserverResolver{
+		liveErrByDomain: map[string]error{"unmatched.example": pluginCore.ErrNoProviderForDomain},
+	}
+	lookup := mocks.NewMockDNSLookup(t)
+	lookup.EXPECT().LookupNS("unmatched.example").Return([]*net.NS{
+		{Host: "ns1.default.example."},
+	}, nil)
+	svc := &DNSServiceDefault{
+		nameserverResolver: resolver,
+		dnsLookup:          lookup,
+	}
+
+	live, err := svc.liveNameservers(context.Background(), "unmatched.example")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"ns1.default.example."}, live)
 }

--- a/internal/service/dns/dns_service.go
+++ b/internal/service/dns/dns_service.go
@@ -34,6 +34,10 @@ type DNSServiceOptions struct {
 	PowerDNSClient *PowerDNSClient
 	// DNSLookup is the DNS lookup implementation (for testing)
 	DNSLookup DNSLookup
+	// NameserverResolver resolves per-namespace nameservers and live NS
+	// resolution for a domain (HNS vs ICANN). When nil, the DNS service
+	// falls back to the ICANN config nameservers + the default lookup.
+	NameserverResolver pluginCore.NameserverResolver
 }
 
 // DNSServiceOption is a function that configures DNSServiceOptions
@@ -53,14 +57,25 @@ func WithDNSLookup(lookup DNSLookup) DNSServiceOption {
 	}
 }
 
+// WithNameserverResolver sets the per-namespace nameserver resolver for the
+// DNS service. It is implemented by the domain provider registry and lets the
+// DNS service provision/validate HNS and ICANN zones through the namespace
+// provider rather than hardcoding ICANN nameservers and the system resolver.
+func WithNameserverResolver(resolver pluginCore.NameserverResolver) DNSServiceOption {
+	return func(opts *DNSServiceOptions) {
+		opts.NameserverResolver = resolver
+	}
+}
+
 var _ pluginCore.DNSService = (*DNSServiceDefault)(nil)
 
 // DNSServiceDefault manages DNS zones and PowerDNS integration
 type DNSServiceDefault struct {
 	*core.BaseComponent
-	config     *pluginConfig.DnsConfig
-	pdnsClient *PowerDNSClient
-	dnsLookup  DNSLookup
+	config             *pluginConfig.DnsConfig
+	pdnsClient         *PowerDNSClient
+	dnsLookup          DNSLookup
+	nameserverResolver pluginCore.NameserverResolver
 }
 
 // GetDNSLookup returns the DNS lookup implementation (for testing)
@@ -71,6 +86,15 @@ func (s *DNSServiceDefault) GetDNSLookup() DNSLookup {
 // SetDNSLookup sets the DNS lookup implementation (for testing)
 func (s *DNSServiceDefault) SetDNSLookup(lookup DNSLookup) {
 	s.dnsLookup = lookup
+}
+
+// SetNameserverResolver injects the per-namespace nameserver resolver (the
+// domain provider registry). It is called by the domain service factory at
+// startup once the provider registry is built, letting the DNS service
+// provision/validate HNS zones through the HNS provider (nameservers +
+// resolver) instead of hardcoding ICANN config.
+func (s *DNSServiceDefault) SetNameserverResolver(resolver pluginCore.NameserverResolver) {
+	s.nameserverResolver = resolver
 }
 
 // NewDNSService creates a new DNS service
@@ -90,6 +114,7 @@ func NewDNSServiceWithOptions(options ...DNSServiceOption) (core.Service, []core
 		option(serviceOpts)
 	}
 	svc.dnsLookup = serviceOpts.DNSLookup
+	svc.nameserverResolver = serviceOpts.NameserverResolver
 
 	opts := core.ContextOptions(
 		core.ContextWithStartupFunc(func(ctx core.Context) error {

--- a/internal/service/dns/dns_service_zone.go
+++ b/internal/service/dns/dns_service_zone.go
@@ -2,11 +2,13 @@ package dns
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
 
 	"go.lumeweb.com/ipfs-sdk/dnsname"
+	pluginCore "go.lumeweb.com/portal-plugin-ipfs/core"
 	pluginDb "go.lumeweb.com/portal-plugin-ipfs/internal/db"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/dns/powerdns"
 	"go.lumeweb.com/portal/core"
@@ -42,11 +44,19 @@ func (s *DNSServiceDefault) nameserversForDomain(domain string) ([]string, error
 
 // liveNameservers returns the live NS records for a zone's domain, resolved
 // through the per-namespace resolver (HNS zones query the HNS-aware resolver,
-// ICANN zones the system resolver). Without an injected resolver it falls back
-// to the default (system) lookup.
+// ICANN zones the system resolver). When the resolver has no provider for the
+// domain (or none is injected) it falls back to the default (system) lookup,
+// mirroring nameserversForDomain's fallback so publication and validation stay
+// consistent for unmatched domains.
 func (s *DNSServiceDefault) liveNameservers(ctx context.Context, domain string) ([]string, error) {
 	if s.nameserverResolver != nil {
-		return s.nameserverResolver.LiveNameservers(ctx, domain)
+		nss, err := s.nameserverResolver.LiveNameservers(ctx, domain)
+		if err == nil {
+			return nss, nil
+		}
+		if !errors.Is(err, pluginCore.ErrNoProviderForDomain) {
+			return nil, err
+		}
 	}
 	nss, err := s.dnsLookup.LookupNS(domain)
 	if err != nil {

--- a/internal/service/dns/dns_service_zone.go
+++ b/internal/service/dns/dns_service_zone.go
@@ -19,6 +19,46 @@ import (
 // DNSLinkTarget represents a DNSLink target path
 type DNSLinkTarget string
 
+// nameserversForDomain returns the nameservers to publish for a zone's
+// domain. When a per-namespace resolver is injected it delegates to the
+// matching provider (HNS zones get the HNS nameservers, ICANN the ICANN
+// list); otherwise it falls back to the ICANN config nameservers, preserving
+// behavior for deployments without the provider resolver wired up.
+func (s *DNSServiceDefault) nameserversForDomain(domain string) ([]string, error) {
+	if s.nameserverResolver != nil {
+		if nss, ok := s.nameserverResolver.NameserversFor(domain); ok {
+			if len(nss) == 0 {
+				return nil, fmt.Errorf("no nameservers configured for domain %s", domain)
+			}
+			return nss, nil
+		}
+	}
+	nss := s.config.Nameservers
+	if len(nss) == 0 {
+		return nil, fmt.Errorf("no approved nameservers configured")
+	}
+	return nss, nil
+}
+
+// liveNameservers returns the live NS records for a zone's domain, resolved
+// through the per-namespace resolver (HNS zones query the HNS-aware resolver,
+// ICANN zones the system resolver). Without an injected resolver it falls back
+// to the default (system) lookup.
+func (s *DNSServiceDefault) liveNameservers(ctx context.Context, domain string) ([]string, error) {
+	if s.nameserverResolver != nil {
+		return s.nameserverResolver.LiveNameservers(ctx, domain)
+	}
+	nss, err := s.dnsLookup.LookupNS(domain)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]string, 0, len(nss))
+	for _, ns := range nss {
+		out = append(out, ns.Host)
+	}
+	return out, nil
+}
+
 // CreateZone creates a new DNS zone
 func (s *DNSServiceDefault) CreateZone(ctx context.Context, domain string, userID uint) (*pluginDb.DNSZone, error) {
 	ctx, span := core.TraceMethod(ctx, "DNSService.CreateZone")
@@ -51,9 +91,9 @@ func (s *DNSServiceDefault) CreateZone(ctx context.Context, domain string, userI
 		return nil, fmt.Errorf("DNS hosting not enabled")
 	}
 
-	nameservers := s.config.Nameservers
-	if len(nameservers) == 0 {
-		return nil, fmt.Errorf("no approved nameservers configured")
+	nameservers, err := s.nameserversForDomain(domain)
+	if err != nil {
+		return nil, err
 	}
 
 	zone, err := s.pdnsClient.CreateZone(ctx, domain, nameservers)
@@ -272,15 +312,16 @@ func (s *DNSServiceDefault) ValidateNameservers(ctx context.Context, zoneID uint
 		return false, fmt.Errorf("zone not found")
 	}
 
-	// Perform actual nameserver validation via DNS lookup
-	// Query DNS for the domain's nameservers and compare against approved nameservers
-	approvedNameservers := s.config.Nameservers
-	if len(approvedNameservers) == 0 {
-		return false, fmt.Errorf("no approved nameservers configured for validation")
+	// Resolve the approved nameservers and the live NS delegation for the
+	// zone's domain through the namespace provider. When no provider resolver
+	// is injected the DNS service falls back to the ICANN config nameservers
+	// and the default lookup, preserving prior behavior.
+	approvedNameservers, err := s.nameserversForDomain(zone.Domain)
+	if err != nil {
+		return false, err
 	}
 
-	// Lookup nameservers for the domain using DNS lookup interface
-	dnsNameservers, err := s.dnsLookup.LookupNS(zone.Domain)
+	liveNameservers, err := s.liveNameservers(ctx, zone.Domain)
 	if err != nil {
 		// Update check timestamp even on failure to prevent retry loops
 		zone.LastNameserverCheckAt = new(time.Now())
@@ -291,12 +332,12 @@ func (s *DNSServiceDefault) ValidateNameservers(ctx context.Context, zoneID uint
 	}
 
 	// Check if at least one approved nameserver is present in DNS response.
-	// net.LookupNS returns FQDNs with trailing dots (e.g. "ns1.example.com.")
-	// while config values typically lack them; dnsname.Equal folds both.
+	// Resolvers may return FQDNs with trailing dots (e.g. "ns1.example.com.")
+	// while approved values typically lack them; dnsname.Equal folds both.
 	valid := false
 	for _, approvedNS := range approvedNameservers {
-		for _, dnsNS := range dnsNameservers {
-			if dnsname.Equal(dnsNS.Host, approvedNS) {
+		for _, dnsNS := range liveNameservers {
+			if dnsname.Equal(dnsNS, approvedNS) {
 				valid = true
 				break
 			}
@@ -588,9 +629,9 @@ func (s *DNSServiceDefault) restoreSoftDeletedZone(ctx context.Context, zone *pl
 	}
 	var newPowerDNSZoneID string
 	if s.pdnsClient != nil {
-		nameservers := s.config.Nameservers
-		if len(nameservers) == 0 {
-			return fmt.Errorf("no approved nameservers configured")
+		nameservers, err := s.nameserversForDomain(domain)
+		if err != nil {
+			return err
 		}
 		pdnsZone, pdnsErr := s.pdnsClient.CreateZone(ctx, domain, nameservers)
 		if pdnsErr != nil {

--- a/internal/service/domain/delegated_domain_service.go
+++ b/internal/service/domain/delegated_domain_service.go
@@ -651,6 +651,15 @@ func NewDelegatedDomainServiceFactory() (core.Service, []core.ContextBuilderOpti
 			dns := core.GetService[pluginCore.DNSService](ctx, pluginCore.DNS_SERVICE)
 			if dns != nil {
 				hnsProv.SetDNSService(dns)
+				// Give the DNS service the per-namespace nameserver resolver
+				// (this registry) so it provisions/validates HNS zones via the
+				// HNS provider (nameservers + HNS resolver) rather than
+				// hardcoding ICANN nameservers and the system resolver.
+				if setter, ok := dns.(interface {
+					SetNameserverResolver(pluginCore.NameserverResolver)
+				}); ok {
+					setter.SetNameserverResolver(reg)
+				}
 			}
 			reg.Register(hnsProv)
 

--- a/internal/service/domain/hns_provider.go
+++ b/internal/service/domain/hns_provider.go
@@ -347,6 +347,22 @@ func (p *HNSProvider) Nameservers() []string {
 	return p.nsRecords
 }
 
+// LiveNameservers returns the NS records currently served for the HNS
+// domain, resolved against the configured HNS-aware resolver. HNS names are
+// visible only to an HNS-aware resolver (e.g. an hsd instance), not the
+// system default resolver. Uses the same raw miekg/dns query path as
+// VerifyDelegation so HSD referrals in the authority section are honored.
+func (p *HNSProvider) LiveNameservers(ctx context.Context, domain string) ([]string, error) {
+	if p.resolverAddr == "" {
+		return nil, fmt.Errorf("HNS resolver not configured (DnsConfig.HNSResolver); standard resolvers cannot resolve HNS names")
+	}
+	nss, err := queryNS(ctx, p.resolverAddr, dnsname.EnsureFQDN(domain))
+	if err != nil {
+		return nil, err
+	}
+	return nss, nil
+}
+
 // VerifyDelegation checks whether a HNS name's delegation is live via the
 // configured HNS resolver. HNS names are resolved against the Handshake
 // blockchain; this requires an HNS-aware resolver (not the system default).

--- a/internal/service/domain/icann_provider.go
+++ b/internal/service/domain/icann_provider.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
 	"strings"
 
 	pluginCore "go.lumeweb.com/portal-plugin-ipfs/core"
@@ -73,4 +74,19 @@ func (p *ICANNProvider) UsesManagedZoneTLSA() bool {
 // Nameservers returns the ICANN nameservers configured for the namespace.
 func (p *ICANNProvider) Nameservers() []string {
 	return p.nameservers
+}
+
+// LiveNameservers returns the NS records currently served for `domain`,
+// resolved against the system default resolver (ICANN names are visible to
+// standard resolvers). Returns the hostnames without trailing dots.
+func (p *ICANNProvider) LiveNameservers(ctx context.Context, domain string) ([]string, error) {
+	nss, err := net.LookupNS(domain)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]string, 0, len(nss))
+	for _, ns := range nss {
+		out = append(out, strings.TrimSuffix(ns.Host, "."))
+	}
+	return out, nil
 }

--- a/internal/service/domain/provider.go
+++ b/internal/service/domain/provider.go
@@ -3,7 +3,6 @@ package domain
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 
 	"github.com/samber/lo"
 	pluginCore "go.lumeweb.com/portal-plugin-ipfs/core"
@@ -98,11 +97,13 @@ func (r *Registry) NameserversFor(domain string) ([]string, bool) {
 }
 
 // LiveNameservers returns the live NS records for the domain resolved
-// against the matching provider's namespace-appropriate resolver.
+// against the matching provider's namespace-appropriate resolver. It returns
+// pluginCore.ErrNoProviderForDomain when no registered provider validates the
+// domain, so callers can fall back to a default resolution path.
 func (r *Registry) LiveNameservers(ctx context.Context, domain string) ([]string, error) {
 	prov := r.providerForDomain(domain)
 	if prov == nil {
-		return nil, fmt.Errorf("no provider validates domain %q", domain)
+		return nil, pluginCore.ErrNoProviderForDomain
 	}
 	return prov.LiveNameservers(ctx, domain)
 }

--- a/internal/service/domain/provider.go
+++ b/internal/service/domain/provider.go
@@ -3,6 +3,7 @@ package domain
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
 	"github.com/samber/lo"
 	pluginCore "go.lumeweb.com/portal-plugin-ipfs/core"
@@ -30,6 +31,12 @@ type DomainProvider interface {
 	// differ from ICANN's; these are operator-provided, not user-provided.
 	// Returns the namespace's nameservers, or nil/empty when none are set.
 	Nameservers() []string
+	// LiveNameservers returns the NS records currently served for `domain`,
+	// resolved against the namespace-appropriate resolver (an alt-root
+	// provider like HNS queries its HNS-aware resolver; ICANN uses the
+	// system default resolver). Used to validate that a zone's namespace
+	// delegation is live.
+	LiveNameservers(ctx context.Context, domain string) ([]string, error)
 	// ApexRecordType returns the DNS record type used for the zone apex.
 	// DNSSEC-signed alt-root providers (e.g. HNS) must return RecordTypeA so
 	// the apex is a real, signable RRset, which PowerDNS cannot provide for a
@@ -60,4 +67,42 @@ func (r *Registry) Get(namespace string) DomainProvider {
 
 func (r *Registry) Names() []string {
 	return lo.Keys(r.providers)
+}
+
+// providerForDomain returns the provider whose namespace accepts `domain`,
+// or nil when no registered provider validates it.
+func (r *Registry) providerForDomain(domain string) DomainProvider {
+	if r == nil {
+		return nil
+	}
+	for _, ns := range r.Names() {
+		prov := r.Get(ns)
+		if prov != nil && prov.Validate(domain) == nil {
+			return prov
+		}
+	}
+	return nil
+}
+
+var _ pluginCore.NameserverResolver = (*Registry)(nil)
+
+// NameserversFor returns the nameservers to publish for the given domain's
+// namespace by delegating to the matching provider. The second return is
+// false when no provider validates the domain.
+func (r *Registry) NameserversFor(domain string) ([]string, bool) {
+	prov := r.providerForDomain(domain)
+	if prov == nil {
+		return nil, false
+	}
+	return prov.Nameservers(), true
+}
+
+// LiveNameservers returns the live NS records for the domain resolved
+// against the matching provider's namespace-appropriate resolver.
+func (r *Registry) LiveNameservers(ctx context.Context, domain string) ([]string, error) {
+	prov := r.providerForDomain(domain)
+	if prov == nil {
+		return nil, fmt.Errorf("no provider validates domain %q", domain)
+	}
+	return prov.LiveNameservers(ctx, domain)
 }

--- a/internal/service/domain/provider_test.go
+++ b/internal/service/domain/provider_test.go
@@ -68,3 +68,34 @@ func TestICANNProvider_ApexRecordType(t *testing.T) {
 	p := NewICANNProvider(nil)
 	assert.Equal(t, pluginCore.RecordTypeALIAS, p.ApexRecordType())
 }
+
+func TestRegistry_NameserversFor(t *testing.T) {
+	r := NewRegistry()
+	r.Register(NewICANNProvider([]string{"ns1.icann.example.", "ns2.icann.example."}))
+	r.Register(NewHNSProvider("", []string{"ns1.hns.example"}, TLSASource{}))
+
+	ns, ok := r.NameserversFor("example.com")
+	assert.True(t, ok)
+	assert.Equal(t, []string{"ns1.icann.example.", "ns2.icann.example."}, ns)
+
+	ns, ok = r.NameserversFor("lumeweb")
+	assert.True(t, ok)
+	assert.Equal(t, []string{"ns1.hns.example"}, ns)
+}
+
+func TestRegistry_LiveNameservers_RoutesByNamespace(t *testing.T) {
+	// The DNS service routes NS resolution through the registry, which must
+	// delegate to the namespace-appropriate provider: HNS domains to the HNS
+	// provider (which requires the HNS-aware resolver, not the system one),
+	// ICANN domains to the ICANN provider.
+	r := NewRegistry()
+	r.Register(NewICANNProvider([]string{"ns1.icann.example."}))
+	r.Register(NewHNSProvider("", []string{"ns1.hns.example"}, TLSASource{}))
+
+	var _ pluginCore.NameserverResolver = r
+
+	// No HNS resolver configured -> HNS provider errors; proves the HNS
+	// domain did not fall through to the system resolver / ICANN provider.
+	_, err := r.LiveNameservers(t.Context(), "lumeweb")
+	assert.ErrorContains(t, err, "HNS resolver")
+}

--- a/internal/testing/mocks/MockDomainProvider.go
+++ b/internal/testing/mocks/MockDomainProvider.go
@@ -170,6 +170,74 @@ func (_c *MockDomainProvider_BuildDelegation_Call) RunAndReturn(run func(ctx con
 	return _c
 }
 
+// LiveNameservers provides a mock function for the type MockDomainProvider
+func (_mock *MockDomainProvider) LiveNameservers(ctx context.Context, domain string) ([]string, error) {
+	ret := _mock.Called(ctx, domain)
+
+	if len(ret) == 0 {
+		panic("no return value specified for LiveNameservers")
+	}
+
+	var r0 []string
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) ([]string, error)); ok {
+		return returnFunc(ctx, domain)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) []string); ok {
+		r0 = returnFunc(ctx, domain)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, domain)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockDomainProvider_LiveNameservers_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'LiveNameservers'
+type MockDomainProvider_LiveNameservers_Call struct {
+	*mock.Call
+}
+
+// LiveNameservers is a helper method to define mock.On call
+//   - ctx context.Context
+//   - domain string
+func (_e *MockDomainProvider_Expecter) LiveNameservers(ctx any, domain any) *MockDomainProvider_LiveNameservers_Call {
+	return &MockDomainProvider_LiveNameservers_Call{Call: _e.mock.On("LiveNameservers", ctx, domain)}
+}
+
+func (_c *MockDomainProvider_LiveNameservers_Call) Run(run func(ctx context.Context, domain string)) *MockDomainProvider_LiveNameservers_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockDomainProvider_LiveNameservers_Call) Return(strings []string, err error) *MockDomainProvider_LiveNameservers_Call {
+	_c.Call.Return(strings, err)
+	return _c
+}
+
+func (_c *MockDomainProvider_LiveNameservers_Call) RunAndReturn(run func(ctx context.Context, domain string) ([]string, error)) *MockDomainProvider_LiveNameservers_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Nameservers provides a mock function for the type MockDomainProvider
 func (_mock *MockDomainProvider) Nameservers() []string {
 	ret := _mock.Called()


### PR DESCRIPTION
Routes DNS zone nameserver provisioning and validation through the namespace provider interface instead of hardcoding ICANN nameservers + the system resolver.

## Problem

HNS zones (`lumeweb`, etc.) were:

- **created** with the ICANN nameservers (`config.Nameservers`) in `CreateZone`/`restoreSoftDeletedZone`, and
- **validated** via `net.LookupNS` (system resolver) against the ICANN approved list in `ValidateNameservers`/the janitor.

The system resolver is not HNS-aware and the approved list is ICANN-only, so HNS zones could never validate → stuck `pending_nameserver` → never `active` → no DS surfaced. The DNS zone service simply had no namespace awareness; it branched on nothing, it just assumed ICANN everywhere.

## Fix (interface, not `if ns`)

- New `NameserverResolver` seam in `core/` — `NameserversFor(domain)` + `LiveNameservers(ctx, domain)`.
- `DomainProvider` gains `LiveNameservers`: HNS → HNS-aware resolver (existing raw miekg/dns queryNS path); ICANN → system resolver.
- `Registry` implements `NameserverResolver`, resolving the provider by domain (`Validate`) and delegating.
- `DNSServiceDefault` consults the injected resolver for zone nameservers + NS validation in `CreateZone`, `ValidateNameservers`, `restoreSoftDeletedZone`.
- Domain service factory injects the registry into the DNS service at startup.
- No `if namespace == hns` branching in the DNS service — routing is polymorphic.
- Falls back to the ICANN config + default lookup when no resolver is injected, preserving existing deployments and tests.

## DS (point 2) — no change needed

`GetActiveDNSSECDS` is already namespace-agnostic and decoupled from zone validation status: it computes the DS live from the PowerDNS cryptokey regardless of `pending_nameserver`/`active`. Once zones provision correctly (point 1), the DS surfaces on its own. The chicken-and-egg (user needs the DS to complete validation) is already resolved by this design.

## Tests

- `TestRegistry_NameserversFor` / `TestRegistry_LiveNameservers_RoutesByNamespace` — provider routing by domain.
- `TestNameserversForDomain_UsesResolver` / `_FallsBackToConfig`, `TestLiveNameservers_DelegatesToResolver` — DNS-service delegation + fallback.
- Regenerated `MockDomainProvider` (mockery v3).

## Verified

- `go build ./...` clean
- `go vet` clean on dns/domain/core
- gofmt clean (my files)
- `go test -count=1 ./internal/service/dns/... ./internal/service/domain/...` green

Note: `go test ./...` reports failures in `internal/api`, `service/website`, `service/block`, `protocol/*`, etc. — these are a pre-existing protobuf namespace conflict (`rpc.proto` from libp2p-pubsub vs etcd) present on clean develop, unrelated to this change.

- `develop` <!-- branch-stack -->
  - **fix(dns): route zone nameserver provisioning/validation by namespace via interface** :point\_left:

***

<!-- kody-pr-summary:start -->

## Summary

This pull request refactors DNS zone nameserver provisioning and validation to route through a namespace-aware provider interface, eliminating hardcoded ICANN-specific logic and enabling proper support for alternative root namespaces (e.g., Handshake/HNS).

## Key Changes

### New Namespace-Aware Nameserver Resolution Interface

A new `NameserverResolver` interface was introduced in the core package, defining two methods:

- `NameserversFor(domain)` – returns the nameservers to publish for a given domain based on its namespace
- `LiveNameservers(ctx, domain)` – returns the live NS records currently served for the domain, resolved against the namespace-appropriate resolver

### Registry Implements the Interface

The domain provider `Registry` now implements `NameserverResolver`, automatically routing:

- **HNS domains** → to the HNS provider, which uses its HNS-aware resolver (not the system resolver)
- **ICANN domains** → to the ICANN provider, which uses the standard system resolver

### DNS Service Refactoring

The DNS service (`DNSServiceDefault`) now:

- Accepts an optional `NameserverResolver` via constructor option or setter injection
- Delegates nameserver selection and live NS resolution to the resolver when available
- Falls back to the existing ICANN config-based behavior when no resolver is injected (backward compatibility)

Key methods updated:

- `CreateZone` – now uses namespace-aware nameservers
- `ValidateNameservers` – resolves both approved and live nameservers through the namespace provider
- `restoreSoftDeletedZone` – uses namespace-aware nameservers when restoring zones

### Provider Implementation Details

- **HNS Provider**: New `LiveNameservers` method uses the configured HNS-aware resolver (via the same raw DNS query path as delegation verification) and errors clearly if no HNS resolver is configured
- **ICANN Provider**: New `LiveNameservers` method uses the standard system DNS lookup

### Wiring & Testing

- The domain service factory now injects the provider registry into the DNS service at startup
- Added unit tests covering namespace routing through the resolver, fallback behavior, and validation that HNS domains don't fall through to the system resolver
- Mock provider updated to support the new interface method

## Impact

This change enables correct DNS zone provisioning and validation for HNS (Handshake) domains, which require HNS-aware resolvers and publish namespace-specific nameservers, while preserving existing behavior for standard ICANN domains and deployments without the provider registry.

<!-- kody-pr-summary:end -->
