### PR TITLE
fix(dns): parse numeric PowerDNS cryptokey id (DS never rendered / verify 500)

### DIFF
--- a/internal/service/dns/powerdns_client.go
+++ b/internal/service/dns/powerdns_client.go
@@ -512,11 +512,15 @@ func sha256DSPresentation(dss []string) (string, error) {
 
 // cryptokey is a PowerDNS cryptokey object (subset of the API response).
 type cryptokey struct {
-	ID      string   `json:"id"`
-	KeyType string   `json:"keytype"`
-	Active  bool     `json:"active"`
-	DNSKey  string   `json:"dnskey"`
-	DS      []string `json:"ds"`
+	// ID is the PowerDNS cryptokey id. PowerDNS returns it as a JSON number;
+	// binding it as json.Number (rather than string) makes unmarshaling accept
+	// the numeric form the API actually sends while remaining tolerant if a
+	// version ever returns a quoted string.
+	ID      json.Number `json:"id"`
+	KeyType string      `json:"keytype"`
+	Active  bool        `json:"active"`
+	DNSKey  string      `json:"dnskey"`
+	DS      []string    `json:"ds"`
 }
 
 // listCryptokeys returns the zone's existing cryptokeys via

--- a/internal/service/dns/powerdns_client_test.go
+++ b/internal/service/dns/powerdns_client_test.go
@@ -1840,6 +1840,32 @@ func TestGetActiveDNSKEYDS(t *testing.T) {
 		}
 	})
 
+	t.Run("parses numeric id as PowerDNS actually returns", func(t *testing.T) {
+		// Regression: PowerDNS sends cryptokey id as a JSON number (not a
+		// quoted string). A struct whose ID field was typed string failed to
+		// unmarshal, breaking every cryptokey read (EnableDNSSEC, DS
+		// derivation) so the DS never rendered and verify 500'd.
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body := `[{"id":5,"keytype":"csk","active":true,"dnskey":"257 3 13 evH3XP==","ds":["60776 13 2 3b35deed97def5fbb5ce939cd5b9036f12db0ccc2e1cb40bb4c565c168c66116"]}]`
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(body))
+		}))
+		defer server.Close()
+		client, err := NewPowerDNSClient(server.URL, testAPIKey(), &core.Logger{Logger: zap.NewNop()})
+		if err != nil {
+			t.Fatalf("NewPowerDNSClient: %v", err)
+		}
+		ds, err := client.GetActiveDNSKEYDS(context.Background(), "lumeweb.")
+		if err != nil {
+			t.Fatalf("GetActiveDNSKEYDS with numeric id: %v", err)
+		}
+		want := "60776 13 2 3b35deed97def5fbb5ce939cd5b9036f12db0ccc2e1cb40bb4c565c168c66116"
+		if ds != want {
+			t.Errorf("expected %q, got %q", want, ds)
+		}
+	})
+
 	t.Run("no active signing key returns empty", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
## Root cause (confirmed via production portal logs — Grafana/Loki)

`DNSZone 8` (`lumeweb`, HNS) never rendered its DS and `verify` failed with 500. Portal logs showed the same error on every cryptokey read path:

```
json: cannot unmarshal number into Go struct field cryptokey.id of type string
```

**PowerDNS returns the cryptokey `id` as a JSON number; the Go struct typed the `ID` field as `string`.** Every call that lists an existing zone's cryptokeys failed to unmarshal:

- `EnableDNSSEC` → `listCryptokeys` → unmarshal error → key minting/reuse broken.
- `GetActiveDNSKEYDS` → derive the DS → unmarshal error → `dns-requirements` rendered no DS and `verify` 500'd (`resolve live DS for zone 8`).

An earlier `EnableDNSSEC` only "succeeded" when the cryptokey list was empty (nothing to unmarshal, so it POSTed a new key and logged `has_ds: true`) — after which the now-present key made every subsequent read fail.

## Fix

Bind `cryptokey.ID` as `json.Number` so unmarshaling accepts the numeric form PowerDNS actually sends, while staying tolerant of a quoted string. The field is never read as a string by logic, so the change is type-safe throughout.

## Tests

- New `TestGetActiveDNSKEYDS/parses numeric id as PowerDNS actually returns` — regression for the exact production payload.
- Existing string-id + enable/reuse/multi-key/concurrency tests all still pass.

## Verified

- `go build ./...`, `go vet`, gofmt clean
- `go test -count=1 ./internal/service/dns/... ./internal/service/domain/...` green

* `develop` <!-- branch-stack -->
  - **fix(dns): parse numeric PowerDNS cryptokey id (DS never rendered / verify 500)** :point\_left:

---

<!-- kody-pr-summary:start -->
This pull request fixes a DNS-related bug where PowerDNS cryptokey IDs were not being parsed correctly, causing DS records to never render and verification requests to fail with a 500 error.

**Problem**: The PowerDNS API returns cryptokey IDs as JSON numbers (e.g., `"id": 5`), but the Go struct used a `string` type for the ID field. This type mismatch caused JSON unmarshaling to fail, breaking all cryptokey read operations including DNSSEC enabling and DS derivation.

**Fix**: Changed the cryptokey ID field from `string` to `json.Number` type, which properly handles the numeric format that PowerDNS actually sends while remaining backwards-compatible if a future API version ever returns quoted strings.

**Changes include**:
- Updated the `cryptokey` struct in `powerdns_client.go` to use `json.Number` for the ID field
- Added a regression test in `powerdns_client_test.go` that verifies successful parsing of numeric cryptokey IDs and correct DS record extraction

This fix ensures that DS records are properly displayed and verification requests complete successfully when working with PowerDNS.
<!-- kody-pr-summary:end -->