### PR TITLE
feat(dns): surface DNSSEC state and self-heal DNSSEC/SOA on verify

### DIFF
--- a/core/dns.go
+++ b/core/dns.go
@@ -101,4 +101,14 @@ type DNSService interface {
 	// zone has no active signing key; errors when multiple active signing keys
 	// exist (in-progress rollover).
 	GetActiveDNSSECDS(ctx context.Context, zoneID uint) (ds string, err error)
+
+	// EnsureSOAMNAME idempotently corrects a zone's SOA MNAME to the primary
+	// authorized nameserver, no-op'ing when it is already correct. PowerDNS
+	// seeds freshly created zones with a placeholder MNAME that is only fixed
+	// on the fresh-create path; this lets verification re-ensure a portal
+	// managed zone's SOA points at the right authority, mirroring the DNSSEC
+	// self-heal. It is best-effort (the SOA MNAME is a secondary authoritative
+	// pointer; delegation is carried by the NS record), so callers must not
+	// treat an error here as a hard verification failure.
+	EnsureSOAMNAME(ctx context.Context, zoneID uint, domain string, nameservers []string) error
 }

--- a/internal/api/api_domains.go
+++ b/internal/api/api_domains.go
@@ -361,35 +361,42 @@ func (a *API) domainDNSRequirements(c echo.Context) error {
 	// The DS to publish is computed live from PowerDNS's current active signing
 	// key rather than read from stored delegation data (which would go stale on
 	// key rotation). Only portal-managed, DNSSEC-signed namespaces (e.g. HNS)
-	// yield a DS; ICANN domains have no parent DS and this is a no-op. The
-	// result of the live read is surfaced explicitly (DNSSEC enabled/disabled/
-	// error) so an absent DS is never a silent gap the user cannot diagnose.
-	// The live DS is injected into parent_records (which renderers draw from).
+	// yield a DS and report DNSSEC state; ICANN domains have no parent DS and
+	// no portal DNSSEC, so this is a no-op that omits the DNSSEC fields
+	// entirely (per the DTO contract) and only defends against a stale DS.
+	managed := a.delegatedDomainSvc != nil && a.delegatedDomainSvc.NamespaceUsesManagedZoneTLSA(string(wd.Namespace))
 	if resp.Delegation != nil && a.dnsService != nil {
-		ds, dsErr := a.dnsService.GetActiveDNSSECDS(reqCtx, wd.ZoneID)
-		switch {
-		case dsErr != nil:
-			// PowerDNS unavailable or a key rollover is in progress: the live
-			// DS cannot be resolved. Surface the error and drop any stored DS
-			// from parent_records so a stale value is never presented as
-			// current when there is no live DS to back it.
-			a.Logger().Warn("could not resolve live DS for dns-requirements",
-				zap.Uint("zone_id", wd.ZoneID), zap.Error(dsErr))
-			resp.Delegation.DNSSEC = "error"
-			resp.Delegation.DNSSECError = dsErr.Error()
-			resp.Delegation.ParentRecords = removeDSRecord(resp.Delegation.ParentRecords)
-		case ds != "":
-			// Active signing key present: DNSSEC is enabled and the live DS
-			// must be injected so CLI renderers show the current value.
-			resp.Delegation.DNSSEC = "enabled"
+		if managed {
+			ds, dsErr := a.dnsService.GetActiveDNSSECDS(reqCtx, wd.ZoneID)
+			switch {
+			case dsErr != nil:
+				// PowerDNS unavailable or a key rollover is in progress: the
+				// live DS cannot be resolved. Surface the error and drop any
+				// stored DS so a stale value is never presented as current.
+				a.Logger().Warn("could not resolve live DS for dns-requirements",
+					zap.Uint("zone_id", wd.ZoneID), zap.Error(dsErr))
+				resp.Delegation.DNSSEC = "error"
+				resp.Delegation.DNSSECError = dsErr.Error()
+				resp.Delegation.ParentRecords = removeDSRecord(resp.Delegation.ParentRecords)
+			case ds != "":
+				// Active signing key present: DNSSEC is enabled and the live
+				// DS must be injected so CLI renderers show the current value.
+				resp.Delegation.DNSSEC = "enabled"
+				resp.Delegation.DNSSECError = ""
+				resp.Delegation.ParentRecords = upsertDSRecord(resp.Delegation.ParentRecords, ds)
+			default:
+				// No active signing key (never enabled, or key rotated away).
+				// Surface "disabled" so the user knows DNSSEC isn't set up
+				// until a verify self-heal mints the key, not a bare missing DS.
+				resp.Delegation.DNSSEC = "disabled"
+				resp.Delegation.DNSSECError = "no active signing key - DNSSEC not enabled"
+				resp.Delegation.ParentRecords = removeDSRecord(resp.Delegation.ParentRecords)
+			}
+		} else {
+			// Not a portal-DNSSEC namespace (e.g. ICANN): omit the DNSSEC
+			// fields and ensure no stale DS leaks into parent_records.
+			resp.Delegation.DNSSEC = ""
 			resp.Delegation.DNSSECError = ""
-			resp.Delegation.ParentRecords = upsertDSRecord(resp.Delegation.ParentRecords, ds)
-		default:
-			// No active signing key (never enabled, or a key was rotated away).
-			// Surface "disabled" so the user knows DNSSEC isn't set up until a
-			// verify self-heal mints the key, instead of a bare missing DS.
-			resp.Delegation.DNSSEC = "disabled"
-			resp.Delegation.DNSSECError = "no active signing key - DNSSEC not enabled"
 			resp.Delegation.ParentRecords = removeDSRecord(resp.Delegation.ParentRecords)
 		}
 	}

--- a/internal/api/api_domains.go
+++ b/internal/api/api_domains.go
@@ -361,27 +361,35 @@ func (a *API) domainDNSRequirements(c echo.Context) error {
 	// The DS to publish is computed live from PowerDNS's current active signing
 	// key rather than read from stored delegation data (which would go stale on
 	// key rotation). Only portal-managed, DNSSEC-signed namespaces (e.g. HNS)
-	// yield a DS; ICANN domains have no parent DS and this is a no-op. The live
-	// DS is injected into parent_records (which renderers draw from); there is
-	// no separate DS field that could otherwise sit empty.
+	// yield a DS; ICANN domains have no parent DS and this is a no-op. The
+	// result of the live read is surfaced explicitly (DNSSEC enabled/disabled/
+	// error) so an absent DS is never a silent gap the user cannot diagnose.
+	// The live DS is injected into parent_records (which renderers draw from).
 	if resp.Delegation != nil && a.dnsService != nil {
 		ds, dsErr := a.dnsService.GetActiveDNSSECDS(reqCtx, wd.ZoneID)
-		if dsErr != nil {
+		switch {
+		case dsErr != nil:
 			// PowerDNS unavailable or a key rollover is in progress: the live
-			// DS cannot be resolved. Log it and drop any stored DS from
-			// parent_records so a stale value is never presented as current.
+			// DS cannot be resolved. Surface the error and drop any stored DS
+			// from parent_records so a stale value is never presented as
+			// current when there is no live DS to back it.
 			a.Logger().Warn("could not resolve live DS for dns-requirements",
 				zap.Uint("zone_id", wd.ZoneID), zap.Error(dsErr))
+			resp.Delegation.DNSSEC = "error"
+			resp.Delegation.DNSSECError = dsErr.Error()
 			resp.Delegation.ParentRecords = removeDSRecord(resp.Delegation.ParentRecords)
-		} else if ds != "" {
-			// Ensure the rendered parent_records carries the live DS so CLI
-			// renderers that draw from parent_records show the current value
-			// (replace any stale stored DS entry, else append).
+		case ds != "":
+			// Active signing key present: DNSSEC is enabled and the live DS
+			// must be injected so CLI renderers show the current value.
+			resp.Delegation.DNSSEC = "enabled"
+			resp.Delegation.DNSSECError = ""
 			resp.Delegation.ParentRecords = upsertDSRecord(resp.Delegation.ParentRecords, ds)
-		} else {
-			// Zone has no active signing key (e.g. after a key was rotated or
-			// removed): drop any stored DS so a stale value is never presented
-			// as current when there is no live DS to back it.
+		default:
+			// No active signing key (never enabled, or a key was rotated away).
+			// Surface "disabled" so the user knows DNSSEC isn't set up until a
+			// verify self-heal mints the key, instead of a bare missing DS.
+			resp.Delegation.DNSSEC = "disabled"
+			resp.Delegation.DNSSECError = "no active signing key - DNSSEC not enabled"
 			resp.Delegation.ParentRecords = removeDSRecord(resp.Delegation.ParentRecords)
 		}
 	}

--- a/internal/api/api_domains_test.go
+++ b/internal/api/api_domains_test.go
@@ -145,6 +145,10 @@ func TestAPI_DomainDNSRequirements(t *testing.T) {
 			dsRec := resp.Delegation.ParentRecords[1]
 			assert.Equal(t, "DS", dsRec.Type)
 			assert.Equal(t, "60776 13 2 3b35deed97def5fbb5ce939cd5b9036f12db0ccc2e1cb40bb4c565c168c66116", dsRec.Value)
+			// Active signing key means DNSSEC is explicitly reported as enabled,
+			// so an enabled zone is never a silent gap.
+			assert.Equal(t, "enabled", resp.Delegation.DNSSEC)
+			assert.Empty(t, resp.Delegation.DNSSECError)
 		}, TestOptions)
 	})
 
@@ -194,6 +198,10 @@ func TestAPI_DomainDNSRequirements(t *testing.T) {
 			// correctness cannot be confirmed is never presented as current.
 			require.Len(t, resp.Delegation.ParentRecords, 1)
 			assert.Equal(t, "NS", resp.Delegation.ParentRecords[0].Type)
+			// Resolution error is surfaced explicitly so the user can diagnose
+			// (PowerDNS down / key rollover) rather than see a bare missing DS.
+			assert.Equal(t, "error", resp.Delegation.DNSSEC)
+			assert.Contains(t, resp.Delegation.DNSSECError, "PowerDNS unreachable")
 		}, TestOptions)
 	})
 
@@ -243,6 +251,11 @@ func TestAPI_DomainDNSRequirements(t *testing.T) {
 			// No live signing key: stale DS must be removed, not presented.
 			require.Len(t, resp.Delegation.ParentRecords, 1)
 			assert.Equal(t, "NS", resp.Delegation.ParentRecords[0].Type)
+			// "No active key" on a managed zone is surfaced as disabled (not
+			// silent), telling the user DNSSEC isn't set up yet — the verify
+			// self-heal will mint the key on the next run.
+			assert.Equal(t, "disabled", resp.Delegation.DNSSEC)
+			assert.Contains(t, resp.Delegation.DNSSECError, "no active signing key")
 		}, TestOptions)
 	})
 

--- a/internal/api/api_domains_test.go
+++ b/internal/api/api_domains_test.go
@@ -268,8 +268,49 @@ func TestAPI_DomainDNSRequirements(t *testing.T) {
 			assert.Equal(t, http.StatusNotFound, rec.Code)
 		}, TestOptions)
 	})
-}
 
+	// ICANN namespaces are not portal-managed for DNSSEC: the DNSSEC fields
+	// must be omitted entirely (per the DTO contract) even when no active key
+	// exists, so the block is gated on NamespaceUsesManagedZoneTLSA — not on
+	// the presence of a key.
+	t.Run("icann_omits_dnssec_fields", func(t *testing.T) {
+		coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+			helper := newMockHelper(t, ctx)
+			token, userID, testCID, _ := helper.SetupAuthenticatedTest()
+
+			website := createTestIPFSGatewayWebsite(1, userID, "example.com", testCID, pluginDb.WebsiteStatusActive)
+			require.NoError(t, ctx.DB().Create(website).Error)
+
+			wd := &pluginDb.WebsiteDomain{
+				WebsiteID: 1, UserID: userID, Domain: "example.com",
+				Namespace:   pluginDb.DomainNamespaceICANN,
+				Status:      pluginDb.DomainStatusRecordsGenerated,
+				ZoneName:    "example.com.",
+				GatewayHost: "gateway.lumeweb.com",
+				DelegationData: datatypes.JSONMap{
+					"mode": "delegated",
+					"parent_records": []map[string]any{
+						{"type": "NS", "value": "ns1.example.com."},
+					},
+				},
+			}
+			require.NoError(t, ctx.DB().Create(wd).Error)
+
+			rec := helper.makeAuthenticatedRequest(http.MethodGet, "/api/websites/1/domains/1/dns-requirements", token, nil)
+			require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+
+			var resp dto.DomainResponse
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+			require.NotNil(t, resp.Delegation)
+			// ICANN: DNSSEC fields omitted (empty => omitempty drops them).
+			assert.Empty(t, resp.Delegation.DNSSEC)
+			assert.Empty(t, resp.Delegation.DNSSECError)
+			// Parent NS record retained.
+			require.Len(t, resp.Delegation.ParentRecords, 1)
+			assert.Equal(t, "NS", resp.Delegation.ParentRecords[0].Type)
+		}, TestOptions)
+	})
+}
 func TestAPI_DANERepublish(t *testing.T) {
 	republishPath := func(websiteID, domainID int) string {
 		return fmt.Sprintf("/api/websites/%d/domains/%d/dane/republish", websiteID, domainID)

--- a/internal/api/dto/domain.go
+++ b/internal/api/dto/domain.go
@@ -96,6 +96,15 @@ type DNSDelegation struct {
 	Nameservers          []string              `json:"nameservers,omitempty"`
 	ParentRecords        []DNSDelegationRecord `json:"parent_records,omitempty"`
 	AuthoritativeRecords []DNSDelegationRecord `json:"authoritative_records,omitempty"`
+	// DNSSEC reports the portal-managed DNSSEC signing state for a
+	// DNSSEC-signed namespace (e.g. HNS): "enabled" when the zone has an
+	// active signing key (the DS injected into parent_records derives from
+	// it), "disabled" when the zone is not DNSSEC-signed (ICANN or no key),
+	// and "error" when enablement/readback failed (details in DNSSECError).
+	// Populated by dns-requirements for portal-managed namespaces so an
+	// absent DS is never silent. ICANN namespaces omit it (no portal DNSSEC).
+	DNSSEC      string `json:"dnssec,omitempty"`
+	DNSSECError string `json:"dnssec_error,omitempty"`
 }
 
 // DomainResponse is a bound domain.

--- a/internal/service/dns/dns_service.go
+++ b/internal/service/dns/dns_service.go
@@ -283,3 +283,51 @@ func (s *DNSServiceDefault) GetActiveDNSSECDS(ctx context.Context, zoneID uint) 
 	}
 	return ds, nil
 }
+
+// EnsureSOAMNAME idempotently corrects a zone's SOA MNAME to the primary
+// authorized nameserver, no-op'ing when it is already correct. It is the
+// verify-time self-heal counterpart to the fresh-create MNAME fix: PowerDNS
+// seeds new zones with a placeholder MNAME that is only corrected once at
+// create, so a zone that slipped past that (or whose MNAME drifted) would
+// otherwise keep the placeholder forever. Verification re-ensures it for
+// portal-managed zones.
+//
+// It is deliberately best-effort: the SOA MNAME is a secondary authoritative
+// pointer (delegation is carried by the NS record whose primary we set), so an
+// error here is logged and returned but callers should not hard-fail
+// verification over it. No nameservers is a no-op (nil), matching the client.
+func (s *DNSServiceDefault) EnsureSOAMNAME(ctx context.Context, zoneID uint, domain string, nameservers []string) error {
+	if s.pdnsClient == nil {
+		return fmt.Errorf("PowerDNS client not configured")
+	}
+	if len(nameservers) == 0 || nameservers[0] == "" {
+		// No nameserver to use as the MNAME; nothing to correct.
+		return nil
+	}
+
+	var pdnsZoneID string
+	txErr := s.DB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var zone pluginDb.DNSZone
+		if err := tx.First(&zone, zoneID).Error; err != nil {
+			return err
+		}
+		if zone.PowerDNSZoneID == "" {
+			return fmt.Errorf("zone %d has no PowerDNS zone ID", zoneID)
+		}
+		pdnsZoneID = zone.PowerDNSZoneID
+		return nil
+	})
+	if txErr != nil {
+		return txErr
+	}
+
+	if err := s.pdnsClient.EnsureSOAMNAME(ctx, pdnsZoneID, domain, nameservers); err != nil {
+		s.Logger().Warn("Failed to ensure SOA MNAME (best-effort)",
+			zap.Uint("zone_id", zoneID),
+			zap.String("pdns_zone_id", pdnsZoneID),
+			zap.String("domain", domain),
+			zap.Error(err))
+		return fmt.Errorf("ensure SOA MNAME: %w", err)
+	}
+	return nil
+}

--- a/internal/service/dns/powerdns_client.go
+++ b/internal/service/dns/powerdns_client.go
@@ -206,6 +206,17 @@ func (c *PowerDNSClient) fixSOAMNAME(ctx context.Context, zoneID, domain string,
 	return c.fixSOAMNAMEOnZone(ctx, zoneID, domain, mname, zone)
 }
 
+// EnsureSOAMNAME idempotently corrects a zone's SOA MNAME to the primary
+// authorized nameserver. It is a public re-usable form of fixSOAMNAME for the
+// verify-time self-heal path: unlike the fresh-create call (which is only safe
+// because we just created the zone and know it is ours), this is gated by the
+// caller for portal-managed zones only. It no-ops when the MNAME is already
+// correct, and returns nil (rather than erroring) when there is no nameserver
+// to use, mirroring fixSOAMNAME's semantics.
+func (c *PowerDNSClient) EnsureSOAMNAME(ctx context.Context, zoneID, domain string, canonicalNameservers []string) error {
+	return c.fixSOAMNAME(ctx, zoneID, domain, canonicalNameservers)
+}
+
 // fixSOAMNAMEOnZone performs the MNAME correction on an already-fetched zone.
 // It is only called from the fresh-create path (fixSOAMNAME), where the zone
 // was just created by this call and is therefore provably portal-owned — no

--- a/internal/service/domain/delegated_domain_service.go
+++ b/internal/service/domain/delegated_domain_service.go
@@ -298,29 +298,24 @@ func (s *DelegatedDomainService) VerifyDomain(ctx context.Context,
 
 // selfHealZone re-ensures the portal-managed-zone invariants that are
 // otherwise only established at bind/create time, so verification recovers a
-// zone that slipped past (or drifted from) those one-time setup steps — without
-// requiring the user to re-bind. The two invariants are independent and gated
-// independently:
+// zone that slipped past (or drifted from) those one-time setup steps without
+// requiring the user to re-bind. The two invariants are gated independently:
 //
-//  1. DNSSEC active signing key (fatal). Gated on UsesManagedZoneTLSA() — the
-//     namespaces whose portal-managed zone is DNSSEC-signed (e.g. HNS). ICANN
-//     zones are not portal-managed for DNSSEC, so this never runs for them. A
-//     "no active key" result (("", nil)) means DNSSEC was never enabled or the
-//     key was rotated away: EnableDNSSEC is idempotent (reuses an active key,
-//     mints one only when none exists), then the live DS is re-read. Failure is
-//     fatal: a managed zone without a key cannot be safely verified. The error
-//     path (GetActiveDNSSECDS errored, not empty) is NOT healed — that state is
-//     indeterminate (PowerDNS down / key rollover) and must fail loudly rather
-//     than mint keys.
+//  1. DNSSEC active signing key (fatal). For managed-DNSSEC namespaces
+//     (UsesManagedZoneTLSA, e.g. HNS). A "no active key" result (("", nil))
+//     means DNSSEC was never enabled or the key was rotated away: EnableDNSSEC
+//     is idempotent (reuses an active key, mints one only when none exists),
+//     then the live DS is re-read. Failure is fatal — a managed zone without a
+//     key cannot be safely verified. The error path (GetActiveDNSSECDS errored,
+//     not empty) is left to fail loudly: that state is indeterminate (PowerDNS
+//     down / key rollover), so we do not mint keys on it.
 //
-//  2. SOA MNAME (best-effort). Gated on the zone being portal-managed in
-//     PowerDNS (wd.ZoneID != 0 — every hosted binding, HNS and ICANN, gets a
-//     portal DNSZone). PowerDNS seeds new zones with a placeholder MNAME that
-//     is only corrected once at create; this re-ensures it idempotently for ALL
-//     portal-managed zones, not just DANE namespaces. It is deliberately
-//     non-fatal: the SOA MNAME is a secondary authoritative pointer (delegation
-//     is carried by the NS record), so a failed correction is logged, not
-//     raised.
+//  2. SOA MNAME (best-effort). For any portal-managed PowerDNS zone
+//     (wd.ZoneID != 0 — every hosted binding, HNS and ICANN). PowerDNS seeds
+//     new zones with a placeholder MNAME that is only corrected once at create;
+//     this re-ensures it idempotently for all portal-managed zones. Non-fatal:
+//     the SOA MNAME is a secondary authoritative pointer (delegation is carried
+//     by the NS record), so a failed correction is logged, not raised.
 //
 // It returns the (possibly healed) expected DS and a fatal error, or nil.
 func (s *DelegatedDomainService) selfHealZone(ctx context.Context, provider DomainProvider, wd *pluginDb.WebsiteDomain, expectedDS string) (string, error) {

--- a/internal/service/domain/delegated_domain_service.go
+++ b/internal/service/domain/delegated_domain_service.go
@@ -263,10 +263,11 @@ func (s *DelegatedDomainService) VerifyDomain(ctx context.Context,
 		return false, fmt.Errorf("resolve live DS for zone %d: %w", wd.ZoneID, dsErr)
 	}
 
-	// Self-heal re-ensures the managed-zone invariants that are otherwise
-	// only established at bind/create time (see selfHealManagedZone). ICANN
-	// namespaces are not portal-managed for DNSSEC/SOA and are skipped.
-	expectedDS, err := s.selfHealManagedZone(ctx, provider, wd, expectedDS)
+	// Self-heal re-ensures the portal-managed-zone invariants that are
+	// otherwise only established at bind/create time (see selfHealZone).
+	// Gate 1 (DNSSEC) covers managed-DNSSEC namespaces; gate 2 (SOA MNAME)
+	// covers any portal-managed PowerDNS zone, ICANN included.
+	expectedDS, err := s.selfHealZone(ctx, provider, wd, expectedDS)
 	if err != nil {
 		return false, err
 	}
@@ -295,36 +296,36 @@ func (s *DelegatedDomainService) VerifyDomain(ctx context.Context,
 	return verified, nil
 }
 
-// selfHealManagedZone re-ensures the portal-managed-zone invariants that are
+// selfHealZone re-ensures the portal-managed-zone invariants that are
 // otherwise only established at bind/create time, so verification recovers a
 // zone that slipped past (or drifted from) those one-time setup steps — without
-// requiring the user to re-bind. It runs only for managed namespaces
-// (UsesManagedZoneTLSA); ICANN zones are not portal-managed for DNSSEC or SOA.
+// requiring the user to re-bind. The two invariants are independent and gated
+// independently:
 //
-// Two invariants, with different failure semantics:
+//  1. DNSSEC active signing key (fatal). Gated on UsesManagedZoneTLSA() — the
+//     namespaces whose portal-managed zone is DNSSEC-signed (e.g. HNS). ICANN
+//     zones are not portal-managed for DNSSEC, so this never runs for them. A
+//     "no active key" result (("", nil)) means DNSSEC was never enabled or the
+//     key was rotated away: EnableDNSSEC is idempotent (reuses an active key,
+//     mints one only when none exists), then the live DS is re-read. Failure is
+//     fatal: a managed zone without a key cannot be safely verified. The error
+//     path (GetActiveDNSSECDS errored, not empty) is NOT healed — that state is
+//     indeterminate (PowerDNS down / key rollover) and must fail loudly rather
+//     than mint keys.
 //
-//  1. DNSSEC active signing key (fatal). A "no active key" result
-//     (("", nil)) on a managed zone means DNSSEC was never enabled or the key
-//     was rotated away. EnableDNSSEC is idempotent (reuses an active key,
-//     mints one only when none exists), then the live DS is re-read. Failure
-//     is fatal: a managed zone without a key cannot be safely verified.
-//     The error path (GetActiveDNSSECDS errored, not empty) is NOT healed —
-//     that state is indeterminate (PowerDNS down / key rollover) and must
-//     fail loudly rather than mint keys.
-//
-//  2. SOA MNAME (best-effort). PowerDNS seeds new zones with a placeholder
-//     MNAME that is only corrected once at create. EnsureSOAMNAME re-ensures
-//     it idempotently. This is deliberately non-fatal: the SOA MNAME is a
-//     secondary authoritative pointer (delegation is carried by the NS record),
-//     so a failed correction is logged, not raised.
+//  2. SOA MNAME (best-effort). Gated on the zone being portal-managed in
+//     PowerDNS (wd.ZoneID != 0 — every hosted binding, HNS and ICANN, gets a
+//     portal DNSZone). PowerDNS seeds new zones with a placeholder MNAME that
+//     is only corrected once at create; this re-ensures it idempotently for ALL
+//     portal-managed zones, not just DANE namespaces. It is deliberately
+//     non-fatal: the SOA MNAME is a secondary authoritative pointer (delegation
+//     is carried by the NS record), so a failed correction is logged, not
+//     raised.
 //
 // It returns the (possibly healed) expected DS and a fatal error, or nil.
-func (s *DelegatedDomainService) selfHealManagedZone(ctx context.Context, provider DomainProvider, wd *pluginDb.WebsiteDomain, expectedDS string) (string, error) {
-	if !provider.UsesManagedZoneTLSA() {
-		return expectedDS, nil
-	}
-
-	if expectedDS == "" {
+func (s *DelegatedDomainService) selfHealZone(ctx context.Context, provider DomainProvider, wd *pluginDb.WebsiteDomain, expectedDS string) (string, error) {
+	// DNSSEC self-heal: only managed-DNSSEC namespaces (UsesManagedZoneTLSA).
+	if provider.UsesManagedZoneTLSA() && expectedDS == "" {
 		if _, err := s.dnsSvc.EnableDNSSEC(ctx, wd.ZoneID); err != nil {
 			return "", fmt.Errorf("enable dnssec for zone %d: %w", wd.ZoneID, err)
 		}
@@ -336,11 +337,15 @@ func (s *DelegatedDomainService) selfHealManagedZone(ctx context.Context, provid
 		expectedDS = healedDS
 	}
 
-	if err := s.dnsSvc.EnsureSOAMNAME(ctx, wd.ZoneID, wd.Domain, provider.Nameservers()); err != nil {
-		s.Logger().Warn("SOA MNAME self-heal failed (best-effort)",
-			zap.String("domain", wd.Domain),
-			zap.Uint("zone_id", wd.ZoneID),
-			zap.Error(err))
+	// SOA MNAME self-heal: any portal-managed PowerDNS zone (wd.ZoneID != 0),
+	// independent of DANE/DNSSEC — applies to ICANN-hosted zones too.
+	if wd.ZoneID != 0 {
+		if err := s.dnsSvc.EnsureSOAMNAME(ctx, wd.ZoneID, wd.Domain, provider.Nameservers()); err != nil {
+			s.Logger().Warn("SOA MNAME self-heal failed (best-effort)",
+				zap.String("domain", wd.Domain),
+				zap.Uint("zone_id", wd.ZoneID),
+				zap.Error(err))
+		}
 	}
 
 	return expectedDS, nil

--- a/internal/service/domain/delegated_domain_service.go
+++ b/internal/service/domain/delegated_domain_service.go
@@ -48,6 +48,15 @@ type DNSZoneService interface {
 	// when the zone has no active signing key; errors when multiple active keys
 	// exist (in-progress rollover).
 	GetActiveDNSSECDS(ctx context.Context, zoneID uint) (ds string, err error)
+	// EnsureSOAMNAME idempotently corrects a zone's SOA MNAME to the primary
+	// authorized nameserver, no-op'ing when it is already correct. PowerDNS
+	// seeds freshly created zones with a placeholder MNAME that is only fixed
+	// on the fresh-create path; this lets verification re-ensure a portal
+	// managed zone's SOA points at the right authority, mirroring the DNSSEC
+	// self-heal. It is best-effort (the SOA MNAME is a secondary authoritative
+	// pointer; delegation is carried by the NS record), so callers must not
+	// treat an error here as a hard verification failure.
+	EnsureSOAMNAME(ctx context.Context, zoneID uint, domain string, nameservers []string) error
 }
 
 // DSRecord represents a Delegation Signer record for DNSSEC.
@@ -254,6 +263,14 @@ func (s *DelegatedDomainService) VerifyDomain(ctx context.Context,
 		return false, fmt.Errorf("resolve live DS for zone %d: %w", wd.ZoneID, dsErr)
 	}
 
+	// Self-heal re-ensures the managed-zone invariants that are otherwise
+	// only established at bind/create time (see selfHealManagedZone). ICANN
+	// namespaces are not portal-managed for DNSSEC/SOA and are skipped.
+	expectedDS, err := s.selfHealManagedZone(ctx, provider, wd, expectedDS)
+	if err != nil {
+		return false, err
+	}
+
 	verified, err := provider.VerifyDelegation(ctx, wd.Domain, expectedDS)
 	if err != nil {
 		wd.Status = pluginDb.DomainStatusError
@@ -276,6 +293,57 @@ func (s *DelegatedDomainService) VerifyDomain(ctx context.Context,
 	}
 
 	return verified, nil
+}
+
+// selfHealManagedZone re-ensures the portal-managed-zone invariants that are
+// otherwise only established at bind/create time, so verification recovers a
+// zone that slipped past (or drifted from) those one-time setup steps — without
+// requiring the user to re-bind. It runs only for managed namespaces
+// (UsesManagedZoneTLSA); ICANN zones are not portal-managed for DNSSEC or SOA.
+//
+// Two invariants, with different failure semantics:
+//
+//  1. DNSSEC active signing key (fatal). A "no active key" result
+//     (("", nil)) on a managed zone means DNSSEC was never enabled or the key
+//     was rotated away. EnableDNSSEC is idempotent (reuses an active key,
+//     mints one only when none exists), then the live DS is re-read. Failure
+//     is fatal: a managed zone without a key cannot be safely verified.
+//     The error path (GetActiveDNSSECDS errored, not empty) is NOT healed —
+//     that state is indeterminate (PowerDNS down / key rollover) and must
+//     fail loudly rather than mint keys.
+//
+//  2. SOA MNAME (best-effort). PowerDNS seeds new zones with a placeholder
+//     MNAME that is only corrected once at create. EnsureSOAMNAME re-ensures
+//     it idempotently. This is deliberately non-fatal: the SOA MNAME is a
+//     secondary authoritative pointer (delegation is carried by the NS record),
+//     so a failed correction is logged, not raised.
+//
+// It returns the (possibly healed) expected DS and a fatal error, or nil.
+func (s *DelegatedDomainService) selfHealManagedZone(ctx context.Context, provider DomainProvider, wd *pluginDb.WebsiteDomain, expectedDS string) (string, error) {
+	if !provider.UsesManagedZoneTLSA() {
+		return expectedDS, nil
+	}
+
+	if expectedDS == "" {
+		if _, err := s.dnsSvc.EnableDNSSEC(ctx, wd.ZoneID); err != nil {
+			return "", fmt.Errorf("enable dnssec for zone %d: %w", wd.ZoneID, err)
+		}
+		// Re-read the DS now that the zone should have an active key.
+		healedDS, dsErr := s.dnsSvc.GetActiveDNSSECDS(ctx, wd.ZoneID)
+		if dsErr != nil {
+			return "", fmt.Errorf("resolve live DS for zone %d after enable: %w", wd.ZoneID, dsErr)
+		}
+		expectedDS = healedDS
+	}
+
+	if err := s.dnsSvc.EnsureSOAMNAME(ctx, wd.ZoneID, wd.Domain, provider.Nameservers()); err != nil {
+		s.Logger().Warn("SOA MNAME self-heal failed (best-effort)",
+			zap.String("domain", wd.Domain),
+			zap.Uint("zone_id", wd.ZoneID),
+			zap.Error(err))
+	}
+
+	return expectedDS, nil
 }
 
 // DeleteDomain deletes a WebsiteDomain row scoped by id, website_id, and user_id.

--- a/internal/service/domain/delegated_domain_service_test.go
+++ b/internal/service/domain/delegated_domain_service_test.go
@@ -151,6 +151,65 @@ func TestDelegatedDomainService_GetWebsiteDomainByDomainAndNamespace(t *testing.
 	}, TestOptions)
 }
 
+func TestDelegatedDomainService_VerifyDomain_SelfHealsDNSSEC(t *testing.T) {
+	// Regression: a managed (HNS) zone reporting "no active signing key"
+	// (GetActiveDNSSECDS -> ("", nil)) must self-heal by running the
+	// idempotent EnableDNSSEC, then re-reading the live DS — instead of
+	// silently verifying NS-only and leaving the zone without a DS. This
+	// recovers zones bound before the cryptokey-id fix whose key was never
+	// readable, without requiring the user to re-bind.
+	t.Run("hns_no_key_triggers_enable", func(t *testing.T) {
+		coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+			db := ctx.DB()
+			require.NoError(tb, db.Create(&pluginDb.WebsiteDomain{
+				WebsiteID: 1, UserID: 1, Domain: "example", Namespace: pluginDb.DomainNamespaceHNS,
+				ZoneID: 42, Status: pluginDb.DomainStatusWaitingDelegation,
+			}).Error)
+
+			svc := core.GetService[*DelegatedDomainService](ctx, pluginCore.DELEGATED_DOMAIN_SERVICE)
+			require.NotNil(tb, svc)
+
+			mockDNS := core.GetService[*mocks.MockDNSService](ctx, pluginCore.DNS_SERVICE)
+			require.NotNil(tb, mockDNS)
+
+			// First read: no active key. Self-heal calls EnableDNSSEC, then
+			// re-reads and finds a live DS (the minted key).
+			mockDNS.EXPECT().GetActiveDNSSECDS(mock.Anything, uint(42)).
+				Return("", nil).Once()
+			mockDNS.EXPECT().EnableDNSSEC(mock.Anything, uint(42)).
+				Return("257 3 13 dGVzdA==", nil).Once()
+			mockDNS.EXPECT().GetActiveDNSSECDS(mock.Anything, uint(42)).
+				Return("60776 13 2 abc", nil).Once()
+			// SOA MNAME self-heal runs for the managed zone (best-effort).
+			mockDNS.EXPECT().EnsureSOAMNAME(mock.Anything, uint(42), "example", mock.Anything).
+				Return(nil).Once()
+
+			wd := &pluginDb.WebsiteDomain{
+				WebsiteID: 1, UserID: 1, Domain: "example", Namespace: pluginDb.DomainNamespaceHNS, ZoneID: 42,
+			}
+
+			// VerifyDomain proceeds to HNSProvider.VerifyDelegation, which
+			// returns the "resolver not configured" error in a unit harness
+			// (no real HNS resolver). The self-heal assertions below are what
+			// this test guards — EnableDNSSEC MUST have been invoked, the DS
+			// re-read, and the SOA MNAME self-heal fired, before delegation
+			// verification.
+			verified, err := svc.VerifyDomain(context.Background(), wd)
+			_ = verified
+			if err != nil {
+				// Allowed: resolver-not-configured after the self-heal mocks
+				// fired. The point of this test is the self-heal sequence.
+				tb.Logf("expected post-self-heal delegation error: %v", err)
+			}
+
+			mockDNS.AssertCalled(tb, "EnableDNSSEC", mock.Anything, uint(42))
+			mockDNS.AssertNumberOfCalls(tb, "GetActiveDNSSECDS", 2)
+			mockDNS.AssertCalled(tb, "EnsureSOAMNAME", mock.Anything, uint(42), "example", mock.Anything)
+			mockDNS.AssertExpectations(tb)
+		}, TestOptions)
+	})
+}
+
 func TestDelegatedDomainService_GetPendingWebsiteDomainsPaginated(t *testing.T) {
 	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 		db := ctx.DB()

--- a/internal/service/domain/delegated_domain_service_test.go
+++ b/internal/service/domain/delegated_domain_service_test.go
@@ -209,10 +209,8 @@ func TestDelegatedDomainService_VerifyDomain_SelfHealsDNSSEC(t *testing.T) {
 		}, TestOptions)
 	})
 
-	// The SOA MNAME self-heal is NOT tied to DANE/DNSSEC: it applies to any
-	// portal-managed PowerDNS zone. An ICANN-hosted binding (ZoneID set) must
-	// therefore get its SOA MNAME re-ensured on verify even though DNSSEC
-	// enablement is skipped (ICANN is not portal-managed for DNSSEC).
+	// The SOA MNAME self-heal applies to any portal-managed PowerDNS zone, so
+	// an ICANN-hosted binding gets its SOA re-ensured on verify too.
 	t.Run("icann_soa_healed_dnssec_skipped", func(t *testing.T) {
 		coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 			db := ctx.DB()

--- a/internal/service/domain/delegated_domain_service_test.go
+++ b/internal/service/domain/delegated_domain_service_test.go
@@ -208,6 +208,49 @@ func TestDelegatedDomainService_VerifyDomain_SelfHealsDNSSEC(t *testing.T) {
 			mockDNS.AssertExpectations(tb)
 		}, TestOptions)
 	})
+
+	// The SOA MNAME self-heal is NOT tied to DANE/DNSSEC: it applies to any
+	// portal-managed PowerDNS zone. An ICANN-hosted binding (ZoneID set) must
+	// therefore get its SOA MNAME re-ensured on verify even though DNSSEC
+	// enablement is skipped (ICANN is not portal-managed for DNSSEC).
+	t.Run("icann_soa_healed_dnssec_skipped", func(t *testing.T) {
+		coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+			db := ctx.DB()
+			require.NoError(tb, db.Create(&pluginDb.WebsiteDomain{
+				WebsiteID: 1, UserID: 1, Domain: "example.com", Namespace: pluginDb.DomainNamespaceICANN,
+				ZoneID: 42, Status: pluginDb.DomainStatusWaitingDelegation,
+			}).Error)
+
+			svc := core.GetService[*DelegatedDomainService](ctx, pluginCore.DELEGATED_DOMAIN_SERVICE)
+			require.NotNil(tb, svc)
+
+			mockDNS := core.GetService[*mocks.MockDNSService](ctx, pluginCore.DNS_SERVICE)
+			require.NotNil(tb, mockDNS)
+
+			// ICANN has no portal DNSSEC: GetActiveDNSSECDS returns ("", nil)
+			// by default and EnableDNSSEC must NOT be touched. Only the SOA
+			// MNAME self-heal fires for the portal-managed zone.
+			mockDNS.EXPECT().GetActiveDNSSECDS(mock.Anything, uint(42)).
+				Return("", nil).Once()
+			mockDNS.EXPECT().EnsureSOAMNAME(mock.Anything, uint(42), "example.com", mock.Anything).
+				Return(nil).Once()
+
+			wd := &pluginDb.WebsiteDomain{
+				WebsiteID: 1, UserID: 1, Domain: "example.com", Namespace: pluginDb.DomainNamespaceICANN, ZoneID: 42,
+			}
+
+			verified, err := svc.VerifyDomain(context.Background(), wd)
+			_ = verified
+			if err != nil {
+				// Allowed: post-heal delegation error (system resolver).
+				tb.Logf("expected post-heal delegation error: %v", err)
+			}
+
+			mockDNS.AssertCalled(tb, "EnsureSOAMNAME", mock.Anything, uint(42), "example.com", mock.Anything)
+			mockDNS.AssertNotCalled(tb, "EnableDNSSEC")
+			mockDNS.AssertExpectations(tb)
+		}, TestOptions)
+	})
 }
 
 func TestDelegatedDomainService_GetPendingWebsiteDomainsPaginated(t *testing.T) {

--- a/internal/service/domain/hns_provider_test.go
+++ b/internal/service/domain/hns_provider_test.go
@@ -207,6 +207,9 @@ func (f *fakeDNSZoneService) GetActiveDNSSECDS(ctx context.Context, zoneID uint)
 	// set it explicitly. Return empty (self-managed / no DS) by default.
 	return "", nil
 }
+func (f *fakeDNSZoneService) EnsureSOAMNAME(ctx context.Context, zoneID uint, domain string, nameservers []string) error {
+	return nil
+}
 
 func TestHNSProvider_BuildDelegation_NoDSRecord(t *testing.T) {
 	// Regression: the delegation bundle must NOT carry a DS record in

--- a/internal/testing/mocks/MockDNSService.go
+++ b/internal/testing/mocks/MockDNSService.go
@@ -902,6 +902,75 @@ func (_c *MockDNSService_EnableDNSSEC_Call) RunAndReturn(run func(ctx context.Co
 	return _c
 }
 
+// EnsureSOAMNAME provides a mock function for the type MockDNSService
+func (_mock *MockDNSService) EnsureSOAMNAME(ctx context.Context, zoneID uint, domain string, nameservers []string) error {
+	ret := _mock.Called(ctx, zoneID, domain, nameservers)
+
+	if len(ret) == 0 {
+		panic("no return value specified for EnsureSOAMNAME")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uint, string, []string) error); ok {
+		r0 = returnFunc(ctx, zoneID, domain, nameservers)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockDNSService_EnsureSOAMNAME_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'EnsureSOAMNAME'
+type MockDNSService_EnsureSOAMNAME_Call struct {
+	*mock.Call
+}
+
+// EnsureSOAMNAME is a helper method to define mock.On call
+//   - ctx context.Context
+//   - zoneID uint
+//   - domain string
+//   - nameservers []string
+func (_e *MockDNSService_Expecter) EnsureSOAMNAME(ctx any, zoneID any, domain any, nameservers any) *MockDNSService_EnsureSOAMNAME_Call {
+	return &MockDNSService_EnsureSOAMNAME_Call{Call: _e.mock.On("EnsureSOAMNAME", ctx, zoneID, domain, nameservers)}
+}
+
+func (_c *MockDNSService_EnsureSOAMNAME_Call) Run(run func(ctx context.Context, zoneID uint, domain string, nameservers []string)) *MockDNSService_EnsureSOAMNAME_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 uint
+		if args[1] != nil {
+			arg1 = args[1].(uint)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		var arg3 []string
+		if args[3] != nil {
+			arg3 = args[3].([]string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+		)
+	})
+	return _c
+}
+
+func (_c *MockDNSService_EnsureSOAMNAME_Call) Return(err error) *MockDNSService_EnsureSOAMNAME_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockDNSService_EnsureSOAMNAME_Call) RunAndReturn(run func(ctx context.Context, zoneID uint, domain string, nameservers []string) error) *MockDNSService_EnsureSOAMNAME_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetActiveDNSSECDS provides a mock function for the type MockDNSService
 func (_mock *MockDNSService) GetActiveDNSSECDS(ctx context.Context, zoneID uint) (string, error) {
 	ret := _mock.Called(ctx, zoneID)

--- a/internal/testing/mocks/MockDNSZoneService.go
+++ b/internal/testing/mocks/MockDNSZoneService.go
@@ -368,6 +368,75 @@ func (_c *MockDNSZoneService_EnableDNSSEC_Call) RunAndReturn(run func(ctx contex
 	return _c
 }
 
+// EnsureSOAMNAME provides a mock function for the type MockDNSZoneService
+func (_mock *MockDNSZoneService) EnsureSOAMNAME(ctx context.Context, zoneID uint, domain string, nameservers []string) error {
+	ret := _mock.Called(ctx, zoneID, domain, nameservers)
+
+	if len(ret) == 0 {
+		panic("no return value specified for EnsureSOAMNAME")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uint, string, []string) error); ok {
+		r0 = returnFunc(ctx, zoneID, domain, nameservers)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockDNSZoneService_EnsureSOAMNAME_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'EnsureSOAMNAME'
+type MockDNSZoneService_EnsureSOAMNAME_Call struct {
+	*mock.Call
+}
+
+// EnsureSOAMNAME is a helper method to define mock.On call
+//   - ctx context.Context
+//   - zoneID uint
+//   - domain string
+//   - nameservers []string
+func (_e *MockDNSZoneService_Expecter) EnsureSOAMNAME(ctx any, zoneID any, domain any, nameservers any) *MockDNSZoneService_EnsureSOAMNAME_Call {
+	return &MockDNSZoneService_EnsureSOAMNAME_Call{Call: _e.mock.On("EnsureSOAMNAME", ctx, zoneID, domain, nameservers)}
+}
+
+func (_c *MockDNSZoneService_EnsureSOAMNAME_Call) Run(run func(ctx context.Context, zoneID uint, domain string, nameservers []string)) *MockDNSZoneService_EnsureSOAMNAME_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 uint
+		if args[1] != nil {
+			arg1 = args[1].(uint)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		var arg3 []string
+		if args[3] != nil {
+			arg3 = args[3].([]string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+		)
+	})
+	return _c
+}
+
+func (_c *MockDNSZoneService_EnsureSOAMNAME_Call) Return(err error) *MockDNSZoneService_EnsureSOAMNAME_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockDNSZoneService_EnsureSOAMNAME_Call) RunAndReturn(run func(ctx context.Context, zoneID uint, domain string, nameservers []string) error) *MockDNSZoneService_EnsureSOAMNAME_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetActiveDNSSECDS provides a mock function for the type MockDNSZoneService
 func (_mock *MockDNSZoneService) GetActiveDNSSECDS(ctx context.Context, zoneID uint) (string, error) {
 	ret := _mock.Called(ctx, zoneID)


### PR DESCRIPTION
## Summary

Makes DNS-delegation failures observable and self-healing, closing the silent-omission class where an absent DS/SOA gave no signal.

### 1. dns-requirements surfaces DNSSEC state - gated to managed namespaces

`DNSDelegation` gains `dnssec` + `dnssec_error`. For portal-managed, DNSSEC-signed namespaces (`NamespaceUsesManagedZoneTLSA`, e.g. HNS), `domainDNSRequirements` reports one of:

- `enabled` - active signing key present; live DS injected into parent\_records.
- `error` - live DS resolution failed (PowerDNS down / key rollover); reason set.
- `disabled` - no active signing key; reason set.

Non-managed namespaces (ICANN) have no portal DNSSEC and **omit the fields entirely** per the DTO contract - only stale DS records are dropped. An absent DS is no longer a silent gap for managed zones.

### 2. VerifyDomain self-heals portal-managed-zone invariants

New `selfHealZone` helper re-ensures two invariants otherwise only set at bind/create time, without re-binding. The two are gated independently:

- **DNSSEC (fatal):** gated on `UsesManagedZoneTLSA()` (managed-DNSSEC namespaces). Empty DS triggers idempotent `EnableDNSSEC` + live DS re-read. Heals zones bound before the cryptokey-id fix whose key was never readable.
- **SOA MNAME (best-effort):** gated on any portal-managed PowerDNS zone (`ZoneID != 0`) - **not tied to DANE/DNSSEC**, so ICANN-hosted zones get their SOA MNAME re-ensured too (PowerDNS seeds a placeholder MNAME only corrected once at create).

New idempotent `EnsureSOAMNAME` on `DNSService`/`PowerDNSClient` (short-transaction zone resolution, mirrors `EnableDNSSEC`).

### Verification

- Domain package: full suite green. New tests: HNS DNSSEC self-heal fires (EnableDNSSEC + DS re-read + SOA heal), ICANN SOA healed while EnableDNSSEC skipped, ICANN dns-requirements omits DNSSEC fields.
- DNS + DTO packages: green. Build, gofmt, go vet: clean.
- `internal/api` full-suite run blocked by a pre-existing `rpc.proto` protobuf namespace conflict (libp2p vs etcd) present on develop; new api\_domains\_test assertions are type-checked via vet.

* `develop` <!-- branch-stack -->
  - **feat(dns): surface DNSSEC state and self-heal DNSSEC/SOA on verify** :point\_left:
