### PR TITLE
feat(domain): default DNSHostingEnabled=true on domain bind

### DIFF
--- a/internal/service/domain/delegated_domain_service.go
+++ b/internal/service/domain/delegated_domain_service.go
@@ -132,12 +132,13 @@ func (s *DelegatedDomainService) CreateDomain(ctx context.Context,
 	}
 
 	wd := &pluginDb.WebsiteDomain{
-		WebsiteID: websiteID,
-		UserID:    userID,
-		Domain:    domain,
-		Namespace: pluginDb.DomainNamespace(namespace),
-		ZoneName:  canonicalZoneName(domain),
-		Status:    pluginDb.DomainStatusDraft,
+		WebsiteID:         websiteID,
+		UserID:            userID,
+		Domain:            domain,
+		Namespace:         pluginDb.DomainNamespace(namespace),
+		ZoneName:          canonicalZoneName(domain),
+		Status:            pluginDb.DomainStatusDraft,
+		DNSHostingEnabled: true,
 	}
 
 	// Soft deletes leave a tombstone row that still occupies the

--- a/internal/service/domain/delegated_domain_service_test.go
+++ b/internal/service/domain/delegated_domain_service_test.go
@@ -68,6 +68,9 @@ func TestDelegatedDomainService_CreateDomain(t *testing.T) {
 		assert.Equal(tb, "example.com", wd.Domain)
 		assert.Equal(tb, pluginDb.DomainNamespaceICANN, wd.Namespace)
 		assert.Equal(tb, uint(1), wd.ZoneID)
+		// DNS hosting defaults to true: binding always creates the authoritative
+		// portal-managed zone, so the per-domain hosting flag matches reality.
+		assert.True(tb, wd.DNSHostingEnabled)
 	}, TestOptions)
 }
 


### PR DESCRIPTION
Binding a domain always creates the portal-managed authoritative zone (CreateZone + DNSLink + apex + delegation), so the per-domain hosting flag previously stayed at its DB default (false) even though Pinner was managing the DNS. This made dns-requirements render the binding as self-managed ('point your own DNS server') and kept the flag out of sync with reality.

Default DNSHostingEnabled=true when a domain is bound, so 'domains add' creates DNS-managed bindings by default. Users can disable it per-domain with 'domains update --no-dns-hosting'.

Verified: domain + dns package tests green (incl. new assertion that CreateDomain defaults DNSHostingEnabled true); build/go vet/gofmt clean.

- `develop` <!-- branch-stack -->
  - **feat(domain): default DNSHostingEnabled=true on domain bind** :point\_left:

---

<!-- kody-pr-summary:start -->
## Summary

This pull request changes the default value for `DNSHostingEnabled` when creating a new domain in the delegated domain service.

## Changes

- When a new `WebsiteDomain` record is created via `CreateDomain`, the `DNSHostingEnabled` field is now explicitly set to `true` by default.
- Previously, this field was left unset (defaulting to `false`), which did not reflect the actual behavior of the system.
- A test assertion was added to verify that the default value of `DNSHostingEnabled` is `true` when a domain is created.

## Rationale

Since binding a domain always creates an authoritative portal-managed DNS zone, setting the `DNSHostingEnabled` flag to `true` by default ensures the per-domain hosting flag accurately matches reality. This prevents inconsistencies between the stored configuration and the actual DNS hosting behavior.
<!-- kody-pr-summary:end -->