### PR TITLE
feat(domain): bind is managed-DNS default (DNSHostingEnabled=true)

### DIFF
--- a/internal/service/domain/delegated_domain_service.go
+++ b/internal/service/domain/delegated_domain_service.go
@@ -138,6 +138,12 @@ func (s *DelegatedDomainService) CreateDomain(ctx context.Context,
 		Namespace: pluginDb.DomainNamespace(namespace),
 		ZoneName:  canonicalZoneName(domain),
 		Status:    pluginDb.DomainStatusDraft,
+		// Binding is managed-DNS by default: this flow creates the authoritative
+		// zone + records below, so the per-domain hosting flag must be true to
+		// stay reconciled with the zone existing (managed == zone non-nil). A
+		// non-managed binding is reached by disabling DNS hosting afterwards
+		// (SetDomainDNSEnabled), not by binding.
+		DNSHostingEnabled: true,
 	}
 
 	// Soft deletes leave a tombstone row that still occupies the
@@ -216,9 +222,10 @@ func (s *DelegatedDomainService) CreateDomain(ctx context.Context,
 	wd.Status = pluginDb.DomainStatusRecordsGenerated
 	wd.DelegationData = jsonToMap(delegationBytes)
 	if err := s.DB().WithContext(ctx).Model(wd).Updates(map[string]any{
-		"zone_id":         zone.ID,
-		"status":          pluginDb.DomainStatusRecordsGenerated,
-		"delegation_data": wd.DelegationData,
+		"zone_id":             zone.ID,
+		"status":              pluginDb.DomainStatusRecordsGenerated,
+		"delegation_data":     wd.DelegationData,
+		"dns_hosting_enabled": true,
 	}).Error; err != nil {
 		return nil, fmt.Errorf("failed to finalize domain record: %w", err)
 	}

--- a/internal/service/domain/delegated_domain_service_test.go
+++ b/internal/service/domain/delegated_domain_service_test.go
@@ -68,6 +68,9 @@ func TestDelegatedDomainService_CreateDomain(t *testing.T) {
 		assert.Equal(tb, "example.com", wd.Domain)
 		assert.Equal(tb, pluginDb.DomainNamespaceICANN, wd.Namespace)
 		assert.Equal(tb, uint(1), wd.ZoneID)
+		// DNS hosting defaults to true: binding always creates the authoritative
+		// portal-managed zone, so the per-domain hosting flag matches reality.
+		assert.True(tb, wd.DNSHostingEnabled)
 	}, TestOptions)
 }
 


### PR DESCRIPTION
## Summary

**`domains add` (and website-create primary binding) are now managed-DNS by default.**

Binding a domain always creates the portal-managed authoritative zone (`CreateZone` + DNSLink + apex + delegation), so the per-domain hosting flag must be `true` to stay reconciled with the zone existing (`managed == zone non-nil`, the invariant `SetDomainDNSEnabled` enforces). Previously the flag stayed at its DB default (`false`) even though Pinner was managing the DNS — so `dns-requirements` rendered the binding as self-managed ("point your own DNS server", "configure on your DNS server") and the flag was out of sync with reality.

## Change

- `DelegatedDomainService.CreateDomain` sets `DNSHostingEnabled: true` on the binding struct **and** persists `dns_hosting_enabled` in the finalize update, matching the authoritative zone this flow creates.
- Non-managed bindings are reached by **disabling** DNS hosting afterwards (`SetDomainDNSEnabled` / `domains update --no-dns-hosting`), not by binding.

This is the corrected version of the closed #890: it keeps the managed-DNS default aligned with the zone that bind actually creates, rather than trying to suppress zone creation (the parallel-zone question is tracked separately).

## Verification

- domain + dns package tests green (incl. new assertion that `CreateDomain` defaults `DNSHostingEnabled` true)
- `go build`, `go vet`, `gofmt` clean

* `develop` <!-- branch-stack -->
  - **feat(domain): bind is managed-DNS default (DNSHostingEnabled=true)** :point\_left:

---

<!-- kody-pr-summary:start -->
## Summary

This pull request modifies the delegated domain creation flow to ensure that DNS hosting is enabled by default when a new domain is bound.

## Changes

**`delegated_domain_service.go`:**
- Added `DNSHostingEnabled: true` to the domain record during initial creation, ensuring the hosting flag is set at binding time.
- Updated the domain finalization update to also set `"dns_hosting_enabled": true` in the database update map, keeping the flag consistent through the creation and zone-generation workflow.

**`delegated_domain_service_test.go`:**
- Added an assertion verifying that `DNSHostingEnabled` is `true` after domain creation, confirming the default behavior.

## Purpose

When a domain is bound through the delegated domain service, an authoritative zone and records are created as part of the flow. Setting `DNSHostingEnabled` to `true` by default ensures the domain's hosting flag stays in sync with the fact that a managed zone exists. Non-managed DNS hosting can still be achieved afterward by explicitly disabling DNS hosting via `SetDomainDNSEnabled`.
<!-- kody-pr-summary:end -->