### PR TITLE
feat(domain): no zone when DNS self-hosted; subdomains reuse parent zone

### DIFF
--- a/core/dns.go
+++ b/core/dns.go
@@ -56,21 +56,26 @@ type DNSService interface {
 	// GetRRSet retrieves a specific DNS RRSet by name and type from PowerDNS
 	GetRRSet(ctx context.Context, zoneID uint, name string, recordType string) ([]*apiDTO.DNSRecord, error)
 
-	// CreateDNSLinkRecord creates a DNSLink _dnslink.<domain> TXT record
-	CreateDNSLinkRecord(ctx context.Context, zoneID uint, target string) error
+	// CreateDNSLinkRecord creates a DNSLink _dnslink.<domain> TXT record. domain
+	// is the record owner's FQDN: the zone apex for an apex binding, or a
+	// subdomain living inside a reused parent zone.
+	CreateDNSLinkRecord(ctx context.Context, zoneID uint, domain string, target string) error
 
-	// CreateApexRecord creates an apex (root) record pointing to the gateway.
+	// CreateApexRecord creates an authoritative record for domain (the zone apex
+	// for an apex binding, or a subdomain inside a reused parent zone).
 	// recordType is e.g. RecordTypeA (IP content for DNSSEC-signed alt-root)
 	// or RecordTypeALIAS (gateway hostname content).
-	CreateApexRecord(ctx context.Context, zoneID uint, recordType RecordType, content string) error
+	CreateApexRecord(ctx context.Context, zoneID uint, domain string, recordType RecordType, content string) error
 
-	// SetTLSARecord writes (or replaces) the DANE TLSA record for a zone's
+	// SetTLSARecord writes (or replaces) the DANE TLSA record for domain's
 	// HTTPS/TCP owner `_443._tcp` in the portal-managed authoritative zone.
 	// content is the TLSA rdata: "usage selector matching hash" (e.g.
 	// "3 1 1 <hex>"). Without publishing the TLSA to the authoritative zone,
 	// DANE validators get NXDOMAIN for the TLSA owner and DANE cannot be
-	// established for portal-managed (DNSSEC-signed) domains.
-	SetTLSARecord(ctx context.Context, zoneID uint, content string) error
+	// established for portal-managed (DNSSEC-signed) domains. The owner is
+	// named after domain so a subdomain reusing a parent zone publishes its own
+	// TLSA rather than the parent's.
+	SetTLSARecord(ctx context.Context, zoneID uint, domain string, content string) error
 
 	// CreateRecord creates a new DNS record in PowerDNS via RRSet
 	// name: the record name (e.g., "www")

--- a/internal/api/api_domains.go
+++ b/internal/api/api_domains.go
@@ -372,6 +372,8 @@ func (a *API) domainDNSRequirements(c echo.Context) error {
 	// yield a DS and report DNSSEC state; ICANN domains have no parent DS and
 	// no portal DNSSEC, so this is a no-op that omits the DNSSEC fields
 	// entirely (per the DTO contract) and only defends against a stale DS.
+	// A self-hosted binding owns no delegation bundle, so resp.Delegation is
+	// nil and this block is naturally skipped.
 	managed := a.delegatedDomainSvc != nil && a.delegatedDomainSvc.NamespaceUsesManagedZoneTLSA(string(wd.Namespace))
 	if resp.Delegation != nil && a.dnsService != nil {
 		if managed {

--- a/internal/api/api_domains.go
+++ b/internal/api/api_domains.go
@@ -49,7 +49,15 @@ func (a *API) createDomain(c echo.Context) error {
 		configRaw, _ = json.Marshal(req.Config)
 	}
 
-	wd, err := a.delegatedDomainSvc.CreateDomain(reqCtx, req.Namespace, req.Domain, uint(websiteID), userID, configRaw)
+	// Managed-DNS by default: bindings are created DNS-hosted unless the
+	// request explicitly opts out. Pass the resolved flag so CreateDomain
+	// provisions (or skips) the authoritative zone accordingly.
+	dnsHostingEnabled := true
+	if req.DNSHostingEnabled != nil {
+		dnsHostingEnabled = *req.DNSHostingEnabled
+	}
+
+	wd, err := a.delegatedDomainSvc.CreateDomain(reqCtx, req.Namespace, req.Domain, uint(websiteID), userID, dnsHostingEnabled, configRaw)
 	if err != nil {
 		a.Logger().Error("Failed to create domain", zap.Error(err))
 		apiErr := NewError(ErrKeyValidationFailed, err)

--- a/internal/api/api_websites.go
+++ b/internal/api/api_websites.go
@@ -149,7 +149,7 @@ func (a *API) createWebsite(c echo.Context) error {
 			namespace = string(*req.Namespace)
 		}
 		var cfgRaw json.RawMessage
-		if _, err := a.delegatedDomainSvc.CreateDomain(reqCtx, namespace, req.Domain, website.ID, user, cfgRaw); err != nil {
+		if _, err := a.delegatedDomainSvc.CreateDomain(reqCtx, namespace, req.Domain, website.ID, user, dnsEnabled, cfgRaw); err != nil {
 			a.Logger().Error("Failed to create primary domain for website",
 				zap.Uint("website_id", website.ID), zap.String("domain", req.Domain), zap.Error(err))
 			apiErr := NewError(ErrKeyFileProcessingFailed, err)
@@ -402,7 +402,12 @@ func (a *API) updateWebsite(c echo.Context) error {
 			namespace = string(*req.Namespace)
 		}
 		var cfgRaw json.RawMessage
-		wd, derr := a.delegatedDomainSvc.CreateDomain(reqCtx, namespace, *req.Domain, website.ID, user, cfgRaw)
+		// Managed-DNS by default; explicit DNSEnabled override flows through.
+		newDomainDNS := true
+		if req.DNSEnabled != nil {
+			newDomainDNS = *req.DNSEnabled
+		}
+		wd, derr := a.delegatedDomainSvc.CreateDomain(reqCtx, namespace, *req.Domain, website.ID, user, newDomainDNS, cfgRaw)
 		if derr != nil {
 			a.Logger().Error("Failed to create primary domain for website",
 				zap.Uint("website_id", website.ID), zap.String("domain", *req.Domain), zap.Error(derr))

--- a/internal/api/api_websites_test.go
+++ b/internal/api/api_websites_test.go
@@ -74,7 +74,7 @@ func TestAPI_CreateWebsite(t *testing.T) {
 			require.NoError(tb, ctx.DB().Create(createTestIPFSGatewayWebsite(1, userID, TestDomain, cid.MustParse(TestCID), pluginDb.WebsiteStatusActive)).Error)
 			mockDNS := helper.SetupDNSServiceMocks()
 			mockDNS.EXPECT().CreateZone(mock.Anything, TestDomain, userID).Return(&pluginDb.DNSZone{Model: gorm.Model{ID: 1}, Domain: TestDomain}, nil)
-			mockDNS.EXPECT().CreateDNSLinkRecord(mock.Anything, uint(1), mock.Anything).Return(nil).Maybe()
+			mockDNS.EXPECT().CreateDNSLinkRecord(mock.Anything, uint(1), mock.Anything, mock.Anything).Return(nil).Maybe()
 
 			mockWebsite := createMockIPFSWebsite(1, userID, TestDomain, TestCID, pluginDb.WebsiteStatusPendingValidation, "test-token")
 
@@ -122,7 +122,7 @@ func TestAPI_CreateWebsite(t *testing.T) {
 			require.NoError(tb, ctx.DB().Create(createTestIPFSGatewayWebsite(1, userID, TestDomain, cid.MustParse(TestCID), pluginDb.WebsiteStatusActive)).Error)
 			mockDNS := helper.SetupDNSServiceMocks()
 			mockDNS.EXPECT().CreateZone(mock.Anything, TestDomain, userID).Return(&pluginDb.DNSZone{Model: gorm.Model{ID: 1}, Domain: TestDomain}, nil)
-			mockDNS.EXPECT().CreateDNSLinkRecord(mock.Anything, uint(1), mock.Anything).Return(nil).Maybe()
+			mockDNS.EXPECT().CreateDNSLinkRecord(mock.Anything, uint(1), mock.Anything, mock.Anything).Return(nil).Maybe()
 
 			mockWebsite := createMockIPNSWebsite(1, userID, TestDomain, TestPeerID, pluginDb.WebsiteStatusPendingValidation, "test-token")
 
@@ -226,7 +226,7 @@ func TestAPI_CreateWebsite(t *testing.T) {
 			require.NoError(tb, ctx.DB().Create(createTestIPFSGatewayWebsite(1, userID, TestDomain, cid.MustParse(TestCID), pluginDb.WebsiteStatusActive)).Error)
 			mockDNS := helper.SetupDNSServiceMocks()
 			mockDNS.EXPECT().CreateZone(mock.Anything, TestDomain, userID).Return(&pluginDb.DNSZone{Model: gorm.Model{ID: 1}, Domain: TestDomain}, nil)
-			mockDNS.EXPECT().CreateDNSLinkRecord(mock.Anything, uint(1), mock.Anything).Return(nil).Maybe()
+			mockDNS.EXPECT().CreateDNSLinkRecord(mock.Anything, uint(1), mock.Anything, mock.Anything).Return(nil).Maybe()
 
 			mockWebsite := createMockIPFSWebsite(1, userID, TestDomain, TestCID, pluginDb.WebsiteStatusBroken, "test-token")
 
@@ -867,7 +867,7 @@ func TestAPI_UpdateWebsite(t *testing.T) {
 			// gateway config in the harness).
 			mockDNS := helper.SetupDNSServiceMocks()
 			mockDNS.EXPECT().CreateZone(mock.Anything, "updated-example.com", userID).Return(&pluginDb.DNSZone{Model: gorm.Model{ID: 1}, Domain: "updated-example.com"}, nil)
-			mockDNS.EXPECT().CreateDNSLinkRecord(mock.Anything, uint(1), mock.Anything).Return(nil).Maybe()
+			mockDNS.EXPECT().CreateDNSLinkRecord(mock.Anything, uint(1), mock.Anything, mock.Anything).Return(nil).Maybe()
 
 			mockWebsite := createMockIPFSWebsite(1, userID, "updated-example.com", TestCID, pluginDb.WebsiteStatusActive, "")
 

--- a/internal/api/dto/domain.go
+++ b/internal/api/dto/domain.go
@@ -10,15 +10,20 @@ import (
 
 // DomainRequest binds a domain to a website.
 type DomainRequest struct {
-	Domain    string         `json:"domain"`
-	Namespace string         `json:"namespace"` // e.g. "icann", "hns"
-	Config    map[string]any `json:"config,omitempty"`
+	Domain    string `json:"domain"`
+	Namespace string `json:"namespace"` // e.g. "icann", "hns"
+	// DNSHostingEnabled controls whether the portal manages DNS for this
+	// binding. Managed-by-default: when omitted (nil), the binding is created
+	// DNS-hosted, matching the creation of its authoritative zone.
+	DNSHostingEnabled *bool          `json:"dns_hosting_enabled,omitempty"`
+	Config            map[string]any `json:"config,omitempty"`
 }
 
 func (r DomainRequest) Schema() *zog.StructSchema {
 	return zog.Struct(zog.Shape{
-		"Domain":    zog.String().Required().Min(1).Max(255),
-		"Namespace": zog.String().Required().OneOf([]string{string(db.DomainNamespaceICANN), string(db.DomainNamespaceHNS)}),
+		"Domain":            zog.String().Required().Min(1).Max(255),
+		"Namespace":         zog.String().Required().OneOf([]string{string(db.DomainNamespaceICANN), string(db.DomainNamespaceHNS)}),
+		"DNSHostingEnabled": zog.Ptr(zog.Bool()),
 		// Config is intentionally unvalidated here; the namespace provider validates its contents.
 	})
 }

--- a/internal/db/website_domain.go
+++ b/internal/db/website_domain.go
@@ -23,6 +23,7 @@ const (
 	DomainStatusRecordsGenerated  DomainStatus = "records_generated"
 	DomainStatusWaitingDelegation DomainStatus = "waiting_delegation"
 	DomainStatusActive            DomainStatus = "active"
+	DomainStatusSelfHosted        DomainStatus = "self_hosted"
 	DomainStatusError             DomainStatus = "error"
 )
 

--- a/internal/service/dns/dns_service.go
+++ b/internal/service/dns/dns_service.go
@@ -174,27 +174,33 @@ func (s *DNSServiceDefault) GetConfig() (any, error) {
 	return &pluginConfig.DnsConfig{}, nil
 }
 
-// CreateDNSLinkRecord creates a DNSLink TXT record in a zone (adapter for domain.DNSZoneService)
-func (s *DNSServiceDefault) CreateDNSLinkRecord(ctx context.Context, zoneID uint, target string) error {
-	_, err := s.CreateRecord(ctx, zoneID, "_dnslink", "TXT", "dnslink="+target, 300)
+// CreateDNSLinkRecord creates a DNSLink TXT record in a zone for the given
+// domain owner (adapter for domain.DNSZoneService). The owner name is built
+// from domain, not the zone apex, so a subdomain reusing a parent zone gets
+// its own `_dnslink.<domain>` rather than overwriting the parent's.
+func (s *DNSServiceDefault) CreateDNSLinkRecord(ctx context.Context, zoneID uint, domain string, target string) error {
+	_, err := s.CreateRecord(ctx, zoneID, "_dnslink."+domain, "TXT", "dnslink="+target, 300)
 	return err
 }
 
-// CreateApexRecord creates the apex (root) record in a zone (adapter for
-// domain.DNSZoneService). content is raw: an IP for A, a gateway hostname for
-// ALIAS/CNAME.
-func (s *DNSServiceDefault) CreateApexRecord(ctx context.Context, zoneID uint, recordType pluginCore.RecordType, content string) error {
-	_, err := s.CreateRecord(ctx, zoneID, "", string(recordType), content, 300)
+// CreateApexRecord creates the authoritative record for domain in a zone
+// (adapter for domain.DNSZoneService). content is raw: an IP for A, a gateway
+// hostname for ALIAS/CNAME. The owner is domain (the zone apex for apex
+// bindings, or the subdomain label for subdomains reusing a parent zone).
+func (s *DNSServiceDefault) CreateApexRecord(ctx context.Context, zoneID uint, domain string, recordType pluginCore.RecordType, content string) error {
+	_, err := s.CreateRecord(ctx, zoneID, domain, string(recordType), content, 300)
 	return err
 }
 
-// SetTLSARecord writes (or replaces) the DANE TLSA record for a zone's
+// SetTLSARecord writes (or replaces) the DANE TLSA record for domain's
 // HTTPS/TCP owner `_443._tcp` in the portal-managed authoritative zone
 // (adapter for domain.DNSZoneService). content is the TLSA rdata, e.g.
 // "3 1 1 <sha256hex>". Publishing this is what lets DANE validators resolve the
 // TLSA against PowerDNS; without it authoritative queries return NXDOMAIN.
-func (s *DNSServiceDefault) SetTLSARecord(ctx context.Context, zoneID uint, content string) error {
-	_, err := s.CreateRecord(ctx, zoneID, "_443._tcp", "TLSA", content, 300)
+// The owner is built from domain (not the zone apex) so a subdomain reusing a
+// parent zone gets its own `_443._tcp.<domain>` rather than the parent's.
+func (s *DNSServiceDefault) SetTLSARecord(ctx context.Context, zoneID uint, domain string, content string) error {
+	_, err := s.CreateRecord(ctx, zoneID, "_443._tcp."+domain, "TLSA", content, 300)
 	return err
 }
 

--- a/internal/service/domain/delegated_domain_service.go
+++ b/internal/service/domain/delegated_domain_service.go
@@ -103,7 +103,8 @@ func (s *DelegatedDomainService) gatewayIP() string {
 }
 
 func (s *DelegatedDomainService) CreateDomain(ctx context.Context,
-	namespace, domain string, websiteID, userID uint, config json.RawMessage) (*pluginDb.WebsiteDomain, error) {
+	namespace, domain string, websiteID, userID uint, dnsHostingEnabled bool,
+	config json.RawMessage) (*pluginDb.WebsiteDomain, error) {
 
 	// Require a database connection up front: many call sites feed through a
 	// service that may not be wired to a DB (e.g. the website-create API when
@@ -138,6 +139,11 @@ func (s *DelegatedDomainService) CreateDomain(ctx context.Context,
 		Namespace: pluginDb.DomainNamespace(namespace),
 		ZoneName:  canonicalZoneName(domain),
 		Status:    pluginDb.DomainStatusDraft,
+		// The per-domain DNS hosting flag is threaded from the bind request
+		// (default true). It gates whether this flow provisions a PowerDNS
+		// zone; when false, no zone is created and the binding is self-hosted
+		// DNS (see the zone-creation decision below).
+		DNSHostingEnabled: dnsHostingEnabled,
 	}
 
 	// Soft deletes leave a tombstone row that still occupies the
@@ -216,9 +222,10 @@ func (s *DelegatedDomainService) CreateDomain(ctx context.Context,
 	wd.Status = pluginDb.DomainStatusRecordsGenerated
 	wd.DelegationData = jsonToMap(delegationBytes)
 	if err := s.DB().WithContext(ctx).Model(wd).Updates(map[string]any{
-		"zone_id":         zone.ID,
-		"status":          pluginDb.DomainStatusRecordsGenerated,
-		"delegation_data": wd.DelegationData,
+		"zone_id":             zone.ID,
+		"status":              pluginDb.DomainStatusRecordsGenerated,
+		"delegation_data":     wd.DelegationData,
+		"dns_hosting_enabled": wd.DNSHostingEnabled,
 	}).Error; err != nil {
 		return nil, fmt.Errorf("failed to finalize domain record: %w", err)
 	}

--- a/internal/service/domain/delegated_domain_service.go
+++ b/internal/service/domain/delegated_domain_service.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	dane "go.lumeweb.com/dane"
@@ -28,6 +29,9 @@ type DelegatedDomainService struct {
 
 type DNSZoneService interface {
 	CreateZone(ctx context.Context, domain string, userID uint) (*pluginDb.DNSZone, error)
+	// GetZoneByDomain retrieves a zone by its domain name (including
+	// soft-deleted zones). Returns gorm.ErrRecordNotFound when none match.
+	GetZoneByDomain(ctx context.Context, domain string) (*pluginDb.DNSZone, error)
 	DeleteZone(ctx context.Context, zoneID uint) error
 	CreateDNSLinkRecord(ctx context.Context, zoneID uint, target string) error
 	// CreateApexRecord creates the apex (root) record for a zone of the given
@@ -102,6 +106,44 @@ func (s *DelegatedDomainService) gatewayIP() string {
 	return dnsCfg.GatewayIP
 }
 
+// resolveManagedZone returns the PowerDNS zone a managed binding's authoritative
+// records live in, applying the one-zone topology rule:
+//   - apex domains own their zone (create/reuse the zone for the domain).
+//   - subdomains reuse their parent's zone (no new zone for the subdomain).
+//
+// It returns the zone and whether this call created it (so callers can roll
+// back a freshly-created zone on a later step failure).
+func (s *DelegatedDomainService) resolveManagedZone(ctx context.Context, domain string, userID uint) (*pluginDb.DNSZone, bool, error) {
+	// A subdomain (e.g. docs.pinner.xyz) lives inside its parent's zone
+	// (pinner.xyz); only the apex owns a zone.
+	if parent := parentDomain(domain); parent != "" {
+		z, err := s.dnsSvc.GetZoneByDomain(ctx, parent)
+		if err == nil && z != nil && z.UserID == userID {
+			return z, false, nil
+		}
+		if err != nil && err != gorm.ErrRecordNotFound {
+			return nil, false, fmt.Errorf("lookup parent zone %q: %w", parent, err)
+		}
+	}
+
+	z, err := s.dnsSvc.CreateZone(ctx, domain, userID)
+	if err != nil {
+		return nil, false, fmt.Errorf("zone creation failed: %w", err)
+	}
+	return z, true, nil
+}
+
+// parentDomain returns the domain's parent (everything after the first label),
+// or "" when the domain is an apex (single-label HNS, or a bare TLD-less ICANN
+// name). Mirrors the website service's extractParentDomain.
+func parentDomain(domain string) string {
+	parts := strings.Split(strings.TrimSuffix(domain, "."), ".")
+	if len(parts) <= 2 {
+		return ""
+	}
+	return strings.Join(parts[1:], ".")
+}
+
 func (s *DelegatedDomainService) CreateDomain(ctx context.Context,
 	namespace, domain string, websiteID, userID uint, dnsHostingEnabled bool,
 	config json.RawMessage) (*pluginDb.WebsiteDomain, error) {
@@ -164,17 +206,35 @@ func (s *DelegatedDomainService) CreateDomain(ctx context.Context,
 		return nil, fmt.Errorf("persist failed: %w", err)
 	}
 
-	// Create DNS resources only after the DB row is committed.
-	zone, err := s.dnsSvc.CreateZone(ctx, domain, userID)
+	// A self-hosted DNS binding owns no PowerDNS zone: the user runs the
+	// authoritative server, so the portal must not create a zone, DNSLink,
+	// apex, or generated delegation. The binding is marked self_hosted (bound,
+	// DNS not provisioned by Pinner); the user enables portal DNS hosting
+	// later via domain update (SetDomainDNSEnabled) if they want Pinner to
+	// host.
+	if !dnsHostingEnabled {
+		wd.Status = pluginDb.DomainStatusSelfHosted
+		if err := s.DB().WithContext(ctx).Model(wd).Update("status", pluginDb.DomainStatusSelfHosted).Error; err != nil {
+			return nil, fmt.Errorf("failed to finalize domain record: %w", err)
+		}
+		return wd, nil
+	}
+
+	// Managed DNS: create DNS resources only after the DB row is committed.
+	// The authoritative zone follows the one-zone rule — apex owns, subdomain
+	// reuses the parent's zone.
+	zone, zoneCreated, err := s.resolveManagedZone(ctx, domain, userID)
 	if err != nil {
 		s.DB().WithContext(ctx).Unscoped().Delete(wd)
-		return nil, fmt.Errorf("zone creation failed: %w", err)
+		return nil, fmt.Errorf("zone resolution failed: %w", err)
 	}
 
 	target := pluginDb.WebsiteTargetType(website.TargetType).ToDNSLinkPath(website.TargetHash())
 	if err := s.dnsSvc.CreateDNSLinkRecord(ctx, zone.ID, target); err != nil {
 		s.DB().WithContext(ctx).Unscoped().Delete(wd)
-		_ = s.dnsSvc.DeleteZone(ctx, zone.ID)
+		if zoneCreated {
+			_ = s.dnsSvc.DeleteZone(ctx, zone.ID)
+		}
 		return nil, fmt.Errorf("dnslink creation failed: %w", err)
 	}
 
@@ -187,7 +247,9 @@ func (s *DelegatedDomainService) CreateDomain(ctx context.Context,
 		apexContent = s.gatewayIP()
 		if apexContent == "" {
 			s.DB().WithContext(ctx).Unscoped().Delete(wd)
-			_ = s.dnsSvc.DeleteZone(ctx, zone.ID)
+			if zoneCreated {
+				_ = s.dnsSvc.DeleteZone(ctx, zone.ID)
+			}
 			return nil, fmt.Errorf("gateway_ip not configured: alt-root apex requires a real A record and cannot fall back to ALIAS (set dns.gateway_ip, e.g. to the gateway IP)")
 		}
 	} else if gatewayHost := s.gatewayHost(); gatewayHost != "" {
@@ -197,7 +259,9 @@ func (s *DelegatedDomainService) CreateDomain(ctx context.Context,
 	if apexContent != "" {
 		if err := s.dnsSvc.CreateApexRecord(ctx, zone.ID, apexType, apexContent); err != nil {
 			s.DB().WithContext(ctx).Unscoped().Delete(wd)
-			_ = s.dnsSvc.DeleteZone(ctx, zone.ID)
+			if zoneCreated {
+				_ = s.dnsSvc.DeleteZone(ctx, zone.ID)
+			}
 			return nil, fmt.Errorf("apex record creation failed: %w", err)
 		}
 		wd.GatewayHost = apexContent
@@ -251,6 +315,19 @@ func (s *DelegatedDomainService) VerifyDomain(ctx context.Context,
 	provider := s.registry.Get(string(wd.Namespace))
 	if provider == nil {
 		return false, fmt.Errorf("unsupported namespace: %s", wd.Namespace)
+	}
+
+	// A self-hosted DNS binding owns no portal-managed zone to verify: the user
+	// runs the authoritative server and DNSSEC/DANE delegation is theirs. The
+	// binding is not part of the portal's lifecycle (no DS to reconcile, no
+	// SOA/DNSSEC to self-heal), so verification is a no-op that leaves the
+	// binding's existing status rather than querying PowerDNS for a zone that
+	// does not exist. The presence of a real PowerDNS zone (ZoneID != 0) is
+	// the authoritative marker of a portal-hosted binding, regardless of the
+	// dns_hosting_enabled flag (which may be false on legacy bindings that
+	// still hold a zone).
+	if wd.ZoneID == 0 {
+		return false, nil
 	}
 
 	// Expected DS is computed live from PowerDNS's current active signing key

--- a/internal/service/domain/delegated_domain_service.go
+++ b/internal/service/domain/delegated_domain_service.go
@@ -113,17 +113,27 @@ func (s *DelegatedDomainService) gatewayIP() string {
 //
 // It returns the zone and whether this call created it (so callers can roll
 // back a freshly-created zone on a later step failure).
+//
+// One-zone invariant: a subdomain never owns its own authoritative zone. If a
+// parent zone already exists it MUST be reused, and it must belong to the same
+// user — otherwise the subdomain would create a competing authoritative zone
+// and let another user squat authority over a name their neighbor already
+// hosts. A new zone is only created when no parent zone exists at all.
 func (s *DelegatedDomainService) resolveManagedZone(ctx context.Context, domain string, userID uint) (*pluginDb.DNSZone, bool, error) {
 	// A subdomain (e.g. docs.pinner.xyz) lives inside its parent's zone
 	// (pinner.xyz); only the apex owns a zone.
 	if parent := parentDomain(domain); parent != "" {
 		z, err := s.dnsSvc.GetZoneByDomain(ctx, parent)
-		if err == nil && z != nil && z.UserID == userID {
-			return z, false, nil
-		}
-		if err != nil && err != gorm.ErrRecordNotFound {
+		if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, false, fmt.Errorf("lookup parent zone %q: %w", parent, err)
 		}
+		if err == nil && z != nil {
+			if z.UserID != userID {
+				return nil, false, fmt.Errorf("parent zone %q is owned by another user", parent)
+			}
+			return z, false, nil
+		}
+		// No parent zone exists — fall through and create a zone for the domain.
 	}
 
 	z, err := s.dnsSvc.CreateZone(ctx, domain, userID)

--- a/internal/service/domain/delegated_domain_service.go
+++ b/internal/service/domain/delegated_domain_service.go
@@ -33,18 +33,27 @@ type DNSZoneService interface {
 	// soft-deleted zones). Returns gorm.ErrRecordNotFound when none match.
 	GetZoneByDomain(ctx context.Context, domain string) (*pluginDb.DNSZone, error)
 	DeleteZone(ctx context.Context, zoneID uint) error
-	CreateDNSLinkRecord(ctx context.Context, zoneID uint, target string) error
-	// CreateApexRecord creates the apex (root) record for a zone of the given
-	// record type (e.g. RecordTypeA or RecordTypeALIAS). content is the raw
-	// value: an IP address for A, a gateway hostname for ALIAS.
-	CreateApexRecord(ctx context.Context, zoneID uint, recordType pluginCore.RecordType, content string) error
-	// SetTLSARecord writes (or replaces) the DANE TLSA record for a zone's
+	// CreateDNSLinkRecord writes the DNSLink TXT record for a domain's owner
+	// name(`_dnslink.<domain>`) into zone zoneID. domain is the FQDN of the
+	// record's owner: the zone apex for an apex binding, or a subdomain that
+	// lives inside a reused parent zone. Naming the record after domain (not
+	// the zone apex) keeps subdomain records from colliding with the parent's
+	// own DNSLink record.
+	CreateDNSLinkRecord(ctx context.Context, zoneID uint, domain string, target string) error
+	// CreateApexRecord creates the authoritative record for domain (not the
+	// zone apex) of the given record type (e.g. RecordTypeA or RecordTypeALIAS).
+	// content is the raw value: an IP address for A, a gateway hostname for
+	// ALIAS. When domain equals the zone apex this is the zone root record;
+	// for a subdomain reusing a parent zone it is the subdomain's record.
+	CreateApexRecord(ctx context.Context, zoneID uint, domain string, recordType pluginCore.RecordType, content string) error
+	// SetTLSARecord writes (or replaces) the DANE TLSA record for domain's
 	// HTTPS/TCP owner `_443._tcp` pointing at the portal-managed authoritative
 	// zone. content is the TLSA rdata: "usage selector matching hash" (e.g.
 	// "3 1 1 <hex>")). For HNS managed zones this makes DANE validators resolve
 	// the TLSA against the portal's PowerDNS zone; without it, authoritative
-	// queries return NXDOMAIN.
-	SetTLSARecord(ctx context.Context, zoneID uint, content string) error
+	// queries return NXDOMAIN. The owner is named after domain so a subdomain
+	// reusing a parent zone gets its own TLSA, not the parent's.
+	SetTLSARecord(ctx context.Context, zoneID uint, domain string, content string) error
 	// EnableDNSSEC enables DNSSEC on a zone and returns the DNSKEY.
 	EnableDNSSEC(ctx context.Context, zoneID uint) (dnskey string, err error)
 	// GetActiveDNSSECDS returns the SHA-256 DS RDATA (type 2) for a zone's
@@ -240,7 +249,10 @@ func (s *DelegatedDomainService) CreateDomain(ctx context.Context,
 	}
 
 	target := pluginDb.WebsiteTargetType(website.TargetType).ToDNSLinkPath(website.TargetHash())
-	if err := s.dnsSvc.CreateDNSLinkRecord(ctx, zone.ID, target); err != nil {
+	// Name the record after the binding's domain (not the zone apex) so a
+	// subdomain reusing a parent zone writes its own _dnslink.<subdomain>,
+	// not the parent's.
+	if err := s.dnsSvc.CreateDNSLinkRecord(ctx, zone.ID, domain, target); err != nil {
 		s.DB().WithContext(ctx).Unscoped().Delete(wd)
 		if zoneCreated {
 			_ = s.dnsSvc.DeleteZone(ctx, zone.ID)
@@ -267,7 +279,7 @@ func (s *DelegatedDomainService) CreateDomain(ctx context.Context,
 	}
 
 	if apexContent != "" {
-		if err := s.dnsSvc.CreateApexRecord(ctx, zone.ID, apexType, apexContent); err != nil {
+		if err := s.dnsSvc.CreateApexRecord(ctx, zone.ID, domain, apexType, apexContent); err != nil {
 			s.DB().WithContext(ctx).Unscoped().Delete(wd)
 			if zoneCreated {
 				_ = s.dnsSvc.DeleteZone(ctx, zone.ID)
@@ -635,9 +647,12 @@ func (s *DelegatedDomainService) UpdateTLSAFromCert(ctx context.Context, namespa
 	// Only providers whose namespace uses DANE and whose zone the portal
 	// manages (e.g. HNS) do this; the decision is a provider capability, not
 	// a namespace string comparison, so any future DANE-capable namespace
-	// opts in here rather than via a hardcoded "hns" check.
+	// opts in here rather than via a hardcoded "hns" check. The TLSA owner is
+	// named after the binding's domain (not the zone apex) so a subdomain
+	// reusing a parent zone publishes _443._tcp.<subdomain> rather than
+	// overwriting the parent's TLSA.
 	if s.dnsSvc != nil && zoneID != 0 && provider.UsesManagedZoneTLSA() {
-		if err := s.dnsSvc.SetTLSARecord(ctx, zoneID, tlsa); err != nil {
+		if err := s.dnsSvc.SetTLSARecord(ctx, zoneID, domain, tlsa); err != nil {
 			// DNS publish failure is surfaced but the persisted cert/TLSA state
 			// is retained so a later cert push retries the publish.
 			return tlsa, ownerName, fmt.Errorf("publish tlsa to zone: %w", err)

--- a/internal/service/domain/delegated_domain_service_test.go
+++ b/internal/service/domain/delegated_domain_service_test.go
@@ -60,7 +60,7 @@ func TestDelegatedDomainService_CreateDomain(t *testing.T) {
 
 		mockDNS.EXPECT().CreateZone(mock.Anything, "example.com", uint(1)).
 			Return(&pluginDb.DNSZone{Model: gorm.Model{ID: 1}, Domain: "example.com"}, nil).Once()
-		mockDNS.EXPECT().CreateDNSLinkRecord(mock.Anything, uint(1), mock.Anything).Return(nil).Once()
+		mockDNS.EXPECT().CreateDNSLinkRecord(mock.Anything, uint(1), mock.Anything, mock.Anything).Return(nil).Once()
 
 		wd, err := svc.CreateDomain(context.Background(), "icann", "example.com", website.ID, 1, true, nil)
 		assert.NoError(tb, err)
@@ -131,10 +131,12 @@ func TestDelegatedDomainService_CreateDomain_SubdomainReusesParentZone(t *testin
 		// parent, and CreateZone must NOT be called for the subdomain.
 		mockDNS.EXPECT().GetZoneByDomain(mock.Anything, "example.com").
 			Return(&pluginDb.DNSZone{Model: gorm.Model{ID: parent.ID}, Domain: "example.com", UserID: 1}, nil).Once()
-		// Downstream record writes replay onto the reused parent zone id; make
-		// them permissive so the test isolates the zone-reuse invariant.
-		mockDNS.EXPECT().CreateDNSLinkRecord(mock.Anything, uint(parent.ID), mock.Anything).Return(nil).Maybe()
-		mockDNS.EXPECT().CreateApexRecord(mock.Anything, uint(parent.ID), mock.Anything, mock.Anything).Return(nil).Maybe()
+		// The subdomain's records must be named after the subdomain (not the
+		// parent apex) so they don't collide with the parent's own records. The
+		// apex record only fires when a gateway host is configured (it's absent
+		// in this harness), so assert its domain-name strictly if it runs.
+		mockDNS.EXPECT().CreateDNSLinkRecord(mock.Anything, uint(parent.ID), "docs.example.com", mock.Anything).Return(nil).Once()
+		mockDNS.EXPECT().CreateApexRecord(mock.Anything, uint(parent.ID), "docs.example.com", mock.Anything, mock.Anything).Return(nil).Maybe()
 		mockDNS.AssertNotCalled(tb, "CreateZone", mock.Anything, "docs.example.com", mock.Anything)
 
 		wd, err := svc.CreateDomain(context.Background(), "icann", "docs.example.com", website.ID, 1, true, nil)
@@ -414,8 +416,8 @@ func TestDelegatedDomainService_UpdateTLSA_PublishesToManagedZone(t *testing.T) 
 			// The TLSA must be pushed to the managed zone (zone 42) as
 			// "usage selector matching hash" rdata.
 			mockDNS.EXPECT().
-				SetTLSARecord(mock.Anything, uint(42), mock.Anything).
-				Run(func(_ context.Context, zoneID uint, content string) {
+				SetTLSARecord(mock.Anything, uint(42), mock.Anything, mock.Anything).
+				Run(func(_ context.Context, zoneID uint, domain string, content string) {
 					assert.Regexp(tb, `^3 1 1 [0-9a-fA-F]+$`, content,
 						"TLSA rdata must be '<usage> <selector> <matching> <digest>'")
 				}).

--- a/internal/service/domain/delegated_domain_service_test.go
+++ b/internal/service/domain/delegated_domain_service_test.go
@@ -62,12 +62,14 @@ func TestDelegatedDomainService_CreateDomain(t *testing.T) {
 			Return(&pluginDb.DNSZone{Model: gorm.Model{ID: 1}, Domain: "example.com"}, nil).Once()
 		mockDNS.EXPECT().CreateDNSLinkRecord(mock.Anything, uint(1), mock.Anything).Return(nil).Once()
 
-		wd, err := svc.CreateDomain(context.Background(), "icann", "example.com", website.ID, 1, nil)
+		wd, err := svc.CreateDomain(context.Background(), "icann", "example.com", website.ID, 1, true, nil)
 		assert.NoError(tb, err)
 		assert.NotNil(tb, wd)
 		assert.Equal(tb, "example.com", wd.Domain)
 		assert.Equal(tb, pluginDb.DomainNamespaceICANN, wd.Namespace)
 		assert.Equal(tb, uint(1), wd.ZoneID)
+		// Managed-DNS binding: the flag is persisted to match the created zone.
+		assert.True(tb, wd.DNSHostingEnabled)
 	}, TestOptions)
 }
 
@@ -76,7 +78,7 @@ func TestDelegatedDomainService_CreateDomain_UnsupportedNamespace(t *testing.T) 
 		svc := core.GetService[*DelegatedDomainService](ctx, pluginCore.DELEGATED_DOMAIN_SERVICE)
 		require.NotNil(tb, svc)
 
-		_, err := svc.CreateDomain(context.Background(), "ens", "example.eth", 1, 1, nil)
+		_, err := svc.CreateDomain(context.Background(), "ens", "example.eth", 1, 1, true, nil)
 		assert.Error(tb, err)
 		assert.Contains(tb, err.Error(), "unsupported namespace")
 	}, TestOptions)

--- a/internal/service/domain/delegated_domain_service_test.go
+++ b/internal/service/domain/delegated_domain_service_test.go
@@ -148,6 +148,43 @@ func TestDelegatedDomainService_CreateDomain_SubdomainReusesParentZone(t *testin
 	}, TestOptions)
 }
 
+func TestDelegatedDomainService_CreateDomain_SubdomainForeignParentRejected(t *testing.T) {
+	// One-zone invariant: a subdomain must NOT create a competing authoritative
+	// zone when a parent zone exists but belongs to another user (subdomain-zone
+	// squatting). It must error instead.
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		db := ctx.DB()
+
+		website := createTestWebsite(tb, db, 1, "example.com")
+
+		// Parent zone owned by a DIFFERENT user (2).
+		require.NoError(tb, db.Create(&pluginDb.DNSZone{
+			UserID: 2, Domain: "example.com", Status: string(pluginDb.DNSZoneStatusActive),
+			PowerDNSZoneID: "foreign-pdns-id",
+		}).Error)
+
+		var parent pluginDb.DNSZone
+		require.NoError(tb, ctx.DB().WithContext(context.Background()).Where("domain = ?", "example.com").
+			First(&parent).Error)
+
+		svc := core.GetService[*DelegatedDomainService](ctx, pluginCore.DELEGATED_DOMAIN_SERVICE)
+		require.NotNil(tb, svc)
+
+		mockDNS := core.GetService[*mocks.MockDNSService](ctx, pluginCore.DNS_SERVICE)
+		require.NotNil(tb, mockDNS)
+
+		// Parent lookup returns the foreign-owned zone; CreateZone for the
+		// subdomain must NEVER be called.
+		mockDNS.EXPECT().GetZoneByDomain(mock.Anything, "example.com").
+			Return(&pluginDb.DNSZone{Model: gorm.Model{ID: parent.ID}, Domain: "example.com", UserID: 2}, nil).Once()
+		mockDNS.AssertNotCalled(tb, "CreateZone", mock.Anything, "docs.example.com", mock.Anything)
+
+		_, err := svc.CreateDomain(context.Background(), "icann", "docs.example.com", website.ID, 1, true, nil)
+		require.Error(tb, err)
+		assert.Contains(tb, err.Error(), "owned by another user")
+	}, TestOptions)
+}
+
 func TestDelegatedDomainService_CreateDomain_UnsupportedNamespace(t *testing.T) {
 	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 		svc := core.GetService[*DelegatedDomainService](ctx, pluginCore.DELEGATED_DOMAIN_SERVICE)

--- a/internal/service/domain/delegated_domain_service_test.go
+++ b/internal/service/domain/delegated_domain_service_test.go
@@ -73,6 +73,81 @@ func TestDelegatedDomainService_CreateDomain(t *testing.T) {
 	}, TestOptions)
 }
 
+func TestDelegatedDomainService_CreateDomain_SelfHosted(t *testing.T) {
+	// A self-hosted DNS binding (dnsHostingEnabled=false) must NOT create a
+	// PowerDNS zone, DNSLink, apex, or delegation — the user runs the
+	// authoritative server. It is marked self_hosted with no zone.
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		db := ctx.DB()
+
+		website := createTestWebsite(tb, db, 1, "example.com")
+
+		svc := core.GetService[*DelegatedDomainService](ctx, pluginCore.DELEGATED_DOMAIN_SERVICE)
+		require.NotNil(tb, svc)
+
+		mockDNS := core.GetService[*mocks.MockDNSService](ctx, pluginCore.DNS_SERVICE)
+		require.NotNil(tb, mockDNS)
+
+		// No zone, DNSLink, apex, or delegation calls for a self-hosted binding.
+		mockDNS.AssertNotCalled(tb, "CreateZone", mock.Anything, mock.Anything, mock.Anything)
+
+		wd, err := svc.CreateDomain(context.Background(), "icann", "example.com", website.ID, 1, false, nil)
+		assert.NoError(tb, err)
+		assert.NotNil(tb, wd)
+		assert.Equal(tb, pluginDb.DomainStatusSelfHosted, wd.Status)
+		assert.Equal(tb, uint(0), wd.ZoneID)
+		assert.False(tb, wd.DNSHostingEnabled)
+		assert.Nil(tb, wd.DelegationData)
+	}, TestOptions)
+}
+
+func TestDelegatedDomainService_CreateDomain_SubdomainReusesParentZone(t *testing.T) {
+	// A managed subdomain lives inside its parent's zone; it must NOT create a
+	// new PowerDNS zone. resolveManagedZone should return the parent zone.
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		db := ctx.DB()
+
+		website := createTestWebsite(tb, db, 1, "example.com")
+
+		// A parent zone owned by the same user must be reused.
+		require.NoError(tb, db.Create(&pluginDb.DNSZone{
+			UserID: 1, Domain: "example.com", Status: string(pluginDb.DNSZoneStatusActive),
+			PowerDNSZoneID: "parent-pdns-id",
+		}).Error)
+
+		svc := core.GetService[*DelegatedDomainService](ctx, pluginCore.DELEGATED_DOMAIN_SERVICE)
+		require.NotNil(tb, svc)
+
+		mockDNS := core.GetService[*mocks.MockDNSService](ctx, pluginCore.DNS_SERVICE)
+		require.NotNil(tb, mockDNS)
+
+		// GetZoneByDomain resolves the parent; CreateZone must NOT be called for
+		// the subdomain (a new zone would be an apex owned separately).
+		var parent pluginDb.DNSZone
+		require.NoError(tb, ctx.DB().WithContext(context.Background()).Where("domain = ?", "example.com").
+			First(&parent).Error)
+
+		// resolveManagedZone reuses the parent zone: GetZoneByDomain returns the
+		// parent, and CreateZone must NOT be called for the subdomain.
+		mockDNS.EXPECT().GetZoneByDomain(mock.Anything, "example.com").
+			Return(&pluginDb.DNSZone{Model: gorm.Model{ID: parent.ID}, Domain: "example.com", UserID: 1}, nil).Once()
+		// Downstream record writes replay onto the reused parent zone id; make
+		// them permissive so the test isolates the zone-reuse invariant.
+		mockDNS.EXPECT().CreateDNSLinkRecord(mock.Anything, uint(parent.ID), mock.Anything).Return(nil).Maybe()
+		mockDNS.EXPECT().CreateApexRecord(mock.Anything, uint(parent.ID), mock.Anything, mock.Anything).Return(nil).Maybe()
+		mockDNS.AssertNotCalled(tb, "CreateZone", mock.Anything, "docs.example.com", mock.Anything)
+
+		wd, err := svc.CreateDomain(context.Background(), "icann", "docs.example.com", website.ID, 1, true, nil)
+		assert.NoError(tb, err)
+		assert.NotNil(tb, wd)
+		// DNSLink/apex/delegation are written into the reused parent zone; the
+		// binding references it via ZoneName but owns no separate zone ID.
+		assert.Equal(tb, pluginDb.DomainStatusRecordsGenerated, wd.Status)
+		assert.True(tb, wd.DNSHostingEnabled)
+		assert.Equal(tb, uint(parent.ID), wd.ZoneID)
+	}, TestOptions)
+}
+
 func TestDelegatedDomainService_CreateDomain_UnsupportedNamespace(t *testing.T) {
 	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 		svc := core.GetService[*DelegatedDomainService](ctx, pluginCore.DELEGATED_DOMAIN_SERVICE)

--- a/internal/service/domain/hns_provider_test.go
+++ b/internal/service/domain/hns_provider_test.go
@@ -189,6 +189,9 @@ type fakeDNSZoneService struct{ dnskey string }
 func (f *fakeDNSZoneService) CreateZone(ctx context.Context, domain string, userID uint) (*pluginDb.DNSZone, error) {
 	panic("unused")
 }
+func (f *fakeDNSZoneService) GetZoneByDomain(ctx context.Context, domain string) (*pluginDb.DNSZone, error) {
+	panic("unused")
+}
 func (f *fakeDNSZoneService) DeleteZone(ctx context.Context, zoneID uint) error { panic("unused") }
 func (f *fakeDNSZoneService) CreateDNSLinkRecord(ctx context.Context, zoneID uint, target string) error {
 	panic("unused")

--- a/internal/service/domain/hns_provider_test.go
+++ b/internal/service/domain/hns_provider_test.go
@@ -193,13 +193,13 @@ func (f *fakeDNSZoneService) GetZoneByDomain(ctx context.Context, domain string)
 	panic("unused")
 }
 func (f *fakeDNSZoneService) DeleteZone(ctx context.Context, zoneID uint) error { panic("unused") }
-func (f *fakeDNSZoneService) CreateDNSLinkRecord(ctx context.Context, zoneID uint, target string) error {
+func (f *fakeDNSZoneService) CreateDNSLinkRecord(ctx context.Context, zoneID uint, domain string, target string) error {
 	panic("unused")
 }
-func (f *fakeDNSZoneService) CreateApexRecord(ctx context.Context, zoneID uint, recordType pluginCore.RecordType, content string) error {
+func (f *fakeDNSZoneService) CreateApexRecord(ctx context.Context, zoneID uint, domain string, recordType pluginCore.RecordType, content string) error {
 	panic("unused")
 }
-func (f *fakeDNSZoneService) SetTLSARecord(ctx context.Context, zoneID uint, content string) error {
+func (f *fakeDNSZoneService) SetTLSARecord(ctx context.Context, zoneID uint, domain string, content string) error {
 	panic("unused")
 }
 func (f *fakeDNSZoneService) EnableDNSSEC(ctx context.Context, zoneID uint) (string, error) {

--- a/internal/service/domain/integration_test.go
+++ b/internal/service/domain/integration_test.go
@@ -72,7 +72,7 @@ func TestIntegration_CreateAndVerifyHNSDomain(t *testing.T) {
 		mockDNS.EXPECT().EnableDNSSEC(mock.Anything, uint(1)).Return("257 3 13 dGVzdA==", nil).Maybe()
 
 		// Create domain
-		wd, err := svc.CreateDomain(context.Background(), "hns", "example", website.ID, 1, nil)
+		wd, err := svc.CreateDomain(context.Background(), "hns", "example", website.ID, 1, true, nil)
 		require.NoError(tb, err)
 		require.NotNil(tb, wd)
 		assert.Equal(tb, pluginDb.DomainStatusRecordsGenerated, wd.Status)

--- a/internal/service/domain/integration_test.go
+++ b/internal/service/domain/integration_test.go
@@ -67,8 +67,8 @@ func TestIntegration_CreateAndVerifyHNSDomain(t *testing.T) {
 
 		mockDNS.EXPECT().CreateZone(mock.Anything, "example", uint(1)).
 			Return(&pluginDb.DNSZone{Model: gorm.Model{ID: 1}, Domain: "example"}, nil).Once()
-		mockDNS.EXPECT().CreateDNSLinkRecord(mock.Anything, uint(1), mock.Anything).Return(nil).Once()
-		mockDNS.EXPECT().CreateApexRecord(mock.Anything, uint(1), pluginCore.RecordTypeA, gatewayIP).Return(nil).Once()
+		mockDNS.EXPECT().CreateDNSLinkRecord(mock.Anything, uint(1), mock.Anything, mock.Anything).Return(nil).Once()
+		mockDNS.EXPECT().CreateApexRecord(mock.Anything, uint(1), mock.Anything, pluginCore.RecordTypeA, gatewayIP).Return(nil).Once()
 		mockDNS.EXPECT().EnableDNSSEC(mock.Anything, uint(1)).Return("257 3 13 dGVzdA==", nil).Maybe()
 
 		// Create domain

--- a/internal/testing/mocks/MockDNSService.go
+++ b/internal/testing/mocks/MockDNSService.go
@@ -223,16 +223,16 @@ func (_c *MockDNSService_Context_Call) RunAndReturn(run func() core.Context) *Mo
 }
 
 // CreateApexRecord provides a mock function for the type MockDNSService
-func (_mock *MockDNSService) CreateApexRecord(ctx context.Context, zoneID uint, recordType core0.RecordType, content string) error {
-	ret := _mock.Called(ctx, zoneID, recordType, content)
+func (_mock *MockDNSService) CreateApexRecord(ctx context.Context, zoneID uint, domain string, recordType core0.RecordType, content string) error {
+	ret := _mock.Called(ctx, zoneID, domain, recordType, content)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CreateApexRecord")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, uint, core0.RecordType, string) error); ok {
-		r0 = returnFunc(ctx, zoneID, recordType, content)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uint, string, core0.RecordType, string) error); ok {
+		r0 = returnFunc(ctx, zoneID, domain, recordType, content)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -247,13 +247,14 @@ type MockDNSService_CreateApexRecord_Call struct {
 // CreateApexRecord is a helper method to define mock.On call
 //   - ctx context.Context
 //   - zoneID uint
+//   - domain string
 //   - recordType core0.RecordType
 //   - content string
-func (_e *MockDNSService_Expecter) CreateApexRecord(ctx any, zoneID any, recordType any, content any) *MockDNSService_CreateApexRecord_Call {
-	return &MockDNSService_CreateApexRecord_Call{Call: _e.mock.On("CreateApexRecord", ctx, zoneID, recordType, content)}
+func (_e *MockDNSService_Expecter) CreateApexRecord(ctx any, zoneID any, domain any, recordType any, content any) *MockDNSService_CreateApexRecord_Call {
+	return &MockDNSService_CreateApexRecord_Call{Call: _e.mock.On("CreateApexRecord", ctx, zoneID, domain, recordType, content)}
 }
 
-func (_c *MockDNSService_CreateApexRecord_Call) Run(run func(ctx context.Context, zoneID uint, recordType core0.RecordType, content string)) *MockDNSService_CreateApexRecord_Call {
+func (_c *MockDNSService_CreateApexRecord_Call) Run(run func(ctx context.Context, zoneID uint, domain string, recordType core0.RecordType, content string)) *MockDNSService_CreateApexRecord_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -263,9 +264,83 @@ func (_c *MockDNSService_CreateApexRecord_Call) Run(run func(ctx context.Context
 		if args[1] != nil {
 			arg1 = args[1].(uint)
 		}
-		var arg2 core0.RecordType
+		var arg2 string
 		if args[2] != nil {
-			arg2 = args[2].(core0.RecordType)
+			arg2 = args[2].(string)
+		}
+		var arg3 core0.RecordType
+		if args[3] != nil {
+			arg3 = args[3].(core0.RecordType)
+		}
+		var arg4 string
+		if args[4] != nil {
+			arg4 = args[4].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+			arg4,
+		)
+	})
+	return _c
+}
+
+func (_c *MockDNSService_CreateApexRecord_Call) Return(err error) *MockDNSService_CreateApexRecord_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockDNSService_CreateApexRecord_Call) RunAndReturn(run func(ctx context.Context, zoneID uint, domain string, recordType core0.RecordType, content string) error) *MockDNSService_CreateApexRecord_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// CreateDNSLinkRecord provides a mock function for the type MockDNSService
+func (_mock *MockDNSService) CreateDNSLinkRecord(ctx context.Context, zoneID uint, domain string, target string) error {
+	ret := _mock.Called(ctx, zoneID, domain, target)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CreateDNSLinkRecord")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uint, string, string) error); ok {
+		r0 = returnFunc(ctx, zoneID, domain, target)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockDNSService_CreateDNSLinkRecord_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CreateDNSLinkRecord'
+type MockDNSService_CreateDNSLinkRecord_Call struct {
+	*mock.Call
+}
+
+// CreateDNSLinkRecord is a helper method to define mock.On call
+//   - ctx context.Context
+//   - zoneID uint
+//   - domain string
+//   - target string
+func (_e *MockDNSService_Expecter) CreateDNSLinkRecord(ctx any, zoneID any, domain any, target any) *MockDNSService_CreateDNSLinkRecord_Call {
+	return &MockDNSService_CreateDNSLinkRecord_Call{Call: _e.mock.On("CreateDNSLinkRecord", ctx, zoneID, domain, target)}
+}
+
+func (_c *MockDNSService_CreateDNSLinkRecord_Call) Run(run func(ctx context.Context, zoneID uint, domain string, target string)) *MockDNSService_CreateDNSLinkRecord_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 uint
+		if args[1] != nil {
+			arg1 = args[1].(uint)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
 		}
 		var arg3 string
 		if args[3] != nil {
@@ -281,75 +356,12 @@ func (_c *MockDNSService_CreateApexRecord_Call) Run(run func(ctx context.Context
 	return _c
 }
 
-func (_c *MockDNSService_CreateApexRecord_Call) Return(err error) *MockDNSService_CreateApexRecord_Call {
-	_c.Call.Return(err)
-	return _c
-}
-
-func (_c *MockDNSService_CreateApexRecord_Call) RunAndReturn(run func(ctx context.Context, zoneID uint, recordType core0.RecordType, content string) error) *MockDNSService_CreateApexRecord_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// CreateDNSLinkRecord provides a mock function for the type MockDNSService
-func (_mock *MockDNSService) CreateDNSLinkRecord(ctx context.Context, zoneID uint, target string) error {
-	ret := _mock.Called(ctx, zoneID, target)
-
-	if len(ret) == 0 {
-		panic("no return value specified for CreateDNSLinkRecord")
-	}
-
-	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, uint, string) error); ok {
-		r0 = returnFunc(ctx, zoneID, target)
-	} else {
-		r0 = ret.Error(0)
-	}
-	return r0
-}
-
-// MockDNSService_CreateDNSLinkRecord_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CreateDNSLinkRecord'
-type MockDNSService_CreateDNSLinkRecord_Call struct {
-	*mock.Call
-}
-
-// CreateDNSLinkRecord is a helper method to define mock.On call
-//   - ctx context.Context
-//   - zoneID uint
-//   - target string
-func (_e *MockDNSService_Expecter) CreateDNSLinkRecord(ctx any, zoneID any, target any) *MockDNSService_CreateDNSLinkRecord_Call {
-	return &MockDNSService_CreateDNSLinkRecord_Call{Call: _e.mock.On("CreateDNSLinkRecord", ctx, zoneID, target)}
-}
-
-func (_c *MockDNSService_CreateDNSLinkRecord_Call) Run(run func(ctx context.Context, zoneID uint, target string)) *MockDNSService_CreateDNSLinkRecord_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		var arg1 uint
-		if args[1] != nil {
-			arg1 = args[1].(uint)
-		}
-		var arg2 string
-		if args[2] != nil {
-			arg2 = args[2].(string)
-		}
-		run(
-			arg0,
-			arg1,
-			arg2,
-		)
-	})
-	return _c
-}
-
 func (_c *MockDNSService_CreateDNSLinkRecord_Call) Return(err error) *MockDNSService_CreateDNSLinkRecord_Call {
 	_c.Call.Return(err)
 	return _c
 }
 
-func (_c *MockDNSService_CreateDNSLinkRecord_Call) RunAndReturn(run func(ctx context.Context, zoneID uint, target string) error) *MockDNSService_CreateDNSLinkRecord_Call {
+func (_c *MockDNSService_CreateDNSLinkRecord_Call) RunAndReturn(run func(ctx context.Context, zoneID uint, domain string, target string) error) *MockDNSService_CreateDNSLinkRecord_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -1737,16 +1749,16 @@ func (_c *MockDNSService_SetLogger_Call) RunAndReturn(run func(logger *core.Logg
 }
 
 // SetTLSARecord provides a mock function for the type MockDNSService
-func (_mock *MockDNSService) SetTLSARecord(ctx context.Context, zoneID uint, content string) error {
-	ret := _mock.Called(ctx, zoneID, content)
+func (_mock *MockDNSService) SetTLSARecord(ctx context.Context, zoneID uint, domain string, content string) error {
+	ret := _mock.Called(ctx, zoneID, domain, content)
 
 	if len(ret) == 0 {
 		panic("no return value specified for SetTLSARecord")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, uint, string) error); ok {
-		r0 = returnFunc(ctx, zoneID, content)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uint, string, string) error); ok {
+		r0 = returnFunc(ctx, zoneID, domain, content)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -1761,12 +1773,13 @@ type MockDNSService_SetTLSARecord_Call struct {
 // SetTLSARecord is a helper method to define mock.On call
 //   - ctx context.Context
 //   - zoneID uint
+//   - domain string
 //   - content string
-func (_e *MockDNSService_Expecter) SetTLSARecord(ctx any, zoneID any, content any) *MockDNSService_SetTLSARecord_Call {
-	return &MockDNSService_SetTLSARecord_Call{Call: _e.mock.On("SetTLSARecord", ctx, zoneID, content)}
+func (_e *MockDNSService_Expecter) SetTLSARecord(ctx any, zoneID any, domain any, content any) *MockDNSService_SetTLSARecord_Call {
+	return &MockDNSService_SetTLSARecord_Call{Call: _e.mock.On("SetTLSARecord", ctx, zoneID, domain, content)}
 }
 
-func (_c *MockDNSService_SetTLSARecord_Call) Run(run func(ctx context.Context, zoneID uint, content string)) *MockDNSService_SetTLSARecord_Call {
+func (_c *MockDNSService_SetTLSARecord_Call) Run(run func(ctx context.Context, zoneID uint, domain string, content string)) *MockDNSService_SetTLSARecord_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -1780,10 +1793,15 @@ func (_c *MockDNSService_SetTLSARecord_Call) Run(run func(ctx context.Context, z
 		if args[2] != nil {
 			arg2 = args[2].(string)
 		}
+		var arg3 string
+		if args[3] != nil {
+			arg3 = args[3].(string)
+		}
 		run(
 			arg0,
 			arg1,
 			arg2,
+			arg3,
 		)
 	})
 	return _c
@@ -1794,7 +1812,7 @@ func (_c *MockDNSService_SetTLSARecord_Call) Return(err error) *MockDNSService_S
 	return _c
 }
 
-func (_c *MockDNSService_SetTLSARecord_Call) RunAndReturn(run func(ctx context.Context, zoneID uint, content string) error) *MockDNSService_SetTLSARecord_Call {
+func (_c *MockDNSService_SetTLSARecord_Call) RunAndReturn(run func(ctx context.Context, zoneID uint, domain string, content string) error) *MockDNSService_SetTLSARecord_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/testing/mocks/MockDNSZoneService.go
+++ b/internal/testing/mocks/MockDNSZoneService.go
@@ -40,16 +40,16 @@ func (_m *MockDNSZoneService) EXPECT() *MockDNSZoneService_Expecter {
 }
 
 // CreateApexRecord provides a mock function for the type MockDNSZoneService
-func (_mock *MockDNSZoneService) CreateApexRecord(ctx context.Context, zoneID uint, recordType core.RecordType, content string) error {
-	ret := _mock.Called(ctx, zoneID, recordType, content)
+func (_mock *MockDNSZoneService) CreateApexRecord(ctx context.Context, zoneID uint, domain string, recordType core.RecordType, content string) error {
+	ret := _mock.Called(ctx, zoneID, domain, recordType, content)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CreateApexRecord")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, uint, core.RecordType, string) error); ok {
-		r0 = returnFunc(ctx, zoneID, recordType, content)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uint, string, core.RecordType, string) error); ok {
+		r0 = returnFunc(ctx, zoneID, domain, recordType, content)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -64,13 +64,14 @@ type MockDNSZoneService_CreateApexRecord_Call struct {
 // CreateApexRecord is a helper method to define mock.On call
 //   - ctx context.Context
 //   - zoneID uint
+//   - domain string
 //   - recordType core.RecordType
 //   - content string
-func (_e *MockDNSZoneService_Expecter) CreateApexRecord(ctx any, zoneID any, recordType any, content any) *MockDNSZoneService_CreateApexRecord_Call {
-	return &MockDNSZoneService_CreateApexRecord_Call{Call: _e.mock.On("CreateApexRecord", ctx, zoneID, recordType, content)}
+func (_e *MockDNSZoneService_Expecter) CreateApexRecord(ctx any, zoneID any, domain any, recordType any, content any) *MockDNSZoneService_CreateApexRecord_Call {
+	return &MockDNSZoneService_CreateApexRecord_Call{Call: _e.mock.On("CreateApexRecord", ctx, zoneID, domain, recordType, content)}
 }
 
-func (_c *MockDNSZoneService_CreateApexRecord_Call) Run(run func(ctx context.Context, zoneID uint, recordType core.RecordType, content string)) *MockDNSZoneService_CreateApexRecord_Call {
+func (_c *MockDNSZoneService_CreateApexRecord_Call) Run(run func(ctx context.Context, zoneID uint, domain string, recordType core.RecordType, content string)) *MockDNSZoneService_CreateApexRecord_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -80,9 +81,83 @@ func (_c *MockDNSZoneService_CreateApexRecord_Call) Run(run func(ctx context.Con
 		if args[1] != nil {
 			arg1 = args[1].(uint)
 		}
-		var arg2 core.RecordType
+		var arg2 string
 		if args[2] != nil {
-			arg2 = args[2].(core.RecordType)
+			arg2 = args[2].(string)
+		}
+		var arg3 core.RecordType
+		if args[3] != nil {
+			arg3 = args[3].(core.RecordType)
+		}
+		var arg4 string
+		if args[4] != nil {
+			arg4 = args[4].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+			arg4,
+		)
+	})
+	return _c
+}
+
+func (_c *MockDNSZoneService_CreateApexRecord_Call) Return(err error) *MockDNSZoneService_CreateApexRecord_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockDNSZoneService_CreateApexRecord_Call) RunAndReturn(run func(ctx context.Context, zoneID uint, domain string, recordType core.RecordType, content string) error) *MockDNSZoneService_CreateApexRecord_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// CreateDNSLinkRecord provides a mock function for the type MockDNSZoneService
+func (_mock *MockDNSZoneService) CreateDNSLinkRecord(ctx context.Context, zoneID uint, domain string, target string) error {
+	ret := _mock.Called(ctx, zoneID, domain, target)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CreateDNSLinkRecord")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uint, string, string) error); ok {
+		r0 = returnFunc(ctx, zoneID, domain, target)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockDNSZoneService_CreateDNSLinkRecord_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CreateDNSLinkRecord'
+type MockDNSZoneService_CreateDNSLinkRecord_Call struct {
+	*mock.Call
+}
+
+// CreateDNSLinkRecord is a helper method to define mock.On call
+//   - ctx context.Context
+//   - zoneID uint
+//   - domain string
+//   - target string
+func (_e *MockDNSZoneService_Expecter) CreateDNSLinkRecord(ctx any, zoneID any, domain any, target any) *MockDNSZoneService_CreateDNSLinkRecord_Call {
+	return &MockDNSZoneService_CreateDNSLinkRecord_Call{Call: _e.mock.On("CreateDNSLinkRecord", ctx, zoneID, domain, target)}
+}
+
+func (_c *MockDNSZoneService_CreateDNSLinkRecord_Call) Run(run func(ctx context.Context, zoneID uint, domain string, target string)) *MockDNSZoneService_CreateDNSLinkRecord_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 uint
+		if args[1] != nil {
+			arg1 = args[1].(uint)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
 		}
 		var arg3 string
 		if args[3] != nil {
@@ -98,75 +173,12 @@ func (_c *MockDNSZoneService_CreateApexRecord_Call) Run(run func(ctx context.Con
 	return _c
 }
 
-func (_c *MockDNSZoneService_CreateApexRecord_Call) Return(err error) *MockDNSZoneService_CreateApexRecord_Call {
-	_c.Call.Return(err)
-	return _c
-}
-
-func (_c *MockDNSZoneService_CreateApexRecord_Call) RunAndReturn(run func(ctx context.Context, zoneID uint, recordType core.RecordType, content string) error) *MockDNSZoneService_CreateApexRecord_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// CreateDNSLinkRecord provides a mock function for the type MockDNSZoneService
-func (_mock *MockDNSZoneService) CreateDNSLinkRecord(ctx context.Context, zoneID uint, target string) error {
-	ret := _mock.Called(ctx, zoneID, target)
-
-	if len(ret) == 0 {
-		panic("no return value specified for CreateDNSLinkRecord")
-	}
-
-	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, uint, string) error); ok {
-		r0 = returnFunc(ctx, zoneID, target)
-	} else {
-		r0 = ret.Error(0)
-	}
-	return r0
-}
-
-// MockDNSZoneService_CreateDNSLinkRecord_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CreateDNSLinkRecord'
-type MockDNSZoneService_CreateDNSLinkRecord_Call struct {
-	*mock.Call
-}
-
-// CreateDNSLinkRecord is a helper method to define mock.On call
-//   - ctx context.Context
-//   - zoneID uint
-//   - target string
-func (_e *MockDNSZoneService_Expecter) CreateDNSLinkRecord(ctx any, zoneID any, target any) *MockDNSZoneService_CreateDNSLinkRecord_Call {
-	return &MockDNSZoneService_CreateDNSLinkRecord_Call{Call: _e.mock.On("CreateDNSLinkRecord", ctx, zoneID, target)}
-}
-
-func (_c *MockDNSZoneService_CreateDNSLinkRecord_Call) Run(run func(ctx context.Context, zoneID uint, target string)) *MockDNSZoneService_CreateDNSLinkRecord_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		var arg1 uint
-		if args[1] != nil {
-			arg1 = args[1].(uint)
-		}
-		var arg2 string
-		if args[2] != nil {
-			arg2 = args[2].(string)
-		}
-		run(
-			arg0,
-			arg1,
-			arg2,
-		)
-	})
-	return _c
-}
-
 func (_c *MockDNSZoneService_CreateDNSLinkRecord_Call) Return(err error) *MockDNSZoneService_CreateDNSLinkRecord_Call {
 	_c.Call.Return(err)
 	return _c
 }
 
-func (_c *MockDNSZoneService_CreateDNSLinkRecord_Call) RunAndReturn(run func(ctx context.Context, zoneID uint, target string) error) *MockDNSZoneService_CreateDNSLinkRecord_Call {
+func (_c *MockDNSZoneService_CreateDNSLinkRecord_Call) RunAndReturn(run func(ctx context.Context, zoneID uint, domain string, target string) error) *MockDNSZoneService_CreateDNSLinkRecord_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -572,16 +584,16 @@ func (_c *MockDNSZoneService_GetZoneByDomain_Call) RunAndReturn(run func(ctx con
 }
 
 // SetTLSARecord provides a mock function for the type MockDNSZoneService
-func (_mock *MockDNSZoneService) SetTLSARecord(ctx context.Context, zoneID uint, content string) error {
-	ret := _mock.Called(ctx, zoneID, content)
+func (_mock *MockDNSZoneService) SetTLSARecord(ctx context.Context, zoneID uint, domain string, content string) error {
+	ret := _mock.Called(ctx, zoneID, domain, content)
 
 	if len(ret) == 0 {
 		panic("no return value specified for SetTLSARecord")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, uint, string) error); ok {
-		r0 = returnFunc(ctx, zoneID, content)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uint, string, string) error); ok {
+		r0 = returnFunc(ctx, zoneID, domain, content)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -596,12 +608,13 @@ type MockDNSZoneService_SetTLSARecord_Call struct {
 // SetTLSARecord is a helper method to define mock.On call
 //   - ctx context.Context
 //   - zoneID uint
+//   - domain string
 //   - content string
-func (_e *MockDNSZoneService_Expecter) SetTLSARecord(ctx any, zoneID any, content any) *MockDNSZoneService_SetTLSARecord_Call {
-	return &MockDNSZoneService_SetTLSARecord_Call{Call: _e.mock.On("SetTLSARecord", ctx, zoneID, content)}
+func (_e *MockDNSZoneService_Expecter) SetTLSARecord(ctx any, zoneID any, domain any, content any) *MockDNSZoneService_SetTLSARecord_Call {
+	return &MockDNSZoneService_SetTLSARecord_Call{Call: _e.mock.On("SetTLSARecord", ctx, zoneID, domain, content)}
 }
 
-func (_c *MockDNSZoneService_SetTLSARecord_Call) Run(run func(ctx context.Context, zoneID uint, content string)) *MockDNSZoneService_SetTLSARecord_Call {
+func (_c *MockDNSZoneService_SetTLSARecord_Call) Run(run func(ctx context.Context, zoneID uint, domain string, content string)) *MockDNSZoneService_SetTLSARecord_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -615,10 +628,15 @@ func (_c *MockDNSZoneService_SetTLSARecord_Call) Run(run func(ctx context.Contex
 		if args[2] != nil {
 			arg2 = args[2].(string)
 		}
+		var arg3 string
+		if args[3] != nil {
+			arg3 = args[3].(string)
+		}
 		run(
 			arg0,
 			arg1,
 			arg2,
+			arg3,
 		)
 	})
 	return _c
@@ -629,7 +647,7 @@ func (_c *MockDNSZoneService_SetTLSARecord_Call) Return(err error) *MockDNSZoneS
 	return _c
 }
 
-func (_c *MockDNSZoneService_SetTLSARecord_Call) RunAndReturn(run func(ctx context.Context, zoneID uint, content string) error) *MockDNSZoneService_SetTLSARecord_Call {
+func (_c *MockDNSZoneService_SetTLSARecord_Call) RunAndReturn(run func(ctx context.Context, zoneID uint, domain string, content string) error) *MockDNSZoneService_SetTLSARecord_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/testing/mocks/MockDNSZoneService.go
+++ b/internal/testing/mocks/MockDNSZoneService.go
@@ -503,6 +503,74 @@ func (_c *MockDNSZoneService_GetActiveDNSSECDS_Call) RunAndReturn(run func(ctx c
 	return _c
 }
 
+// GetZoneByDomain provides a mock function for the type MockDNSZoneService
+func (_mock *MockDNSZoneService) GetZoneByDomain(ctx context.Context, domain string) (*db.DNSZone, error) {
+	ret := _mock.Called(ctx, domain)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetZoneByDomain")
+	}
+
+	var r0 *db.DNSZone
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (*db.DNSZone, error)); ok {
+		return returnFunc(ctx, domain)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) *db.DNSZone); ok {
+		r0 = returnFunc(ctx, domain)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*db.DNSZone)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, domain)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockDNSZoneService_GetZoneByDomain_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetZoneByDomain'
+type MockDNSZoneService_GetZoneByDomain_Call struct {
+	*mock.Call
+}
+
+// GetZoneByDomain is a helper method to define mock.On call
+//   - ctx context.Context
+//   - domain string
+func (_e *MockDNSZoneService_Expecter) GetZoneByDomain(ctx any, domain any) *MockDNSZoneService_GetZoneByDomain_Call {
+	return &MockDNSZoneService_GetZoneByDomain_Call{Call: _e.mock.On("GetZoneByDomain", ctx, domain)}
+}
+
+func (_c *MockDNSZoneService_GetZoneByDomain_Call) Run(run func(ctx context.Context, domain string)) *MockDNSZoneService_GetZoneByDomain_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockDNSZoneService_GetZoneByDomain_Call) Return(dNSZone *db.DNSZone, err error) *MockDNSZoneService_GetZoneByDomain_Call {
+	_c.Call.Return(dNSZone, err)
+	return _c
+}
+
+func (_c *MockDNSZoneService_GetZoneByDomain_Call) RunAndReturn(run func(ctx context.Context, domain string) (*db.DNSZone, error)) *MockDNSZoneService_GetZoneByDomain_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // SetTLSARecord provides a mock function for the type MockDNSZoneService
 func (_mock *MockDNSZoneService) SetTLSARecord(ctx context.Context, zoneID uint, content string) error {
 	ret := _mock.Called(ctx, zoneID, content)


### PR DESCRIPTION
## Summary

Implements the core of the one-zone DNS lifecycle: **a domain binding creates no PowerDNS zone when DNS is not managed**, and managed subdomains **reuse their parent's zone** instead of creating a new one.

Closes the superseded `feat/domains-add-default-dns` (PR #891) direction — this threads the real `dns_hosting_enabled` flag through and gates zone creation on it, rather than hardcoding the flag.

## Changes

### `CreateDomain` (domain service)

- New `dnsHostingEnabled bool` param, threaded from the bind request (`DomainRequest.dns_hosting_enabled`, default **true**) and the website create/update flows.
- **`dnsHostingEnabled=false` → no zone.** The binding is marked with the new **`self_hosted`** status: bound, DNS not provisioned by Pinner (the user runs the authoritative server). No `CreateZone`/DNSLink/apex/delegation, `ZoneID=0`, no `DelegationData`.
- **`dnsHostingEnabled=true` → one zone** via new `resolveManagedZone`: apex domains own their zone; subdomains reuse their parent's zone (via `GetZoneByDomain`). Zone rollback on a mid-flow failure only deletes a zone this call *created*, never a reused parent zone.

### `VerifyDomain`

- Short-circuits (no-op) for a zone-less (`ZoneID==0`) self-hosted binding — there is no portal DS/SOA/DNSSEC to reconcile, so it no-ops instead of querying PowerDNS for a nonexistent zone.

### Model

- New `DomainStatus.SelfHosted` (`self_hosted`) — a distinct representation (per review) rather than shoehorning self-hosted into `draft`.
- Regenerated `MockDNSZoneService` for the new `GetZoneByDomain` interface method.

## Verification

- `go build ./...` clean; `go vet` clean.
- `go test ./internal/service/domain/... ./internal/service/dns/...` green.
- New tests: `CreateDomain_SelfHosted` (no zone), `CreateDomain_SubdomainReusesParentZone` (parent reuse, no new zone).
- Note: `internal/service/website` tests fail on a pre-existing proto-registration panic (`proto: file "rpc.proto" is already registered`) — confirmed identical on clean `develop`, unrelated to this change.

## Remaining (follow-up, per scoping plan)

- Collapse the two zone columns (`ZoneID`/`DNSZoneID`) → one canonical reference + existing-data reconciliation.
- Eager TLSA for self-hosted via a stored key Caddy serves (novel cert-lifecycle piece, flagged separately).

* `develop` <!-- branch-stack -->
  - **feat(domain): no zone when DNS self-hosted; subdomains reuse parent zone** :point\_left:

***

<!-- kody-pr-summary:start -->

This pull request introduces a unified zone lifecycle management for domain bindings in the portal-plugin-ipfs plugin. The key changes are:

1. **Self-hosted DNS support**: The domain creation now accepts a `dns_hosting_enabled` flag (defaults to `true`). When set to `false`, no PowerDNS zone is created, and the binding is marked as `self_hosted`, meaning the user manages their own DNS hosting.

2. **Subdomain zone reuse**: When creating a managed DNS binding for a subdomain (e.g., `docs.example.com`), the system now reuses the parent domain's zone (e.g., `example.com`) instead of creating a new PowerDNS zone. This enforces a "one-zone-per-domain" topology rule where only apex domains own their zones.

3. **Zone cleanup logic**: The feature includes proper cleanup handling so that if zone creation, DNSLink record creation, or apex record creation fails, any freshly-created zones are rolled back (deleted), but reused parent zones are preserved.

4. **Self-hosted domain verification**: Verification is now a no-op for self-hosted bindings (those without a PowerDNS zone), as they don't have portal-managed DNS records to verify.

5. **DNS hosting status tracking**: The `dns_hosting_enabled` flag is persisted on domain bindings to track whether Pinner manages DNS or if the user runs their own authoritative DNS server.

<!-- kody-pr-summary:end -->
