### PR TITLE
fix(ipfs): optimize bitswap tracker disconnect cleanup

### DIFF
--- a/internal/protocol/ipfs/peer_tracker.go
+++ b/internal/protocol/ipfs/peer_tracker.go
@@ -14,14 +14,16 @@ import (
 // This enables probabilistic peer attribution when the actual client IP context
 // is not available (e.g., in bitswap scenarios).
 type BlockRequestTracker struct {
-	mu      sync.RWMutex
+	mu       sync.RWMutex
 	requests map[cid.Cid][]string
+	peerCIDs map[string]map[cid.Cid]struct{}
 }
 
 // NewBlockRequestTracker creates a new empty BlockRequestTracker
 func NewBlockRequestTracker() *BlockRequestTracker {
 	return &BlockRequestTracker{
 		requests: make(map[cid.Cid][]string),
+		peerCIDs: make(map[string]map[cid.Cid]struct{}),
 	}
 }
 
@@ -41,6 +43,7 @@ func (br *BlockRequestTracker) AddRequest(c cid.Cid, peerIP string) {
 	}
 
 	br.requests[c] = append(peers, peerIP)
+	br.addPeerCIDLocked(peerIP, c)
 }
 
 // GetAndRemoveRandomPeer selects a random peer IP for the given CID and removes it from the tracker
@@ -62,6 +65,7 @@ func (br *BlockRequestTracker) GetAndRemoveRandomPeer(c cid.Cid) (string, bool) 
 	}
 
 	selected := peers[index]
+	br.removePeerCIDLocked(selected, c)
 
 	// Remove selected peer from list
 	if len(peers) == 1 {
@@ -74,7 +78,7 @@ func (br *BlockRequestTracker) GetAndRemoveRandomPeer(c cid.Cid) (string, bool) 
 	return selected, true
 }
 
-// PopPeer removes and returns the first peer IP for the given CID
+// PopPeer removes and returns the first peer IP for the CID
 // Returns (peerIP, true) if a peer was found, or ("", false) otherwise
 func (br *BlockRequestTracker) PopPeer(c cid.Cid) (string, bool) {
 	br.mu.Lock()
@@ -87,6 +91,7 @@ func (br *BlockRequestTracker) PopPeer(c cid.Cid) (string, bool) {
 	}
 
 	selected := peers[0]
+	br.removePeerCIDLocked(selected, c)
 
 	if len(peers) == 1 {
 		delete(br.requests, c)
@@ -110,6 +115,7 @@ func (br *BlockRequestTracker) RemovePeer(c cid.Cid, peerIP string) {
 
 	for i, p := range peers {
 		if p == peerIP {
+			br.removePeerCIDLocked(peerIP, c)
 			if len(peers) == 1 {
 				delete(br.requests, c)
 			} else {
@@ -130,26 +136,41 @@ func (br *BlockRequestTracker) RemovePeerFromAll(peerIP string) {
 		return
 	}
 
-	for c, peers := range br.requests {
-		found := false
+	cids := br.peerCIDs[peerIP]
+	for c := range cids {
+		peers := br.requests[c]
 		for i, p := range peers {
-			if p == peerIP {
-				found = true
-				if len(peers) == 1 {
-					// Remove the entire entry if this was the only peer
-					delete(br.requests, c)
-				} else {
-					// Remove just this peer from the list
-					br.requests[c] = append(peers[:i], peers[i+1:]...)
-				}
-				break
+			if p != peerIP {
+				continue
 			}
+			if len(peers) == 1 {
+				delete(br.requests, c)
+			} else {
+				br.requests[c] = append(peers[:i], peers[i+1:]...)
+			}
+			break
 		}
-		// If we found and removed the peer, we can continue to next CID
-		// (we only need to remove each peer once per CID)
-		if found {
-			continue
-		}
+	}
+	delete(br.peerCIDs, peerIP)
+}
+
+func (br *BlockRequestTracker) addPeerCIDLocked(peerIP string, c cid.Cid) {
+	cids := br.peerCIDs[peerIP]
+	if cids == nil {
+		cids = make(map[cid.Cid]struct{})
+		br.peerCIDs[peerIP] = cids
+	}
+	cids[c] = struct{}{}
+}
+
+func (br *BlockRequestTracker) removePeerCIDLocked(peerIP string, c cid.Cid) {
+	cids := br.peerCIDs[peerIP]
+	if cids == nil {
+		return
+	}
+	delete(cids, c)
+	if len(cids) == 0 {
+		delete(br.peerCIDs, peerIP)
 	}
 }
 
@@ -158,15 +179,15 @@ func randomIndex(n int) (int, error) {
 	if n <= 0 {
 		return 0, nil
 	}
-	
+
 	// Calculate the range size
 	rangeSize := big.NewInt(int64(n))
-	
+
 	// Generate a random number in [0, n)
 	index, err := rand.Int(rand.Reader, rangeSize)
 	if err != nil {
 		return 0, err
 	}
-	
+
 	return int(index.Int64()), nil
 }

--- a/internal/protocol/ipfs/peer_tracker_test.go
+++ b/internal/protocol/ipfs/peer_tracker_test.go
@@ -520,3 +520,77 @@ func TestBlockRequestTracker_RemovePeerFromAll_DisconnectScenario(t *testing.T) 
 	
 	t.Log("Disconnect scenario test passed - ghost wants cleaned up correctly")
 }
+
+func TestBlockRequestTrackerMaintainsPeerIndex(t *testing.T) {
+	tracker := NewBlockRequestTracker()
+	cidA := mustTestCID(t, "QmYwAPJzv5CZsnA625qs3FTJ2xDkg7WjNnCm129r48gVfX")
+	cidB := mustTestCID(t, "QmYwAPJzv5CZsnA625qs3FTJ2xDkg7WjNnCm129r48gVfW")
+
+	tracker.AddRequest(cidA, "peer-a")
+	tracker.AddRequest(cidA, "peer-a")
+	tracker.AddRequest(cidB, "peer-a")
+	tracker.AddRequest(cidB, "peer-b")
+
+	tracker.mu.RLock()
+	if got := len(tracker.peerCIDs["peer-a"]); got != 2 {
+		t.Fatalf("peer-a CID count = %d, want 2", got)
+	}
+	if got := len(tracker.peerCIDs["peer-b"]); got != 1 {
+		t.Fatalf("peer-b CID count = %d, want 1", got)
+	}
+	tracker.mu.RUnlock()
+
+	tracker.RemovePeerFromAll("peer-a")
+
+	if _, ok := tracker.GetAndRemoveRandomPeer(cidA); ok {
+		t.Fatal("peer-a request remained for cidA")
+	}
+	peer, ok := tracker.GetAndRemoveRandomPeer(cidB)
+	if !ok || peer != "peer-b" {
+		t.Fatalf("cidB peer = %q, %v, want peer-b, true", peer, ok)
+	}
+
+	tracker.mu.RLock()
+	if _, ok := tracker.peerCIDs["peer-a"]; ok {
+		t.Fatal("peer-a reverse index remained after cleanup")
+	}
+	tracker.mu.RUnlock()
+}
+
+func TestBlockRequestTrackerRemovesReverseIndexEntries(t *testing.T) {
+	tracker := NewBlockRequestTracker()
+	cidA := mustTestCID(t, "QmYwAPJzv5CZsnA625qs3FTJ2xDkg7WjNnCm129r48gVfX")
+	cidB := mustTestCID(t, "QmYwAPJzv5CZsnA625qs3FTJ2xDkg7WjNnCm129r48gVfW")
+
+	tracker.AddRequest(cidA, "peer-a")
+	tracker.AddRequest(cidA, "peer-b")
+	tracker.AddRequest(cidB, "peer-a")
+
+	tracker.RemovePeer(cidA, "peer-a")
+
+	tracker.mu.RLock()
+	if _, ok := tracker.peerCIDs["peer-a"][cidA]; ok {
+		t.Fatal("cidA remained in peer-a reverse index")
+	}
+	if _, ok := tracker.peerCIDs["peer-a"][cidB]; !ok {
+		t.Fatal("cidB missing from peer-a reverse index")
+	}
+	tracker.mu.RUnlock()
+
+	tracker.PopPeer(cidB)
+
+	tracker.mu.RLock()
+	if _, ok := tracker.peerCIDs["peer-a"]; ok {
+		t.Fatal("empty peer reverse index remained after PopPeer")
+	}
+	tracker.mu.RUnlock()
+}
+
+func mustTestCID(t *testing.T, value string) cid.Cid {
+	t.Helper()
+	c, err := cid.Decode(value)
+	if err != nil {
+		t.Fatalf("decode test CID: %v", err)
+	}
+	return c
+}


### PR DESCRIPTION
Replace full tracker scans during peer disconnect cleanup with a reverse peer-to-CID index.\n\nTracker mutations maintain both CID-to-peer and peer-to-CID indexes. Disconnect cleanup now visits only CIDs associated with the disconnected peer, reducing lock hold time under connection churn.\n\nAdds reverse-index consistency regression tests.

- `develop` <!-- branch-stack -->
  - **fix(ipfs): optimize bitswap tracker disconnect cleanup** :point\_left:

---

<!-- kody-pr-summary:start -->
This pull request optimizes the bitswap tracker's disconnect cleanup by introducing a reverse index that maps peers to their associated CIDs. This eliminates the need to scan through all requests when removing a peer, significantly improving cleanup performance during disconnects.

The changes include:

1. **Reverse index implementation**: Added a `peerCIDs` field to the `BlockRequestTracker` that maintains a bidirectional mapping between peers and CIDs, allowing direct lookup of all CIDs associated with a specific peer.

2. **Index maintenance**: Updated existing methods (`AddRequest`, `GetAndRemoveRandomPeer`, `PopPeer`, `RemovePeer`) to keep the reverse index synchronized whenever requests are added or removed.

3. **Optimized `RemovePeerFromAll` method**: Rewrote the disconnect cleanup logic to use the new reverse index, directly retrieving and removing only the affected CIDs for a given peer instead of iterating through the entire requests map.

4. **Helper functions**: Added `addPeerCIDLocked` and `removePeerCIDLocked` utility functions to manage the reverse index entries while maintaining consistency with the main request tracker.

5. **Comprehensive test coverage**: Added new tests verifying the reverse index stays consistent across various operations, including scenarios with duplicate requests, multiple peers, and cleanup when the last reference is removed.
<!-- kody-pr-summary:end -->