### PR TITLE
fix(ipfs): bound reprovider execution time

### DIFF
--- a/internal/protocol/ipfs/provide.go
+++ b/internal/protocol/ipfs/provide.go
@@ -291,10 +291,9 @@ func (r *Reprovider) performProvide(ctx context.Context, trigger string) time.Du
 	ctx, span := core.TraceMethod(ctx, "Reprovider.performProvide")
 	defer span.End()
 
-	// Wrap the entire cycle with a timeout. The inner ProvideManyTimeout
-	// only covers the DHT call — the rest (CountPinned, ProvideCIDs,
-	// SetLastAnnouncement) can hang indefinitely under connection saturation.
-	ctx, cancel := context.WithTimeout(ctx, r.cfg.ProvideManyTimeout*2)
+	// Reserve one timeout window for setup and announcement bookkeeping, and
+	// one full window for the DHT operation itself.
+	ctx, cancel := context.WithTimeout(ctx, r.cfg.ProvideManyTimeout*3)
 	defer cancel()
 
 	cycleStart := time.Now()

--- a/internal/protocol/ipfs/provide_test.go
+++ b/internal/protocol/ipfs/provide_test.go
@@ -623,6 +623,38 @@ func TestFullrtProvider_ProvideMany(t *testing.T) {
 	})
 }
 
+func TestReprovider_performProvide_UsesProvideManyTimeout(t *testing.T) {
+	provider := mocks.NewMockProvider(t)
+	store := mocks.NewMockReprovideStore(t)
+	logger, _ := zap.NewDevelopment()
+
+	cfg := newTestReproviderCfg(time.Second, 1)
+	cfg.ProvideManyTimeout = 100 * time.Millisecond
+	reprovider := &Reprovider{
+		provider:       provider,
+		store:          store,
+		log:            logger,
+		cfg:            cfg,
+		triggerProvide: make(chan struct{}, 1),
+	}
+
+	testCID := cid.NewCidV1(cid.Raw, mustMultihash(t, "provide-timeout"))
+	store.EXPECT().CountPinned(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, _ time.Time) (core.PinnedCIDStats, error) {
+		time.Sleep(200 * time.Millisecond)
+		return core.PinnedCIDStats{}, nil
+	}).Once()
+	store.EXPECT().ProvideCIDs(mock.Anything, mock.Anything, 1).Return([]core.PinnedCID{{CID: testCID}}, nil).Once()
+	provider.EXPECT().ProvideMany(mock.Anything, mock.Anything).Run(func(ctx context.Context, _ []multihash.Multihash) {
+		deadline, ok := ctx.Deadline()
+		require.True(t, ok, "ProvideMany context must have deadline")
+		remaining := time.Until(deadline)
+		assert.Greater(t, remaining, 40*time.Millisecond)
+		assert.Less(t, remaining, 200*time.Millisecond)
+	}).Return(context.DeadlineExceeded).Once()
+
+	assert.Equal(t, time.Minute, reprovider.performProvide(context.Background(), LabelTriggerScheduled))
+}
+
 func TestReprovider_performProvide_PartialFailure_AllFail(t *testing.T) {
 	ctx := context.Background()
 


### PR DESCRIPTION
Reserve a full ProvideMany timeout after setup work by extending the reprovider cycle deadline to three timeout windows.

Prevents slow CountPinned or ProvideCIDs work from shrinking the DHT operation deadline while retaining an upper bound for the complete cycle.

Adds regression coverage for the ProvideMany deadline.

- `develop` <!-- branch-stack -->
  - **fix(ipfs): bound reprovider execution time** :point\_left:
