### PR TITLE
fix(ipfs): bound peer request tracker memory

### DIFF
--- a/internal/protocol/ipfs/peer_tracker.go
+++ b/internal/protocol/ipfs/peer_tracker.go
@@ -19,6 +19,14 @@ type BlockRequestTracker struct {
 	peerCIDs map[string]map[cid.Cid]struct{}
 }
 
+const (
+	// maxPeersPerCID bounds attribution memory for a single hot block.
+	maxPeersPerCID = 64
+	// maxTrackedCIDs bounds total tracker memory. Attribution is best-effort
+	// once this limit is reached; block retrieval must not be blocked by it.
+	maxTrackedCIDs = 100_000
+)
+
 // NewBlockRequestTracker creates a new empty BlockRequestTracker
 func NewBlockRequestTracker() *BlockRequestTracker {
 	return &BlockRequestTracker{
@@ -40,6 +48,15 @@ func (br *BlockRequestTracker) AddRequest(c cid.Cid, peerIP string) {
 	peers := br.requests[c]
 	if slices.Contains(peers, peerIP) {
 		return
+	}
+	if len(peers) >= maxPeersPerCID {
+		// Keep attribution current for hot blocks by rotating out the oldest
+		// requester when the per-CID bound is reached.
+		br.removePeerCIDLocked(peers[0], c)
+		peers = peers[1:]
+	}
+	if peers == nil && len(br.requests) >= maxTrackedCIDs {
+		br.evictOneCIDLocked()
 	}
 
 	br.requests[c] = append(peers, peerIP)
@@ -171,6 +188,16 @@ func (br *BlockRequestTracker) removePeerCIDLocked(peerIP string, c cid.Cid) {
 	delete(cids, c)
 	if len(cids) == 0 {
 		delete(br.peerCIDs, peerIP)
+	}
+}
+
+func (br *BlockRequestTracker) evictOneCIDLocked() {
+	for c, peers := range br.requests {
+		delete(br.requests, c)
+		for _, peerIP := range peers {
+			br.removePeerCIDLocked(peerIP, c)
+		}
+		return
 	}
 }
 

--- a/internal/protocol/ipfs/peer_tracker_test.go
+++ b/internal/protocol/ipfs/peer_tracker_test.go
@@ -1,9 +1,11 @@
 package ipfs
 
 import (
+	"strconv"
 	"testing"
 
 	"github.com/ipfs/go-cid"
+	"github.com/multiformats/go-multihash"
 )
 
 func TestBlockRequestTracker_AddRequest(t *testing.T) {
@@ -593,4 +595,57 @@ func mustTestCID(t *testing.T, value string) cid.Cid {
 		t.Fatalf("decode test CID: %v", err)
 	}
 	return c
+}
+
+func TestBlockRequestTracker_BoundsPeersPerCID(t *testing.T) {
+	tracker := NewBlockRequestTracker()
+	block := cid.NewCidV1(cid.Raw, mustTrackerHash(t, "bounded-block"))
+
+	for i := 0; i < maxPeersPerCID; i++ {
+		tracker.AddRequest(block, "peer-"+strconv.Itoa(i))
+	}
+	tracker.AddRequest(block, "new-peer")
+
+	count := 0
+	foundNewest := false
+	for {
+		peer, ok := tracker.PopPeer(block)
+		if !ok {
+			break
+		}
+		count++
+		if peer == "new-peer" {
+			foundNewest = true
+		}
+	}
+	if count != maxPeersPerCID {
+		t.Fatalf("expected %d peers, got %d", maxPeersPerCID, count)
+	}
+	if !foundNewest {
+		t.Fatal("expected newest requester to replace an older attribution")
+	}
+}
+
+func TestBlockRequestTracker_BoundsTotalCIDsAndCleansReverseIndex(t *testing.T) {
+	tracker := NewBlockRequestTracker()
+	for i := 0; i < maxTrackedCIDs+1; i++ {
+		block := cid.NewCidV1(cid.Raw, mustTrackerHash(t, strconv.Itoa(i)))
+		tracker.AddRequest(block, "same-peer")
+	}
+
+	if len(tracker.requests) != maxTrackedCIDs {
+		t.Fatalf("expected %d tracked CIDs, got %d", maxTrackedCIDs, len(tracker.requests))
+	}
+	if len(tracker.peerCIDs["same-peer"]) != maxTrackedCIDs {
+		t.Fatalf("expected reverse index to contain %d CIDs, got %d", maxTrackedCIDs, len(tracker.peerCIDs["same-peer"]))
+	}
+}
+
+func mustTrackerHash(t *testing.T, value string) multihash.Multihash {
+	t.Helper()
+	hash, err := multihash.Sum([]byte(value), multihash.SHA2_256, -1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return hash
 }


### PR DESCRIPTION
Bound BlockRequestTracker attribution memory to prevent unbounded growth.\n\nLimit each CID to 64 peer attributions and rotate the oldest requester when the limit is reached so hot-block attribution remains current.\n\nLimit the tracker to 100,000 CIDs and evict an existing CID when the limit is reached. Eviction updates both the CID and peer reverse indexes.\n\nAdds focused coverage for per-CID rotation, total CID bounds, and reverse-index consistency.

- `develop` <!-- branch-stack -->
  - **fix(ipfs): bound peer request tracker memory** :point\_left:

---

<!-- kody-pr-summary:start -->
## Summary

This pull request addresses an unbounded memory growth issue in the IPFS peer request tracker by introducing memory bounds and eviction policies.

## Key Changes

### Memory Bounds Implementation
- Added two new constants to bound tracker memory:
  - `maxPeersPerCID = 64` — limits how many peer attributions are stored for a single block (CID)
  - `maxTrackedCIDs = 100,000` — limits the total number of blocks (CIDs) tracked in memory

### Peer Rotation for Hot Blocks
- When a block reaches the maximum of 64 peers, new peer requests rotate out the oldest requester rather than accumulating unboundedly
- This ensures attribution stays current for frequently requested (hot) blocks while preventing memory exhaustion

### Global Eviction Strategy
- When the tracker reaches the maximum of 100,000 CIDs, one cached entry is evicted to make room for new entries
- Eviction removes both the forward mapping (CID → peers) and the reverse index (peer → CIDs) to keep the data structure consistent

### Design Principle
- The system maintains **best-effort attribution** semantics — block retrieval functionality is never blocked by these memory limits; tracking is considered optional metadata

## Tests Added
Two new test cases validate:
1. Per-CID peer bounds work correctly, ensuring newest peers replace oldest entries while maintaining the limit
2. Global CID count stays within the configured maximum, and the reverse index is properly cleaned up during eviction
<!-- kody-pr-summary:end -->