### PR TITLE
fix(ipfs): back off missing block prefetches

### DIFF
--- a/internal/protocol/store/downloader/backoff_test.go
+++ b/internal/protocol/store/downloader/backoff_test.go
@@ -1,0 +1,162 @@
+package downloader
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/ipfs/go-cid"
+	format "github.com/ipfs/go-ipld-format"
+	"github.com/multiformats/go-multihash"
+)
+
+func TestPruneExpiredFailures(t *testing.T) {
+	now := time.Unix(100, 0)
+	failedUntil := map[string]time.Time{
+		"expired": now,
+		"stale":   now.Add(-time.Second),
+		"active":  now.Add(time.Second),
+	}
+
+	pruneExpiredFailures(failedUntil, now)
+
+	if len(failedUntil) != 1 {
+		t.Fatalf("expected one active failure, got %d", len(failedUntil))
+	}
+	if _, ok := failedUntil["active"]; !ok {
+		t.Fatal("active failure was pruned")
+	}
+}
+
+func TestPrefetchMissingBlockArmsBackoff(t *testing.T) {
+	testCID := testCidForBackoff(t)
+	key := cidKey(testCID)
+	now := time.Now()
+	failedUntil := make(map[string]time.Time)
+	err := fmt.Errorf("failed to download block: %w", format.ErrNotFound{Cid: testCID})
+
+	recordDownloadFailure(failedUntil, key, err, now)
+	if _, ok := failedUntil[key]; !ok {
+		t.Fatal("wrapped not-found error did not activate backoff")
+	}
+
+	bd := &BlockDownloaderDefault{failedUntil: failedUntil, queue: &priorityQueue{}}
+	resp, queued := bd.queueBlock(context.Background(), testCID, downloadPriorityMedium, "")
+	if queued {
+		t.Fatal("missing prefetch was re-queued during backoff")
+	}
+	if resp == nil || resp.err == nil {
+		t.Fatal("missing prefetch did not return a backoff error")
+	}
+
+	// A transient failure must not clear an existing missing-CID cooldown.
+	recordDownloadFailure(failedUntil, key, errors.New("temporary storage failure"), now)
+	if _, ok := failedUntil[key]; !ok {
+		t.Fatal("transient error cleared an existing backoff")
+	}
+}
+
+// TestPrefetchOriginUpgradeKeepsBackoff guards the anti-amplification
+// guarantee: a prefetch task whose priority is upgraded by a concurrent
+// foreground Get must still arm the missing-CID cooldown, so a genuine
+// ErrNotFound is not silently dropped.
+func TestPrefetchOriginUpgradeKeepsBackoff(t *testing.T) {
+	testCID := testCidForBackoff(t)
+	bd := &BlockDownloaderDefault{failedUntil: make(map[string]time.Time), inflight: make(map[string]*blockResponse), queue: &priorityQueue{}}
+
+	// A prefetch initiates the task, then a foreground Get bonds to it.
+	bd.queueBlock(context.Background(), testCID, downloadPriorityMedium, "")
+	resp, _ := bd.queueBlock(context.Background(), testCID, downloadPriorityMax, "client-ip")
+	if !resp.prefetchOrigin {
+		t.Fatal("prefetch task lost its prefetch-origin marker")
+	}
+
+	key := cidKey(testCID)
+	err := fmt.Errorf("failed to download block: %w", format.ErrNotFound{Cid: testCID})
+	recordDownloadFailure(bd.failedUntil, key, err, time.Now())
+	if _, ok := bd.failedUntil[key]; !ok {
+		t.Fatal("prefetch-origin missing block did not arm a backoff despite upgrade")
+	}
+}
+
+// TestForegroundOriginDoesNotArmBackoff preserves the separation that a
+// foreground-initiated request is not marked as prefetch-origin, so a missing
+// failure on it never arms a prefetch cooldown.
+func TestForegroundOriginDoesNotArmBackoff(t *testing.T) {
+	testCID := testCidForBackoff(t)
+	bd := &BlockDownloaderDefault{failedUntil: make(map[string]time.Time), inflight: make(map[string]*blockResponse), queue: &priorityQueue{}}
+
+	resp, _ := bd.queueBlock(context.Background(), testCID, downloadPriorityMax, "client-ip")
+	if resp.prefetchOrigin {
+		t.Fatal("foreground-created task was marked prefetch-origin")
+	}
+}
+
+func TestWrappedNotFoundIsClassified(t *testing.T) {
+	var notFound format.ErrNotFound
+	err := fmt.Errorf("failed to download block: %w", format.ErrNotFound{})
+	if !errors.As(err, &notFound) {
+		t.Fatal("wrapped not-found error was not classified")
+	}
+}
+
+// TestSuccessfulFetchClearsBackoff verifies a block that becomes available again
+// within the cooldown window is no longer suppressed after a successful fetch.
+func TestSuccessfulFetchClearsBackoff(t *testing.T) {
+	testCID := testCidForBackoff(t)
+	key := cidKey(testCID)
+	bd := &BlockDownloaderDefault{failedUntil: make(map[string]time.Time)}
+	bd.failedUntil[key] = time.Now().Add(failedDownloadBackoff)
+
+	task := &blockResponse{cid: testCID, priority: downloadPriorityMedium}
+	task.prefetchOrigin = true
+
+	bd.finalizeDownload(task, key, time.Now())
+	if _, ok := bd.failedUntil[key]; ok {
+		t.Fatal("successful fetch did not clear the stale backoff")
+	}
+}
+
+// TestPrefetchOriginFailureArmsBackoff verifies a prefetch-origin missing block
+// arms the cooldown even after the retry is attempted.
+func TestPrefetchOriginFailureArmsBackoff(t *testing.T) {
+	testCID := testCidForBackoff(t)
+	key := cidKey(testCID)
+	bd := &BlockDownloaderDefault{failedUntil: make(map[string]time.Time)}
+
+	task := &blockResponse{cid: testCID, priority: downloadPriorityMedium}
+	task.prefetchOrigin = true
+	task.err = fmt.Errorf("failed to download block: %w", format.ErrNotFound{Cid: testCID})
+
+	bd.finalizeDownload(task, key, time.Now())
+	if _, ok := bd.failedUntil[key]; !ok {
+		t.Fatal("prefetch-origin missing block did not arm a backoff")
+	}
+}
+
+// TestForegroundOriginFailureDoesNotArmBackoff verifies a foreground-origin
+// missing block never arms a prefetch cooldown.
+func TestForegroundOriginFailureDoesNotArmBackoff(t *testing.T) {
+	testCID := testCidForBackoff(t)
+	key := cidKey(testCID)
+	bd := &BlockDownloaderDefault{failedUntil: make(map[string]time.Time)}
+
+	task := &blockResponse{cid: testCID, priority: downloadPriorityMax}
+	task.err = fmt.Errorf("failed to download block: %w", format.ErrNotFound{Cid: testCID})
+
+	bd.finalizeDownload(task, key, time.Now())
+	if _, ok := bd.failedUntil[key]; ok {
+		t.Fatal("foreground-origin missing block armed a prefetch backoff")
+	}
+}
+
+func testCidForBackoff(t *testing.T) cid.Cid {
+	t.Helper()
+	mh, err := multihash.Sum([]byte("missing-cid"), multihash.SHA2_256, -1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return cid.NewCidV1(cid.Raw, mh)
+}

--- a/internal/protocol/store/downloader/downloader.go
+++ b/internal/protocol/store/downloader/downloader.go
@@ -7,11 +7,13 @@ import (
 	"bytes"
 	"container/heap"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"sync"
 	"time"
 
+	format "github.com/ipfs/go-ipld-format"
 	"github.com/samber/lo"
 	pluginCore "go.lumeweb.com/portal-plugin-ipfs/core"
 	"go.lumeweb.com/portal-plugin-ipfs/internal"
@@ -26,6 +28,8 @@ import (
 )
 
 const (
+	failedDownloadBackoff = 30 * time.Second
+
 	downloadPriorityLow downloadPriority = iota + 1
 	downloadPriorityMedium
 	downloadPriorityHigh
@@ -40,13 +44,14 @@ type (
 		b   []byte
 		err error
 
-		cid       cid.Cid
-		priority  downloadPriority
-		index     int
-		timestamp time.Time
-		log       *core.Logger
-		clientIP  string
-		ctx       context.Context
+		cid            cid.Cid
+		priority       downloadPriority
+		prefetchOrigin bool
+		index          int
+		timestamp      time.Time
+		log            *core.Logger
+		clientIP       string
+		ctx            context.Context
 
 		mu sync.Mutex // protects ch, b, and err fields
 	}
@@ -65,10 +70,12 @@ type (
 		storage core.StorageService
 		log     *core.Logger
 
-		mu       sync.Mutex // protects the fields below
-		cond     sync.Cond
-		inflight map[string]*blockResponse
-		queue    *priorityQueue
+		mu               sync.Mutex // protects the fields below
+		cond             sync.Cond
+		inflight         map[string]*blockResponse
+		failedUntil      map[string]time.Time
+		lastFailurePrune time.Time
+		queue            *priorityQueue
 	}
 )
 
@@ -285,10 +292,34 @@ func (bd *BlockDownloaderDefault) downloadWorker(n int) {
 		log.Debug("popped task from queue")
 		bd.doDownloadTask(task, log)
 
-		// delete the task from the inflight map after it's done
+		// Remove the task from inflight and suppress immediate retries after
+		// failed fetches so a missing block cannot amplify storage/network load.
 		bd.mu.Lock()
-		delete(bd.inflight, cidKey(task.cid))
+		key := cidKey(task.cid)
+		delete(bd.inflight, key)
+		bd.finalizeDownload(task, key, time.Now())
 		bd.mu.Unlock()
+	}
+}
+
+// finalizeDownload applies the missing-CID cooldown after a task completes. A
+// prefetch-origin failure arms the backoff (even if a concurrent foreground Get
+// upgraded the task's priority); a successful fetch clears any stale entry so a
+// block that becomes available again within the window is no longer suppressed.
+func (bd *BlockDownloaderDefault) finalizeDownload(task *blockResponse, key string, now time.Time) {
+	if task.err != nil {
+		if task.prefetchOrigin {
+			recordDownloadFailure(bd.failedUntil, key, task.err, now)
+		}
+		return
+	}
+	delete(bd.failedUntil, key)
+}
+
+func recordDownloadFailure(failedUntil map[string]time.Time, key string, err error, now time.Time) {
+	var notFound format.ErrNotFound
+	if err != nil && errors.As(err, &notFound) {
+		failedUntil[key] = now.Add(failedDownloadBackoff)
 	}
 }
 
@@ -297,7 +328,26 @@ func (bd *BlockDownloaderDefault) queueBlock(ctx context.Context, c cid.Cid, pri
 		core.WithAttributes(attribute.String("cid", c.String())))
 	defer span.End()
 
-	resp, ok := bd.inflight[cidKey(c)]
+	key := cidKey(c)
+	if priority < downloadPriorityHigh {
+		now := time.Now()
+		if now.Sub(bd.lastFailurePrune) >= failedDownloadBackoff {
+			pruneExpiredFailures(bd.failedUntil, now)
+			bd.lastFailurePrune = now
+		}
+		if until, ok := bd.failedUntil[key]; ok {
+			if remaining := time.Until(until); remaining > 0 {
+				resp := &blockResponse{
+					cid: c, ch: make(chan struct{}), err: fmt.Errorf("block download backoff active for %s (retry in %s)", c, remaining.Round(time.Millisecond)), log: bd.log,
+				}
+				close(resp.ch)
+				return resp, false
+			}
+			delete(bd.failedUntil, key)
+		}
+	}
+
+	resp, ok := bd.inflight[key]
 	if ok {
 		if resp.priority < priority {
 			resp.priority = priority
@@ -324,10 +374,21 @@ func (bd *BlockDownloaderDefault) queueBlock(ctx context.Context, c cid.Cid, pri
 		clientIP: clientIP,
 		ctx:      ctx,
 	}
+	if priority < downloadPriorityHigh {
+		resp.prefetchOrigin = true
+	}
 	bd.inflight[cidKey(c)] = resp
 	heap.Push(bd.queue, resp)
 	bd.cond.Signal()
 	return resp, true
+}
+
+func pruneExpiredFailures(failedUntil map[string]time.Time, now time.Time) {
+	for key, until := range failedUntil {
+		if !now.Before(until) {
+			delete(failedUntil, key)
+		}
+	}
 }
 
 // Get returns a block by CID.
@@ -388,8 +449,9 @@ func NewBlockDownloader(ctx core.Context, store pluginCore.MetadataStore, worker
 		log:     log,
 		storage: storage,
 
-		inflight: make(map[string]*blockResponse),
-		queue:    &priorityQueue{},
+		inflight:    make(map[string]*blockResponse),
+		failedUntil: make(map[string]time.Time),
+		queue:       &priorityQueue{},
 	}
 	bd.cond.L = &bd.mu
 	heap.Init(bd.queue)

--- a/internal/protocol/store/tests/downloader_test.go
+++ b/internal/protocol/store/tests/downloader_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/ipfs/go-cid"
+	format "github.com/ipfs/go-ipld-format"
 	"github.com/multiformats/go-multihash"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -110,19 +111,21 @@ func TestBlockDownloader_DownloadObjectWithOptionsError(t *testing.T) {
 		require.NoError(tb, err)
 		testCid := cid.NewCidV1(cid.Raw, mh)
 
-		// Mock the BlockExists call
-		mockStore.EXPECT().BlockExists(mock.Anything, testCid).Return(nil).Once()
+		// Foreground requests remain retryable after a failed fetch.
+		mockStore.EXPECT().BlockExists(mock.Anything, testCid).Return(nil).Twice()
 
-		// Mock the DownloadObjectWithOptions call to return an error
 		mockStorage.EXPECT().DownloadObjectWithOptions(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
-			Return(nil, fmt.Errorf("download failed")).Once()
+			Return(nil, format.ErrNotFound{Cid: testCid}).Twice()
 
-		// Call Get
 		block, err := bd.Get(context.Background(), testCid)
 		assert.Error(tb, err)
 		assert.Nil(tb, block)
-
 		assert.Contains(t, err.Error(), "failed to download block")
+
+		block, err = bd.Get(context.Background(), testCid)
+		assert.Error(tb, err)
+		assert.Nil(tb, block)
+		assert.Contains(tb, err.Error(), "failed to download block")
 	}, ipfsTestConfig)
 }
 


### PR DESCRIPTION
Add a bounded cooldown for missing block prefetch failures.

Failed missing-block requests remain deduplicated for 30 seconds when queued as sibling or child prefetch work, preventing repeated storage and network amplification for unavailable CIDs.

Foreground block requests continue retrying normally, and transient storage or network failures do not activate the cooldown.

Adds regression coverage for downloader failure behavior.

- `develop` <!-- branch-stack -->
  - **fix(ipfs): back off missing block prefetches** :point\_left:

***

<!-- kody-pr-summary:start -->

This pull request implements a backoff mechanism for missing block downloads in the IPFS block downloader to prevent repeated download attempts from amplifying storage and network load.

**Key Changes:**

1. **Added retry backoff for missing blocks**: When a block download fails with a "not found" error, the downloader now records a 30-second backoff period before that same block can be retried.

2. **Backoff enforcement**:
   - Low and medium priority download requests for blocks in the backoff period are immediately rejected without attempting another download.
   - High priority requests bypass the backoff restriction, allowing critical downloads to proceed immediately.
   - Once the backoff expires, the block becomes eligible for normal retry attempts.

3. **Backoff cleanup logic**: The system automatically clears the backoff state when a download succeeds, so subsequently requested blocks aren't unnecessarily delayed.

4. **Updated tests**: Modified the existing test to verify that:
   - Multiple download attempts for the same missing block still work correctly
   - The retry behavior remains functional for foreground requests while respecting the new backoff mechanism

The primary purpose is to prevent a missing block from causing repeated download attempts that could strain the underlying storage system, while ensuring high-priority requests and successful downloads aren't impacted by the backoff logic.

<!-- kody-pr-summary:end -->
