### PR TITLE
feat(ipfs): make PROXY protocol support opt-in via config

### DIFF
--- a/internal/config/protocol.go
+++ b/internal/config/protocol.go
@@ -37,6 +37,7 @@ type ProtocolConfig struct {
 	AutoScaleResourceLimits bool          `config:"auto_scale_resource_limits"`
 	DHTMode                 string        `config:"dht_mode"`
 	TrustedProxies          []string      `config:"trusted_proxies"`
+	ProxyProtocol           bool          `config:"proxy_protocol"`
 	Gateways                []string      `config:"gateways"`
 	Bitswap                 BitswapConfig `config:"bitswap"`
 }

--- a/internal/protocol/ipfs/node.go
+++ b/internal/protocol/ipfs/node.go
@@ -58,6 +58,7 @@ import (
 	rcmgr "github.com/libp2p/go-libp2p/p2p/host/resource-manager"
 	"github.com/libp2p/go-libp2p/p2p/net/connmgr"
 	quic "github.com/libp2p/go-libp2p/p2p/transport/quic"
+	tcp "github.com/libp2p/go-libp2p/p2p/transport/tcp"
 	webrtc "github.com/libp2p/go-libp2p/p2p/transport/webrtc"
 	ws "github.com/libp2p/go-libp2p/p2p/transport/websocket"
 	webtransport "github.com/libp2p/go-libp2p/p2p/transport/webtransport"
@@ -490,13 +491,26 @@ func NewNode(ctx core.Context, cfg *config.ProtocolConfig, rs pluginCore.Reprovi
 		libp2p.ResourceManager(rm),
 		libp2p.DefaultPeerstore,
 		libp2p.UserAgent("lumeweb-ipfs/" + pluginBuild.GetInfo().Short()),
-		libp2p.Transport(newProxyTCPTransport(trustedProxies)),
+	}
+
+	// The TCP transport is wired one of two ways. When the node sits behind a
+	// proxy that appends PROXY protocol headers (e.g. nginx stream or HAProxy
+	// with send-proxy), it must accept and parse those headers; otherwise use a
+	// plain TCP transport so direct libp2p peers can connect without sending a
+	// PROXY header first.
+	if cfg.ProxyProtocol {
+		opts = append(opts, libp2p.Transport(newProxyTCPTransport(trustedProxies)))
+	} else {
+		opts = append(opts, libp2p.Transport(tcp.NewTCPTransport))
+	}
+
+	opts = append(opts,
 		libp2p.Transport(quic.NewTransport),
 		libp2p.Transport(webtransport.New),
 		libp2p.Transport(webrtc.New),
 		libp2p.Transport(ws.New),
 		libp2p.PrometheusRegisterer(prometheus.WrapRegistererWithPrefix("libp2p_", core.PluginMetricsRegistry(internal.ProtocolName))),
-	}
+	)
 
 	opts = append(opts, libp2p.AddrsFactory(func(addrs []multiaddr.Multiaddr) []multiaddr.Multiaddr {
 		var domain string

--- a/internal/protocol/ipfs/proxy_protocol_test.go
+++ b/internal/protocol/ipfs/proxy_protocol_test.go
@@ -320,3 +320,70 @@ func TestProxyProtocolUntrustedProxy(t *testing.T) {
 		t.Error("untrusted proxy should not have PROXY header parsed")
 	}
 }
+
+// TestProxyProtocolUseRequiresHeader demonstrates why the node must NOT install
+// the proxy transport when no proxy is configured. The empty-whitelist policy
+// is proxyproto.USE, which requires an inbound connection to open with a PROXY
+// protocol header before its data is relayed. A direct libp2p peer sends raw
+// multistream+noise bytes (no PROXY header), so its first bytes are consumed by
+// header detection and its dial does not proceed — the failure mode behind the
+// reported downtime. The config gate in node.go (proxy_protocol=false → plain
+// TCP transport) avoids this path entirely.
+func TestProxyProtocolUseRequiresHeader(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	// Default (no trusted proxies) policy is USE.
+	proxyLn := newProxyProtocolListener(ln, nil)
+
+	accepted := make(chan net.Conn, 1)
+	go func() {
+		c, aerr := proxyLn.Accept()
+		if aerr == nil {
+			accepted <- c
+		} else {
+			accepted <- nil
+		}
+	}()
+
+	// A raw client sends libp2p-style bytes with no PROXY header. Under the USE
+	// policy these bytes are swallowed by proxy-protocol detection, so the
+	// server-side handshake cannot observe them.
+	conn, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	// Send non-PROXY bytes (e.g. a libp2p multistream header).
+	conn.Write([]byte("/multistream/1.0.0\n"))
+	conn.SetReadDeadline(time.Now().Add(50 * time.Millisecond))
+	buf := make([]byte, 64)
+	n, _ := conn.Read(buf)
+
+	select {
+	case acceptedConn := <-accepted:
+		acceptedConn.Close()
+		// The raw dial did not receive a response within the deadline: the
+		// server consumed the bytes as a (malformed) proxy header and did not
+		// drive a libp2p handshake. n == 0 asserts no reply was echoed back.
+		if n > 0 {
+			t.Fatalf("under USE policy a raw client was still served: %q", buf[:n])
+		}
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("raw client connection was never accepted as a proxied connection")
+	}
+}
+
+// TestMakeProxyPolicyDefaultIsUse pins the current empty-whitelist default so
+// the config gate that selects the plain TCP transport when proxy_protocol is
+// disabled stays meaningful: with no trusted proxies configured the wrapper
+// would otherwise require the PROXY header.
+func TestMakeProxyPolicyDefaultIsUse(t *testing.T) {
+	p, _ := makeProxyPolicy(nil)(&net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 4001})
+	if p != proxyproto.USE {
+		t.Errorf("makeProxyPolicy(nil) = %v, want proxyproto.USE", p)
+	}
+}


### PR DESCRIPTION
## Summary

Makes PROXY protocol support on the IPFS node's TCP listener opt-in via a new `proxy_protocol` config flag (default `false`).

## Problem

The TCP listen address was always wrapped in a PROXY-protocol transport. When no trusted proxy is configured, the empty whitelist resolves to `proxyproto.USE`, which requires every inbound connection to open with a PROXY protocol header before its data is relayed. A direct libp2p peer sends raw multistream+noise bytes (no PROXY header), so its dial cannot proceed and the node is unreachable on its TCP address.

## Change

- `internal/config/protocol.go`: add `ProxyProtocol bool` (`proxy_protocol`) to `ProtocolConfig`.
- `internal/protocol/ipfs/node.go`: when `proxy_protocol` is enabled, install the PROXY-protocol TCP transport as before; when disabled, install a plain TCP transport so direct peers connect normally. `trusted_proxies` still controls the header trust policy when enabled.
- `internal/protocol/ipfs/proxy_protocol_test.go`: pin the empty-whitelist `USE` default and demonstrate why the wrapper must not be installed when no proxy is configured.

## Testing

- `go build ./...`
- `go vet ./...`
- `go test` on the proxy protocol suite (all pass)

Operators behind nginx/HAProxy with `send-proxy` should set `proxy_protocol: true` (and `trusted_proxies` as before); a node with no proxy keeps the default `false` and accepts direct connects.

- `develop` <!-- branch-stack -->
  - **feat(ipfs): make PROXY protocol support opt-in via config** :point\_left:

***

<!-- kody-pr-summary:start -->

This pull request makes PROXY protocol support opt-in via configuration, preventing downtime when no proxy is configured.

**Key Changes:**

1. **Added `ProxyProtocol` configuration option** (`internal/config/protocol.go`): A new boolean field `proxy_protocol` has been added to the protocol configuration, allowing operators to explicitly enable or disable PROXY protocol support.

2. **Conditional transport selection** (`internal/protocol/ipfs/node.go`): The TCP transport is now wired conditionally based on the new configuration:
   - When `proxy_protocol` is enabled: the node uses a proxy-aware TCP transport that parses PROXY protocol headers from incoming connections (for deployments behind proxies like nginx or HAProxy).
   - When `proxy_protocol` is disabled (default): the node uses a standard TCP transport, allowing direct connections from regular libp2p peers without requiring PROXY headers.

3. **Added test coverage** (`internal/protocol/ipfs/proxy_protocol_test.go`): New tests document and verify:
   - The failure mode when PROXY protocol is enforced without a proxy (raw libp2p connections cannot establish because their initial bytes are consumed by proxy header detection).
   - The default policy behavior when no trusted proxies are configured, confirming the requirement for the PROXY header.

**Purpose:** This change prevents service downtime for deployments without a proxy infrastructure. Previously, the proxy protocol transport was always used, which could block legitimate direct peer connections when the empty-whitelist policy enforced PROXY headers. Now, operators can explicitly opt-in to PROXY protocol support only when behind a proxy, while direct connections work seamlessly by default.

<!-- kody-pr-summary:end -->
