### PR TITLE
fix(ipfs): correct connmgr watermarks vs rcmgr hard limits

### DIFF
--- a/internal/config/protocol.go
+++ b/internal/config/protocol.go
@@ -8,11 +8,11 @@ import (
 )
 
 const (
-	DefaultPort  = 4001
+	DefaultPort   = 4001
 	DefaultWSPort = 4002
 
-	DefaultBitswapGlobalWantRateLimit = 2500
-	DefaultBitswapGlobalWantBurst     = 5000
+	DefaultBitswapGlobalWantRateLimit  = 2500
+	DefaultBitswapGlobalWantBurst      = 5000
 	DefaultBitswapPerPeerWantRateLimit = 200
 	DefaultBitswapPerPeerWantBurst     = 512
 
@@ -24,22 +24,22 @@ var _ config.Defaults = (*ProtocolConfig)(nil)
 var _ config.Defaults = (*BitswapConfig)(nil)
 
 type ProtocolConfig struct {
-	Port                    int           `config:"port"`
-	WSPort                  int           `config:"ws_port"`
-	AnnounceWeb             bool          `config:"announce_web"`
-	ListenAddresses         []string      `config:"listen_addresses"`
-	Peers                   []IPFSPeer    `config:"peers"`
-	BootstrapPeers          []IPFSPeer    `config:"bootstrap_peers"`
-	Provider                IPFSProvider  `config:"provider"`
-	BlockStore              BlockStore    `config:"blockstore"`
-	IPNS                    IPNS          `config:"ipns"`
-	LogLevel                string        `config:"log_level"`
-	AutoScaleResourceLimits bool          `config:"auto_scale_resource_limits"`
-	DHTMode                 string        `config:"dht_mode"`
-	TrustedProxies          []string      `config:"trusted_proxies"`
-	ProxyProtocol           bool          `config:"proxy_protocol"`
-	Gateways                []string      `config:"gateways"`
-	Bitswap                 BitswapConfig `config:"bitswap"`
+	Port                  int           `config:"port"`
+	WSPort                int           `config:"ws_port"`
+	AnnounceWeb           bool          `config:"announce_web"`
+	ListenAddresses       []string      `config:"listen_addresses"`
+	Peers                 []IPFSPeer    `config:"peers"`
+	BootstrapPeers        []IPFSPeer    `config:"bootstrap_peers"`
+	Provider              IPFSProvider  `config:"provider"`
+	BlockStore            BlockStore    `config:"blockstore"`
+	IPNS                  IPNS          `config:"ipns"`
+	LogLevel              string        `config:"log_level"`
+	DisableResourceLimits bool          `config:"disable_resource_limits"`
+	DHTMode               string        `config:"dht_mode"`
+	TrustedProxies        []string      `config:"trusted_proxies"`
+	ProxyProtocol         bool          `config:"proxy_protocol"`
+	Gateways              []string      `config:"gateways"`
+	Bitswap               BitswapConfig `config:"bitswap"`
 }
 
 type BitswapConfig struct {
@@ -53,7 +53,7 @@ type BitswapConfig struct {
 func (b BitswapConfig) Defaults() map[string]any {
 	return map[string]any{
 		"GlobalWantRateLimit":  DefaultBitswapGlobalWantRateLimit,
-		"GlobalWantBurst":     DefaultBitswapGlobalWantBurst,
+		"GlobalWantBurst":      DefaultBitswapGlobalWantBurst,
 		"PerPeerWantRateLimit": DefaultBitswapPerPeerWantRateLimit,
 		"PerPeerWantBurst":     DefaultBitswapPerPeerWantBurst,
 	}
@@ -70,7 +70,7 @@ func (c ProtocolConfig) Defaults() map[string]any {
 
 func (l ProtocolConfig) Schema() z.ZogSchema {
 	return z.Struct(z.Shape{
-		"Port": z.Int().Default(DefaultPort).GT(0, z.Message("port must be positive")),
+		"Port":   z.Int().Default(DefaultPort).GT(0, z.Message("port must be positive")),
 		"WSPort": z.Int().Default(DefaultWSPort).GT(0, z.Message("ws port must be positive")),
 		"LogLevel": z.String().
 			Default("info").

--- a/internal/protocol/ipfs/node.go
+++ b/internal/protocol/ipfs/node.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io"
+	"math"
 	"net"
 	"net/netip"
 	"strconv"
@@ -50,7 +51,6 @@ import (
 	"github.com/libp2p/go-libp2p-kad-dht/fullrt"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	pubsubrouter "github.com/libp2p/go-libp2p-pubsub-router"
-	libp2pCoreConnmgr "github.com/libp2p/go-libp2p/core/connmgr"
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -420,10 +420,29 @@ func NewNode(ctx core.Context, cfg *config.ProtocolConfig, rs pluginCore.Reprovi
 	scalingLimits := rcmgr.DefaultLimits
 	libp2p.SetDefaultServiceLimits(&scalingLimits)
 
-	limits := rcmgr.InfiniteLimits
+	scaled := scalingLimits.AutoScale()
+	limits := scaled
 
-	if cfg.AutoScaleResourceLimits {
-		limits = scalingLimits.AutoScale()
+	if cfg.DisableResourceLimits {
+		limits = rcmgr.InfiniteLimits
+	} else {
+		// This node runs as a public server (ForceReachabilityPublic +
+		// companion ModeServer), so inbound is a fundamental traffic class,
+		// not a secondary direction. libp2p's default autoscale policy gives
+		// the system inbound cap roughly HALF the total connection ceiling
+		// (64 inbound vs 128 total), which would make inbound the de-facto
+		// global cap and let the soft connmgr never prune before the hard
+		// fence rejects new public peers. Raise the system inbound ceiling to
+		// the total connection limit while keeping the autoscaled memory, FD,
+		// stream, peer, and protocol limits intact.
+		scaledLimiter := rcmgr.NewFixedLimiter(scaled)
+		baseTotal := scaledLimiter.GetSystemLimits().GetConnTotalLimit()
+
+		limits = rcmgr.PartialLimitConfig{
+			System: rcmgr.ResourceLimits{
+				ConnsInbound: rcmgr.LimitVal(baseTotal),
+			},
+		}.Build(scaled)
 	}
 	limiter := rcmgr.NewFixedLimiter(limits)
 
@@ -467,14 +486,26 @@ func NewNode(ctx core.Context, cfg *config.ProtocolConfig, rs pluginCore.Reprovi
 		return nil, fmt.Errorf("failed to create resource manager: %w", err)
 	}
 
-	connLimit := rm.(libp2pCoreConnmgr.GetConnLimiter).GetConnLimit()
-	lowWater := int(float64(connLimit) * 0.5)
-	if lowWater < 160 {
-		lowWater = 160
-	}
-	cmgr, err := connmgr.NewConnManager(lowWater, connLimit)
+	lowWater, highWater := deriveConnLimits(limiter)
+	cmgr, err := connmgr.NewConnManager(
+		lowWater,
+		highWater,
+		connmgr.WithGracePeriod(30*time.Second),
+		connmgr.WithSilencePeriod(5*time.Second),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create connection manager: %w", err)
+	}
+
+	// Keep configured gateway peers out of the soft-pruning set, matching the
+	// whitelisted treatment they already get at the hard rcmgr layer
+	// (NetworkPrefixLimit / rate-limiter bypass). With finite watermarks the
+	// connection manager actually prunes now, so without this a gateway peer
+	// could be disconnected once the pool crosses high-water even though the
+	// hard layer explicitly allows those whitelisted endpoints.
+	const gatewayProtectionTag = "portal-gateway"
+	for _, gatewayID := range gatewayPeerIDs {
+		cmgr.Protect(gatewayID, gatewayProtectionTag)
 	}
 
 	trustedProxies, err := parseTrustedProxies(cfg.TrustedProxies)
@@ -1074,6 +1105,70 @@ func parseGatewayMultiaddrs(addrs []string) (ipNets []*net.IPNet, peerIDs []peer
 		}
 	}
 	return ipNets, peerIDs
+}
+
+// deriveConnLimits converts the rcmgr hard limits into the connection
+// manager's soft watermarks.
+//
+// The connection manager is the SOFT working-set manager: it prunes the pool
+// back toward low-water once the count exceeds high-water. The rcmgr is the
+// HARD emergency fence: it rejects new connections once a hard limit is
+// reached. For graceful operation the invariant must be
+//
+//	lowWater < highWater << rcmgr hard limit (for the direction that bites)
+//
+// libp2p's GetConnLimit() on a limiter returns the TOTAL connection hard
+// limit. For a public server the inbound ceiling can be the binding one (a
+// rejected inbound dial is external downtime, whereas an outbound dial is
+// just silently re-tried). So derive the watermarks from min(total, inbound)
+// to act on the direction that first fills up, and leave high-water meaningfully
+// below that hard limit to preserve burst headroom.
+func deriveConnLimits(limiter rcmgr.Limiter) (low, high int) {
+	sys := limiter.GetSystemLimits()
+	hardTotal := sys.GetConnTotalLimit()
+	hardInbound := sys.GetConnLimit(network.DirInbound)
+
+	hardConnLimit := hardTotal
+	if hardInbound < hardTotal {
+		hardConnLimit = hardInbound
+	}
+
+	// Degenerate / unbounded hard limit. InfiniteLimits (used by
+	// disable_resource_limits for a debug/unlimited mode) resolves its Conns
+	// limits to math.MaxInt rather than a real ceiling, and a BlockAll ("0")
+	// or -1 value would carry no meaningful bound either. There is nothing to
+	// derive proportions from in those cases, so return effectively-never-
+	// prune watermarks (math.MaxInt scale). This keeps the connection manager
+	// out of the way in unlimited mode instead of collapsing the pool down to
+	// an aggressive tiny floor, which would contradict the mode's intent.
+	if hardConnLimit <= 0 || hardConnLimit >= math.MaxInt/2 {
+		// Preserve the low < high ordering BasicConnMgr requires while keeping
+		// both at a scale that never triggers ordinary pruning on a real host.
+		return math.MaxInt / 2, math.MaxInt
+	}
+
+	high = int(float64(hardConnLimit) * 0.70)
+	low = int(float64(high) * 0.75)
+	if low < 1 {
+		low = 1
+	}
+	if high < low {
+		high = low
+	}
+	// Keep the pair strictly ordered (low < high) for tiny ceilings and clamp
+	// high-water to the hard limit so the prune threshold can never exceed the
+	// rcmgr fence. Without this, hard limits of 1 or 2 collapse low==high==1,
+	// which violates the ordering BasicConnMgr requires.
+	if high > hardConnLimit {
+		high = hardConnLimit
+	}
+	if low >= high {
+		low = high - 1
+		if low < 1 {
+			low, high = 1, 2
+		}
+	}
+	return low, high
 }
 
 func netIPNetToPrefix(n *net.IPNet) netip.Prefix {

--- a/internal/protocol/ipfs/node_connmgr_test.go
+++ b/internal/protocol/ipfs/node_connmgr_test.go
@@ -1,0 +1,199 @@
+package ipfs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/libp2p/go-libp2p/core/network"
+	rcmgr "github.com/libp2p/go-libp2p/p2p/host/resource-manager"
+)
+
+// newTestLimiter builds a fixed limiter whose System connection limits are set
+// explicitly, independent of machine-specific autoscaling. This lets the
+// watermark derivation be tested deterministically.
+func newTestLimiter(t *testing.T, connsTotal, connsInbound, connsOutbound int) rcmgr.Limiter {
+	t.Helper()
+
+	limits := rcmgr.PartialLimitConfig{
+		System: rcmgr.ResourceLimits{
+			Conns:         rcmgr.LimitVal(connsTotal),
+			ConnsInbound:  rcmgr.LimitVal(connsInbound),
+			ConnsOutbound: rcmgr.LimitVal(connsOutbound),
+		},
+	}.Build(rcmgr.DefaultLimits.AutoScale())
+
+	return rcmgr.NewFixedLimiter(limits)
+}
+
+func TestDeriveConnLimits_InvariantHolds(t *testing.T) {
+	// Simulates the autoscaled default that bit production: total hard ceiling
+	// ~2x the inbound ceiling (the classic 128 total / 64 inbound default).
+	limiter := newTestLimiter(t, 377, 188, 377)
+
+	low, high := deriveConnLimits(limiter)
+
+	// The binding direction is inbound (188) but the derivation must act on
+	// min(total, inbound), so high-water must be driven by 188, not 377.
+	if high >= 188 {
+		t.Fatalf("high-water %d must be < inbound hard limit 188 (was driven by total)", high)
+	}
+	if !(low < high && high < 188) {
+		t.Fatalf("invariant low(%d) < high(%d) < hard(188) violated", low, high)
+	}
+
+	// high = 70% of 188 = 131; low = 75% of 131 = 98
+	if high != 131 {
+		t.Errorf("expected high-water 131, got %d", high)
+	}
+	if low != 98 {
+		t.Errorf("expected low-water 98, got %d", low)
+	}
+}
+
+func TestDeriveConnLimits_UsesMinOfTotalAndInbound(t *testing.T) {
+	cases := []struct {
+		name           string
+		total          int
+		inbound        int
+		wantHardDrives int // the hard limit that should drive the result
+	}{
+		// Inbound is the binding direction (classic default: inbound ~half).
+		{"inbound_binding", 377, 188, 188},
+		// Inbound equals total (public server override in Task 1.2).
+		{"inbound_equals_total", 377, 377, 377},
+		// With equal inbound/total, derivation is driven by the shared ceiling.
+		{"shared_ceiling", 100, 100, 100},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			limiter := newTestLimiter(t, tc.total, tc.inbound, tc.total)
+			low, high := deriveConnLimits(limiter)
+
+			wantHigh := int(float64(tc.wantHardDrives) * 0.70)
+			if high != wantHigh {
+				t.Errorf("high-water = %d, want %d (driven by hard limit %d)",
+					high, wantHigh, tc.wantHardDrives)
+			}
+			if low >= high {
+				t.Errorf("low-water %d >= high-water %d", low, high)
+			}
+			// low = 75% of high
+			wantLow := int(float64(wantHigh) * 0.75)
+			if low != wantLow {
+				t.Errorf("low-water = %d, want %d", low, wantLow)
+			}
+		})
+	}
+}
+
+func TestDeriveConnLimits_TinyHardLimitStillOrdered(t *testing.T) {
+	// A tiny ceiling must always yield strictly low < high and keep both >= 1.
+	// Regression guard: hard limits of 1 and 2 previously collapsed to
+	// low==high==1, violating the ordering BasicConnMgr requires.
+	//
+	// For hard limits >= 2 the pair must also stay within the ceiling (a
+	// valid low<high pair exists there). For a hard limit of exactly 1 no
+	// ordered pair fits inside the ceiling, so the function returns (1,2):
+	// connmgr high=2 merely means "never prune below 2", while the rcmgr still
+	// enforces the real 1-connection cap, so nothing exceeds the hard fence.
+	for n := 1; n <= 5; n++ {
+		n := n
+		t.Run(fmt.Sprintf("hard_%d", n), func(t *testing.T) {
+			limiter := newTestLimiter(t, n, n, n)
+
+			low, high := deriveConnLimits(limiter)
+
+			if low < 1 || high < 1 {
+				t.Fatalf("watermarks must be >= 1, got low=%d high=%d", low, high)
+			}
+			if low >= high {
+				t.Fatalf("low(%d) >= high(%d) for hard limit %d", low, high, n)
+			}
+			if n == 1 {
+				if low != 1 || high != 2 {
+					t.Fatalf("hard 1 must escape to (1,2), got (%d,%d)", low, high)
+				}
+				return
+			}
+			if low > n || high > n {
+				t.Fatalf("watermarks exceed hard limit %d: low=%d high=%d", n, low, high)
+			}
+		})
+	}
+}
+
+func TestDeriveConnLimits_InBoundDirectionRead(t *testing.T) {
+	// Regression guard: GetConnLimit must be queried with the inbound
+	// direction. If the code accidentally used the total limit for both, this
+	// test (inbound < total) would produce a high-water that matches the total
+	// ceiling instead of the inbound one.
+	limiter := newTestLimiter(t, 200, 80, 200)
+
+	// Sanity-check the limiter itself reports what we configured.
+	sys := limiter.GetSystemLimits()
+	if got := sys.GetConnLimit(network.DirInbound); got != 80 {
+		t.Fatalf("test setup: GetConnLimit(inbound) = %d, want 80", got)
+	}
+	if got := sys.GetConnTotalLimit(); got != 200 {
+		t.Fatalf("test setup: GetConnTotalLimit() = %d, want 200", got)
+	}
+
+	low, high := deriveConnLimits(limiter)
+
+	wantHigh := int(float64(80) * 0.70) // 56
+	if high != wantHigh {
+		t.Errorf("high-water = %d, want %d (must be inbound-driven, not 200)", high, wantHigh)
+	}
+	if low != int(float64(wantHigh)*0.75) { // 42
+		t.Errorf("low-water = %d, want 42", low)
+	}
+}
+
+func TestDeriveConnLimits_UnlimitedDoesNotCollapse(t *testing.T) {
+	// Regression guard for the disable_resource_limits / debug-unlimited path.
+	// InfiniteLimits resolves its connection limits to math.MaxInt (not a real
+	// ceiling). Deriving proportions from it must neither collapse the pool to
+	// a tiny floor (e.g. low=1/high=1) nor produce an inverted pair; it should
+	// return effectively-never-prune watermarks so the unlimited mode behaves
+	// as "no connection manager interference".
+	limiter := rcmgr.NewFixedLimiter(rcmgr.InfiniteLimits)
+
+	low, high := deriveConnLimits(limiter)
+
+	if low == 1 && high == 1 {
+		t.Fatalf("unlimited hard limit collapsed watermarks to 1/1; must stay effectively-never-prune")
+	}
+	if low >= high {
+		t.Fatalf("unlimited path must keep low(%d) < high(%d)", low, high)
+	}
+	// They must be at a scale that never triggers ordinary pruning on a real
+	// host (way above any realistic connection count).
+	if low < 1<<20 || high < 1<<20 {
+		t.Fatalf("unlimited watermarks must be large (no pruning), got low=%d high=%d", low, high)
+	}
+}
+
+func TestDeriveConnLimits_DegenerateHardLimitGuarded(t *testing.T) {
+	// BlockAll ("0") or a negative/degenerate hard limit must be treated as
+	// "no meaningful ceiling" and yield never-prune watermarks, never an
+	// inverted or collapsed pair.
+	//
+	// NOTE: LimitVal(0) is DefaultLimit (falls back to the default autoscaled
+	// value), so a genuinely-zero ceiling requires BlockAllLimit (-2), which
+	// resolves to 0 in Build.
+	for name, limiter := range map[string]rcmgr.Limiter{
+		"block_all_inbound": newTestLimiter(t, 100, int(rcmgr.BlockAllLimit), 100), // inbound blocked -> 0
+		"block_all_total":   newTestLimiter(t, int(rcmgr.BlockAllLimit), int(rcmgr.BlockAllLimit), int(rcmgr.BlockAllLimit)),
+	} {
+		t.Run(name, func(t *testing.T) {
+			low, high := deriveConnLimits(limiter)
+			if low >= high {
+				t.Fatalf("low(%d) >= high(%d) for %s", low, high, name)
+			}
+			if low < 1<<20 || high < 1<<20 {
+				t.Fatalf("degenerate %s must yield never-prune watermarks, got low=%d high=%d", name, low, high)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

The IPFS plugin's connection manager derives its high-water mark from `GetConnLimit()`, which returns the **total** rcmgr hard ceiling (\~377), while rcmgr's **inbound** hard cap is roughly half that (\~188) under libp2p's default autoscale policy. As a result the soft connection manager never prunes before the hard fence rejects new **inbound** connections — the pool fills to the inbound hard limit, then external peers are refused, surfacing as downtime instead of graceful pruning on this public FullRT host.

This PR restores the invariant:

```
lowWater < highWater << rcmgr hard limit (for the binding direction)
```

## Changes

- **Autoscaled resource limits by default.** The node previously defaulted to `InfiniteLimits` unless `auto_scale_resource_limits` was explicitly set. It now autoscales by default, with an explicit `disable_resource_limits` escape hatch for debugging instead of `autoscale=false` silently meaning "unlimited".
- **Raise the system inbound ceiling** to the total connection limit for this public server (`ForceReachabilityPublic` + companion `ModeServer`), so inbound is not the de-facto global cap. Autoscaled memory, FD, stream, peer, and protocol limits are unchanged.
- **Derive connmgr watermarks from `min(total, inbound)`** hard limits (`low` = 75% of `high`, `high` = 70% of the binding hard limit), remove the arbitrary 160 floor that destroyed the proportional relationship, and tune grace/silence periods for burst prune behaviour.
- **Unit tests** covering the watermark derivation invariant.

## Testing

- `go build ./...` passes
- New `TestDeriveConnLimits_*` tests pass
- `go test ./internal/config/` passes

## Notes

- `auto_scale_resource_limits` is no longer a read config field; autoscaling is now the default and `disable_resource_limits` is the explicit unlimited mode.

***

<!-- kody-pr-summary:start -->

## Summary

This pull request fixes connection management watermarks in the IPFS plugin to align them correctly with the resource manager (rcmgr) hard limits, preventing premature rejection of inbound connections on public servers.

## Key Changes

### 1. Connection Watermark Derivation Rewrite

Replaced the previous simplistic watermark calculation (which used only the total connection limit with a fixed 50% low-water threshold and 160 minimum) with a new `deriveConnLimits` function that:

- Reads both total and inbound connection hard limits from the rcmgr
- Uses the **minimum** of total and inbound limits as the driving hard ceiling
- Sets high-water at 70% of that ceiling and low-water at 75% of high
- Ensures watermarks stay ordered and ≥1 even for tiny limits
- Adds a 30-second grace period and 5-second silence period to the connection manager

### 2. Resource Limit Configuration Restructured

Replaces the `AutoScaleResourceLimits` config flag with `DisableResourceLimits`:

- When `DisableResourceLimits` is true, infinite limits are used (as before)
- When enabled (default), limits are always autoscaled, but now with a critical fix:
  - Raises the **inbound connection ceiling** to match the total connection limit
  - This addresses a production issue where libp2p's default autoscale policy gave inbound roughly half the total ceiling (64 vs 128), making inbound the de-facto global cap and preventing the soft connection manager from pruning before the hard fence rejected new public peers

### 3. Configuration Schema Update

- Renamed `auto_scale_resource_limits` to `disable_resource_limits` (semantic inversion)
- Applied minor formatting/alignment cleanups across protocol config structures

### 4. Comprehensive Testing Added

New test file (`node_connmgr_test.go`) with deterministic tests verifying:

- The invariant `low < high << hard limit` holds
- Watermark derivation uses the minimum of total/inbound limits
- Correct behavior for equal inbound/total ceilings
- Proper handling of tiny limits (e.g., 5 connections) with guaranteed ordering
- Regression guard ensuring the inbound direction is correctly queried

## Impact

This fix ensures the soft connection manager triggers pruning **before** the hard resource manager limits are reached, particularly for inbound connections on public IPFS servers. This prevents external peers from being rejected due to premature hard-limit enforcement, improving peer connectivity and network reliability.

<!-- kody-pr-summary:end -->

- `develop` <!-- branch-stack -->
  - **fix(ipfs): correct connmgr watermarks vs rcmgr hard limits** :point\_left:
