### PR TITLE
feat(ipfs): trusted gateway first-class policy

### DIFF
--- a/internal/protocol/ipfs/node.go
+++ b/internal/protocol/ipfs/node.go
@@ -446,26 +446,28 @@ func NewNode(ctx core.Context, cfg *config.ProtocolConfig, rs pluginCore.Reprovi
 	}
 	limiter := rcmgr.NewFixedLimiter(limits)
 
-	// Build list of IP ranges that bypass rate limiting and connection limits.
-	// Private/Docker networks are always whitelisted (nginx and internal services
-	// connect through these). Loopback is always unlimited.
-	// Gateways (parsed from multiaddrs) add additional edge gateway ranges.
-	gatewayNets := []*net.IPNet{
-		mustParseCIDR("127.0.0.0/8"),
-		mustParseCIDR("::1/128"),
-		mustParseCIDR("172.16.0.0/12"),
-		mustParseCIDR("10.0.0.0/8"),
-		mustParseCIDR("192.168.0.0/16"),
-		mustParseCIDR("fc00::/7"),
+	// Build the sets of IP ranges that bypass rate limiting and the per-source
+	// connection limiter.
+	//
+	// rateBypassNets (private/loopback/Docker) are always exempt so nginx and
+	// internal services can connect regardless of public traffic shaping.
+	// trustedGatewayNets come from explicitly configured gateways
+	// (cfg.Gateways) and additionally receive reserved rcmgr admission and
+	// connmgr peer protection below. Private-range peers are NOT automatically
+	// granted gateway reserved capacity — that is an explicit, configured
+	// decision.
+	rateBypassNets := privateAndLoopbackNets()
+	gatewayIPs, gatewayPeerIDs, gatewayAllowlisted, err := parseGatewayMultiaddrs(cfg.Gateways)
+	if err != nil {
+		return nil, err
 	}
-	gatewayIPs, gatewayPeerIDs := parseGatewayMultiaddrs(cfg.Gateways)
-	gatewayNets = append(gatewayNets, gatewayIPs...)
+	trustedGatewayNets := gatewayIPs
 
-	prefixLimits := make([]libp2pRate.PrefixLimit, 0, len(gatewayNets))
+	prefixLimits := make([]libp2pRate.PrefixLimit, 0, len(rateBypassNets)+len(trustedGatewayNets))
 	connLimits4 := make([]rcmgr.NetworkPrefixLimit, 0)
 	connLimits6 := make([]rcmgr.NetworkPrefixLimit, 0)
 
-	for _, cidr := range gatewayNets {
+	for _, cidr := range append(rateBypassNets, trustedGatewayNets...) {
 		prefix := netIPNetToPrefix(cidr)
 		prefixLimits = append(prefixLimits, libp2pRate.PrefixLimit{Prefix: prefix, Limit: libp2pRate.Limit{}})
 		if cidr.IP.To4() != nil {
@@ -475,12 +477,24 @@ func NewNode(ctx core.Context, cfg *config.ProtocolConfig, rs pluginCore.Reprovi
 		}
 	}
 
+	// Trusted gateways are also allowlisted in the resource manager. libp2p
+	// draws allowlisted connections against a separate reserved system pool
+	// that activates once the normal system pool is full, so a trusted gateway
+	// can still be admitted when public capacity is exhausted. The peer-
+	// constrained form (/ip4/x/p2p/...) is preferred where a peer ID is known:
+	// libp2p first admits by IP, then re-checks the authenticated peer ID after
+	// the handshake and moves non-matching peers back to the normal pool.
+	//
+	// NOTE: the WithNetworkPrefixLimit 1024 above only relaxes the per-source/IP
+	// limiter — it does NOT exempt these ranges from the global system ceiling.
+	// The allowlist is what provides the reserved admission path.
 	rm, err := rcmgr.NewResourceManager(limiter,
 		rcmgr.WithConnRateLimiters(&libp2pRate.Limiter{
 			NetworkPrefixLimits: prefixLimits,
 			GlobalLimit:         libp2pRate.Limit{},
 		}),
 		rcmgr.WithNetworkPrefixLimit(connLimits4, connLimits6),
+		rcmgr.WithAllowlistedMultiaddrs(gatewayAllowlisted),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create resource manager: %w", err)
@@ -1075,36 +1089,136 @@ func mustParseCIDR(s string) *net.IPNet {
 	return ipNet
 }
 
-func parseGatewayMultiaddrs(addrs []string) (ipNets []*net.IPNet, peerIDs []peer.ID) {
-	for _, s := range addrs {
-		ma, err := multiaddr.NewMultiaddr(s)
-		if err != nil {
-			continue
+// parseGatewayMultiaddrs parses configured gateway multiaddrs into a single
+// source of truth consumed by every trust layer:
+//
+//   - ipNets:      IP networks for the rate-limiter exemption and the
+//     per-source/IP connection limiter.
+//   - peerIDs:     peer IDs for connmgr protection (never pruned) and the
+//     Bitswap want-rate bypass.
+//   - allowlisted: the full original multiaddrs (including any /p2p and
+//     /ipcidr components, verbatim) for the rcmgr allowlist, which reserves
+//     connection admission when the normal system pool is full. Only
+//     multiaddrs that carry an IP component are returned.
+//
+// An IP with an explicit /ipcidr/N prefix yields that subnet (previously the
+// /ipcidr component was ignored and the address collapsed to a /32 or /128
+// host route). A malformed or invalid gateway component is a configuration
+// error and fails node startup rather than being silently skipped.
+func parseGatewayMultiaddrs(addrs []string) (
+	ipNets []*net.IPNet,
+	peerIDs []peer.ID,
+	allowlisted []multiaddr.Multiaddr,
+	err error,
+) {
+	for _, raw := range addrs {
+		ma, maErr := multiaddr.NewMultiaddr(raw)
+		if maErr != nil {
+			return nil, nil, nil, fmt.Errorf("invalid gateway multiaddr %q: %w", raw, maErr)
 		}
 
-		for _, c := range ma {
-			switch c.Protocol().Code {
-			case multiaddr.P_IP4, multiaddr.P_IP6:
-				ip := net.ParseIP(c.Value())
-				if ip != nil {
-					bits := 128
-					if ip.To4() != nil {
-						bits = 32
-					}
-					_, ipNet, _ := net.ParseCIDR(fmt.Sprintf("%s/%d", ip.String(), bits))
-					if ipNet != nil {
-						ipNets = append(ipNets, ipNet)
-					}
-				}
-			case multiaddr.P_P2P:
-				p, err := peer.Decode(c.Value())
-				if err == nil {
-					peerIDs = append(peerIDs, p)
-				}
+		ipStr := ""
+		prefixBits := -1
+		hasIP := false
+		var parseErr error
+
+		// Emit the currently-pending IP (with its /ipcidr prefix, if any) as a
+		// network. Called when a new IP component is seen and after the loop, so
+		// every IP component in the multiaddr yields a network — including
+		// p2p-circuit relays, where the relay IP that actually originates the
+		// connection must remain rate/conn-exempt and allowlisted.
+		emitPending := func() {
+			if ipStr == "" || prefixBits <= 0 {
+				return
 			}
+			_, network, netErr := net.ParseCIDR(fmt.Sprintf("%s/%d", ipStr, prefixBits))
+			if netErr != nil {
+				parseErr = netErr
+				return
+			}
+			ipNets = append(ipNets, network)
+			ipStr = ""
+			prefixBits = -1
+		}
+
+		multiaddr.ForEach(ma, func(c multiaddr.Component) bool {
+			switch c.Protocol().Code {
+			case multiaddr.P_IP4:
+				emitPending()
+				ipStr = c.Value()
+				prefixBits = 32
+				hasIP = true
+			case multiaddr.P_IP6:
+				emitPending()
+				ipStr = c.Value()
+				prefixBits = 128
+				hasIP = true
+			case multiaddr.P_IPCIDR:
+				bits, atoiErr := strconv.Atoi(c.Value())
+				if atoiErr != nil {
+					parseErr = fmt.Errorf("invalid /ipcidr value %q: %w", c.Value(), atoiErr)
+					return false
+				}
+				// /ipcidr binds to the pending IP (the one it follows).
+				if ipStr != "" {
+					maxBits := 32
+					if ip := net.ParseIP(ipStr); ip != nil && ip.To4() == nil {
+						maxBits = 128
+					}
+					if bits > maxBits {
+						parseErr = fmt.Errorf(
+							"invalid /ipcidr prefix /%d for %s (max /%d)", bits, ipStr, maxBits)
+						return false
+					}
+				}
+				prefixBits = bits
+			case multiaddr.P_P2P:
+				p, decodeErr := peer.Decode(c.Value())
+				if decodeErr != nil {
+					parseErr = fmt.Errorf("invalid /p2p peer ID %q: %w", c.Value(), decodeErr)
+					return false
+				}
+				peerIDs = append(peerIDs, p)
+			}
+			return true
+		})
+		emitPending()
+		if parseErr != nil {
+			return nil, nil, nil, fmt.Errorf("invalid gateway multiaddr %q: %w", raw, parseErr)
+		}
+
+		// The allowlist receives the full original multiaddr (including any
+		// /p2p and /ipcidr components) verbatim, as a single source of truth
+		// shared by all four gateway trust consumers. Keeping /p2p is what
+		// enables the post-handshake peer re-check (rcmgr.go:799
+		// AllowedPeerAndMultiaddr) after the IP-based admission. Only
+		// multiaddrs carrying an IP component are allowlisted: an IP-less,
+		// peer-only multiaddr would make the rcmgr decline the entry with
+		// "missing ip address" and fail node startup; the peer is still
+		// enforced via cmgr.Protect and the Bitswap want-rate bypass.
+		if hasIP {
+			allowlisted = append(allowlisted, ma)
 		}
 	}
-	return ipNets, peerIDs
+
+	return ipNets, peerIDs, allowlisted, nil
+}
+
+// privateAndLoopbackNets returns the fixed set of private / loopback / Docker
+// networks that bypass IP-rate and per-subnet connection abuse controls. These
+// are always exempt so nginx and internal services can connect regardless of
+// public traffic shaping. They are intentionally distinct from configured
+// trusted gateway networks: a private-range peer is not automatically treated
+// as critical infrastructure that reserves capacity or is never pruned.
+func privateAndLoopbackNets() []*net.IPNet {
+	return []*net.IPNet{
+		mustParseCIDR("127.0.0.0/8"),
+		mustParseCIDR("::1/128"),
+		mustParseCIDR("172.16.0.0/12"),
+		mustParseCIDR("10.0.0.0/8"),
+		mustParseCIDR("192.168.0.0/16"),
+		mustParseCIDR("fc00::/7"),
+	}
 }
 
 // deriveConnLimits converts the rcmgr hard limits into the connection

--- a/internal/protocol/ipfs/node_gateway_test.go
+++ b/internal/protocol/ipfs/node_gateway_test.go
@@ -1,0 +1,329 @@
+package ipfs
+
+import (
+	"net"
+	"strings"
+	"testing"
+
+	"github.com/libp2p/go-libp2p/core/peer"
+	rcmgr "github.com/libp2p/go-libp2p/p2p/host/resource-manager"
+	"github.com/multiformats/go-multiaddr"
+)
+
+func mustDecodePeerFromMultiaddr(t *testing.T, raw string) peer.ID {
+	t.Helper()
+	// Extract the peer ID from a multiaddr string like
+	// /ip4/10.1.2.3/p2p/12D3Koo...
+	const p2pPrefix = "/p2p/"
+	idx := strings.LastIndex(raw, p2pPrefix)
+	if idx < 0 {
+		t.Fatalf("multiaddr %q has no /p2p/ peer ID", raw)
+	}
+	id, err := peer.Decode(raw[idx+len(p2pPrefix):])
+	if err != nil {
+		t.Fatalf("failed to decode peer ID from %q: %v", raw, err)
+	}
+	return id
+}
+
+func ipNetContains(t *testing.T, nets []*net.IPNet, contains string) {
+	t.Helper()
+	ip := net.ParseIP(contains)
+	if ip == nil {
+		t.Fatalf("bad test IP %q", contains)
+	}
+	for _, n := range nets {
+		if n.Contains(ip) {
+			return
+		}
+	}
+	t.Fatalf("no parsed network contains %q", contains)
+}
+
+func TestParseGatewayMultiaddrs_HonorsIPCIDR(t *testing.T) {
+	// Regression guard: /ipcidr/24 must yield the /24 subnet, not collapse to
+	// a /32 host route (the old parser ignored the ipcidr component).
+	ipNets, peerIDs, allowlisted, err := parseGatewayMultiaddrs([]string{
+		"/ip4/10.10.0.0/ipcidr/24",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(ipNets) != 1 {
+		t.Fatalf("expected 1 network, got %d", len(ipNets))
+	}
+	ones, _ := ipNets[0].Mask.Size()
+	if ones != 24 {
+		t.Fatalf("expected /24 prefix, got /%d", ones)
+	}
+	ipNetContains(t, ipNets, "10.10.0.200") // inside subnet
+	// Ensure the single host itself is covered and a host outside the /24 is not.
+	if ipNets[0].Contains(net.ParseIP("10.10.1.1")) {
+		t.Fatalf("network %s unexpectedly contains 10.10.1.1 (should be /24 not /16)", ipNets[0])
+	}
+
+	if want := 1; len(allowlisted) != want {
+		t.Fatalf("allowlisted: got %d, want %d", len(allowlisted), want)
+	}
+	if len(peerIDs) != 0 {
+		t.Fatalf("expected no peer IDs, got %d", len(peerIDs))
+	}
+}
+
+func TestParseGatewayMultiaddrs_HostDefaultsToHostBits(t *testing.T) {
+	// A bare IPv4/IPv6 without /ipcidr defaults to a /32 or /128 host route.
+	ipNets, _, _, err := parseGatewayMultiaddrs([]string{
+		"/ip4/10.1.2.3",
+		"/ip6/::1",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(ipNets) != 2 {
+		t.Fatalf("expected 2 networks, got %d", len(ipNets))
+	}
+
+	mask4 := ipNets[0].Mask
+	ones4, _ := mask4.Size()
+	if ones4 != 32 {
+		t.Fatalf("bare ipv4 must be /32, got /%d", ones4)
+	}
+
+	ones6, _ := ipNets[1].Mask.Size()
+	if ones6 != 128 {
+		t.Fatalf("bare ipv6 must be /128, got /%d", ones6)
+	}
+}
+
+func TestParseGatewayMultiaddrs_PeerConstrainedForm(t *testing.T) {
+	rawA := "/ip4/10.1.2.3/p2p/12D3KooWB5sNsAocc5F37JnGjYE1t6WKkJwGeahDgg99cN1QL3dM"
+	rawB := "/ip6/::1/p2p/12D3KooWB5sNsAocc5F37JnGjYE1t6WKkJwGeahDgg99cN1QL3dM"
+
+	ipNets, peerIDs, allowlisted, err := parseGatewayMultiaddrs([]string{rawA, rawB})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(peerIDs) != 2 {
+		t.Fatalf("expected 2 peer IDs, got %d", len(peerIDs))
+	}
+	if wantA := mustDecodePeerFromMultiaddr(t, rawA); peerIDs[0] != wantA {
+		t.Errorf("peerIDs[0] mismatch, got %s want %s", peerIDs[0], wantA)
+	}
+
+	// The allowlist keeps the full original multiaddr (including /p2p), so the
+	// rcmgr can do the post-handshake peer re-check (rcmgr.go:799
+	// AllowedPeerAndMultiaddr) after the IP-based admission.
+	if len(allowlisted) != 2 {
+		t.Fatalf("expected 2 allowlisted multiaddrs, got %d", len(allowlisted))
+	}
+	for i, am := range allowlisted {
+		if _, hasP2P := am.ValueForProtocol(multiaddr.P_P2P); hasP2P != nil {
+			t.Errorf("allowlisted[%d] lost its /p2p component: %s", i, am)
+		}
+	}
+
+	// IP networks are still derived from the peer-constrained addrs.
+	if len(ipNets) != 2 {
+		t.Fatalf("expected 2 networks, got %d", len(ipNets))
+	}
+	ipNetContains(t, ipNets, "10.1.2.3")
+}
+
+func TestParseGatewayMultiaddrs_BareP2PNoStartupAbort(t *testing.T) {
+	// A bare /p2p gateway multiaddr (peer-only, no IP component) must not
+	// reach rcmgr.WithAllowlistedMultiaddrs, which rejects IP-less multiaddrs
+	// with "missing ip address" and would fail node startup. The peer must
+	// still be extracted for cmgr.Protect / Bitswap bypass.
+	ipNets, peerIDs, allowlisted, err := parseGatewayMultiaddrs([]string{
+		"/p2p/12D3KooWB5sNsAocc5F37JnGjYE1t6WKkJwGeahDgg99cN1QL3dM",
+	})
+	if err != nil {
+		t.Fatalf("bare /p2p must not fail startup: %v", err)
+	}
+	if len(ipNets) != 0 {
+		t.Fatalf("bare /p2p has no IP, expected 0 networks, got %d", len(ipNets))
+	}
+	// The peer is still protected even though it is not allowlisted.
+	if len(peerIDs) != 1 {
+		t.Fatalf("expected 1 peer ID, got %d", len(peerIDs))
+	}
+	// No IP means nothing to allowlist — passing this to the rcmgr would abort.
+	if len(allowlisted) != 0 {
+		t.Fatalf("bare /p2p must not be allowlisted, got %d", len(allowlisted))
+	}
+}
+
+func TestParseGatewayMultiaddrs_InvalidReturnsError(t *testing.T) {
+	// A malformed gateway multiaddr is a config error (the old parser silently
+	// skipped it), so a typo'd gateway fails fast at startup instead of
+	// silently losing gateway trust policy.
+	_, _, _, err := parseGatewayMultiaddrs([]string{"not-a-multiaddr"})
+	if err == nil {
+		t.Fatal("expected error for invalid multiaddr, got nil")
+	}
+}
+
+func TestParseGatewayMultiaddrs_NonNumericIPCIDRIsError(t *testing.T) {
+	// A non-numeric /ipcidr value must fail fast (config error), not silently
+	// fall back to a /32 or /128 host route. That fallback would collapse an
+	// intended subnet into a single-host trust policy with the wrong security
+	// semantics, contradicting the fail-fast behavior of the parser.
+	for _, raw := range []string{
+		"/ip4/10.10.0.0/ipcidr/foo",
+		"/ip6/2001:db8::/ipcidr/bar",
+	} {
+		_, _, _, err := parseGatewayMultiaddrs([]string{raw})
+		if err == nil {
+			t.Fatalf("expected error for non-numeric /ipcidr in %q, got nil", raw)
+		}
+	}
+}
+
+func TestParseGatewayMultiaddrs_InvalidP2PPeerIsError(t *testing.T) {
+	// A /p2p value that fails peer.Decode must fail fast (config error), not be
+	// silently dropped. Silently dropping it would leave the gateway allowlisted
+	// by IP while silently disabling connmgr.Protect and the Bitswap want-rate
+	// bypass — granting IP trust without the peer-level protections, which
+	// changes trust semantics for a config error.
+	for _, raw := range []string{
+		"/ip4/10.1.2.3/p2p/not-a-valid-peer-id",
+		"/ip6/::1/p2p/!!!invalid!!!",
+	} {
+		_, _, _, err := parseGatewayMultiaddrs([]string{raw})
+		if err == nil {
+			t.Fatalf("expected error for invalid /p2p in %q, got nil", raw)
+		}
+	}
+}
+
+func TestParseGatewayMultiaddrs_HostBitsSetNotAnError(t *testing.T) {
+	// A gateway address carrying host bits below its /ipcidr prefix (e.g.
+	// /10.10.0.5/24) must not be rejected. net.ParseCIDR masks the network
+	// (10.10.0.0/24) rather than erroring, so this must parse cleanly and cover
+	// the whole advertised subnet. Regression guard against any future switch
+	// to netip.ParsePrefix, which does reject set host bits.
+	ipNets, _, _, err := parseGatewayMultiaddrs([]string{
+		"/ip4/10.10.0.5/ipcidr/24",
+		"/ip6/2001:db8::5/ipcidr/64",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error for host-bits-set cidr: %v", err)
+	}
+	if len(ipNets) != 2 {
+		t.Fatalf("expected 2 networks, got %d", len(ipNets))
+	}
+
+	// ipv4 network must be the masked /24.
+	if !ipNets[0].Contains(net.ParseIP("10.10.0.200")) {
+		t.Fatalf("v4 network %s must be 10.10.0.0/24", ipNets[0])
+	}
+	if ipNets[0].Contains(net.ParseIP("10.10.1.1")) {
+		t.Fatalf("v4 network %s escaped the /24", ipNets[0])
+	}
+
+	// ipv6 network must be the masked /64.
+	if !ipNets[1].Contains(net.ParseIP("2001:db8::1234")) {
+		t.Fatalf("v6 network %s must be 2001:db8::/64", ipNets[1])
+	}
+	ones6, _ := ipNets[1].Mask.Size()
+	if ones6 != 64 {
+		t.Fatalf("v6 network prefix bits = %d, want 64", ones6)
+	}
+}
+
+func TestPrivateAndLoopbackNets_ContainsLoopbackAndPrivate(t *testing.T) {
+	nets := privateAndLoopbackNets()
+
+	// All the classic private/loopback/ULA ranges must be present.
+	for _, ip := range []string{"127.0.0.1", "::1", "10.0.0.1", "172.16.0.1", "192.168.1.1", "fd00::1"} {
+		ipNetContains(t, nets, ip)
+	}
+	// A public address must not be covered.
+	if containsPublic(nets, "8.8.8.8") {
+		t.Fatal("privateAndLoopbackNets must not contain public address 8.8.8.8")
+	}
+}
+
+func TestParseGatewayMultiaddrs_RejectsOversizedIPCIDR(t *testing.T) {
+	// A /ipcidr prefix larger than the address family's bit length is a config
+	// error and must fail fast, not silently broaden or mis-scope the trust
+	// subnet.
+	for _, raw := range []string{
+		"/ip4/10.10.0.0/ipcidr/64",   // > 32 for IPv4
+		"/ip6/2001:db8::/ipcidr/129", // > 128 for IPv6
+		"/ip4/10.10.0.0/ipcidr/33",   // > 32 for IPv4
+	} {
+		_, _, _, err := parseGatewayMultiaddrs([]string{raw})
+		if err == nil {
+			t.Fatalf("expected error for oversized /ipcidr in %q, got nil", raw)
+		}
+	}
+}
+
+func TestParseGatewayMultiaddrs_EmitsNetworkPerIP(t *testing.T) {
+	// Regression guard: a p2p-circuit relayed gateway multiaddr has more than
+	// one IP component. The relay IP that actually originates the connection
+	// must stay in ipNets so it remains rate/conn-exempt and allowlisted. The
+	// old parser kept only the last IP (dropping the relay).
+	ipNets, _, _, err := parseGatewayMultiaddrs([]string{
+		"/ip4/10.9.9.9/tcp/4001/p2p-circuit/ip4/10.8.8.8/tcp/4001/ipfs/12D3KooWB5sNsAocc5F37JnGjYE1t6WKkJwGeahDgg99cN1QL3dM",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	ipNetContains(t, ipNets, "10.9.9.9") // relay
+	ipNetContains(t, ipNets, "10.8.8.8") // target
+	if len(ipNets) != 2 {
+		t.Fatalf("expected a network per IP (relay + target), got %d", len(ipNets))
+	}
+}
+
+func TestGatewayAllowlist_ExpandsIPCIDRSubnet(t *testing.T) {
+	// Regression guard: the full gateway multiaddr (including /ipcidr/N) must
+	// be passed through to the rcmgr allowlist unchanged. libp2p's allowlist
+	// expands /ipcidr into a *net.IPNet and matches addresses with
+	// network.Contains, so a /24 gateway entry must cover the whole subnet —
+	// not only the base host. Stripping the /ipcidr component here would
+	// silently reduce subnet gateways to a single /32 reserve slot.
+	_, _, allowlisted, err := parseGatewayMultiaddrs([]string{
+		"/ip4/10.10.0.0/ipcidr/24",
+	})
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+	if len(allowlisted) != 1 {
+		t.Fatalf("expected 1 allowlisted multiaddr, got %d", len(allowlisted))
+	}
+
+	rm, err := rcmgr.NewResourceManager(
+		rcmgr.NewFixedLimiter(rcmgr.DefaultLimits.AutoScale()),
+		rcmgr.WithAllowlistedMultiaddrs(allowlisted),
+	)
+	if err != nil {
+		t.Fatalf("rcmgr rejected /ipcidr gateway multiaddr: %v", err)
+	}
+	al := rm.(interface{ GetAllowlist() *rcmgr.Allowlist }).GetAllowlist()
+
+	for _, host := range []string{"10.10.0.0", "10.10.0.200"} {
+		ma, _ := multiaddr.NewMultiaddr("/ip4/" + host)
+		if !al.Allowed(ma) {
+			t.Fatalf("gateway host %s not allowed — /24 did not expand", host)
+		}
+	}
+	outside, _ := multiaddr.NewMultiaddr("/ip4/10.10.1.1")
+	if al.Allowed(outside) {
+		t.Fatal("host outside /24 unexpectedly allowed — subnet over-expanded")
+	}
+}
+
+func containsPublic(nets []*net.IPNet, ipStr string) bool {
+	ip := net.ParseIP(ipStr)
+	for _, n := range nets {
+		if n.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

Configured gateway peers currently bypass IP-rate and want-rate limits but remain ordinary connection candidates: the rcmgr only exempts gateway **IPs** from the pre-handshake per-source limiter, so a gateway can still be rejected when the normal system connection pool fills, and nothing stops the connection manager pruning a gateway connection. This PR makes trusted gateway peers a first-class policy across every libp2p layer off a **single parsed source of truth**.

## Changes

- **`parseGatewayMultiaddrs` rewrite** — now honors `/ipcidr/N` subnet prefixes (previously ignored, collapsing e.g. `/10.10.0.0/ipcidr/24` to a `/32` host route), and returns the full allowlisted multiaddrs alongside IP networks and peer IDs. A malformed gateway multiaddr now fails startup instead of being silently skipped.
- **Split private-net from trusted-gateway** — the fixed private/loopback/Docker bypass ranges are separated from explicitly configured gateway networks, so a private-range peer is not automatically treated as reserved critical infrastructure.
- **rcmgr allowlist** — trusted gateway multiaddrs are allowlisted, letting them be admitted against a reserved system pool even once the normal public pool is full. Peer-constrained forms (`/ip4/x/p2p/...`) get a post-handshake peer-ID re-check; non-matching peers fall back to the normal pool.
- **Corrected misleading comment** — `WithNetworkPrefixLimit(..., 1024)` only relaxes the per-source/IP limiter; it does not exempt ranges from the global system ceiling. The allowlist is what provides the reserved admission path.

`connmgr` peer protection for gateway IDs was already added in the preceding connection-manager PR.

## Testing

- `go build ./...` passes
- New `TestParseGatewayMultiaddrs_*` + `TestPrivateAndLoopbackNets_*` tests pass
- Full `internal/protocol/ipfs` suite passes (except pre-existing unrelated `TestBlockRequestTrackerRemovesReverseIndexEntries`)

* `develop` <!-- branch-stack -->
  - **feat(ipfs): trusted gateway first-class policy** :point\_left:

***

<!-- kody-pr-summary:start -->

## Summary

This pull request makes trusted gateways a **first-class citizen** in the IPFS node's connection and resource management policy. Previously, gateway IP ranges were lumped together with private/loopback networks for rate-limit bypasses, but they received no special treatment in the resource manager or peer protection. This change introduces a clear separation between:

1. **Private/loopback networks** — always bypass rate limiting so internal services (nginx, Docker) can connect freely.
2. **Explicitly configured trusted gateways** — these now receive **reserved capacity** in the resource manager (via allowlisting), meaning they can still be admitted when the normal system pool is full. Their peer IDs are also protected from pruning (connmgr) and get Bitswap want-rate bypass.

Additionally, the fix corrects a **parsing bug**: `/ipcidr/N` prefixes in gateway multiaddrs are now honored — previously they were ignored, collapsing addresses to `/32` or `/128` host routes. Malformed gateway multiaddrs now cause **fail-fast startup** instead of being silently skipped.

<!-- kody-pr-summary:end -->
