### PR TITLE
feat(ipfs): make FullRT crawler parallelism configurable

### DIFF
--- a/internal/config/protocol.go
+++ b/internal/config/protocol.go
@@ -16,6 +16,8 @@ const (
 	DefaultBitswapPerPeerWantRateLimit = 200
 	DefaultBitswapPerPeerWantBurst     = 512
 
+	DefaultFullRTCrawlerParallelism = 96
+
 	DHTModeBasic  = "basic"
 	DHTModeFullRT = "fullrt"
 )
@@ -24,22 +26,23 @@ var _ config.Defaults = (*ProtocolConfig)(nil)
 var _ config.Defaults = (*BitswapConfig)(nil)
 
 type ProtocolConfig struct {
-	Port                  int           `config:"port"`
-	WSPort                int           `config:"ws_port"`
-	AnnounceWeb           bool          `config:"announce_web"`
-	ListenAddresses       []string      `config:"listen_addresses"`
-	Peers                 []IPFSPeer    `config:"peers"`
-	BootstrapPeers        []IPFSPeer    `config:"bootstrap_peers"`
-	Provider              IPFSProvider  `config:"provider"`
-	BlockStore            BlockStore    `config:"blockstore"`
-	IPNS                  IPNS          `config:"ipns"`
-	LogLevel              string        `config:"log_level"`
-	DisableResourceLimits bool          `config:"disable_resource_limits"`
-	DHTMode               string        `config:"dht_mode"`
-	TrustedProxies        []string      `config:"trusted_proxies"`
-	ProxyProtocol         bool          `config:"proxy_protocol"`
-	Gateways              []string      `config:"gateways"`
-	Bitswap               BitswapConfig `config:"bitswap"`
+	Port                     int           `config:"port"`
+	WSPort                   int           `config:"ws_port"`
+	AnnounceWeb              bool          `config:"announce_web"`
+	ListenAddresses          []string      `config:"listen_addresses"`
+	Peers                    []IPFSPeer    `config:"peers"`
+	BootstrapPeers           []IPFSPeer    `config:"bootstrap_peers"`
+	Provider                 IPFSProvider  `config:"provider"`
+	BlockStore               BlockStore    `config:"blockstore"`
+	IPNS                     IPNS          `config:"ipns"`
+	LogLevel                 string        `config:"log_level"`
+	DisableResourceLimits    bool          `config:"disable_resource_limits"`
+	DHTMode                  string        `config:"dht_mode"`
+	FullRTCrawlerParallelism int           `config:"fullrt_crawler_parallelism"`
+	TrustedProxies           []string      `config:"trusted_proxies"`
+	ProxyProtocol            bool          `config:"proxy_protocol"`
+	Gateways                 []string      `config:"gateways"`
+	Bitswap                  BitswapConfig `config:"bitswap"`
 }
 
 type BitswapConfig struct {
@@ -61,10 +64,11 @@ func (b BitswapConfig) Defaults() map[string]any {
 
 func (c ProtocolConfig) Defaults() map[string]any {
 	return map[string]any{
-		"Port":           DefaultPort,
-		"WSPort":         DefaultWSPort,
-		"BootstrapPeers": BootstrapPeers,
-		"DHTMode":        "fullrt",
+		"Port":                     DefaultPort,
+		"WSPort":                   DefaultWSPort,
+		"BootstrapPeers":           BootstrapPeers,
+		"DHTMode":                  "fullrt",
+		"FullRTCrawlerParallelism": DefaultFullRTCrawlerParallelism,
 	}
 }
 
@@ -78,6 +82,9 @@ func (l ProtocolConfig) Schema() z.ZogSchema {
 		"DHTMode": z.String().
 			Default(DHTModeFullRT).
 			OneOf([]string{DHTModeBasic, DHTModeFullRT}, z.Message("dht mode must be one of: basic, fullrt")),
+		"FullRTCrawlerParallelism": z.Int().
+			Default(DefaultFullRTCrawlerParallelism).
+			GT(0, z.Message("fullrt crawler parallelism must be positive")),
 	})
 }
 

--- a/internal/protocol/ipfs/node.go
+++ b/internal/protocol/ipfs/node.go
@@ -48,6 +48,7 @@ import (
 	format "github.com/ipfs/go-ipld-format"
 	"github.com/libp2p/go-libp2p"
 	dht "github.com/libp2p/go-libp2p-kad-dht"
+	"github.com/libp2p/go-libp2p-kad-dht/crawler"
 	"github.com/libp2p/go-libp2p-kad-dht/fullrt"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	pubsubrouter "github.com/libp2p/go-libp2p-pubsub-router"
@@ -676,7 +677,22 @@ func NewNode(ctx core.Context, cfg *config.ProtocolConfig, rs pluginCore.Reprovi
 		}
 		ipfsNode.companionDHT = companion
 
+		// FullRT's default crawler runs 200 parallel workers, which is the
+		// largest connection-burst generator in the process and can exceed the
+		// connmgr high-water during a crawl. Make its parallelism configurable
+		// (default 96) so operators can bound the burst headroom against the
+		// rcmgr connection ceiling.
+		frtCrawler, crawlerErr := crawler.NewDefaultCrawler(
+			node,
+			crawler.WithParallelism(cfg.FullRTCrawlerParallelism),
+		)
+		if crawlerErr != nil {
+			companion.Close()
+			return nil, fmt.Errorf("failed to create fullrt crawler: %w", crawlerErr)
+		}
+
 		fullRTOpts := []fullrt.Option{
+			fullrt.WithCrawler(frtCrawler),
 			fullrt.DHTOption(
 				append(dhtOpts,
 					dht.BucketSize(20), // this cannot be changed


### PR DESCRIPTION
## Summary

FullRT's default crawler runs **200 parallel workers** — the largest connection-burst generator in the process. Each crawl is an immediate pass plus an hourly pass over the whole DHT keyspace, flooding the shared libp2p host with concurrent dials. On a public node with a finite rcmgr connection ceiling, a crawl can push the pool past the connmgr high-water and start rejecting inbound traffic while pruning catches up.

This PR makes the crawler's parallelism configurable so operators can bound that burst headroom against the rcmgr ceiling.

## Changes

- **`internal/config/protocol.go`**: add `fullrt_crawler_parallelism` (default **96**) with schema validation requiring a positive value.
- **`internal/protocol/ipfs/node.go`**: build a custom crawler via `crawler.NewDefaultCrawler(node, crawler.WithParallelism(cfg.FullRTCrawlerParallelism))` and wire it into FullRT with `fullrt.WithCrawler(...)`. Default DHT behaviour is otherwise unchanged.

## Rationale

96 sits in the reviewer-recommended 64–100 range and bounds the connection burst without materially slowing the crawl. Left as a knob (not a hardcoded constant) so deployments can tune against their measured `connections` and `rcmgr_blocked_resources` deltas. Crawl duration can be compared before/after via the existing FullRT readiness/timing metrics.

## Testing

- `go build ./...`, `go vet`, `gofmt` clean
- `internal/config` tests pass (default of 96 verified)
- Full `internal/protocol/ipfs` suite passes (except pre-existing unrelated `TestBlockRequestTrackerRemovesReverseIndexEntries`)

* `develop` <!-- branch-stack -->
  - **feat(ipfs): make FullRT crawler parallelism configurable** :point\_left:

---

<!-- kody-pr-summary:start -->
## Summary

This pull request makes the FullRT crawler parallelism configurable in the IPFS protocol configuration.

## Changes

### Configuration
- Added a new `fullrt_crawler_parallelism` configuration option with a default value of **96**.
- The option is validated to ensure it must be a positive integer (greater than 0).
- Added default value in the protocol configuration defaults and schema validation.

### Implementation
- Modified the IPFS node setup to create a custom crawler instance for the FullRT DHT mode using the configured parallelism value.
- The default crawler in FullRT runs **200 parallel workers**, which is the largest connection-burst generator in the process and could exceed the connection manager's high-water limit during a crawl.
- The new configurable setting allows operators to bound the burst headroom against the resource manager connection ceiling.

## Functional Impact

This change gives operators control over the connection burst behavior during FullRT DHT crawls. By adjusting `fullrt_crawler_parallelism`, they can tune the number of concurrent connections the crawler opens based on their infrastructure capacity and connection limits. The default of 96 provides a more conservative starting point than the library's default of 200, reducing the risk of exceeding connection management limits.
<!-- kody-pr-summary:end -->