### PR TITLE
fix(website): populate domain and email in website-created notifications

### DIFF
--- a/core/website.go
+++ b/core/website.go
@@ -88,6 +88,12 @@ type WebsiteService interface {
 	// the given WebsiteDomain. Returns the new primary binding.
 	SetPrimaryDomain(ctx context.Context, userID, websiteID, domainID uint) (*pluginDb.WebsiteDomain, error)
 
+	// NotifyAdminWebsiteCreated sends the admin "website created" notification
+	// for the given website. The caller must have created the primary domain
+	// binding first so the email's Domain field resolves. Resolves the
+	// recipient user's email internally. No-op when notifications are disabled.
+	NotifyAdminWebsiteCreated(ctx context.Context, websiteID uint) error
+
 	// WaitForPublishes blocks until all in-flight async publish operations complete
 	WaitForPublishes()
 }

--- a/internal/api/api_domains.go
+++ b/internal/api/api_domains.go
@@ -57,7 +57,7 @@ func (a *API) createDomain(c echo.Context) error {
 		dnsHostingEnabled = *req.DNSHostingEnabled
 	}
 
-	wd, err := a.delegatedDomainSvc.CreateDomain(reqCtx, req.Namespace, req.Domain, uint(websiteID), userID, dnsHostingEnabled, configRaw)
+	wd, err := a.delegatedDomainSvc.CreateDomain(reqCtx, req.Namespace, req.Domain, uint(websiteID), userID, dnsHostingEnabled, false, configRaw)
 	if err != nil {
 		a.Logger().Error("Failed to create domain", zap.Error(err))
 		apiErr := NewError(ErrKeyValidationFailed, err)

--- a/internal/api/api_websites.go
+++ b/internal/api/api_websites.go
@@ -149,7 +149,7 @@ func (a *API) createWebsite(c echo.Context) error {
 			namespace = string(*req.Namespace)
 		}
 		var cfgRaw json.RawMessage
-		if _, err := a.delegatedDomainSvc.CreateDomain(reqCtx, namespace, req.Domain, website.ID, user, dnsEnabled, cfgRaw); err != nil {
+		if _, err := a.delegatedDomainSvc.CreateDomain(reqCtx, namespace, req.Domain, website.ID, user, dnsEnabled, true, cfgRaw); err != nil {
 			a.Logger().Error("Failed to create primary domain for website",
 				zap.Uint("website_id", website.ID), zap.String("domain", req.Domain), zap.Error(err))
 			apiErr := NewError(ErrKeyFileProcessingFailed, err)
@@ -407,7 +407,7 @@ func (a *API) updateWebsite(c echo.Context) error {
 		if req.DNSEnabled != nil {
 			newDomainDNS = *req.DNSEnabled
 		}
-		wd, derr := a.delegatedDomainSvc.CreateDomain(reqCtx, namespace, *req.Domain, website.ID, user, newDomainDNS, cfgRaw)
+		wd, derr := a.delegatedDomainSvc.CreateDomain(reqCtx, namespace, *req.Domain, website.ID, user, newDomainDNS, false, cfgRaw)
 		if derr != nil {
 			a.Logger().Error("Failed to create primary domain for website",
 				zap.Uint("website_id", website.ID), zap.String("domain", *req.Domain), zap.Error(derr))

--- a/internal/api/api_websites_test.go
+++ b/internal/api/api_websites_test.go
@@ -92,6 +92,7 @@ func TestAPI_CreateWebsite(t *testing.T) {
 			}
 			mockWebsiteService.EXPECT().GetApexDomainBinding(mock.Anything, uint(1)).Return(mockApex, nil)
 			mockWebsiteService.EXPECT().SetDomainDNSEnabled(mock.Anything, userID, uint(1), uint(1), true).Return(mockApex, nil)
+			mockWebsiteService.EXPECT().NotifyAdminWebsiteCreated(mock.Anything, uint(1)).Return(nil)
 
 			reqBody := fmt.Sprintf(`{"domain":"%s","target_type":"ipfs","target_hash":"%s"}`, TestDomain, TestCID)
 			rec := helper.makeAuthenticatedRequest(http.MethodPost, "/api/websites", token, []byte(reqBody))
@@ -137,6 +138,7 @@ func TestAPI_CreateWebsite(t *testing.T) {
 			}
 			mockWebsiteService.EXPECT().GetApexDomainBinding(mock.Anything, uint(1)).Return(mockApex, nil)
 			mockWebsiteService.EXPECT().SetDomainDNSEnabled(mock.Anything, userID, uint(1), uint(1), true).Return(mockApex, nil)
+			mockWebsiteService.EXPECT().NotifyAdminWebsiteCreated(mock.Anything, uint(1)).Return(nil)
 
 			reqBody := fmt.Sprintf(`{"domain":"%s","target_type":"ipns","target_hash":"%s"}`, TestDomain, TestPeerID)
 			rec := helper.makeAuthenticatedRequest(http.MethodPost, "/api/websites", token, []byte(reqBody))
@@ -234,8 +236,10 @@ func TestAPI_CreateWebsite(t *testing.T) {
 
 			// Broken status returns 410 before the response is built, but the
 			// handler still resolves (and finds absent) the primary binding
-			// during domain enablement.
+			// during domain enablement, and CreateDomain still fires the
+			// service-layer created notification on the primary binding.
 			mockWebsiteService.EXPECT().GetApexDomainBinding(mock.Anything, uint(1)).Return(nil, nil)
+			mockWebsiteService.EXPECT().NotifyAdminWebsiteCreated(mock.Anything, uint(1)).Return(nil)
 
 			reqBody := fmt.Sprintf(`{"domain":"%s","target_type":"ipfs","target_hash":"%s"}`, TestDomain, TestCID)
 			rec := helper.makeAuthenticatedRequest(http.MethodPost, "/api/websites", token, []byte(reqBody))
@@ -884,6 +888,10 @@ func TestAPI_UpdateWebsite(t *testing.T) {
 			}
 			mockWebsiteService.EXPECT().SetPrimaryDomain(mock.Anything, userID, uint(1), mock.Anything).Return(mockApex, nil)
 			mockWebsiteService.EXPECT().GetApexDomainBinding(mock.Anything, uint(1)).Return(mockApex, nil).Maybe()
+			// Updating a website (even one that lacked a primary domain) must
+			// NOT emit a "website created" notification — that is reserved for
+			// genuine creations via the create handler.
+			mockWebsiteService.AssertNotCalled(tb, "NotifyAdminWebsiteCreated", mock.Anything, mock.Anything)
 
 			reqBody := fmt.Sprintf(`{"domain":"updated-example.com","target_type":"ipfs","target_hash":"%s"}`, TestCID)
 			rec := helper.makeAuthenticatedRequest(http.MethodPut, "/api/websites/1", token, []byte(reqBody))

--- a/internal/service/domain/delegated_domain_service.go
+++ b/internal/service/domain/delegated_domain_service.go
@@ -165,7 +165,7 @@ func parentDomain(domain string) string {
 
 func (s *DelegatedDomainService) CreateDomain(ctx context.Context,
 	namespace, domain string, websiteID, userID uint, dnsHostingEnabled bool,
-	config json.RawMessage) (*pluginDb.WebsiteDomain, error) {
+	notifyCreated bool, config json.RawMessage) (*pluginDb.WebsiteDomain, error) {
 
 	// Require a database connection up front: many call sites feed through a
 	// service that may not be wired to a DB (e.g. the website-create API when
@@ -241,6 +241,23 @@ func (s *DelegatedDomainService) CreateDomain(ctx context.Context,
 				s.DB().WithContext(ctx).Unscoped().Delete(wd)
 				return nil, fmt.Errorf("failed to bootstrap DANE identity: %w", err)
 			}
+		}
+		// This binding is the new website's first (primary) domain. Record it
+		// so the website service resolves the apex domain via PrimaryDomainID
+		// rather than the status=active fallback — a self-hosted binding is
+		// not active, so it would otherwise resolve to an empty domain.
+		if website.PrimaryDomainID == nil {
+			primaryID := wd.ID
+			if err := s.DB().WithContext(ctx).Model(&website).Update("primary_domain_id", primaryID).Error; err != nil {
+				return nil, fmt.Errorf("failed to set primary domain: %w", err)
+			}
+			website.PrimaryDomainID = &primaryID
+		}
+		// Self-hosted bindings skip the managed-DNS primary assignment below,
+		// so fire the created notification here for a genuine creation. The
+		// PrimaryDomainID set above lets the service resolve the domain.
+		if notifyCreated {
+			s.notifyAdminWebsiteCreated(ctx, website.ID)
 		}
 		return wd, nil
 	}
@@ -333,7 +350,29 @@ func (s *DelegatedDomainService) CreateDomain(ctx context.Context,
 		website.PrimaryDomainID = &wd.ID
 	}
 
+	// Only a genuine website creation (flagged by the create API caller) fires
+	// the admin "website created" notification. Domain-add operations on an
+	// existing website, which also flow through CreateDomain, must not emit a
+	// spurious created email. Firing here (service layer) lets the email's
+	// Domain field resolve against the binding just persisted. Non-fatal: a
+	// template/mail failure must not fail domain creation.
+	if notifyCreated {
+		s.notifyAdminWebsiteCreated(ctx, website.ID)
+	}
+
 	return wd, nil
+}
+
+// notifyAdminWebsiteCreated fires the admin "website created" notification for
+// the given website, delegating to the WebsiteService. It never fails the
+// caller: a resolution or template/mail error is logged and swallowed.
+func (s *DelegatedDomainService) notifyAdminWebsiteCreated(ctx context.Context, websiteID uint) {
+	if ws := core.GetServiceOptional[pluginCore.WebsiteService](s.Context(), pluginCore.WEBSITE_SERVICE); ws != nil {
+		if nerr := ws.NotifyAdminWebsiteCreated(ctx, websiteID); nerr != nil {
+			s.Logger().Warn("Failed to send website created notification",
+				zap.Uint("website_id", websiteID), zap.Error(nerr))
+		}
+	}
 }
 
 // VerifyDomain checks delegation and persists the result.

--- a/internal/service/domain/delegated_domain_service_test.go
+++ b/internal/service/domain/delegated_domain_service_test.go
@@ -62,7 +62,12 @@ func TestDelegatedDomainService_CreateDomain(t *testing.T) {
 			Return(&pluginDb.DNSZone{Model: gorm.Model{ID: 1}, Domain: "example.com"}, nil).Once()
 		mockDNS.EXPECT().CreateDNSLinkRecord(mock.Anything, uint(1), mock.Anything, mock.Anything).Return(nil).Once()
 
-		wd, err := svc.CreateDomain(context.Background(), "icann", "example.com", website.ID, 1, true, nil)
+		// Setting the website's primary domain fires the admin "created"
+		// notification from the service layer.
+		mockWebsite := core.GetService[*mocks.MockWebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
+		mockWebsite.EXPECT().NotifyAdminWebsiteCreated(mock.Anything, website.ID).Return(nil).Once()
+
+		wd, err := svc.CreateDomain(context.Background(), "icann", "example.com", website.ID, 1, true, true, nil)
 		assert.NoError(tb, err)
 		assert.NotNil(tb, wd)
 		assert.Equal(tb, "example.com", wd.Domain)
@@ -70,6 +75,43 @@ func TestDelegatedDomainService_CreateDomain(t *testing.T) {
 		assert.Equal(tb, uint(1), wd.ZoneID)
 		// Managed-DNS binding: the flag is persisted to match the created zone.
 		assert.True(tb, wd.DNSHostingEnabled)
+	}, TestOptions)
+}
+
+// TestDelegatedDomainService_CreateDomain_NotifyEvenWhenPrimarySet ensures the
+// created notification is gated on the notifyCreated flag alone — not on the
+// website lacking a primary domain. A managed-DNS create on a website that
+// already has a primary still fires when notifyCreated is true.
+func TestDelegatedDomainService_CreateDomain_NotifyEvenWhenPrimarySet(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		db := ctx.DB()
+
+		website := createTestWebsite(tb, db, 1, "example.com")
+		existingPrimary := uint(999)
+		require.NoError(tb, db.Model(website).Update("primary_domain_id", existingPrimary).Error)
+
+		svc := core.GetService[*DelegatedDomainService](ctx, pluginCore.DELEGATED_DOMAIN_SERVICE)
+		require.NotNil(tb, svc)
+
+		mockDNS := core.GetService[*mocks.MockDNSService](ctx, pluginCore.DNS_SERVICE)
+		mockDNS.EXPECT().CreateZone(mock.Anything, "alt-example.com", uint(1)).
+			Return(&pluginDb.DNSZone{Model: gorm.Model{ID: 2}, Domain: "alt-example.com"}, nil).Once()
+		mockDNS.EXPECT().CreateDNSLinkRecord(mock.Anything, uint(2), mock.Anything, mock.Anything).Return(nil).Once()
+
+		// Primary already set, but notifyCreated=true must still emit.
+		mockWebsite := core.GetService[*mocks.MockWebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
+		mockWebsite.EXPECT().NotifyAdminWebsiteCreated(mock.Anything, website.ID).Return(nil).Once()
+
+		wd, err := svc.CreateDomain(context.Background(), "icann", "alt-example.com", website.ID, 1, true, true, nil)
+		assert.NoError(tb, err)
+		assert.NotNil(tb, wd)
+		assert.Equal(tb, "alt-example.com", wd.Domain)
+
+		// The pre-existing primary is left untouched.
+		var reloaded pluginDb.Website
+		require.NoError(tb, db.First(&reloaded, website.ID).Error)
+		require.NotNil(tb, reloaded.PrimaryDomainID)
+		assert.Equal(tb, existingPrimary, *reloaded.PrimaryDomainID)
 	}, TestOptions)
 }
 
@@ -91,13 +133,26 @@ func TestDelegatedDomainService_CreateDomain_SelfHosted(t *testing.T) {
 		// No zone, DNSLink, apex, or delegation calls for a self-hosted binding.
 		mockDNS.AssertNotCalled(tb, "CreateZone", mock.Anything, mock.Anything, mock.Anything)
 
-		wd, err := svc.CreateDomain(context.Background(), "icann", "example.com", website.ID, 1, false, nil)
+		// Self-hosted creation still fires the service-layer created
+		// notification (the binding is the new website's primary).
+		mockWebsite := core.GetService[*mocks.MockWebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
+		mockWebsite.EXPECT().NotifyAdminWebsiteCreated(mock.Anything, website.ID).Return(nil).Once()
+
+		wd, err := svc.CreateDomain(context.Background(), "icann", "example.com", website.ID, 1, false, true, nil)
 		assert.NoError(tb, err)
 		assert.NotNil(tb, wd)
 		assert.Equal(tb, pluginDb.DomainStatusSelfHosted, wd.Status)
 		assert.Equal(tb, uint(0), wd.ZoneID)
 		assert.False(tb, wd.DNSHostingEnabled)
 		assert.Nil(tb, wd.DelegationData)
+
+		// The binding is recorded as the website's primary so the website
+		// service resolves the apex domain via PrimaryDomainID (the
+		// status=active fallback would miss a self-hosted, non-active binding).
+		var reloaded pluginDb.Website
+		require.NoError(tb, db.First(&reloaded, website.ID).Error)
+		require.NotNil(tb, reloaded.PrimaryDomainID)
+		assert.Equal(tb, wd.ID, *reloaded.PrimaryDomainID)
 	}, TestOptions)
 }
 
@@ -109,7 +164,7 @@ func TestDelegatedDomainService_CreateDomain_SelfHostedDANEFailurePurgesBinding(
 		svc := core.GetService[*DelegatedDomainService](ctx, pluginCore.DELEGATED_DOMAIN_SERVICE)
 		require.NotNil(tb, svc)
 
-		_, err := svc.CreateDomain(context.Background(), "hns", "example", website.ID, 1, false, nil)
+		_, err := svc.CreateDomain(context.Background(), "hns", "example", website.ID, 1, false, false, nil)
 		require.Error(tb, err)
 		assert.Contains(tb, err.Error(), "failed to bootstrap DANE identity")
 
@@ -159,7 +214,12 @@ func TestDelegatedDomainService_CreateDomain_SubdomainReusesParentZone(t *testin
 		mockDNS.EXPECT().CreateApexRecord(mock.Anything, uint(parent.ID), "docs.example.com", mock.Anything, mock.Anything).Return(nil).Maybe()
 		mockDNS.AssertNotCalled(tb, "CreateZone", mock.Anything, "docs.example.com", mock.Anything)
 
-		wd, err := svc.CreateDomain(context.Background(), "icann", "docs.example.com", website.ID, 1, true, nil)
+		// The subdomain becomes the website's primary binding, firing the
+		// admin "created" notification from the service layer.
+		mockWebsite := core.GetService[*mocks.MockWebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
+		mockWebsite.EXPECT().NotifyAdminWebsiteCreated(mock.Anything, website.ID).Return(nil).Once()
+
+		wd, err := svc.CreateDomain(context.Background(), "icann", "docs.example.com", website.ID, 1, true, true, nil)
 		assert.NoError(tb, err)
 		assert.NotNil(tb, wd)
 		// DNSLink/apex/delegation are written into the reused parent zone; the
@@ -201,7 +261,7 @@ func TestDelegatedDomainService_CreateDomain_SubdomainForeignParentRejected(t *t
 			Return(&pluginDb.DNSZone{Model: gorm.Model{ID: parent.ID}, Domain: "example.com", UserID: 2}, nil).Once()
 		mockDNS.AssertNotCalled(tb, "CreateZone", mock.Anything, "docs.example.com", mock.Anything)
 
-		_, err := svc.CreateDomain(context.Background(), "icann", "docs.example.com", website.ID, 1, true, nil)
+		_, err := svc.CreateDomain(context.Background(), "icann", "docs.example.com", website.ID, 1, true, false, nil)
 		require.Error(tb, err)
 		assert.Contains(tb, err.Error(), "owned by another user")
 	}, TestOptions)
@@ -212,7 +272,7 @@ func TestDelegatedDomainService_CreateDomain_UnsupportedNamespace(t *testing.T) 
 		svc := core.GetService[*DelegatedDomainService](ctx, pluginCore.DELEGATED_DOMAIN_SERVICE)
 		require.NotNil(tb, svc)
 
-		_, err := svc.CreateDomain(context.Background(), "ens", "example.eth", 1, 1, true, nil)
+		_, err := svc.CreateDomain(context.Background(), "ens", "example.eth", 1, 1, true, false, nil)
 		assert.Error(tb, err)
 		assert.Contains(tb, err.Error(), "unsupported namespace")
 	}, TestOptions)

--- a/internal/service/domain/integration_test.go
+++ b/internal/service/domain/integration_test.go
@@ -71,8 +71,13 @@ func TestIntegration_CreateAndVerifyHNSDomain(t *testing.T) {
 		mockDNS.EXPECT().CreateApexRecord(mock.Anything, uint(1), mock.Anything, pluginCore.RecordTypeA, gatewayIP).Return(nil).Once()
 		mockDNS.EXPECT().EnableDNSSEC(mock.Anything, uint(1)).Return("257 3 13 dGVzdA==", nil).Maybe()
 
+		// The website acquires its primary domain, firing the service-layer
+		// admin "created" notification.
+		mockWebsite := core.GetService[*mocks.MockWebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
+		mockWebsite.EXPECT().NotifyAdminWebsiteCreated(mock.Anything, website.ID).Return(nil).Once()
+
 		// Create domain
-		wd, err := svc.CreateDomain(context.Background(), "hns", "example", website.ID, 1, true, nil)
+		wd, err := svc.CreateDomain(context.Background(), "hns", "example", website.ID, 1, true, true, nil)
 		require.NoError(tb, err)
 		require.NotNil(tb, wd)
 		assert.Equal(tb, pluginDb.DomainStatusRecordsGenerated, wd.Status)

--- a/internal/service/website/website.go
+++ b/internal/service/website/website.go
@@ -73,6 +73,7 @@ type WebsiteServiceDefault struct {
 	pinSvc             pluginCore.IPFSPinService
 	ipnsKeySvc         pluginCore.IPNSKeyService
 	mailerSvc          core.MailerService
+	userSvc            core.UserService
 	dnsSvc             pluginCore.DNSService
 	config             *pluginConfig.WebsiteConfig
 	dnsConfig          *pluginConfig.DnsConfig
@@ -158,6 +159,7 @@ func NewWebsiteService() (core.Service, []core.ContextBuilderOption, error) {
 			svc.pinSvc = core.GetService[pluginCore.IPFSPinService](ctx, pluginCore.PIN_SERVICE)
 			svc.ipnsKeySvc = core.GetService[pluginCore.IPNSKeyService](ctx, pluginCore.IPNS_KEY_SERVICE)
 			svc.mailerSvc = core.GetService[core.MailerService](ctx, core.MAILER_SERVICE)
+			svc.userSvc = core.GetService[core.UserService](ctx, core.USER_SERVICE)
 			svc.dnsSvc = core.GetService[pluginCore.DNSService](ctx, pluginCore.DNS_SERVICE)
 			var dds *domsvc.DelegatedDomainService = core.GetServiceOptional[*domsvc.DelegatedDomainService](ctx, pluginCore.DELEGATED_DOMAIN_SERVICE)
 			if dds != nil {
@@ -381,15 +383,19 @@ func (s *WebsiteServiceDefault) CreateWebsite(ctx context.Context, website *plug
 				zap.String("target_hash", website.TargetHash()),
 				zap.Bool("dns_hosting_enabled", primaryWD != nil && primaryWD.DNSHostingEnabled))
 
+			// Admin "website created" notification. When a delegated-domain
+			// service is wired it fires inside DelegatedDomainService.CreateDomain
+			// (so the domain resolves); otherwise fire here so every created
+			// website notifies. The two paths are mutually exclusive per
+			// deployment, so the email is never sent twice.
+			if s.delegatedDomainSvc == nil {
+				s.NotifyAdminWebsiteCreated(ctx, website.ID)
+			}
+
 			// Emit website published event for SSE gateway notification
 			core.Fire(s.Context(), pluginEvent.EVENT_WEBSITE_PUBLISHED, pluginEvent.NewWebsitePublishedEvent(
 				ctx, primaryDomain, website.TargetHash(), website.UserID, website.ID,
 			))
-
-			// Send notification to admin
-			if err := s.notifyAdminWebsiteCreated(ctx, website, ""); err != nil {
-				s.Logger().Warn("Failed to send website created notification", zap.Error(err))
-			}
 
 			return website, nil
 		},
@@ -893,7 +899,7 @@ func (s *WebsiteServiceDefault) UpdateWebsite(ctx context.Context, userID uint, 
 	}
 
 	// Send notification to admin
-	if err := s.notifyAdminWebsiteUpdated(ctx, updatedWebsite, "", updates); err != nil {
+	if err := s.notifyAdminWebsiteUpdated(ctx, updatedWebsite, updates); err != nil {
 		s.Logger().Warn("Failed to send website updated notification", zap.Error(err))
 	}
 
@@ -1728,7 +1734,7 @@ func (s *WebsiteServiceDefault) CheckStatus(ctx context.Context, website *plugin
 
 			// Send notification if status changed
 			if oldStatus != newStatus {
-				if err := s.notifyUserStatusChanged(ctx, website, "", oldStatus, newStatus); err != nil {
+				if err := s.notifyUserStatusChanged(ctx, website, oldStatus, newStatus); err != nil {
 					s.Logger().Warn("Failed to send status changed notification", zap.Error(err))
 				}
 			}
@@ -1931,8 +1937,26 @@ func (s *WebsiteServiceDefault) generateValidationToken() (string, error) {
 	return hex.EncodeToString(bytes), nil
 }
 
-// notifyAdminWebsiteCreated sends an email notification to admin when a new website is created
-func (s *WebsiteServiceDefault) notifyAdminWebsiteCreated(ctx context.Context, website *pluginDb.Website, userEmail string) error {
+// resolveUserEmail looks up a user's email address by ID. Returns an empty
+// string when the user service is unavailable or the account can't be found,
+// so notification callers never fail on an unresolvable email.
+func (s *WebsiteServiceDefault) resolveUserEmail(ctx context.Context, userID uint) string {
+	if s.userSvc == nil {
+		return ""
+	}
+	queryCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	_, u, err := s.userSvc.AccountExists(queryCtx, userID)
+	if err != nil || u == nil {
+		return ""
+	}
+	return u.Email
+}
+
+// notifyAdminWebsiteCreated sends an email notification to admin when a new website is created.
+// The notification must be fired after the primary domain binding exists (the API layer
+// creates/points it before calling this) so the domain resolves.
+func (s *WebsiteServiceDefault) notifyAdminWebsiteCreated(ctx context.Context, website *pluginDb.Website) error {
 	if !s.config.NotificationsEnabled || s.mailerSvc == nil {
 		return nil
 	}
@@ -1946,7 +1970,7 @@ func (s *WebsiteServiceDefault) notifyAdminWebsiteCreated(ctx context.Context, w
 
 	vars := map[string]interface{}{
 		"Domain":     primaryDomain,
-		"UserEmail":  userEmail,
+		"UserEmail":  s.resolveUserEmail(ctx, website.UserID),
 		"TargetType": website.TargetType,
 		"TargetHash": website.TargetHash(),
 		"Status":     website.Status,
@@ -1967,8 +1991,24 @@ func (s *WebsiteServiceDefault) notifyAdminWebsiteCreated(ctx context.Context, w
 	return nil
 }
 
+// NotifyAdminWebsiteCreated implements the WebsiteService interface method. It
+// reloads the website fresh so the primary domain binding (created by
+// CreateDomain) resolves, then fires the admin notification.
+func (s *WebsiteServiceDefault) NotifyAdminWebsiteCreated(ctx context.Context, websiteID uint) error {
+	queryCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	var website pluginDb.Website
+	if err := s.DB().WithContext(queryCtx).First(&website, websiteID).Error; err != nil {
+		s.Logger().Warn("Failed to load website for created notification",
+			zap.Error(err), zap.Uint("website_id", websiteID))
+		return err
+	}
+	return s.notifyAdminWebsiteCreated(ctx, &website)
+}
+
 // notifyAdminWebsiteUpdated sends an email notification to admin when a website is updated
-func (s *WebsiteServiceDefault) notifyAdminWebsiteUpdated(ctx context.Context, website *pluginDb.Website, userEmail string, changes map[string]interface{}) error {
+func (s *WebsiteServiceDefault) notifyAdminWebsiteUpdated(ctx context.Context, website *pluginDb.Website, changes map[string]interface{}) error {
 	if !s.config.NotificationsEnabled || s.mailerSvc == nil {
 		return nil
 	}
@@ -1982,7 +2022,7 @@ func (s *WebsiteServiceDefault) notifyAdminWebsiteUpdated(ctx context.Context, w
 
 	vars := map[string]interface{}{
 		"Domain":     primaryDomain,
-		"UserEmail":  userEmail,
+		"UserEmail":  s.resolveUserEmail(ctx, website.UserID),
 		"TargetType": website.TargetType,
 		"TargetHash": website.TargetHash(),
 		"Status":     website.Status,
@@ -2005,11 +2045,12 @@ func (s *WebsiteServiceDefault) notifyAdminWebsiteUpdated(ctx context.Context, w
 }
 
 // notifyUserStatusChanged sends an email notification to user when website status changes
-func (s *WebsiteServiceDefault) notifyUserStatusChanged(ctx context.Context, website *pluginDb.Website, userEmail string, oldStatus pluginDb.WebsiteStatus, newStatus pluginDb.WebsiteStatus) error {
+func (s *WebsiteServiceDefault) notifyUserStatusChanged(ctx context.Context, website *pluginDb.Website, oldStatus pluginDb.WebsiteStatus, newStatus pluginDb.WebsiteStatus) error {
 	if !s.config.NotificationsEnabled || s.mailerSvc == nil {
 		return nil
 	}
 
+	userEmail := s.resolveUserEmail(ctx, website.UserID)
 	if userEmail == "" {
 		s.Logger().Debug("User email not available, skipping notification")
 		return nil

--- a/internal/service/website/website_test.go
+++ b/internal/service/website/website_test.go
@@ -271,6 +271,59 @@ func TestWebsiteService_CreateWebsite_IPFSTarget(t *testing.T) {
 	}, TestOptions)
 }
 
+// notifyEnabledTestOptions mirrors the base test options but turns on the admin
+// website-created notification so a test can observe the email send. No
+// delegated-domain service is wired, exercising the domain-service-absent path.
+var notifyEnabledTestOptions = coreTesting.CombineOptions(
+	coreTesting.WithProtocolConfig(internal.ProtocolName, &pluginConfig.ProtocolConfig{}),
+	testopts.NewBaseMockPluginBuilder().
+		WithService(pluginCore.WEBSITE_SERVICE, NewWebsiteService).
+		WithServiceConfig(pluginCore.WEBSITE_SERVICE, &pluginConfig.WebsiteConfig{
+			NotificationsEnabled: true,
+			AdminEmail:           "admin@test",
+			ValidationTokenTTL:   24 * time.Hour,
+		}).
+		WithMockServiceFactory(pluginCore.DNS_SERVICE, mocks.NewMockDNSService).
+		WithServiceConfig(pluginCore.DNS_SERVICE, &pluginConfig.DnsConfig{
+			Enabled:                      true,
+			Nameservers:                  []string{"ns1.localhost", "ns2.localhost"},
+			NameserverValidationInterval: 5 * time.Minute,
+			VerificationTokenKey:         "lumeweb-verify",
+		}).
+		WithMigrations(map[core.DBType]fs.FS{
+			core.DB_TYPE_SQLITE: migrations.GetSQLite(),
+		}).BuilderOption(),
+	coreTesting.WithMockMailerService(),
+	util.GetProtocolMock(),
+)
+
+// TestWebsiteService_CreateWebsite_NoDomainServiceFiresNotification verifies
+// that a website created when the delegated-domain service is absent still
+// fires the admin "website created" notification (previous behavior dropped it
+// because CreateDomain, which normally fires it, is never invoked). The email's
+// Domain is allowed to be empty, matching the "no domain set" contract.
+func TestWebsiteService_CreateWebsite_NoDomainServiceFiresNotification(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		websiteService := core.GetService[pluginCore.WebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
+		require.NotNil(tb, websiteService)
+
+		mailer := coreTesting.GetMockMailerService(ctx)
+		require.NotNil(tb, mailer)
+		mailer.EXPECT().TemplateSend(
+			"website_created_admin",
+			mock.Anything, mock.Anything,
+			"admin@test",
+		).Return(nil).Once()
+
+		testCID := util.GenerateTestCID(t, "test data")
+		website := createTestIPFSWebsite(testUserID1, "example.com", testCID.String())
+
+		created, err := websiteService.CreateWebsite(context.Background(), website)
+		require.NoError(tb, err)
+		require.NotNil(tb, created)
+	}, notifyEnabledTestOptions)
+}
+
 func TestWebsiteService_SSLStatusDoesNotAffectWebsiteStatus(t *testing.T) {
 	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 		// Arrange

--- a/internal/testing/mocks/MockWebsiteService.go
+++ b/internal/testing/mocks/MockWebsiteService.go
@@ -1511,6 +1511,63 @@ func (_c *MockWebsiteService_ValidateDNS_Call) RunAndReturn(run func(ctx context
 	return _c
 }
 
+// NotifyAdminWebsiteCreated provides a mock function for the type MockWebsiteService
+func (_mock *MockWebsiteService) NotifyAdminWebsiteCreated(ctx context.Context, websiteID uint) error {
+	ret := _mock.Called(ctx, websiteID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for NotifyAdminWebsiteCreated")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uint) error); ok {
+		r0 = returnFunc(ctx, websiteID)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockWebsiteService_NotifyAdminWebsiteCreated_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'NotifyAdminWebsiteCreated'
+type MockWebsiteService_NotifyAdminWebsiteCreated_Call struct {
+	*mock.Call
+}
+
+// NotifyAdminWebsiteCreated is a helper method to define mock.On call
+//   - ctx context.Context
+//   - websiteID uint
+func (_e *MockWebsiteService_Expecter) NotifyAdminWebsiteCreated(ctx any, websiteID any) *MockWebsiteService_NotifyAdminWebsiteCreated_Call {
+	return &MockWebsiteService_NotifyAdminWebsiteCreated_Call{Call: _e.mock.On("NotifyAdminWebsiteCreated", ctx, websiteID)}
+}
+
+func (_c *MockWebsiteService_NotifyAdminWebsiteCreated_Call) Run(run func(ctx context.Context, websiteID uint)) *MockWebsiteService_NotifyAdminWebsiteCreated_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 uint
+		if args[1] != nil {
+			arg1 = args[1].(uint)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockWebsiteService_NotifyAdminWebsiteCreated_Call) Return(err error) *MockWebsiteService_NotifyAdminWebsiteCreated_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockWebsiteService_NotifyAdminWebsiteCreated_Call) RunAndReturn(run func(ctx context.Context, websiteID uint) error) *MockWebsiteService_NotifyAdminWebsiteCreated_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // WaitForPublishes provides a mock function for the type MockWebsiteService
 func (_mock *MockWebsiteService) WaitForPublishes() {
 	_mock.Called()


### PR DESCRIPTION
## What

Fixes the admin "website created" email rendering blank `Domain` and `User Email` fields, caused by the per-domain DNS refactor that removed `Website.Domain`.

- **Domain resolution**: The notification previously fired inside `CreateWebsite`, before the primary `WebsiteDomain` binding exists, so the apex domain never resolved. The trigger now fires where the domain is guaranteed to resolve.
- **Recipient email**: All notification helpers relied on a caller-supplied email that every caller passed as an empty string. They now self-resolve the recipient via `core.UserService` (`AccountExists`).
- **Creation-only gating**: `CreateDomain` is shared by the create, update, and add-domain flows, so its created-notification is gated on an explicit `notifyCreated` flag passed only by the create handler. This covers managed and self-hosted bindings, while update/add-domain operations never emit a spurious "created" email.
- **Domain-service-absent deployment**: `CreateWebsite` fires the created notification when no delegated-domain service is wired (the case where `CreateDomain` never runs). The two paths are mutually exclusive per deployment, so the email is never sent twice and every created website notifies the admin.
- Added `WebsiteService.NotifyAdminWebsiteCreated(ctx, websiteID)`; it reloads the website and sends the admin notification. Bounded-context timeouts on the new DB access paths.

## Changes

- `internal/service/website/website.go` — notify helpers self-resolve the user email; drop the dead `userEmail` parameter; add `NotifyAdminWebsiteCreated` + `resolveUserEmail`; fire the created notification from `CreateWebsite` when the domain service is absent.
- `internal/service/domain/delegated_domain_service.go` — set the primary binding (managed and self-hosted paths) and fire the created notification gated on `notifyCreated`.
- `core/website.go` — add `NotifyAdminWebsiteCreated` to the `WebsiteService` interface.
- `internal/api/api_websites.go` / `internal/api/api_domains.go` — pass `notifyCreated` (`true` only from the create handler).
- `internal/testing/mocks/MockWebsiteService.go` — mock the new interface method.
- Tests: assert create notifies (managed, self-hosted, and domain-service-absent), update/add-domain do not, and primary is persisted for self-hosted.

## Notes

- Notification failures are non-fatal: a template/mail error never fails website or domain creation.
- Applies to the admin "website created"/"website updated" and the user "status changed" notifications.

* **fix(website): populate domain and email in website-created notifications** :point\_left: <!-- branch-stack -->
  - \#908
