### PR TITLE
fix(website): drop raw field-diff from website-updated admin email

### DIFF
--- a/internal/service/website/website.go
+++ b/internal/service/website/website.go
@@ -899,7 +899,7 @@ func (s *WebsiteServiceDefault) UpdateWebsite(ctx context.Context, userID uint, 
 	}
 
 	// Send notification to admin
-	if err := s.notifyAdminWebsiteUpdated(ctx, updatedWebsite, updates); err != nil {
+	if err := s.notifyAdminWebsiteUpdated(ctx, updatedWebsite); err != nil {
 		s.Logger().Warn("Failed to send website updated notification", zap.Error(err))
 	}
 
@@ -2008,7 +2008,7 @@ func (s *WebsiteServiceDefault) NotifyAdminWebsiteCreated(ctx context.Context, w
 }
 
 // notifyAdminWebsiteUpdated sends an email notification to admin when a website is updated
-func (s *WebsiteServiceDefault) notifyAdminWebsiteUpdated(ctx context.Context, website *pluginDb.Website, changes map[string]interface{}) error {
+func (s *WebsiteServiceDefault) notifyAdminWebsiteUpdated(ctx context.Context, website *pluginDb.Website) error {
 	if !s.config.NotificationsEnabled || s.mailerSvc == nil {
 		return nil
 	}
@@ -2027,7 +2027,6 @@ func (s *WebsiteServiceDefault) notifyAdminWebsiteUpdated(ctx context.Context, w
 		"TargetHash": website.TargetHash(),
 		"Status":     website.Status,
 		"UpdatedAt":  website.UpdatedAt.Format(time.RFC3339),
-		"Changes":    changes,
 	}
 
 	if err := s.mailerSvc.TemplateSend("website_updated_admin", vars, vars, s.config.AdminEmail); err != nil {

--- a/templates/website_updated_admin_body.tpl
+++ b/templates/website_updated_admin_body.tpl
@@ -4,11 +4,6 @@ Domain: {{.Domain}}
 User Email: {{.UserEmail}}
 Updated At: {{.UpdatedAt}}
 
-Changes:
-{{range $key, $value := .Changes}}
-  - {{$key}}: {{$value}}
-{{end}}
-
 Target Type: {{.TargetType}}
 Target Hash: {{.TargetHash}}
 Status: {{.Status}}


### PR DESCRIPTION
## What

De-clutters the admin "website updated" email. It was rendering a raw GORM field-diff map (`cid_type`, `cid_version`, `target_multihash`, `target_type`) under a `Changes:` block — internal storage representation that duplicated the human-readable summary fields already shown (Target Type, Target Hash, Status).

## Before

```
Domain: get.pinner.xyz
User Email: user@example.com
Updated At: 2026-08-12T19:19:28Z
Changes:
  - cid_type: 112
  - cid_version: 1
  - target_multihash: 1220f29fd...
  - target_type: ipfs
Target Type: ipfs
Target Hash: bafybeihst...
Status: active
```

## After

```
Domain: get.pinner.xyz
User Email: user@example.com
Updated At: 2026-08-12T19:19:28Z
Target Type: ipfs
Target Hash: bafybeihst...
Status: active
```

## Changes

- `templates/website_updated_admin_body.tpl` — remove the `Changes:` field-diff block.
- `internal/service/website/website.go` — `notifyAdminWebsiteUpdated` no longer takes or sends the raw `changes` map; the update path no longer passes the GORM `updates` diff into the email. The `UserEmail` self-resolution and summary fields are unchanged.

Stacked on #906 (depends on its user-email resolution).
