### PR TITLE
fix(ipfs): track reprovide success per-CID instead of trusting FullRT.ProvideMany

### DIFF
--- a/internal/protocol/ipfs/provide.go
+++ b/internal/protocol/ipfs/provide.go
@@ -20,21 +20,26 @@ import (
 	"go.lumeweb.com/portal/core"
 )
 
-// provideManyProvider is the minimal interface we need from a DHT that natively
-// implements batched ProvideMany (e.g. FullRT). Using an interface here keeps
-// provide.go free of fullrt imports.
-type provideManyProvider interface {
-	ProvideMany(ctx context.Context, keys []multihash.Multihash) error
+// provideProvider is the minimal interface we need for per-CID provides. Both
+// *fullrt.FullRT and basic IpfsDHT satisfy routing.ContentRouting, whose
+// Provide returns an error unless THAT key was put to at least one peer. Using
+// a narrow interface keeps provide.go free of fullrt imports.
+type provideProvider interface {
+	Provide(ctx context.Context, key cid.Cid, brdcst bool) error
 }
 
-// fullrtProvider delegates to FullRT.ProvideMany, which does keyspace-region
-// batching internally: one GetClosestPeers lookup per key (local trie, no
-// network round-trips), then groups keys by target peer so each peer receives
-// multiple ADD_PROVIDER messages over a single connection. This eliminates the
-// per-CID GCP bottleneck that basicDHTProvider has.
+// fullrtProvider delegates to FullRT.Provide per CID with a bounded worker
+// pool. Unlike FullRT.ProvideMany (which reports success at batch granularity
+// and returns nil when just one key succeeds), per-CID Provide preserves the
+// error semantics needed to mark only the CIDs that actually reached the DHT
+// as announced. FullRT.Provide's GetClosestPeers is a local trie lookup
+// (microseconds), so this avoids the per-CID network bottleneck that made the
+// companion basic DHT slow.
 type fullrtProvider struct {
-	dht   provideManyProvider
-	ready func() bool
+	dht            provideProvider
+	ready          func() bool
+	perCIDTimeout  time.Duration
+	provideWorkers int
 }
 
 func (f *fullrtProvider) Ready() bool {
@@ -45,32 +50,74 @@ func (f *fullrtProvider) Ready() bool {
 }
 
 func (f *fullrtProvider) ProvideMany(ctx context.Context, keys []multihash.Multihash) error {
-	start := time.Now()
+	var (
+		mu     sync.Mutex
+		failed []multihash.Multihash
+	)
 
-	err := f.dht.ProvideMany(ctx, keys)
+	workers := f.provideWorkers
+	if workers <= 0 {
+		workers = len(keys)
+	}
 
-	elapsed := time.Since(start).Seconds()
-	if err != nil {
-		ReprovideCIDDuration.WithLabelValues(classifyProvideError(err)).Observe(elapsed)
-		// FullRT.ProvideMany returns a single error, not per-CID. Treat all
-		// keys as failed so the reprovider can retry them next cycle.
-		ReprovideCIDsTotal.WithLabelValues(LabelResultFailure).Add(float64(len(keys)))
-		ReprovideCIDFailures.WithLabelValues(classifyProvideError(err)).Add(float64(len(keys)))
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(workers)
+
+	for i, k := range keys {
+		if gctx.Err() != nil {
+			mu.Lock()
+			failed = append(failed, keys[i:]...)
+			mu.Unlock()
+			break
+		}
+
+		k := k
+		g.Go(func() error {
+			provideCtx := gctx
+			var cancel context.CancelFunc
+			if f.perCIDTimeout > 0 {
+				provideCtx, cancel = context.WithTimeout(gctx, f.perCIDTimeout)
+			}
+
+			cidStart := time.Now()
+			err := f.dht.Provide(provideCtx, cid.NewCidV1(cid.Raw, k), true)
+			cidElapsed := time.Since(cidStart).Seconds()
+			if cancel != nil {
+				cancel()
+			}
+
+			if err != nil {
+				ReprovideCIDDuration.WithLabelValues(classifyProvideError(err)).Observe(cidElapsed)
+				ReprovideCIDFailures.WithLabelValues(classifyProvideError(err)).Inc()
+				ReprovideCIDsTotal.WithLabelValues(LabelResultFailure).Inc()
+				mu.Lock()
+				failed = append(failed, k)
+				mu.Unlock()
+			} else {
+				ReprovideCIDDuration.WithLabelValues(LabelCIDResultSuccess).Observe(cidElapsed)
+				ReprovideCIDsTotal.WithLabelValues(LabelResultSuccess).Inc()
+			}
+			return nil
+		})
+	}
+
+	_ = g.Wait()
+
+	if len(failed) > 0 {
+		ReprovideCIDsTotal.WithLabelValues(LabelResultFailure).Add(float64(len(failed)))
 		return &provideManyError{
-			failed:     len(keys),
+			failed:     len(failed),
 			total:      len(keys),
-			err:        err,
-			failedKeys: keys,
+			err:        errors.New("provide failed for some CIDs"),
+			failedKeys: failed,
 		}
 	}
 
-	ReprovideCIDDuration.WithLabelValues(LabelCIDResultSuccess).Observe(elapsed)
-	ReprovideCIDsTotal.WithLabelValues(LabelResultSuccess).Add(float64(len(keys)))
 	return nil
 }
 
-func newFullrtProvider(dht provideManyProvider, ready func() bool) pluginCore.Provider {
-	return &fullrtProvider{dht: dht, ready: ready}
+func newFullrtProvider(dht provideProvider, ready func() bool, perCIDTimeout time.Duration, provideWorkers int) pluginCore.Provider {
+	return &fullrtProvider{dht: dht, ready: ready, perCIDTimeout: perCIDTimeout, provideWorkers: provideWorkers}
 }
 
 // basicDHTProvider wraps a basic DHT that doesn't implement ProvideMany
@@ -164,15 +211,16 @@ func newBasicDHTProvider(dht routing.ContentRouting, ready func() bool, perCIDTi
 // fullrt vs basic DHT choice behind a single call so node.go never branches
 // on DHT mode.
 //
-// When fullrt is non-nil, it delegates to FullRT.ProvideMany (keyspace-region
-// batching, local GetClosestPeers, bulk ADD_PROVIDER per peer).
+// When fullrt is non-nil, it uses fullrtProvider (per-CID FullRT.Provide with a
+// bounded worker pool). Per-CID Provide preserves per-key success semantics so
+// the reprovider only marks CIDs that actually reached the DHT as announced.
 //
 // When fullrt is nil, it uses basicDHTProvider with the provided DHT (the
 // primary DHT in basic mode, or the companion DHT in fullrt mode without
 // fullRT available). The ready function gates health if needed.
-func NewDHTProvider(fullrt provideManyProvider, dht routing.ContentRouting, ready func() bool, cfg config.IPFSProvider) pluginCore.Provider {
+func NewDHTProvider(fullrt provideProvider, dht routing.ContentRouting, ready func() bool, cfg config.IPFSProvider) pluginCore.Provider {
 	if fullrt != nil {
-		return newFullrtProvider(fullrt, ready)
+		return newFullrtProvider(fullrt, ready, cfg.PerCIDTimeout, cfg.ProvideWorkers)
 	}
 	return newBasicDHTProvider(dht, ready, cfg.PerCIDTimeout, cfg.ProvideWorkers)
 }

--- a/internal/protocol/ipfs/provide_test.go
+++ b/internal/protocol/ipfs/provide_test.go
@@ -497,119 +497,119 @@ func TestBasicDHTProvider_ProvideMany(t *testing.T) {
 	})
 }
 
-// stubProvideMany is a minimal provideManyProvider stub for testing fullrtProvider.
-type stubProvideMany struct {
+// stubProvide is a minimal provideProvider stub for testing fullrtProvider.
+// It records per-CID provide calls and lets the caller control which keys fail,
+// so fullrtProvider's per-CID success tracking can be verified.
+type stubProvide struct {
 	mu        sync.Mutex
-	calls     int
-	keys      []multihash.Multihash
-	err       error
-	provideFn func(keys []multihash.Multihash) error
+	provideFn func(ctx context.Context, key cid.Cid) error
 }
 
-func (s *stubProvideMany) ProvideMany(_ context.Context, keys []multihash.Multihash) error {
+func (s *stubProvide) Provide(ctx context.Context, key cid.Cid, _ bool) error {
 	s.mu.Lock()
-	s.calls++
-	s.keys = keys
 	fn := s.provideFn
 	s.mu.Unlock()
 	if fn != nil {
-		return fn(keys)
+		return fn(ctx, key)
 	}
-	return s.err
-}
-
-func (s *stubProvideMany) getCalls() int {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.calls
+	return nil
 }
 
 func TestFullrtProvider_ProvideMany(t *testing.T) {
 	t.Run("ready_returns_false_when_fn_returns_false", func(t *testing.T) {
-		provider := newFullrtProvider(&stubProvideMany{}, func() bool { return false })
+		provider := newFullrtProvider(&stubProvide{}, func() bool { return false }, 0, 0)
 		assert.False(t, provider.Ready())
 	})
 
 	t.Run("ready_returns_true_when_fn_returns_true", func(t *testing.T) {
-		provider := newFullrtProvider(&stubProvideMany{}, func() bool { return true })
+		provider := newFullrtProvider(&stubProvide{}, func() bool { return true }, 0, 0)
 		assert.True(t, provider.Ready())
 	})
 
 	t.Run("ready_defaults_to_true_when_fn_is_nil", func(t *testing.T) {
-		provider := newFullrtProvider(&stubProvideMany{}, nil)
+		provider := newFullrtProvider(&stubProvide{}, nil, 0, 0)
 		assert.True(t, provider.Ready())
 	})
 
-	t.Run("provide_many_delegates_all_keys", func(t *testing.T) {
+	t.Run("provide_many_all_succeed_returns_nil", func(t *testing.T) {
 		c1 := cid.NewCidV1(cid.Raw, mustMultihash(t, "frt-key1"))
 		c2 := cid.NewCidV1(cid.Raw, mustMultihash(t, "frt-key2"))
 
-		stub := &stubProvideMany{}
-		provider := newFullrtProvider(stub, nil)
+		provider := newFullrtProvider(&stubProvide{}, nil, 0, 0)
 
 		keys := []multihash.Multihash{c1.Hash(), c2.Hash()}
 		err := provider.ProvideMany(context.Background(), keys)
 		assert.NoError(t, err)
-		assert.Equal(t, 1, stub.getCalls())
-		assert.Equal(t, keys, stub.keys)
 	})
 
-	t.Run("provide_many_returns_provideManyError_on_failure", func(t *testing.T) {
-		c1 := cid.NewCidV1(cid.Raw, mustMultihash(t, "frt-err1"))
-		c2 := cid.NewCidV1(cid.Raw, mustMultihash(t, "frt-err2"))
+	t.Run("provide_many_only_reports_actually_failed_keys", func(t *testing.T) {
+		// Regression: FullRT.ProvideMany returns nil if just one key in a batch
+		// succeeded, masking per-CID failures. Per-CID Provide must only mark
+		// the keys that genuinely failed, so the reprovider does not record
+		// false confirmations for CIDs that never reached the DHT.
+		c1 := cid.NewCidV1(cid.Raw, mustMultihash(t, "frt-ok1"))
+		c2 := cid.NewCidV1(cid.Raw, mustMultihash(t, "frt-bad2"))
+		c3 := cid.NewCidV1(cid.Raw, mustMultihash(t, "frt-bad3"))
 
-		testErr := errors.New("fullrtbulk send failed")
-		stub := &stubProvideMany{err: testErr}
-		provider := newFullrtProvider(stub, nil)
-
-		keys := []multihash.Multihash{c1.Hash(), c2.Hash()}
-		err := provider.ProvideMany(context.Background(), keys)
-
-		require.Error(t, err)
-
-		var pme *provideManyError
-		require.ErrorAs(t, err, &pme)
-		assert.Equal(t, 2, pme.failed)
-		assert.Equal(t, 2, pme.total)
-		assert.Equal(t, testErr, pme.err)
-		assert.Equal(t, keys, pme.failedKeys)
-	})
-
-	t.Run("provide_many_returns_all_keys_as_failed_on_error", func(t *testing.T) {
-		c1 := cid.NewCidV1(cid.Raw, mustMultihash(t, "frt-fail1"))
-		c2 := cid.NewCidV1(cid.Raw, mustMultihash(t, "frt-fail2"))
-		c3 := cid.NewCidV1(cid.Raw, mustMultihash(t, "frt-fail3"))
-
-		stub := &stubProvideMany{err: errors.New("network error")}
-		provider := newFullrtProvider(stub, nil)
+		bad := map[string]bool{string(c2.Hash()): true, string(c3.Hash()): true}
+		stub := &stubProvide{
+			provideFn: func(_ context.Context, key cid.Cid) error {
+				if bad[string(key.Hash())] {
+					return errors.New("send failed")
+				}
+				return nil
+			},
+		}
+		provider := newFullrtProvider(stub, nil, 0, 0)
 
 		keys := []multihash.Multihash{c1.Hash(), c2.Hash(), c3.Hash()}
 		err := provider.ProvideMany(context.Background(), keys)
 
+		require.Error(t, err)
 		var pme *provideManyError
 		require.ErrorAs(t, err, &pme)
-		// All 3 keys should be in failedKeys for retry
-		assert.Equal(t, 3, len(pme.failedKeys))
+		// Only the 2 failing CIDs should be reported failed; the successful one
+		// must NOT be retried.
+		assert.Equal(t, 2, pme.failed)
+		assert.Equal(t, 3, pme.total)
+		assert.ElementsMatch(t, []multihash.Multihash{c2.Hash(), c3.Hash()}, pme.failedKeys)
+	})
+
+	t.Run("provide_many_all_fail_returns_all_keys", func(t *testing.T) {
+		c1 := cid.NewCidV1(cid.Raw, mustMultihash(t, "frt-fail1"))
+		c2 := cid.NewCidV1(cid.Raw, mustMultihash(t, "frt-fail2"))
+
+		stub := &stubProvide{
+			provideFn: func(_ context.Context, _ cid.Cid) error {
+				return errors.New("network error")
+			},
+		}
+		provider := newFullrtProvider(stub, nil, 0, 0)
+
+		keys := []multihash.Multihash{c1.Hash(), c2.Hash()}
+		err := provider.ProvideMany(context.Background(), keys)
+
+		var pme *provideManyError
+		require.ErrorAs(t, err, &pme)
+		assert.Equal(t, 2, len(pme.failedKeys))
 	})
 
 	t.Run("provide_many_with_empty_keys_returns_nil", func(t *testing.T) {
-		stub := &stubProvideMany{}
-		provider := newFullrtProvider(stub, nil)
+		provider := newFullrtProvider(&stubProvide{}, nil, 0, 0)
 
 		err := provider.ProvideMany(context.Background(), []multihash.Multihash{})
 		assert.NoError(t, err)
-		assert.Equal(t, 1, stub.getCalls())
 	})
 
 	t.Run("provide_many_respects_context_cancellation", func(t *testing.T) {
 		key := mustMultihash(t, "frt-cancel-key")
 
-		stub := &stubProvideMany{
-			provideFn: func(_ []multihash.Multihash) error {
+		stub := &stubProvide{
+			provideFn: func(_ context.Context, _ cid.Cid) error {
 				return context.Canceled
 			},
 		}
-		provider := newFullrtProvider(stub, nil)
+		provider := newFullrtProvider(stub, nil, 0, 0)
 
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()


### PR DESCRIPTION
## Problem

The reprovider delegated to `FullRT.ProvideMany` and treated a `nil` return as proof that every CID in the batch had been announced.

`FullRT.ProvideMany` does not work that way. Upstream, success is tracked independently per key and the call returns `nil` as soon as **one** key in the batch gets a successful send:

```go
for _, v := range keySuccesses {
    if v.successes > 0 {
        numSendsSuccessful++
    }
}
if numSendsSuccessful == 0 {
    return errors.New("failed to complete bulk sending")
}
return nil
```

So a 500-CID batch where only CID #1 reached the DHT returns `nil`. The reprovider then called `SetLastAnnouncement` for all 500, and the metadata query excluded every one of them until their `last_announcement` went stale again — up to the 4-hour interval. The result: CIDs with `ready = true` and a recent `last_announcement` in the DB, but no usable provider record in the DHT.

## Fix

Route `fullrtProvider` through **per-CID `FullRT.Provide`** with a bounded worker pool instead of the lossy batch call.

`FullRT.Provide` returns an error unless **that specific key** was put to at least one peer, so only genuinely-failed CIDs are reported back (`provideManyError`) for retry, and the rest are recorded as announced.

- `ProvideWorkers` bounds concurrency (default 32)
- `PerCIDTimeout` bounds each individual provide (default 15s)
- `ProvideManyTimeout` still bounds the whole batch

`FullRT.Provide`'s `GetClosestPeers` is a local trie lookup (microseconds), so this avoids the per-CID network bottleneck that made the companion basic DHT slow — the throughput motivation for the original FullRT switch is preserved.

## Regression test

`TestFullrtProvider_ProvideMany/provide_many_only_reports_actually_failed_keys` verifies that when a batch mixes successes and failures, only the failed keys land in `provideManyError.failedKeys` — the successful CID is not retried or falsely recorded.

Build passes and provide/reprovider tests are green.

- `develop` <!-- branch-stack -->
  - **fix(ipfs): track reprovide success per-CID instead of trusting FullRT.ProvideMany** :point\_left:

---

<!-- kody-pr-summary:start -->
## Summary

This PR fixes per-CID success tracking for DHT reprovide operations in the IPFS protocol plugin. The change replaces the batched `ProvideMany` method with per-CID `Provide` calls to ensure only CIDs that actually reached the DHT are marked as successfully announced.

## Key Changes

### Per-CID Success Tracking (internal/protocol/ipfs/provide.go)
- **Replaced batched `ProvideMany` with per-CID `Provide`**: The fullrt provider now uses `FullRT.Provide` for each individual CID instead of relying on `FullRT.ProvideMany`, which returned a single error at batch granularity and could mask individual CID failures.
- **Added worker pool with error isolation**: Implemented a bounded worker pool (`errgroup` with configurable concurrency) that processes each CID independently. Failures for individual CIDs are collected without aborting the entire batch, allowing only genuinely failed CIDs to be retried.
- **Preserved per-CID metrics**: Metrics now track success/failure and duration per individual CID rather than at the batch level, providing more accurate operational visibility.
- **Added per-CID timeout support**: Each CID provide operation can now have its own timeout, preventing a slow single CID from blocking the entire batch indefinitely.

### Consistent Interface Across DHT Modes (internal/protocol/ipfs/provide.go)
- Unified the provider interface: both FullRT and basic DHT modes now use the same `ContentRouting.Provide` interface, though the FullRT path still benefits from its local trie lookup for `GetClosestPeers`.
- Added configuration wiring for the new per-CID timeout and worker concurrency settings.

### Test Updates (internal/protocol/ipfs/provide_test.go)
- **New regression test**: Added a test specifically verifying that when some CIDs succeed and others fail within a batch, only the failed CIDs are returned for retry, with the successful ones not being marked as failed.
- **Updated test stubs**: Replaced the batched `ProvideMany` stub with a per-CID `Provide` stub that allows per-key failure injection for more precise test coverage.
- **Adjusted existing tests**: Updated tests to reflect the new per-CID error semantics, including scenarios where all keys fail, partial failures, and context cancellation handling.

## Impact

This change ensures the reprovider only schedules retries for CIDs that genuinely failed to reach the DHT, avoiding unnecessary reprovide work for CIDs that were successfully announced. It also provides more accurate per-CID metrics and improves isolation so a single problematic CID doesn't cause the entire batch to be marked as failed.
<!-- kody-pr-summary:end -->