### PR TITLE
fix(domain): only require DS for DNSSEC-managed namespaces during delegation verification

### DIFF
--- a/internal/service/domain/delegated_domain_service.go
+++ b/internal/service/domain/delegated_domain_service.go
@@ -398,20 +398,40 @@ func (s *DelegatedDomainService) VerifyDomain(ctx context.Context,
 	}
 
 	// Expected DS is computed live from PowerDNS's current active signing key
-	// (never persisted, so it cannot go stale on key rotation). ICANN's
-	// VerifyDelegation ignores it; HNS uses it to require the parent zone to
-	// serve the DS before marking the domain Active.
+	// (never persisted, so it cannot go stale on key rotation). Only
+	// managed-DNSSEC namespaces (provider.RequiresDNSSEC, e.g. HNS)
+	// require it: HNS uses the DS to require the parent zone to serve it before
+	// marking the domain Active. Other providers (e.g. ICANN) verify on NS
+	// visibility alone and ignore DS, so a DS-resolution failure must never fail
+	// their verification — otherwise transient PowerDNS/DS slowness on an ICANN
+	// root blocks delegation validation entirely.
 	//
-	// A zone with no active signing key (("", nil)) is genuinely self-managed —
-	// the portal generated no DS, so NS-only verification is correct. But if
-	// resolution ERRORS (key rollover with multiple active keys, PowerDNS
-	// unreachable), the zone is portal-managed and the live DS is
-	// indeterminate. We must NOT silently weaken a managed zone to NS-only on
-	// a transient failure: that would mark Active a zone whose DS chain of
-	// trust was not actually confirmed.
-	expectedDS, dsErr := s.dnsSvc.GetActiveDNSSECDS(ctx, wd.ZoneID)
-	if dsErr != nil {
-		return false, fmt.Errorf("resolve live DS for zone %d: %w", wd.ZoneID, dsErr)
+	// For a managed-DNSSEC zone with no active signing key (("", nil)) the zone
+	// is genuinely self-managed — the portal generated no DS, so NS-only
+	// verification is correct. But if resolution ERRORS (key rollover with
+	// multiple active keys, PowerDNS unreachable), the zone is portal-managed and
+	// the live DS is indeterminate. We must NOT silently weaken a managed zone to
+	// NS-only on a transient failure: that would mark Active a zone whose DS
+	// chain of trust was not actually confirmed.
+	var expectedDS string
+	if provider.RequiresDNSSEC() {
+		var dsErr error
+		expectedDS, dsErr = s.dnsSvc.GetActiveDNSSECDS(ctx, wd.ZoneID)
+		if dsErr != nil {
+			return false, fmt.Errorf("resolve live DS for zone %d: %w", wd.ZoneID, dsErr)
+		}
+	} else if wd.ZoneID != 0 {
+		// Best-effort for non-DNSSEC providers: surface DB/PowerDNS errors so
+		// they are observable, but the provider verifies on NS and ignores DS,
+		// so a failure here must not block delegation.
+		if ds, dsErr := s.dnsSvc.GetActiveDNSSECDS(ctx, wd.ZoneID); dsErr != nil {
+			s.Logger().Warn("failed to resolve live DS for non-DNSSEC namespace, continuing",
+				zap.Uint("zone_id", wd.ZoneID),
+				zap.String("domain", wd.Domain),
+				zap.Error(dsErr))
+		} else {
+			expectedDS = ds
+		}
 	}
 
 	// Self-heal re-ensures the portal-managed-zone invariants that are

--- a/internal/service/domain/delegated_domain_service_test.go
+++ b/internal/service/domain/delegated_domain_service_test.go
@@ -2,6 +2,7 @@ package domain
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -442,6 +443,53 @@ func TestDelegatedDomainService_VerifyDomain_SelfHealsDNSSEC(t *testing.T) {
 
 			mockDNS.AssertCalled(tb, "EnsureSOAMNAME", mock.Anything, uint(42), "example.com", mock.Anything)
 			mockDNS.AssertNotCalled(tb, "EnableDNSSEC")
+			mockDNS.AssertExpectations(tb)
+		}, TestOptions)
+	})
+
+	// Regression: an ICANN root must not fail delegation verification when the
+	// live DS cannot be resolved (e.g. transient PowerDNS slowness/timeout). DS
+	// is only meaningful for managed-DNSSEC namespaces (HNS); ICANN verifies on
+	// NS visibility and ignores DS. A GetActiveDNSSECDS error on an ICANN zone
+	// used to abort VerifyDomain with "resolve live DS for zone N" and pin the
+	// domain at "Domain delegation not yet published" forever.
+	t.Run("icann_ds_error_does_not_fail_verification", func(t *testing.T) {
+		coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+			db := ctx.DB()
+			require.NoError(tb, db.Create(&pluginDb.WebsiteDomain{
+				WebsiteID: 1, UserID: 1, Domain: "lumeweb.com", Namespace: pluginDb.DomainNamespaceICANN,
+				ZoneID: 8, Status: pluginDb.DomainStatusWaitingDelegation,
+			}).Error)
+
+			svc := core.GetService[*DelegatedDomainService](ctx, pluginCore.DELEGATED_DOMAIN_SERVICE)
+			require.NotNil(tb, svc)
+
+			mockDNS := core.GetService[*mocks.MockDNSService](ctx, pluginCore.DNS_SERVICE)
+			require.NotNil(tb, mockDNS)
+
+			// DS resolution fails (the production symptom: context canceled /
+			// PowerDNS timeout). This must NOT abort verification for an ICANN
+			// root. SOA MNAME self-heal still fires for the portal-managed zone.
+			mockDNS.EXPECT().GetActiveDNSSECDS(mock.Anything, uint(8)).
+				Return("", errors.New("context canceled")).Once()
+			mockDNS.EXPECT().EnsureSOAMNAME(mock.Anything, uint(8), "lumeweb.com", mock.Anything).
+				Return(nil).Once()
+
+			wd := &pluginDb.WebsiteDomain{
+				WebsiteID: 1, UserID: 1, Domain: "lumeweb.com", Namespace: pluginDb.DomainNamespaceICANN, ZoneID: 8,
+			}
+
+			verified, err := svc.VerifyDomain(context.Background(), wd)
+			_ = verified
+			if err != nil {
+				// Allowed: post-heal ICANN delegation error (system resolver).
+				// The key assertion is that the DS error itself was swallowed —
+				// err must NOT wrap "resolve live DS for zone 8".
+				tb.Logf("expected post-heal delegation error: %v", err)
+				require.NotContains(tb, err.Error(), "resolve live DS")
+			}
+
+			mockDNS.AssertCalled(tb, "EnsureSOAMNAME", mock.Anything, uint(8), "lumeweb.com", mock.Anything)
 			mockDNS.AssertExpectations(tb)
 		}, TestOptions)
 	})

--- a/internal/service/domain/hns_provider.go
+++ b/internal/service/domain/hns_provider.go
@@ -562,3 +562,9 @@ func (p *HNSProvider) OnCertAvailable(ctx context.Context, domain string, certPE
 func (p *HNSProvider) UsesManagedZoneTLSA() bool {
 	return true
 }
+
+// RequiresDNSSEC reports that HNS confirms delegation against a live DS served
+// by the alt-root parent before marking the domain Active (managed-DNSSEC).
+func (p *HNSProvider) RequiresDNSSEC() bool {
+	return true
+}

--- a/internal/service/domain/icann_provider.go
+++ b/internal/service/domain/icann_provider.go
@@ -71,6 +71,12 @@ func (p *ICANNProvider) UsesManagedZoneTLSA() bool {
 	return false
 }
 
+// RequiresDNSSEC reports that ICANN verifies delegation on NS visibility alone
+// and does not require a live DS from the parent zone.
+func (p *ICANNProvider) RequiresDNSSEC() bool {
+	return false
+}
+
 // Nameservers returns the ICANN nameservers configured for the namespace.
 func (p *ICANNProvider) Nameservers() []string {
 	return p.nameservers

--- a/internal/service/domain/provider.go
+++ b/internal/service/domain/provider.go
@@ -24,6 +24,14 @@ type DomainProvider interface {
 	// whose zone the portal DNSSEC-signs). Providers that do not use DANE
 	// (e.g. ICANN) return false so no spurious _443._tcp TLSA is published.
 	UsesManagedZoneTLSA() bool
+	// RequiresDNSSEC reports whether this provider's delegation is confirmed
+	// against a live DS record served by the parent zone (managed-DNSSEC
+	// namespaces, e.g. HNS). Providers that verify on NS visibility alone
+	// (e.g. ICANN) and ignore DS return false, so a DS-resolution failure never
+	// blocks their verification. Distinct from UsesManagedZoneTLSA: a provider
+	// could DNSSEC-sign without DANE (and vice versa), so DNSSEC-requirement is
+	// its own capability.
+	RequiresDNSSEC() bool
 	// Nameservers returns the nameservers this provider publishes and
 	// validates delegation against for its namespace. Alt-root providers
 	// (e.g. HNS) return their own namespace-specific nameservers, which

--- a/internal/testing/mocks/MockDomainProvider.go
+++ b/internal/testing/mocks/MockDomainProvider.go
@@ -435,6 +435,50 @@ func (_c *MockDomainProvider_UsesManagedZoneTLSA_Call) RunAndReturn(run func() b
 	return _c
 }
 
+// RequiresDNSSEC provides a mock function for the type MockDomainProvider
+func (_mock *MockDomainProvider) RequiresDNSSEC() bool {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for RequiresDNSSEC")
+	}
+
+	var r0 bool
+	if returnFunc, ok := ret.Get(0).(func() bool); ok {
+		r0 = returnFunc()
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+	return r0
+}
+
+// MockDomainProvider_RequiresDNSSEC_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RequiresDNSSEC'
+type MockDomainProvider_RequiresDNSSEC_Call struct {
+	*mock.Call
+}
+
+// RequiresDNSSEC is a helper method to define mock.On call
+func (_e *MockDomainProvider_Expecter) RequiresDNSSEC() *MockDomainProvider_RequiresDNSSEC_Call {
+	return &MockDomainProvider_RequiresDNSSEC_Call{Call: _e.mock.On("RequiresDNSSEC")}
+}
+
+func (_c *MockDomainProvider_RequiresDNSSEC_Call) Run(run func()) *MockDomainProvider_RequiresDNSSEC_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockDomainProvider_RequiresDNSSEC_Call) Return(b bool) *MockDomainProvider_RequiresDNSSEC_Call {
+	_c.Call.Return(b)
+	return _c
+}
+
+func (_c *MockDomainProvider_RequiresDNSSEC_Call) RunAndReturn(run func() bool) *MockDomainProvider_RequiresDNSSEC_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Validate provides a mock function for the type MockDomainProvider
 func (_mock *MockDomainProvider) Validate(domain string) error {
 	ret := _mock.Called(domain)


### PR DESCRIPTION
DomainProvider gains a RequiresDNSSEC capability method. VerifyDomain now resolves and fails on a live DS only for providers that require it (HNS); ICANN and other NS-only providers get a best-effort DS read that never blocks validation.

Previously a DS-resolution error (e.g. a PowerDNS timeout surfaced as context canceled) failed delegation verification on every root, pinning domains like lumeweb.com at "Domain delegation not yet published" even though those roots verify on NS visibility and ignore DS.

Adds a regression test asserting an ICANN root with a failing DS resolution still proceeds to delegation verification.

- `develop` <!-- branch-stack -->
  - **fix(domain): only require DS for DNSSEC-managed namespaces during delegation verification** :point\_left:

---

<!-- kody-pr-summary:start -->
## Summary

This pull request fixes a critical bug in domain delegation verification where DNSSEC DS record resolution failures were incorrectly blocking verification for providers that don't actually require DNSSEC.

## Problem

Previously, the `VerifyDomain` function always attempted to resolve the live DS (Delegation Signer) record from PowerDNS before verifying delegation. If this resolution failed—due to transient issues like PowerDNS slowness, timeouts, or key rollover scenarios—the entire verification process would abort with an error. This was particularly problematic for ICANN domains, which verify delegation based on nameserver (NS) visibility alone and completely ignore DS records. As a result, transient DS resolution failures would permanently pin ICANN domains in a "Domain delegation not yet published" state, blocking them from becoming Active.

## Changes

### Provider Capability (DNSSEC Requirement)
- Added a new `RequiresDNSSEC()` method to the `DomainProvider` interface to indicate whether a provider's delegation verification depends on a live DS record.
- **HNSProvider**: Returns `true` — HNS requires a live DS served by the parent zone before marking a domain Active (managed-DNSSEC).
- **ICANNProvider**: Returns `false` — ICANN verifies on NS visibility alone and ignores DS.

### Verification Logic
- **For DNSSEC-required providers (e.g., HNS)**: DS resolution remains mandatory. If it fails, verification aborts as before—this preserves the security guarantee that a managed zone's DS chain of trust is confirmed before activation.
- **For non-DNSSEC providers (e.g., ICANN)**: DS resolution is now best-effort:
  - If it succeeds, the DS value is captured (preserving prior behavior).
  - If it fails, a warning is logged for observability, but verification proceeds without aborting—transient DS issues no longer block delegation.

This change ensures that transient PowerDNS/DS slowness on ICANN roots cannot block delegation validation, while maintaining strict DNSSEC verification for namespaces that require it (like HNS).

### Test Coverage
Added a regression test (`icann_ds_error_does_not_fail_verification`) confirming that when DS resolution fails for an ICANN domain, verification continues and the error is properly swallowed without being wrapped in the "resolve live DS" message.
<!-- kody-pr-summary:end -->