### PR TITLE
test(api): fix SetTLSARecord mock matcher arity in DANE republish test

### DIFF
--- a/internal/api/api_domains_test.go
+++ b/internal/api/api_domains_test.go
@@ -438,11 +438,14 @@ func TestAPI_DANERepublish(t *testing.T) {
 			mockDNS := core.GetService[*mocks.MockDNSService](ctx, pluginCore.DNS_SERVICE)
 			require.NotNil(tb, mockDNS)
 			// The seeding push and the HTTP republish each call SetTLSARecord(zoneID=42).
-			mockDNS.On("SetTLSARecord", mock.Anything, uint(42), mock.Anything).Return(nil).Times(2)
+			// The mock signature is SetTLSARecord(ctx, zoneID, domain, content); all
+			// four args must be matched, otherwise the calls register as a mismatch
+			// and only the expectation bookkeeping (not the real call) advances.
+			mockDNS.On("SetTLSARecord", mock.Anything, uint(42), mock.Anything, mock.Anything).Return(nil).Times(2)
 			_, _, err := svc.UpdateTLSAFromCert(ctx, "hns", wd.Domain, certPEM, keyPEM)
 			require.NoError(t, err, "seeding stored cert via UpdateTLSAFromCert")
 
-			mockDNS.AssertCalled(tb, "SetTLSARecord", mock.Anything, uint(42), mock.Anything)
+			mockDNS.AssertCalled(tb, "SetTLSARecord", mock.Anything, uint(42), mock.Anything, mock.Anything)
 
 			rec := helper.makeAuthenticatedRequest(http.MethodPost, republishPath(int(websiteID), int(wd.ID)), token, nil)
 			require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())


### PR DESCRIPTION
The MockDNSService.SetTLSARecord signature is (ctx, zoneID, domain, content), but the DANE republish test declared its .On() expectation and AssertCalled with only three args. Mockery treats the four-arg calls as mismatches, so the test failed asserting the second SetTLSARecord during the HTTP republish (hns\_with\_stored\_cert\_republishes). Matches all four args; the test now passes.

- `develop` <!-- branch-stack -->
  - **test(api): fix SetTLSARecord mock matcher arity in DANE republish test** :point\_left:

---

<!-- kody-pr-summary:start -->
## Summary

This pull request fixes a failing DANE republish test by correcting the mock matcher arity for the `SetTLSARecord` method.

## Changes

The test in `internal/api/api_domains_test.go` previously used a mock expectation with only three arguments:
```go
mockDNS.On("SetTLSARecord", mock.Anything, uint(42), mock.Anything).Return(nil).Times(2)
```

The actual `SetTLSARecord` method signature requires **four** arguments (`ctx`, `zoneID`, `domain`, `content`). Because the mock matcher didn't match all four parameters, the mock calls were being registered as mismatches, and only the expectation bookkeeping (not the actual call) was advancing.

The fix updates both the mock setup and the assertion to use the correct four-argument signature:
```go
mockDNS.On("SetTLSARecord", mock.Anything, uint(42), mock.Anything, mock.Anything).Return(nil).Times(2)
mockDNS.AssertCalled(tb, "SetTLSARecord", mock.Anything, uint(42), mock.Anything, mock.Anything)
```

## Impact

This change ensures the DANE republish test correctly mocks the `SetTLSARecord` DNS service method, allowing the test to properly verify that the method is called exactly twice (once during seeding and once during HTTP republish) with the expected zone ID.
<!-- kody-pr-summary:end -->