### PR TITLE
fix(website): gate delegation validation on the primary domain only

### DIFF
--- a/internal/service/website/validate_dns_test.go
+++ b/internal/service/website/validate_dns_test.go
@@ -586,6 +586,63 @@ func TestValidateDNS_DelegatedAttached_Success(t *testing.T) {
 	}, TestOptions)
 }
 
+// TestValidateDNS_SecondaryPending_DoesNotBlockPrimary validates the primary-only
+// delegation gate: a website remains valid when its primary domain delegation
+// verifies, even if a secondary attached domain's delegation is still pending.
+// Secondaries own their own DNS and validate independently; they must not hold
+// the whole site at "Domain delegation not yet published".
+func TestValidateDNS_SecondaryPending_DoesNotBlockPrimary(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		ws := core.GetService[pluginCore.WebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
+		require.NotNil(tb, ws)
+
+		testCID := util.GenerateTestCID(t, "secondary-pending")
+		website := createTestIPFSWebsite(testUserID1, "primary.com", testCID.String())
+		created, err := ws.CreateWebsite(context.Background(), website)
+		require.NoError(tb, err)
+		_ = bindPrimaryDomain(tb, ctx, created.ID, "primary.com", false)
+
+		// Insert a secondary HNS binding whose delegation is pending (verifies
+		// false). This must NOT fail the website's DNS validation.
+		svc := ws.(*WebsiteServiceDefault)
+		require.NotNil(tb, svc.DB())
+		require.NoError(tb, svc.DB().Create(&pluginDb.WebsiteDomain{
+			WebsiteID:      created.ID,
+			UserID:         testUserID1,
+			Domain:         "secondary.hns",
+			Namespace:      pluginDb.DomainNamespaceHNS,
+			DelegationData: datatypes.JSONMap{},
+		}).Error)
+
+		mockResolver := mocks.NewMockDNSResolver(t)
+		mockResolver.EXPECT().ResolveDNSLink("primary.com").Return(dnslink.Result{
+			Links: map[string]dnslink.NamespaceEntries{
+				"ipfs": {{Identifier: created.TargetHash()}},
+			},
+		}, nil)
+		setMockResolver(ws, mockResolver)
+
+		mockDelegated := &testDelegatedDomainService{
+			// Ownership proven via delegation for both bindings, so the token
+			// lookup is skipped and only the delegation gate is exercised.
+			uses: func(d string) bool { return true },
+			// The primary verifies; the secondary would fail if ever checked.
+			verify: func(ctx context.Context, wd *pluginDb.WebsiteDomain) (bool, error) {
+				if wd.Domain == "secondary.hns" {
+					return false, nil
+				}
+				return true, nil
+			},
+		}
+		setMockDelegatedDomainSvc(ws, mockDelegated)
+
+		result, err := ws.ValidateDNS(context.Background(), testUserID1, created.ID)
+		require.NoError(tb, err)
+		assert.True(tb, result.Valid, "secondary pending delegation must not block primary validation")
+		assert.Equal(tb, pluginCore.ValidationReasonValidated, result.Reason)
+	}, TestOptions)
+}
+
 func TestValidateDNS_DelegatedAttached_FailsVerification(t *testing.T) {
 	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 		ws := core.GetService[pluginCore.WebsiteService](ctx, pluginCore.WEBSITE_SERVICE)

--- a/internal/service/website/website.go
+++ b/internal/service/website/website.go
@@ -20,7 +20,6 @@ import (
 	pluginDb "go.lumeweb.com/portal-plugin-ipfs/internal/db"
 	pluginEvent "go.lumeweb.com/portal-plugin-ipfs/internal/event"
 	domsvc "go.lumeweb.com/portal-plugin-ipfs/internal/service/domain"
-	"golang.org/x/sync/errgroup"
 
 	"go.lumeweb.com/portal-plugin-ipfs/internal/protocol/encoding"
 	"go.lumeweb.com/portal/core"
@@ -1497,7 +1496,7 @@ func (s *WebsiteServiceDefault) ValidateDNS(ctx context.Context, userID uint, we
 				}
 			}
 
-			if ok, msg, reason, err := s.checkAttachedDelegations(ctx, &website); err != nil {
+			if ok, msg, reason, err := s.checkDelegation(ctx, primaryWD); err != nil {
 				return pluginCore.ValidateDNSResult{}, err
 			} else if !ok {
 				return pluginCore.ValidateDNSResult{
@@ -1586,51 +1585,22 @@ func (s *WebsiteServiceDefault) checkValidationToken(ctx context.Context, websit
 	return false, fmt.Sprintf(msgTokenMissing, s.verificationTokenKey(), primaryDomain, primaryDomain), pluginCore.ValidationReasonTokenMissing, nil
 }
 
-func (s *WebsiteServiceDefault) checkAttachedDelegations(ctx context.Context, website *pluginDb.Website) (bool, string, pluginCore.ValidationReason, error) {
+// checkDelegation verifies the website's primary domain delegation. Only the
+// primary (apex) binding gates website validation: secondaries own their own
+// DNS and validate independently, so a pending secondary must not block a
+// site whose primary hosting DNS is correct.
+func (s *WebsiteServiceDefault) checkDelegation(ctx context.Context, primaryWD *pluginDb.WebsiteDomain) (bool, string, pluginCore.ValidationReason, error) {
 	if s.delegatedDomainSvc == nil {
 		return true, "", "", nil
 	}
 
-	var attached []pluginDb.WebsiteDomain
-	if err := db.RetryableComponentTransaction(s, ctx, func(tx *gorm.DB) *gorm.DB {
-		return tx.Where("website_id = ?", website.ID).Find(&attached)
-	}); err != nil {
-		s.Logger().Error("failed to load attached domains for delegation verification",
-			zap.Error(err),
-			zap.Uint("website_id", website.ID))
-		return false, "", "", fmt.Errorf("failed to verify domain delegations: %w", err)
-	}
+	verifyCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
 
-	// Verify delegations concurrently with a bounded worker pool and a
-	// shared context deadline to avoid N*10s serial blocking.
-	grp, verifyCtx := errgroup.WithContext(ctx)
-	grp.SetLimit(5)
-	var mu sync.Mutex
-	var failedDomain string
-	var failed bool
-	for i := range attached {
-		ad := &attached[i]
-		grp.Go(func() error {
-			verifyCtx2, cancel := context.WithTimeout(verifyCtx, 10*time.Second)
-			defer cancel()
-			verified, verr := s.delegatedDomainSvc.VerifyDomain(verifyCtx2, ad)
-			if verr != nil || !verified {
-				s.Logger().Info("delegation not verified for attached domain",
-					zap.String("domain", ad.Domain), zap.Error(verr))
-				mu.Lock()
-				if !failed {
-					failed = true
-					failedDomain = ad.Domain
-				}
-				mu.Unlock()
-				return errors.New("delegation not verified")
-			}
-			return nil
-		})
-	}
-	if err := grp.Wait(); err != nil {
-		s.Logger().Info("delegation verification failed for attached domain",
-			zap.String("domain", failedDomain))
+	verified, verr := s.delegatedDomainSvc.VerifyDomain(verifyCtx, primaryWD)
+	if verr != nil || !verified {
+		s.Logger().Info("delegation not verified for primary domain",
+			zap.String("domain", primaryWD.Domain), zap.Error(verr))
 		return false, msgDelegationPending, pluginCore.ValidationReasonDelegationPending, nil
 	}
 	return true, "", "", nil


### PR DESCRIPTION
ValidateDNS previously verified the delegation of every attached domain and failed the whole website when any one was not yet verified. A pending secondary (e.g. a not-yet-delegated HNS binding) kept the site at "Domain delegation not yet published" even when the primary hosting domain DNS was correct.

Delegation verification is now scoped to the primary (apex) binding only; secondaries own their own DNS and validate independently, so a pending secondary no longer blocks the site. Adds a regression test asserting a website with a valid primary stays valid while a secondary is pending.

- `develop` <!-- branch-stack -->
  - **fix(website): gate delegation validation on the primary domain only** :point\_left:

---

<!-- kody-pr-summary:start -->
## Summary

This pull request fixes the website DNS validation logic to gate delegation verification on the primary domain only, rather than checking all attached (secondary) domains.

## Changes

### Behavioral Fix

Previously, the `ValidateDNS` method checked delegation status for **all** domains attached to a website (primary and secondaries). This caused websites to be marked as invalid ("Domain delegation not yet published") when any secondary domain's delegation was still pending, even if the primary domain was correctly configured.

The fix changes this behavior so that **only the primary domain** drives delegation validation. Secondary domains now validate independently and no longer block the entire website's DNS validation.

### Implementation Details

- Replaced the `checkAttachedDelegations` function (which loaded and verified all attached domains concurrently) with a new `checkDelegation` function that verifies just the primary domain's delegation.
- Removed the concurrency logic (worker pool, errgroup, mutex) that was previously needed for checking multiple domains.
- Simplified the verification flow to a single domain check with a 10-second timeout.

### Tests

Added a test case (`TestValidateDNS_SecondaryPending_DoesNotBlockPrimary`) that verifies a website remains valid when:
- The primary domain delegation verifies successfully
- A secondary domain's delegation is still pending (fails verification)

The test asserts that the website validation passes with a "Validated" reason, confirming secondary domains no longer block primary validation.

## Impact

This fix ensures that website owners are not incorrectly blocked from using their site when only a secondary domain is pending delegation verification. The primary domain remains the authoritative gate for website validation, while secondaries manage their own DNS requirements independently.
<!-- kody-pr-summary:end -->