### PR TITLE
test(website): persist owning Website row in DNS hosting toggle tests

### DIFF
--- a/internal/service/website/website_test.go
+++ b/internal/service/website/website_test.go
@@ -1934,6 +1934,12 @@ func TestWebsiteService_EnableDNSHosting_RecordFailurePreservesDelegationZone(t 
 
 		website := createTestIPFSWebsite(testUserID1, domain, testCID.String())
 		website.ID = 9013
+		// The enable transition loads the owning Website row for target/token
+		// state, so it must exist in the DB (this test bypasses CreateWebsite in
+		// favor of a prebound primary domain). A valid status satisfies the
+		// Website.BeforeSave hook.
+		website.Status = string(pluginDb.WebsiteStatusActive)
+		require.NoError(tb, ctx.DB().Create(website).Error)
 		wd := prebindPrimaryDomain(tb, ctx, website, domain, false)
 		wd.ZoneID = testZoneID
 		wd.Status = pluginDb.DomainStatusRecordsGenerated
@@ -2840,6 +2846,13 @@ func TestWebsiteService_DisableDNSHosting_PreservesDelegationOwnedZone(t *testin
 
 		website := createTestIPFSWebsite(testUserID1, domain, testCID.String())
 		website.ID = 9012
+
+		// The disable transition loads and rewrites the owning Website row, so
+		// it must actually exist in the DB (this test bypasses CreateWebsite in
+		// favor of a prebound primary domain). A valid status satisfies the
+		// Website.BeforeSave hook.
+		website.Status = string(pluginDb.WebsiteStatusActive)
+		require.NoError(tb, ctx.DB().Create(website).Error)
 
 		// Bind the primary domain as a delegation-owned binding: it has
 		// progressed into the delegation lifecycle (delegation_data present,


### PR DESCRIPTION
EnableDNSHosting\_RecordFailurePreservesDelegationZone and DisableDNSHosting\_PreservesDelegationOwnedZone both used prebindPrimaryDomain, which attaches a WebsiteDomain but never persists the owning Website row. The enable/disable transitions load and rewrite that Website row, so both tests failed (record not found on disable; orphaned-Website mock drift on enable).

Inserts the Website row (with a valid status to satisfy the BeforeSave hook) in each setup so the transition under test has the row it requires. Both tests now pass.

- `develop` <!-- branch-stack -->
  - **test(website): persist owning Website row in DNS hosting toggle tests** :point\_left:

---

<!-- kody-pr-summary:start -->
This pull request fixes failing tests for the DNS hosting toggle feature by persisting the owning Website row in test fixtures.

**Changes Made:**
- In `TestWebsiteService_EnableDNSHosting_RecordFailurePreservesDelegationZone`, added setup to create and persist a Website record in the database before testing the enable transition.
- In `TestWebsiteService_DisableDNSHosting_PreservesDelegationOwnedZone`, added similar setup to create and persist a Website record before testing the disable transition.

**Why:**
Both test cases previously bypassed the normal `CreateWebsite` flow by directly creating a website object and binding a pre-existing primary domain. However, the production code paths being tested (enable/disable DNS hosting transitions) need to load and modify the owning Website row from the database. The tests were missing this database record, causing failures. The fix ensures the Website row exists in the database with a valid status (`active`) that satisfies the `BeforeSave` hook requirements.
<!-- kody-pr-summary:end -->