### PR TITLE
fix(website): pass delegation gate for self-hosted (zone-less) primaries

### DIFF
--- a/internal/service/website/validate_dns_test.go
+++ b/internal/service/website/validate_dns_test.go
@@ -746,6 +746,58 @@ func TestValidateDNS_DelegatedAttached_FailsVerification(t *testing.T) {
 	}, TestOptions)
 }
 
+// TestValidateDNS_SelfHostedHNSPrimary_RequiresDelegation guards against the
+// self-hosted short-circuit being applied to delegated namespaces. An HNS
+// primary skips the TXT token check (shouldPerformTokenCheck returns false for
+// delegated namespaces), so a DNSLink match alone is NOT an ownership proof for
+// a zone-less HNS binding. The delegation gate must still run VerifyDomain and
+// fail pending here, rather than letting the site activate with no proof.
+func TestValidateDNS_SelfHostedHNSPrimary_RequiresDelegation(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		ws := core.GetService[pluginCore.WebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
+		require.NotNil(tb, ws)
+
+		testCID := util.GenerateTestCID(t, "self-hosted-hns-primary")
+		website := createTestIPFSWebsite(testUserID1, "selfhosted.hns", testCID.String())
+		created, err := ws.CreateWebsite(context.Background(), website)
+		require.NoError(tb, err)
+		// bindPrimaryDomain(false) yields a zone-less (ZoneID==0) primary; the
+		// namespace is HNS, so it is a self-hosted binding in a delegated
+		// namespace.
+		_ = bindPrimaryDomain(tb, ctx, created.ID, "selfhosted.hns", false)
+		require.NoError(tb, ctx.DB().Model(&pluginDb.WebsiteDomain{}).
+			Where("website_id = ? AND domain = ?", created.ID, "selfhosted.hns").
+			Update("namespace", string(pluginDb.DomainNamespaceHNS)).Error)
+
+		mockResolver := mocks.NewMockDNSResolver(t)
+		mockResolver.EXPECT().ResolveDNSLink("selfhosted.hns").Return(dnslink.Result{
+			Links: map[string]dnslink.NamespaceEntries{
+				"ipfs": {{Identifier: created.TargetHash()}},
+			},
+		}, nil)
+		// No LookupTXT expectation: the token check is skipped for the
+		// delegated (HNS) namespace.
+		setMockResolver(ws, mockResolver)
+
+		mockDelegated := &testDelegatedDomainService{
+			// HNS uses delegation for ownership, so the token check is skipped.
+			uses: func(d string) bool { return d == "selfhosted.hns" },
+			// A self-hosted (zone-less) HNS binding has no delegated zone
+			// published, so VerifyDomain returns false: no ownership proof.
+			verify: func(ctx context.Context, wd *pluginDb.WebsiteDomain) (bool, error) {
+				return false, nil
+			},
+		}
+		setMockDelegatedDomainSvc(ws, mockDelegated)
+
+		result, err := ws.ValidateDNS(context.Background(), testUserID1, created.ID)
+		require.NoError(tb, err)
+		assert.False(tb, result.Valid, "self-hosted HNS primary must not activate on DNSLink alone")
+		assert.Equal(tb, pluginCore.ValidationReasonDelegationPending, result.Reason)
+		assert.Contains(tb, result.Message, "Domain delegation not yet published")
+	}, TestOptions)
+}
+
 func TestValidateDNS_DelegatedAttached_VerifyError_Fails(t *testing.T) {
 	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 		ws := core.GetService[pluginCore.WebsiteService](ctx, pluginCore.WEBSITE_SERVICE)

--- a/internal/service/website/validate_dns_test.go
+++ b/internal/service/website/validate_dns_test.go
@@ -508,6 +508,57 @@ func TestValidateDNS_WebsiteNotFound_ReturnsError(t *testing.T) {
 	}, TestOptions)
 }
 
+// TestValidateDNS_SelfHostedPrimary_DoesNotRequireDelegation verifies that a
+// website whose primary binding is self-hosted (ZoneID == 0, no portal-managed
+// zone) validates once its hosting DNS is correct. VerifyDomain no-ops with
+// false for self-hosted bindings (there is no portal delegation to wait on),
+// so the delegation gate must pass for them (their DNSLink + token were already
+// validated by the earlier ValidateDNS steps), rather than leaving the site at
+// "Domain delegation not yet published" forever.
+func TestValidateDNS_SelfHostedPrimary_DoesNotRequireDelegation(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		ws := core.GetService[pluginCore.WebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
+		require.NotNil(tb, ws)
+
+		testCID := util.GenerateTestCID(t, "self-hosted-primary")
+		website := createTestIPFSWebsite(testUserID1, "selfhosted.com", testCID.String())
+		created, err := ws.CreateWebsite(context.Background(), website)
+		require.NoError(tb, err)
+		// bindPrimaryDomain with DNSHostingEnabled=false yields a zone-less
+		// (ZoneID==0) self-hosted primary binding.
+		_ = bindPrimaryDomain(tb, ctx, created.ID, "selfhosted.com", false)
+
+		mockResolver := mocks.NewMockDNSResolver(t)
+		mockResolver.EXPECT().ResolveDNSLink("selfhosted.com").Return(dnslink.Result{
+			Links: map[string]dnslink.NamespaceEntries{
+				"ipfs": {{Identifier: created.TargetHash()}},
+			},
+		}, nil)
+		mockResolver.EXPECT().LookupTXT(mock.Anything, "lumeweb-verify.selfhosted.com").Return([]string{
+			fmt.Sprintf("lumeweb-verify=%s", created.ValidationToken),
+		}, nil)
+		setMockResolver(ws, mockResolver)
+
+		mockDelegated := &testDelegatedDomainService{
+			uses: func(d string) bool { return false },
+			// Mirror the real VerifyDomain: a self-hosted (zone-less) binding
+			// returns (false, nil). checkDelegation must not fail on this.
+			verify: func(ctx context.Context, wd *pluginDb.WebsiteDomain) (bool, error) {
+				if wd.ZoneID == 0 {
+					return false, nil
+				}
+				return true, nil
+			},
+		}
+		setMockDelegatedDomainSvc(ws, mockDelegated)
+
+		result, err := ws.ValidateDNS(context.Background(), testUserID1, created.ID)
+		require.NoError(tb, err)
+		assert.True(tb, result.Valid, "self-hosted primary must not be blocked at delegation pending")
+		assert.Equal(tb, pluginCore.ValidationReasonValidated, result.Reason)
+	}, TestOptions)
+}
+
 func TestValidateDNS_PendingDelegated_SkipsTokenCheck(t *testing.T) {
 	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 		ws := core.GetService[pluginCore.WebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
@@ -653,6 +704,12 @@ func TestValidateDNS_DelegatedAttached_FailsVerification(t *testing.T) {
 		created, err := ws.CreateWebsite(context.Background(), website)
 		require.NoError(tb, err)
 		_ = bindPrimaryDomain(tb, ctx, created.ID, "attached-fail.hns", false)
+		// Give the primary a portal-managed zone so checkDelegation actually
+		// invokes VerifyDomain (a zone-less/self-hosted primary does not
+		// require delegation and would pass the gate).
+		require.NoError(tb, ctx.DB().Model(&pluginDb.WebsiteDomain{}).
+			Where("website_id = ? AND domain = ?", created.ID, "attached-fail.hns").
+			Update("zone_id", uint(42)).Error)
 
 		svc := ws.(*WebsiteServiceDefault)
 		if db := svc.DB(); db != nil {
@@ -699,6 +756,12 @@ func TestValidateDNS_DelegatedAttached_VerifyError_Fails(t *testing.T) {
 		created, err := ws.CreateWebsite(context.Background(), website)
 		require.NoError(tb, err)
 		_ = bindPrimaryDomain(tb, ctx, created.ID, "verify-err.hns", false)
+		// Give the primary a portal-managed zone so checkDelegation actually
+		// invokes VerifyDomain (a zone-less/self-hosted primary does not
+		// require delegation and would pass the gate).
+		require.NoError(tb, ctx.DB().Model(&pluginDb.WebsiteDomain{}).
+			Where("website_id = ? AND domain = ?", created.ID, "verify-err.hns").
+			Update("zone_id", uint(42)).Error)
 
 		svc := ws.(*WebsiteServiceDefault)
 		if db := svc.DB(); db != nil {

--- a/internal/service/website/validate_dns_test.go
+++ b/internal/service/website/validate_dns_test.go
@@ -746,13 +746,14 @@ func TestValidateDNS_DelegatedAttached_FailsVerification(t *testing.T) {
 	}, TestOptions)
 }
 
-// TestValidateDNS_SelfHostedHNSPrimary_RequiresDelegation guards against the
-// self-hosted short-circuit being applied to delegated namespaces. An HNS
-// primary skips the TXT token check (shouldPerformTokenCheck returns false for
-// delegated namespaces), so a DNSLink match alone is NOT an ownership proof for
-// a zone-less HNS binding. The delegation gate must still run VerifyDomain and
-// fail pending here, rather than letting the site activate with no proof.
-func TestValidateDNS_SelfHostedHNSPrimary_RequiresDelegation(t *testing.T) {
+// TestValidateDNS_SelfHostedHNSPrimary_DoesNotDeadEnd guards against trapping a
+// zone-less (self-hosted) HNS primary in an unreachable delegation-pending
+// state. A self-hosted binding (ZoneID == 0) has no portal-managed PowerDNS
+// zone, so VerifyDomain structurally cannot succeed for it (it no-ops with
+// false). The delegation gate must pass for every zone-less primary once its
+// hosting DNS validated, regardless of namespace: for HNS the DNSLink resolves
+// from the owner-controlled HNS zone, which is itself the ownership proof.
+func TestValidateDNS_SelfHostedHNSPrimary_DoesNotDeadEnd(t *testing.T) {
 	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 		ws := core.GetService[pluginCore.WebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
 		require.NotNil(tb, ws)
@@ -776,25 +777,29 @@ func TestValidateDNS_SelfHostedHNSPrimary_RequiresDelegation(t *testing.T) {
 			},
 		}, nil)
 		// No LookupTXT expectation: the token check is skipped for the
-		// delegated (HNS) namespace.
+		// delegated (HNS) namespace; the DNSLink from the owner's HNS zone is
+		// the ownership proof.
 		setMockResolver(ws, mockResolver)
 
 		mockDelegated := &testDelegatedDomainService{
 			// HNS uses delegation for ownership, so the token check is skipped.
 			uses: func(d string) bool { return d == "selfhosted.hns" },
-			// A self-hosted (zone-less) HNS binding has no delegated zone
-			// published, so VerifyDomain returns false: no ownership proof.
+			// Mirror the real VerifyDomain on a zone-less binding: it returns
+			// (false, nil). checkDelegation must NOT route zone-less bindings
+			// through it (that is an unreachable dead-end), so it must pass.
 			verify: func(ctx context.Context, wd *pluginDb.WebsiteDomain) (bool, error) {
-				return false, nil
+				if wd.ZoneID == 0 {
+					return false, nil
+				}
+				return true, nil
 			},
 		}
 		setMockDelegatedDomainSvc(ws, mockDelegated)
 
 		result, err := ws.ValidateDNS(context.Background(), testUserID1, created.ID)
 		require.NoError(tb, err)
-		assert.False(tb, result.Valid, "self-hosted HNS primary must not activate on DNSLink alone")
-		assert.Equal(tb, pluginCore.ValidationReasonDelegationPending, result.Reason)
-		assert.Contains(tb, result.Message, "Domain delegation not yet published")
+		assert.True(tb, result.Valid, "self-hosted HNS primary must not dead-end at delegation pending")
+		assert.Equal(tb, pluginCore.ValidationReasonValidated, result.Reason)
 	}, TestOptions)
 }
 

--- a/internal/service/website/website.go
+++ b/internal/service/website/website.go
@@ -1595,12 +1595,23 @@ func (s *WebsiteServiceDefault) checkValidationToken(ctx context.Context, websit
 // ValidateDNS steps that run before this check. There is no portal delegation
 // to wait on, so the gate passes rather than leaving the site at "Domain
 // delegation not yet published" forever.
+//
+// This only applies when the hosting DNS was independently proven this pass.
+// Delegated namespaces (HNS) skip the TXT token via shouldPerformTokenCheck, so
+// for a zone-less self-hosted binding in a delegated namespace a DNSLink-only
+// pass is not an ownership proof: the delegation gate must still run
+// VerifyDomain so the site does not activate with no ownership proof at all.
 func (s *WebsiteServiceDefault) checkDelegation(ctx context.Context, primaryWD *pluginDb.WebsiteDomain) (bool, string, pluginCore.ValidationReason, error) {
 	if s.delegatedDomainSvc == nil {
 		return true, "", "", nil
 	}
 
-	if primaryWD.ZoneID == 0 {
+	// A zone-less primary is self-hosted: no portal zone to reconcile. Only
+	// pass when hosting DNS was independently proven (the TXT token ran, i.e.
+	// the namespace does not use delegation for ownership). For delegated
+	// namespaces (HNS) the token check is skipped, so this is not an ownership
+	// proof and we must keep the delegation gate.
+	if primaryWD.ZoneID == 0 && !s.delegatedDomainSvc.UsesDelegationForOwnership(primaryWD.Domain) {
 		return true, "", "", nil
 	}
 

--- a/internal/service/website/website.go
+++ b/internal/service/website/website.go
@@ -1590,28 +1590,25 @@ func (s *WebsiteServiceDefault) checkValidationToken(ctx context.Context, websit
 // DNS and validate independently, so a pending secondary must not block a
 // site whose primary hosting DNS is correct.
 //
-// A self-hosted primary (ZoneID == 0) owns no portal-managed zone to reconcile
-// and its hosting DNS (DNSLink + validation token) was already verified by the
-// ValidateDNS steps that run before this check. There is no portal delegation
-// to wait on, so the gate passes rather than leaving the site at "Domain
-// delegation not yet published" forever.
+// A self-hosted primary (ZoneID == 0) owns no portal-managed zone, so the
+// delegation gate passes once its hosting DNS validated earlier in ValidateDNS.
+// The presence of a real PowerDNS zone (ZoneID != 0) is the authoritative
+// marker of a portal-hosted, delegatable binding. VerifyDomain structurally
+// cannot succeed for a zone-less binding (it no-ops with false), so routing one
+// through the delegation gate is an unreachable dead-end.
 //
-// This only applies when the hosting DNS was independently proven this pass.
-// Delegated namespaces (HNS) skip the TXT token via shouldPerformTokenCheck, so
-// for a zone-less self-hosted binding in a delegated namespace a DNSLink-only
-// pass is not an ownership proof: the delegation gate must still run
-// VerifyDomain so the site does not activate with no ownership proof at all.
+// Ownership for a self-hosted binding is proven by its hosting DNS, which
+// ValidateDNS already validated just before this gate: ICANN runs the TXT token
+// check, and for a delegated namespace (HNS) the DNSLink record resolves from
+// the owner-controlled HNS zone (only the domain owner can publish it there),
+// so a DNSLink that matches the website's exact target is itself an ownership
+// proof for that namespace.
 func (s *WebsiteServiceDefault) checkDelegation(ctx context.Context, primaryWD *pluginDb.WebsiteDomain) (bool, string, pluginCore.ValidationReason, error) {
 	if s.delegatedDomainSvc == nil {
 		return true, "", "", nil
 	}
 
-	// A zone-less primary is self-hosted: no portal zone to reconcile. Only
-	// pass when hosting DNS was independently proven (the TXT token ran, i.e.
-	// the namespace does not use delegation for ownership). For delegated
-	// namespaces (HNS) the token check is skipped, so this is not an ownership
-	// proof and we must keep the delegation gate.
-	if primaryWD.ZoneID == 0 && !s.delegatedDomainSvc.UsesDelegationForOwnership(primaryWD.Domain) {
+	if primaryWD.ZoneID == 0 {
 		return true, "", "", nil
 	}
 

--- a/internal/service/website/website.go
+++ b/internal/service/website/website.go
@@ -1589,8 +1589,18 @@ func (s *WebsiteServiceDefault) checkValidationToken(ctx context.Context, websit
 // primary (apex) binding gates website validation: secondaries own their own
 // DNS and validate independently, so a pending secondary must not block a
 // site whose primary hosting DNS is correct.
+//
+// A self-hosted primary (ZoneID == 0) owns no portal-managed zone to reconcile
+// and its hosting DNS (DNSLink + validation token) was already verified by the
+// ValidateDNS steps that run before this check. There is no portal delegation
+// to wait on, so the gate passes rather than leaving the site at "Domain
+// delegation not yet published" forever.
 func (s *WebsiteServiceDefault) checkDelegation(ctx context.Context, primaryWD *pluginDb.WebsiteDomain) (bool, string, pluginCore.ValidationReason, error) {
 	if s.delegatedDomainSvc == nil {
+		return true, "", "", nil
+	}
+
+	if primaryWD.ZoneID == 0 {
 		return true, "", "", nil
 	}
 


### PR DESCRIPTION
A self-hosted primary binding (ZoneID == 0) owns no portal-managed zone to reconcile, and VerifyDomain correctly no-ops with false for it. checkDelegation treated that false as a failed delegation, so a self-hosted ICANN primary (whose hosting DNS was already validated by the earlier DNSLink + token steps) was left stuck at "Domain delegation not yet published" forever.

checkDelegation now passes for ZoneID == 0 primaries; only portal-managed primaries invoke VerifyDomain and gate on delegation. Adds a regression test and updates the two delegation-failure tests to use a zone-assigned primary so they keep exercising the portal-managed failure path.

- `develop` <!-- branch-stack -->
  - **fix(website): pass delegation gate for self-hosted (zone-less) primaries** :point\_left:

***

<!-- kody-pr-summary:start -->

## Summary

This pull request fixes a bug where self-hosted (zone-less) websites with primary domain bindings would remain stuck in a "Domain delegation not yet published" state indefinitely, even after their hosting DNS (DNSLink and validation token) had been correctly configured.

## Changes

### Core Fix (`internal/service/website/website.go`)

The `checkDelegation` function now short-circuits and returns `true` (delegation gate passed) for self-hosted primary bindings where `ZoneID == 0`.

Previously, the function would call `VerifyDomain` on all primary bindings and treat a `false` return as "delegation pending." However, for self-hosted (zone-less) primaries, `VerifyDomain` returns `false, nil` because there's no portal-managed zone to verify delegation for. This caused the validation process to incorrectly wait for a delegation that would never happen for self-hosted sites.

For self-hosted websites:

- There is no portal-managed zone to reconcile
- Their hosting DNS (DNSLink + validation token) is already verified in earlier `ValidateDNS` steps
- There's no portal delegation to wait for, so the gate should pass immediately

### Tests Updated (`internal/service/website/validate_dns_test.go`)

1. **New test added**: `TestValidateDNS_SelfHostedPrimary_DoesNotRequireDelegation` — verifies that a website with a self-hosted primary binding (no portal-managed zone) validates successfully once its hosting DNS is correct, without being blocked by the delegation gate.

2. **Two existing tests updated**: `TestValidateDNS_DelegatedAttached_FailsVerification` and `TestValidateDNS_DelegatedAttached_VerifyError_Fails` were modified to explicitly set a portal-managed `zone_id` on the test domain. This ensures these tests continue to exercise the delegation verification failure paths, which now only apply to portal-managed zones.

<!-- kody-pr-summary:end -->
