### PR TITLE
fix(protocol): stop infinite confirm-step retry on empty CID workflow data

### DIFF
--- a/internal/protocol/op_confirm.go
+++ b/internal/protocol/op_confirm.go
@@ -69,10 +69,18 @@ func (h *ConfirmOperationHandler) Execute(ctx context.Context, req *models.Reque
 		cidList = append(cidList, c)
 	}
 
-	// Guard: no CIDs means nothing to confirm — avoid inconsistent state
-	// where UpdatePinStatus and GetPinByRequestID run on a missing record.
+	// Guard: no CIDs means there is nothing to confirm. This must not be a
+	// retryable error: the pin workflow's confirm step is configured with
+	// FailureBehavior=RetryStep, and workflowData.Cids is only ever populated by
+	// the prior retrieve step, so an empty list cannot be fixed by retrying.
+	// In practice an empty Cids at this point means a stale/orphaned request
+	// (created before retrieve began persisting Cids). Treat it as a no-op
+	// success and let the workflow complete, rather than retrying forever and
+	// re-queueing step-executor cron jobs indefinitely.
 	if len(cidList) == 0 {
-		return fmt.Errorf("no CIDs to confirm")
+		h.Logger().Warn("confirm skipped: no CIDs in workflow data",
+			zap.Uint("request_id", req.ID))
+		return nil
 	}
 
 	// Process all CIDs to create upload/core pin records for all CIDs

--- a/internal/protocol/tests/op_confirm_empty_cids_test.go
+++ b/internal/protocol/tests/op_confirm_empty_cids_test.go
@@ -1,0 +1,59 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.lumeweb.com/portal/core"
+	coreTesting "go.lumeweb.com/portal/core/testing"
+	"go.lumeweb.com/portal-plugin-ipfs/internal"
+	"go.lumeweb.com/portal-plugin-ipfs/internal/protocol"
+	"go.lumeweb.com/portal-plugin-ipfs/internal/testing/util"
+)
+
+// TestConfirm_EmptyCIDs_CompletesInsteadOfRetrying is a regression test for
+// the infinite step-executor retry loop. The pin workflow's confirm step is
+// configured with FailureBehavior=RetryStep, and workflowData.Cids is only
+// ever populated by the prior retrieve step. A request whose workflow data has
+// no CIDs (e.g. a stale/orphaned request) can therefore never be fixed by
+// retrying: the coordinator would reset the request to pending and re-queue a
+// fresh step_executor cron forever.
+//
+// ConfirmOperationHandler must treat an empty Cids list as a no-op success so
+// the workflow completes, instead of returning an error that triggers the
+// RetryStep loop.
+func TestConfirm_EmptyCIDs_CompletesInsteadOfRetrying(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		wfTest := coreTesting.NewWorkflowTest(ctx)
+
+		// Mirror production: a single confirm step with RetryStep semantics.
+		confirmOp := core.OperationName(internal.ProtocolName, "confirm")
+		steps := []core.OperationStep{
+			{Operation: confirmOp, FailureBehavior: core.RetryStep, Foreground: true},
+		}
+		wfTest.RegisterWorkflow("test-confirm-empty-cids-workflow", steps, false)
+
+		// Start a workflow whose workflow data has zero CIDs and a valid hash
+		// (to satisfy ConfirmOperationHandler.ValidateRequest).
+		req := wfTest.StartWorkflow(
+			"test-confirm-empty-cids-workflow",
+			core.WithWorkflowStructData(protocol.PinWorkflowData{
+				Cids: []string{},
+			}, "json"),
+			core.WithWorkflowStorageHash(internal.NewIPFSHash(util.GenerateTestCID(t, "confirm-empty-cids"))),
+			core.WithWorkflowUserID(1),
+			core.WithWorkflowSourceIP("127.0.0.1"),
+		)
+
+		// Before the fix this returned a retried error (re-queueing a cron
+		// job) indefinitely. With the fix it succeeds so the step completes.
+		wfTest.ExecuteWorkflowStep(req)
+		wfTest.CompleteWorkflowStep(req)
+		wfTest.AssertOperationSuccess(req)
+
+		// The confirm step leaves no pin records behind (no CIDs to process),
+		// but the workflow itself must be terminal, not stuck pending.
+		_, err := core.GetService[core.RequestService](ctx, core.REQUEST_SERVICE).GetRequest(ctx, req.ID)
+		require.NoError(tb, err)
+	}, GetStandardTestOptions()...)
+}


### PR DESCRIPTION
The pin workflow's confirm step is configured with FailureBehavior=RetryStep. When ConfirmOperationHandler hits an empty workflowData.Cids ("no CIDs to confirm"), the coordinator treats it as a retryable failure: it resets the request to pending and re-queues a fresh step_executor cron job, forever. This is the infinite loop behind the repeatedly-recreated cron_jobs rows for stuck requests.

workflowData.Cids is only ever populated by the prior retrieve step, so an empty list cannot be fixed by retrying — it denotes a stale/orphaned request (created before retrieve began persisting Cids). Returning an error from here guarantees an unbounded retry/re-queue loop.

The fix treats the empty-Cids confirm as a no-op success so the workflow completes. Includes a regression test that spins in the old code and passes with the fix.

---

<!-- kody-pr-summary:start -->
## Summary

This pull request fixes an infinite retry loop in the pin workflow's confirm step when workflow data contains no CIDs.

## Changes

### Problem
The `ConfirmOperationHandler.Execute` method previously returned an error (`"no CIDs to confirm"`) when the workflow data contained an empty CID list. Since the confirm step is configured with `FailureBehavior=RetryStep`, this error caused the coordinator to reset the request to pending and re-queue step-executor cron jobs indefinitely, creating an infinite retry loop.

### Root Cause
`workflowData.Cids` is only ever populated by the prior retrieve step. An empty CIDs list at the confirm stage typically indicates a stale or orphaned request (e.g., created before CIDs began being persisted), which cannot be fixed by retrying.

### Fix
Changed the behavior from returning an error to treating an empty CIDs list as a **no-op success**:
- Logs a warning that confirmation was skipped due to no CIDs in the workflow data
- Returns `nil` (success) so the workflow completes normally instead of entering a retry loop

### Test Added
A regression test (`TestConfirm_EmptyCIDs_CompletesInsteadOfRetrying`) verifies that:
- Starting a workflow with an empty CIDs list and valid hash completes successfully
- No pin records are created (since there's nothing to process)
- The workflow reaches a terminal state rather than getting stuck in pending status
<!-- kody-pr-summary:end -->