### PR TITLE
fix(ipns): stop doubling /ipfs/ and /ipns/ path prefixes

### DIFF
--- a/internal/api/api_ipns_test.go
+++ b/internal/api/api_ipns_test.go
@@ -473,6 +473,12 @@ func TestAPI_ResolveIPNS(t *testing.T) {
 			rec := helper.makeAuthenticatedRequest(http.MethodGet, fmt.Sprintf("/api/ipns/resolve/%s?check_routing=0", TestIPNSName), token, nil)
 
 			assert.Equal(t, http.StatusOK, rec.Code)
+
+			// The /ipfs/ prefix must not be doubled by IPFSPath.
+			var resp dto.IPNSResolveResponse
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+			assert.Equal(t, "/ipfs/"+TestCID, resp.Value)
+			assert.Equal(t, "/ipfs/"+TestCID, resp.Path)
 		}, TestOptions)
 	})
 

--- a/internal/api/dto/utils.go
+++ b/internal/api/dto/utils.go
@@ -9,14 +9,20 @@ import (
 	"go.lumeweb.com/ipfs-content/paths"
 )
 
-// IPFSPath creates a properly formatted IPFS path from a CID string
+// IPFSPath creates a properly formatted IPFS path from a CID string.
+// It defensively strips a leading /ipfs/ prefix so a path or already-prefixed
+// value is not doubled (e.g. "/ipfs/ipfs/<cid>").
 func IPFSPath(cid string) string {
-	return paths.IPFSPathPrefix + trimPath(cid)
+	trimmed := strings.TrimPrefix(cid, paths.IPFSPathPrefix)
+	return paths.IPFSPathPrefix + trimPath(trimmed)
 }
 
-// IPNSPath creates a properly formatted IPNS path from a peer ID string
+// IPNSPath creates a properly formatted IPNS path from a peer ID string.
+// It defensively strips a leading /ipns/ prefix so a path or already-prefixed
+// value is not doubled (e.g. "/ipns/ipns/<peerID>").
 func IPNSPath(peerID string) string {
-	return paths.IPNSPathPrefix + trimPath(peerID)
+	trimmed := strings.TrimPrefix(peerID, paths.IPNSPathPrefix)
+	return paths.IPNSPathPrefix + trimPath(trimmed)
 }
 
 // trimPath defensively trims leading and trailing slashes from path components

--- a/internal/api/dto/utils_test.go
+++ b/internal/api/dto/utils_test.go
@@ -1,0 +1,33 @@
+package dto
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.lumeweb.com/ipfs-content/paths"
+)
+
+// TestIPFSPath_NoDoublePrefix guards against the /ipfs/ipfs/<cid> doubling
+// bug: resolve's normalized value already carries the /ipfs/ prefix
+// (TryNormalizeCIDFromPath returns a full path), so IPFSPath must strip it
+// before prepending, never produce a doubled prefix.
+func TestIPFSPath_NoDoublePrefix(t *testing.T) {
+	cid := "bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi"
+
+	// Bare CID input: prefix added once (regression: was already correct).
+	assert.Equal(t, paths.IPFSPathPrefix+cid, IPFSPath(cid))
+	assert.Equal(t, paths.IPFSPathPrefix+cid, IPFSPath(paths.IPFSPathPrefix+cid))
+	assert.Equal(t, paths.IPFSPathPrefix+cid, IPFSPath(paths.IPFSPathPrefix+"/"+cid))
+
+	// A prefixed value with a sub-path is preserved intact after trimming.
+	sub := paths.IPFSPathPrefix + cid + "/some/file.txt"
+	assert.Equal(t, sub, IPFSPath(sub))
+}
+
+// TestIPNSPath_NoDoublePrefix mirrors the IPFSPath guard for IPNS peer IDs,
+// which are always bare (no prefix expected) but must not double either.
+func TestIPNSPath_NoDoublePrefix(t *testing.T) {
+	peer := "12D3KooWJv8RMQd2Q2XrboA6XP2qKqJpRrYgX5e5y9QVA"
+	assert.Equal(t, paths.IPNSPathPrefix+peer, IPNSPath(peer))
+	assert.Equal(t, paths.IPNSPathPrefix+peer, IPNSPath(paths.IPNSPathPrefix+peer))
+}


### PR DESCRIPTION
`ipns_resolve` returned a doubled path: `path="/ipfs/ipfs/<cid>"` while `value="/ipfs/<cid>"`.

**Root cause:** resolve's `normalizedValue` already carries the `/ipfs/` prefix — `TryNormalizeCIDFromPath` (`ipfs-content/paths`) always returns a full path (`valuePath.String()` on parse failure, or `path.FromCid(cid).String()` on success). `dto.IPFSPath` then prepended `/ipfs/` a second time, producing `/ipfs/ipfs/<cid>`.

**Fix:** strip a leading `/ipfs/` (and, for parity, `/ipns/`) prefix before prepending in `dtIPFSPath`/`IPNSPath` (`internal/api/dto/utils.go`). Call sites that pass bare CIDs (dnslink `Identifier`, `TargetHash`) are unaffected — the trim is a no-op for them.

**Tests:**

- new `internal/api/dto/utils_test.go` asserting `IPFSPath`/`IPNSPath` never double the prefix for bare, prefixed, and prefixed-subpath inputs;
- extended `TestAPI_ResolveIPNS/success` to assert `Value` and `Path` are the single-prefix form (it previously only checked the status code, so it could not catch this bug).

`go build ./...`, `go vet ./internal/api/...`, and `go test ./internal/api/dto/` pass. Note: `go test ./internal/api/...` panics at init in this container on a pre-existing duplicate protobuf/etcd registration (reproduced on unmodified code) — the dto tests cover the regression directly and the api test additions compile via `go vet`.

- `develop` <!-- branch-stack -->
  - **fix(ipns): stop doubling /ipfs/ and /ipns/ path prefixes** :point\_left:

---

<!-- kody-pr-summary:start -->
This pull request fixes a bug where IPFS/IPNS path prefixes were being doubled (e.g., resulting in `/ipfs/ipfs/<cid>` or `/ipns/ipns/<peerID>`).

The issue occurred because the `IPFSPath` and `IPNSPath` utility functions in `internal/api/dto/utils.go` would prepend the `/ipfs/` or `/ipns/` prefix to values that sometimes already contained that prefix (particularly when incoming CID values were already normalized to full paths containing the prefix).

The fix adds defensive prefix stripping: both functions now check for and remove a leading `/ipfs/` or `/ipns/` prefix (respectively) before prepending a fresh one, ensuring the prefix appears only once in the output.

Includes test coverage for:
- Bare CID/peer ID inputs (prefix added once)
- Already-prefixed values (no doubling)
- Prefixed values with additional sub-paths (preserved intact)
- Integration test verifying the `/ipfs/` prefix is not doubled in the IPNS resolve API response
<!-- kody-pr-summary:end -->