### PR TITLE
fix(dto): make website validation_token format order-independent

### DIFF
--- a/internal/api/dto/website.go
+++ b/internal/api/dto/website.go
@@ -397,8 +397,12 @@ type WebsiteResponse struct {
 	// Whether validation token has expired
 	Expired bool           `json:"expired"`
 	SSL     *SSLStatusInfo `json:"ssl,omitempty"`
-	// Set by SetValidationRecordInfo; consumed by FromModel to format ValidationToken/ValidationRecordHost
+	// tokenKey is set by SetValidationRecordInfo; rawToken holds the raw
+	// per-resource validation token set by FromModel. Backing ValidationToken
+	// off rawToken makes the token format deterministic regardless of whether
+	// SetValidationRecordInfo runs before or after FromModel.
 	tokenKey string
+	rawToken string
 }
 
 func (r *WebsiteResponse) FromModel(model *db.Website) error {
@@ -412,14 +416,24 @@ func (r *WebsiteResponse) FromModel(model *db.Website) error {
 	r.Created = model.CreatedAt
 	r.Updated = model.UpdatedAt
 	r.Expired = model.IsExpired()
-
-	if r.tokenKey != "" && model.ValidationToken != "" {
-		r.ValidationToken = r.tokenKey + "=" + model.ValidationToken
-	} else {
-		r.ValidationToken = model.ValidationToken
-	}
+	// Keep the raw model token in rawToken so the format can be derived
+	// consistently once tokenKey is known, independent of call order.
+	r.rawToken = model.ValidationToken
+	r.applyTokenFormat()
 
 	return nil
+}
+
+// applyTokenFormat derives ValidationToken from the raw token and tokenKey.
+// It is idempotent: repeated calls (e.g. EncodeResponse re-running FromModel)
+// never double the prefix, and calling it with an unset tokenKey yields the
+// raw token.
+func (r *WebsiteResponse) applyTokenFormat() {
+	if r.tokenKey != "" && r.rawToken != "" {
+		r.ValidationToken = r.tokenKey + "=" + r.rawToken
+	} else {
+		r.ValidationToken = r.rawToken
+	}
 }
 
 // SetPrimaryDomain populates the website-level domain/DNS fields from the
@@ -441,7 +455,7 @@ func (r *WebsiteResponse) SetPrimaryDomain(primary *db.WebsiteDomain) {
 		r.ZoneID = nil
 	}
 	r.Enabled = primary.DNSHostingEnabled
-	if r.tokenKey != "" && r.ValidationToken != "" {
+	if r.tokenKey != "" && r.rawToken != "" {
 		r.ValidationRecordHost = r.tokenKey + "." + primary.Domain
 	}
 }
@@ -471,11 +485,10 @@ func (r *WebsiteResponse) SetSubdomainInfo(zoneDomain string) {
 
 func (r *WebsiteResponse) SetValidationRecordInfo(tokenKey string) {
 	r.tokenKey = tokenKey
-	// The primary domain may already be set; recompute the validation record
-	// host so it is populated regardless of whether SetPrimaryDomain ran before
-	// or after this call (a website has no validation record host without a
-	// primary domain, so leave it empty if Domain is blank).
-	if r.Domain != "" && r.ValidationToken != "" {
+	// Re-derive the token format (and record host) so the result is correct
+	// regardless of whether this runs before or after FromModel.
+	r.applyTokenFormat()
+	if r.Domain != "" && r.rawToken != "" {
 		r.ValidationRecordHost = tokenKey + "." + r.Domain
 	}
 }

--- a/internal/api/dto/website_test.go
+++ b/internal/api/dto/website_test.go
@@ -549,4 +549,22 @@ func TestWebsiteResponse_SetValidationRecordInfo(t *testing.T) {
 		assert.Equal(t, "lumeweb-verify=abc123", resp.ValidationToken)
 		assert.Equal(t, "lumeweb-verify.dev.pinner.xyz", resp.ValidationRecordHost)
 	})
+
+	// Regression: both handlers (get and list) call FromModel before
+	// SetValidationRecordInfo. The token format must converge to the prefixed
+	// form regardless, so websites_list and websites_get never disagree on the
+	// same resource's validation_token (raw vs pinner-verify= prefix).
+	t.Run("FromModel-before-SetValidationRecordInfo still prefixes token", func(t *testing.T) {
+		resp := &WebsiteResponse{}
+		err := resp.FromModel(model)
+		require.NoError(t, err)
+		assert.Equal(t, "abc123", resp.ValidationToken, "raw before tokenKey known")
+		resp.SetValidationRecordInfo("pinner-verify")
+		assert.Equal(t, "pinner-verify=abc123", resp.ValidationToken)
+
+		// Idempotent across the EncodeResponse re-FromModel the get path hits.
+		err = resp.FromModel(model)
+		require.NoError(t, err)
+		assert.Equal(t, "pinner-verify=abc123", resp.ValidationToken)
+	})
 }


### PR DESCRIPTION
## Problem

`websites_list` and `websites_get` disagreed on the same resource's `validation_token`: list returned the raw hex (e.g. `3b8b3108...`), get returned the prefixed TXT value (`pinner-verify=3b8b3108...`). Reproduced back-to-back against the same resource, same second — a real field-level split, not staleness.

## Root cause

Both endpoints serialize through the same `WebsiteResponse`, but the token format silently depended on whether `SetValidationRecordInfo` ran before or after `FromModel`:

- `FromModel` prefixes the token only if `tokenKey` is already set (empty at that point in both handlers).
- `getWebsite` only produced the prefixed form **by accident**: `httputil.EncodeResponse` re-runs `FromModel` after `SetValidationRecordInfo`, so the second pass applies the prefix.
- `listWebsites` converts to `WebsiteItem` (a plain type alias) with no second `FromModel` pass, so it kept the raw token.

## Fix

Back `ValidationToken` off a new `rawToken` field captured in `FromModel`, and derive the format idempotently (`applyTokenFormat`) so the result is correct regardless of whether `SetValidationRecordInfo` runs before or after `FromModel`, or whether `FromModel` is re-run. Both endpoints now converge on the same prefixed format for the same resource.

## Tests

`TestWebsiteResponse_SetValidationRecordInfo/FromModel-before-SetValidationRecordInfo_still_prefixes_token` — regression for the exact handler order, plus idempotence across the `EncodeResponse` re-`FromModel`. Full `internal/api/dto` suite and `go vet` pass.

- `develop` <!-- branch-stack -->
  - **fix(dto): make website validation\_token format order-independent** :point\_left:

---

<!-- kody-pr-summary:start -->
This pull request fixes an inconsistency in how website validation tokens are formatted in the DTO layer. The issue was that the token format depended on the order in which methods were called (`FromModel` vs `SetValidationRecordInfo`), causing the website list and get endpoints to return different formats for the same resource.

The changes:
- Refactor the token formatting logic into a reusable helper (`applyTokenFormat`) that keeps the raw token separately and derives the formatted token based on the token key.
- Make the token formatting order-independent and idempotent, so it always converges to the correct "key=token" format regardless of whether `SetValidationRecordInfo` runs before or after `FromModel`.
- Add a regression test verifying that a token processed first by `FromModel` and then by `SetValidationRecordInfo` still produces the correctly prefixed format, even after repeated calls.
<!-- kody-pr-summary:end -->