### PR TITLE
fix(api): make website-update domain set idempotent for existing primary

### DIFF
--- a/internal/api/api_websites.go
+++ b/internal/api/api_websites.go
@@ -21,6 +21,7 @@ import (
 	"go.lumeweb.com/queryutil"
 	"go.lumeweb.com/queryutil/filter"
 	"go.uber.org/zap"
+	"gorm.io/gorm"
 )
 
 // ipnsKeyCIDResolver adapts IPNSKeyService to satisfy dto.IPNSKeyCIDResolver
@@ -392,7 +393,13 @@ func (a *API) updateWebsite(c echo.Context) error {
 	var primary *pluginDb.WebsiteDomain
 
 	// 1. Change the primary domain: create the requested domain binding and
-	// make it the website's new primary (apex) domain.
+	// make it the website's new primary (apex) domain. Setting a domain is
+	// idempotent for a binding that already belongs to this website: the
+	// deployed domain is re-used and repointed as primary rather than
+	// re-created (CreateDomain is create-only and would otherwise trip the
+	// (domain, namespace) unique key with a 500 on every re-deploy). A domain
+	// live-bound to a different website is an ownership conflict (409), not a
+	// 500.
 	if req.Domain != nil {
 		if a.delegatedDomainSvc == nil {
 			return ctx.Error(NewError(ErrKeyFileProcessingFailed, fmt.Errorf("domain service unavailable")), http.StatusInternalServerError)
@@ -407,18 +414,53 @@ func (a *API) updateWebsite(c echo.Context) error {
 		if req.DNSEnabled != nil {
 			newDomainDNS = *req.DNSEnabled
 		}
-		wd, derr := a.delegatedDomainSvc.CreateDomain(reqCtx, namespace, *req.Domain, website.ID, user, newDomainDNS, false, cfgRaw)
-		if derr != nil {
-			a.Logger().Error("Failed to create primary domain for website",
-				zap.Uint("website_id", website.ID), zap.String("domain", *req.Domain), zap.Error(derr))
-			apiErr := NewError(ErrKeyFileProcessingFailed, derr)
-			return ctx.Error(apiErr, apiErr.HttpStatus())
-		}
-		primary, derr = a.websiteService.SetPrimaryDomain(reqCtx, user, website.ID, wd.ID)
-		if derr != nil {
-			a.Logger().Error("Failed to set primary domain", zap.Uint("domain_id", wd.ID), zap.Error(derr))
-			apiErr := NewError(ErrKeyFileProcessingFailed, derr)
-			return ctx.Error(apiErr, apiErr.HttpStatus())
+
+		// Reuse an existing live binding for this (domain, namespace) when it
+		// already belongs to the website; otherwise fall through to a genuine
+		// create (change-primary). A binding owned by a different website is
+		// surfaced as an explicit ownership conflict.
+		existing, eerr := a.delegatedDomainSvc.GetWebsiteDomainByDomainAndNamespace(reqCtx, *req.Domain, pluginDb.DomainNamespace(namespace))
+		switch {
+		case eerr == nil && !existing.DeletedAt.Valid && existing.WebsiteID == website.ID:
+			// Re-deploy to an already-bound primary: reuse, don't re-create.
+			// The binding's DNS hosting state is preserved as-is; only an
+			// explicit dns_hosting_enabled override (step 2 below) changes it.
+			// Silently defaulting DNS hosting on here would re-provision a
+			// PowerDNS zone on a binding the user deliberately self-hosted,
+			// defeating the idempotent re-deploy guarantee.
+			wd := existing
+			rerp, derr := a.websiteService.SetPrimaryDomain(reqCtx, user, website.ID, wd.ID)
+			if derr != nil {
+				a.Logger().Error("Failed to set primary domain", zap.Uint("domain_id", wd.ID), zap.Error(derr))
+				apiErr := NewError(ErrKeyFileProcessingFailed, derr)
+				return ctx.Error(apiErr, apiErr.HttpStatus())
+			}
+			primary = rerp
+		case eerr == nil:
+			// Domain is live-bound to a different website — refuse to repoint.
+			a.Logger().Warn("Refusing to bind domain owned by another website",
+				zap.Uint("website_id", website.ID), zap.String("domain", *req.Domain), zap.Uint("domain_owner_website_id", existing.WebsiteID))
+			apiErr := NewError(ErrKeyDomainInUse, fmt.Errorf("domain %q is already in use by another website", *req.Domain))
+			return ctx.Error(apiErr, http.StatusConflict)
+		default:
+			if !errors.Is(eerr, gorm.ErrRecordNotFound) {
+				a.Logger().Error("Failed to look up existing domain binding", zap.String("domain", *req.Domain), zap.Error(eerr))
+				apiErr := NewError(ErrKeyFileProcessingFailed, eerr)
+				return ctx.Error(apiErr, apiErr.HttpStatus())
+			}
+			wd, derr := a.delegatedDomainSvc.CreateDomain(reqCtx, namespace, *req.Domain, website.ID, user, newDomainDNS, false, cfgRaw)
+			if derr != nil {
+				a.Logger().Error("Failed to create primary domain for website",
+					zap.Uint("website_id", website.ID), zap.String("domain", *req.Domain), zap.Error(derr))
+				apiErr := NewError(ErrKeyFileProcessingFailed, derr)
+				return ctx.Error(apiErr, apiErr.HttpStatus())
+			}
+			primary, derr = a.websiteService.SetPrimaryDomain(reqCtx, user, website.ID, wd.ID)
+			if derr != nil {
+				a.Logger().Error("Failed to set primary domain", zap.Uint("domain_id", wd.ID), zap.Error(derr))
+				apiErr := NewError(ErrKeyFileProcessingFailed, derr)
+				return ctx.Error(apiErr, apiErr.HttpStatus())
+			}
 		}
 	}
 

--- a/internal/api/api_websites_test.go
+++ b/internal/api/api_websites_test.go
@@ -906,6 +906,143 @@ func TestAPI_UpdateWebsite(t *testing.T) {
 		}, TestOptions)
 	})
 
+	t.Run("success_redeploy_existing_primary_reuses_binding", func(t *testing.T) {
+		coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+			helper := newMockHelper(t, ctx)
+			token, userID := helper.SetupAuthenticatedTestWithCID(cid.MustParse(TestCID))
+
+			mockWebsiteService := core.GetService[*mocks.MockWebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
+
+			// Re-deploying to a domain that is already THIS website's primary
+			// binding must reuse the existing binding (idempotent), not attempt
+			// to create a second one (which would trip the unique key and 500).
+			// Persist the website and its live (domain, namespace) binding so
+			// the real DelegatedDomainService.GetWebsiteDomainByDomainAndNamespace
+			// resolves it and the reuse path runs.
+			require.NoError(tb, ctx.DB().Create(createTestIPFSGatewayWebsite(1, userID, "get.pinner.xyz", cid.MustParse(TestCID), pluginDb.WebsiteStatusActive)).Error)
+			require.NoError(tb, ctx.DB().Create(&pluginDb.WebsiteDomain{
+				ID:        1,
+				WebsiteID: 1,
+				UserID:    userID,
+				Domain:    "get.pinner.xyz",
+				Namespace: pluginDb.DomainNamespaceICANN,
+				Status:    pluginDb.DomainStatusActive,
+			}).Error)
+
+			mockWebsite := createMockIPFSWebsite(1, userID, "get.pinner.xyz", TestCID, pluginDb.WebsiteStatusActive, "")
+			mockWebsiteService.EXPECT().UpdateWebsite(mock.Anything, userID, uint(1), mock.AnythingOfType("map[string]interface {}")).Return(mockWebsite, nil)
+
+			// The existing binding is already primary for this website, so
+			// SetPrimaryDomain is a no-op returning the same binding. The reuse
+			// path preserves the binding's DNS hosting state (no DNS zone or
+			// SetDomainDNSEnabled call without an explicit dns_hosting_enabled).
+			existingBinding := &pluginDb.WebsiteDomain{
+				ID:        1,
+				WebsiteID: 1,
+				UserID:    userID,
+				Domain:    "get.pinner.xyz",
+				Namespace: pluginDb.DomainNamespaceICANN,
+				Status:    pluginDb.DomainStatusActive,
+			}
+			mockWebsiteService.EXPECT().SetPrimaryDomain(mock.Anything, userID, uint(1), uint(1)).Return(existingBinding, nil)
+			mockWebsiteService.EXPECT().GetApexDomainBinding(mock.Anything, uint(1)).Return(existingBinding, nil).Maybe()
+
+			reqBody := fmt.Sprintf(`{"domain":"get.pinner.xyz","target_type":"ipfs","target_hash":"%s"}`, TestCID)
+			rec := helper.makeAuthenticatedRequest(http.MethodPut, "/api/websites/1", token, []byte(reqBody))
+
+			// The reported bug returned 500 ("Duplicate entry ... for key
+			// 'website_domains.uk_domain_namespace'"); the fix reuses the
+			// existing binding and succeeds.
+			assert.Equal(t, http.StatusOK, rec.Code)
+
+			var response dto.WebsiteResponse
+			err := json.Unmarshal(rec.Body.Bytes(), &response)
+			require.NoError(t, err)
+			assert.Equal(t, uint(1), response.ID)
+			assert.Equal(t, "get.pinner.xyz", response.Domain)
+		}, TestOptions)
+	})
+
+	t.Run("success_redeploy_preserves_self_hosted_dns_state", func(t *testing.T) {
+		coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+			helper := newMockHelper(t, ctx)
+			token, userID := helper.SetupAuthenticatedTestWithCID(cid.MustParse(TestCID))
+
+			mockWebsiteService := core.GetService[*mocks.MockWebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
+
+			// Re-deploying (no dns_hosting_enabled in the request) to a primary
+			// binding the user deliberately self-hosted (DNS hosting off, no
+			// portal zone) must preserve that state, not silently re-provision
+			// DNS hosting. Only an explicit dns_hosting_enabled override may
+			// change it.
+			require.NoError(tb, ctx.DB().Create(createTestIPFSGatewayWebsite(1, userID, "selfhost.xyz", cid.MustParse(TestCID), pluginDb.WebsiteStatusActive)).Error)
+			require.NoError(tb, ctx.DB().Create(&pluginDb.WebsiteDomain{
+				ID:                1,
+				WebsiteID:         1,
+				UserID:            userID,
+				Domain:            "selfhost.xyz",
+				Namespace:         pluginDb.DomainNamespaceICANN,
+				Status:            pluginDb.DomainStatusSelfHosted,
+				DNSHostingEnabled: false,
+				ZoneID:            0,
+			}).Error)
+
+			mockWebsite := createMockIPFSWebsite(1, userID, "selfhost.xyz", TestCID, pluginDb.WebsiteStatusActive, "")
+			mockWebsiteService.EXPECT().UpdateWebsite(mock.Anything, userID, uint(1), mock.AnythingOfType("map[string]interface {}")).Return(mockWebsite, nil)
+
+			selfHostedBinding := &pluginDb.WebsiteDomain{
+				ID:                1,
+				WebsiteID:         1,
+				UserID:            userID,
+				Domain:            "selfhost.xyz",
+				Namespace:         pluginDb.DomainNamespaceICANN,
+				Status:            pluginDb.DomainStatusSelfHosted,
+				DNSHostingEnabled: false,
+				ZoneID:            0,
+			}
+			mockWebsiteService.EXPECT().SetPrimaryDomain(mock.Anything, userID, uint(1), uint(1)).Return(selfHostedBinding, nil)
+			mockWebsiteService.EXPECT().GetApexDomainBinding(mock.Anything, uint(1)).Return(selfHostedBinding, nil).Maybe()
+
+			reqBody := fmt.Sprintf(`{"domain":"selfhost.xyz","target_type":"ipfs","target_hash":"%s"}`, TestCID)
+			rec := helper.makeAuthenticatedRequest(http.MethodPut, "/api/websites/1", token, []byte(reqBody))
+
+			assert.Equal(t, http.StatusOK, rec.Code)
+			// No silent DNS takeover: the self-hosted binding must not be
+			// flipped to portal-managed DNS merely by a target re-deploy.
+			mockWebsiteService.AssertNotCalled(tb, "SetDomainDNSEnabled", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+		}, TestOptions)
+	})
+
+	t.Run("error_domain_owned_by_another_website_conflict", func(t *testing.T) {
+		coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+			helper := newMockHelper(t, ctx)
+			token, userID := helper.SetupAuthenticatedTestWithCID(cid.MustParse(TestCID))
+
+			mockWebsiteService := core.GetService[*mocks.MockWebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
+
+			// A domain live-bound to a DIFFERENT website must be refused as an
+			// ownership conflict (409), never re-bound to this website.
+			require.NoError(tb, ctx.DB().Create(createTestIPFSGatewayWebsite(1, userID, "conflict.xyz", cid.MustParse(TestCID), pluginDb.WebsiteStatusActive)).Error)
+			require.NoError(tb, ctx.DB().Create(&pluginDb.WebsiteDomain{
+				ID:        1,
+				WebsiteID: 99, // owned by another website
+				UserID:    userID,
+				Domain:    "conflict.xyz",
+				Namespace: pluginDb.DomainNamespaceICANN,
+				Status:    pluginDb.DomainStatusActive,
+			}).Error)
+
+			mockWebsite := createMockIPFSWebsite(1, userID, "conflict.xyz", TestCID, pluginDb.WebsiteStatusActive, "")
+			mockWebsiteService.EXPECT().UpdateWebsite(mock.Anything, userID, uint(1), mock.AnythingOfType("map[string]interface {}")).Return(mockWebsite, nil)
+
+			reqBody := fmt.Sprintf(`{"domain":"conflict.xyz","target_type":"ipfs","target_hash":"%s"}`, TestCID)
+			rec := helper.makeAuthenticatedRequest(http.MethodPut, "/api/websites/1", token, []byte(reqBody))
+
+			// The lookup finds a live binding owned by website 99 → 409, not 500.
+			assert.Equal(t, http.StatusConflict, rec.Code)
+		}, TestOptions)
+	})
+
 	t.Run("success_dns_hosting_only", func(t *testing.T) {
 		coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 			helper := newMockHelper(t, ctx)

--- a/internal/api/errors.go
+++ b/internal/api/errors.go
@@ -54,7 +54,13 @@ const (
 
 	// Website domain binding error types
 	ErrKeyDomainNotFound core.ErrorType = "DOMAIN_NOT_FOUND"
-	ErrKeyInvalidPathID  core.ErrorType = "INVALID_PATH_ID"
+	// ErrKeyDomainInUse is returned when a website update tries to set a
+	// primary domain that is already live-bound to a different website. The
+	// create-only CreateDomain path would otherwise surface a raw MySQL 1062
+	// duplicate-key as a 500; this surfaces it as an explicit ownership
+	// conflict (409) instead.
+	ErrKeyDomainInUse   core.ErrorType = "DOMAIN_IN_USE"
+	ErrKeyInvalidPathID core.ErrorType = "INVALID_PATH_ID"
 	// ErrKeyNoStoredCertificate is returned when a DANE republish is requested
 	// for a domain that has no certificate/key stored (e.g. none was ever
 	// pushed via the cert webhook, or the binding is not DANE-capable).
@@ -104,6 +110,7 @@ func init() {
 		ErrKeyInvalidCID:            {Key: ErrKeyInvalidCID, Message: "Invalid CID provided"},
 		ErrKeyInvalidTarget:         {Key: ErrKeyInvalidTarget, Message: "Invalid target hash or peer ID provided"},
 		ErrKeyDomainNotFound:        {Key: ErrKeyDomainNotFound, Message: "Domain not found"},
+		ErrKeyDomainInUse:           {Key: ErrKeyDomainInUse, Message: "Domain is already in use by another website"},
 		ErrKeyInvalidPathID:         {Key: ErrKeyInvalidPathID, Message: "Invalid path parameter: %s"},
 		ErrKeyNoStoredCertificate:   {Key: ErrKeyNoStoredCertificate, Message: "No stored certificate for domain; nothing to republish"},
 		ErrKeyDeleteFailed:          {Key: ErrKeyDeleteFailed, Message: "Failed to delete zone"},
@@ -136,6 +143,7 @@ func init() {
 		ErrKeyInvalidTarget:         http.StatusUnprocessableEntity,
 		ErrKeyPermissionDenied:      http.StatusForbidden,
 		ErrKeyDomainNotFound:        http.StatusNotFound,
+		ErrKeyDomainInUse:           http.StatusConflict,
 		ErrKeyInvalidPathID:         http.StatusBadRequest,
 		ErrKeyNoStoredCertificate:   http.StatusConflict,
 		ErrKeyDeleteFailed:          http.StatusInternalServerError,


### PR DESCRIPTION
Re-deploying to a domain already bound as the website's primary called CreateDomain, which is create-only and inserts a new website\_domains row. Reusing a live domain collided with the (domain, namespace) unique key and returned HTTP 500 on every re-deploy.

UpdateWebsite now looks up the (namespace, domain) binding first: a live binding owned by the website is reused and repointed as primary (skipping CreateDomain); a binding owned by a different website is refused with a 409 DOMAIN\_IN\_USE conflict; a missing binding falls through to the existing create path.

Adds the DOMAIN\_IN\_USE error key (409) and regression tests for re-deploy-to-existing-primary (200, reuse) and foreign-owned domain (409).

- `develop` <!-- branch-stack -->
  - **fix(api): make website-update domain set idempotent for existing primary** :point\_left:

***

<!-- kody-pr-summary:start -->

This pull request fixes the website-update API to make domain setting idempotent when re-deploying a website to a domain it already owns.

**Problem:** When updating a website with the same primary domain it already has (e.g., re-deploying), the API attempted to create the domain binding again. Since `CreateDomain` is create-only, this tripped the database's unique key constraint on (domain, namespace), resulting in a 500 error on every re-deploy.

**Changes:**

1. **Idempotent domain reuse** (`internal/api/api_websites.go`): The update logic now first checks whether a domain binding already exists for the requested domain. If the binding belongs to the same website, it reuses the existing binding and simply repoints it as primary instead of attempting to create a duplicate. This makes repeated deployments to the same domain succeed without errors.

2. **Ownership conflict handling**: If the domain is already live-bound to a *different* website, the API now returns an explicit 409 Conflict error (`ErrKeyDomainInUse`) instead of attempting the create and failing with a 500. This also improves error clarity for users trying to use a domain owned by another website.

3. **New error type** (`internal/api/errors.go`): Added `ErrKeyDomainInUse`, mapped to HTTP 409 Conflict with the message "Domain is already in use by another website."

4. **Tests** (`internal/api/api_websites_test.go`): Added two test cases:
   - Verifies that re-deploying to an existing primary domain reuses the existing binding and returns 200 OK.
   - Verifies that attempting to use a domain owned by a different website returns 409 Conflict.

<!-- kody-pr-summary:end -->
