### PR TITLE
feat(dns): content-scoped record delete

### DIFF
--- a/core/dns.go
+++ b/core/dns.go
@@ -98,8 +98,12 @@ type DNSService interface {
 	// records: list of record contents to update
 	UpdateRecord(ctx context.Context, zoneID uint, name string, recordType string, records []string, ttl uint) ([]*apiDTO.DNSRecord, error)
 
-	// DeleteRecord deletes a DNS RRSet from PowerDNS
-	DeleteRecord(ctx context.Context, zoneID uint, name string, recordType string) error
+	// DeleteRecord deletes DNS records from PowerDNS. When no contents are
+	// given it removes the entire RRSet (all records with the name+type). When
+	// one or more contents are given it removes only the records whose content
+	// matches, leaving sibling records (e.g. other TXT values at the same name)
+	// untouched.
+	DeleteRecord(ctx context.Context, zoneID uint, name string, recordType string, contents ...string) error
 
 	// BulkDeleteRecords deletes multiple DNS records in a single PowerDNS API call
 	BulkDeleteRecords(ctx context.Context, zoneID uint, userID uint, records []apiDTO.RecordIdentifier, dryRun bool) (*apiDTO.BulkDeleteResponse, error)

--- a/internal/api/api_dns.go
+++ b/internal/api/api_dns.go
@@ -1,7 +1,9 @@
 package api
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -10,12 +12,12 @@ import (
 	"github.com/samber/lo"
 	"go.lumeweb.com/httputil"
 	"go.lumeweb.com/ipfs-sdk/dnsname"
-	"go.lumeweb.com/queryutil"
-	"go.lumeweb.com/queryutil/filter"
-	queryutilHttp "go.lumeweb.com/queryutil/http"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/api/dto"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/db"
 	dnsservice "go.lumeweb.com/portal-plugin-ipfs/internal/service/dns"
+	"go.lumeweb.com/queryutil"
+	"go.lumeweb.com/queryutil/filter"
+	queryutilHttp "go.lumeweb.com/queryutil/http"
 	"go.uber.org/zap"
 )
 
@@ -408,7 +410,19 @@ func (a *API) deleteRecord(c echo.Context) error {
 		return err
 	}
 
-	err = a.dnsService.DeleteRecord(reqCtx, zoneID, name, recordType)
+	// Optional body may narrow the delete to a specific record content. When
+	// absent or empty, the whole RRSet for (name, type) is deleted.
+	body, _ := io.ReadAll(c.Request().Body)
+	if len(bytes.TrimSpace(body)) == 0 {
+		err = a.dnsService.DeleteRecord(reqCtx, zoneID, name, recordType)
+	} else {
+		c.Request().Body = io.NopCloser(bytes.NewReader(body))
+		var req dto.RecordDeleteRequest
+		if _, ok := httputil.DecodeAndValidateRequest(ctx, &req); !ok {
+			return nil
+		}
+		err = a.dnsService.DeleteRecord(reqCtx, zoneID, name, recordType, req.Content)
+	}
 	if err != nil {
 		a.Logger().Error("Failed to delete DNS record", zap.Error(err), zap.String("name", name), zap.String("type", recordType))
 		apiErr := NewError(mapDNSErrorToAPIError(err, "record"), err)

--- a/internal/api/api_dns.go
+++ b/internal/api/api_dns.go
@@ -411,20 +411,24 @@ func (a *API) deleteRecord(c echo.Context) error {
 	}
 
 	// Optional body may narrow the delete to a specific record content. When
-	// absent or when content is empty, the whole RRSet for (name, type) is
-	// deleted.
-	body, _ := io.ReadAll(c.Request().Body)
+	// no body is sent the whole RRSet for (name, type) is deleted. A supplied
+	// body that yields no content selector is rejected (4xx) rather than
+	// silently broad-deleting.
+	body, err := io.ReadAll(io.LimitReader(c.Request().Body, 1<<20))
+	if err != nil {
+		return err
+	}
 	if len(bytes.TrimSpace(body)) > 0 {
 		c.Request().Body = io.NopCloser(bytes.NewReader(body))
 		var req dto.RecordDeleteRequest
 		if _, ok := httputil.DecodeAndValidateRequest(ctx, &req); !ok {
 			return nil
 		}
-		if req.Content != "" {
-			err = a.dnsService.DeleteRecord(reqCtx, zoneID, name, recordType, req.Content)
-		} else {
-			err = a.dnsService.DeleteRecord(reqCtx, zoneID, name, recordType)
+		if req.Content == "" {
+			apiErr := NewError(ErrKeyInvalidRequest, nil)
+			return ctx.Error(apiErr, apiErr.HttpStatus())
 		}
+		err = a.dnsService.DeleteRecord(reqCtx, zoneID, name, recordType, req.Content)
 	} else {
 		err = a.dnsService.DeleteRecord(reqCtx, zoneID, name, recordType)
 	}

--- a/internal/api/api_dns.go
+++ b/internal/api/api_dns.go
@@ -411,17 +411,22 @@ func (a *API) deleteRecord(c echo.Context) error {
 	}
 
 	// Optional body may narrow the delete to a specific record content. When
-	// absent or empty, the whole RRSet for (name, type) is deleted.
+	// absent or when content is empty, the whole RRSet for (name, type) is
+	// deleted.
 	body, _ := io.ReadAll(c.Request().Body)
-	if len(bytes.TrimSpace(body)) == 0 {
-		err = a.dnsService.DeleteRecord(reqCtx, zoneID, name, recordType)
-	} else {
+	if len(bytes.TrimSpace(body)) > 0 {
 		c.Request().Body = io.NopCloser(bytes.NewReader(body))
 		var req dto.RecordDeleteRequest
 		if _, ok := httputil.DecodeAndValidateRequest(ctx, &req); !ok {
 			return nil
 		}
-		err = a.dnsService.DeleteRecord(reqCtx, zoneID, name, recordType, req.Content)
+		if req.Content != "" {
+			err = a.dnsService.DeleteRecord(reqCtx, zoneID, name, recordType, req.Content)
+		} else {
+			err = a.dnsService.DeleteRecord(reqCtx, zoneID, name, recordType)
+		}
+	} else {
+		err = a.dnsService.DeleteRecord(reqCtx, zoneID, name, recordType)
 	}
 	if err != nil {
 		a.Logger().Error("Failed to delete DNS record", zap.Error(err), zap.String("name", name), zap.String("type", recordType))

--- a/internal/api/dto/dns.go
+++ b/internal/api/dto/dns.go
@@ -125,9 +125,11 @@ func (r ZoneListRequest) ToModel() (ZoneListRequest, error) {
 
 // DNSRecord represents a DNS record from PowerDNS
 // This is a data structure for API responses, records are managed entirely by PowerDNS
-// Records are identified by (name, type) within a zone, not by persistent IDs
+// ID is a compact synthesized identifier for the record value (see recordID);
+// it lets a caller target one record among several sharing the same name+type.
 type DNSRecord struct {
 	ZoneID   uint    `json:"zone_id"`
+	ID       string  `json:"id"`
 	Name     string  `json:"name"`
 	Type     string  `json:"type"`
 	Content  string  `json:"content"`
@@ -215,11 +217,34 @@ func (r RecordListRequest) ToModel() (RecordListRequest, error) {
 	return r, nil
 }
 
-// RecordIdentifier represents a DNS record identifier for deletion operations
+// RecordIdentifier represents a DNS record identifier for deletion operations.
+// Name+Type select the RRSet; an optional Content narrows the delete to a
+// specific record value (e.g. one TXT value among several at the same name).
+// When Content is empty the whole RRSet is deleted.
 type RecordIdentifier struct {
-	Name string `json:"name"`
-	Type string `json:"type"`
+	Name    string `json:"name"`
+	Type    string `json:"type"`
+	Content string `json:"content,omitempty"`
 }
+
+// RecordDeleteRequest is the optional body for a single DNS record delete. It
+// narrows the delete to a specific record content (e.g. one TXT value among
+// several at the same name); when Content is empty the whole RRSet is deleted.
+type RecordDeleteRequest struct {
+	Content string `json:"content,omitempty"`
+}
+
+func (r RecordDeleteRequest) Schema() *zog.StructSchema {
+	return zog.Struct(zog.Shape{
+		"Content": zog.String().Optional().Max(1024),
+	})
+}
+
+func (r *RecordDeleteRequest) ToModel() (*RecordDeleteRequest, error) {
+	return r, nil
+}
+
+var _ httputil.DTOValidator = (*RecordDeleteRequest)(nil)
 
 // BulkRecordRequest represents a request to bulk create/update DNS records
 type BulkRecordRequest struct {

--- a/internal/api/dto/dns_test.go
+++ b/internal/api/dto/dns_test.go
@@ -1,6 +1,7 @@
 package dto
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/Oudwins/zog"
@@ -539,6 +540,18 @@ func TestRecordIdentifier(t *testing.T) {
 		}
 		assert.Equal(t, "mail.example.com", ri.Name)
 		assert.Equal(t, "MX", ri.Type)
+	})
+
+	t.Run("record identifier carries optional content and omits it when empty", func(t *testing.T) {
+		ri := RecordIdentifier{Name: "@", Type: "TXT", Content: "v=spf1 include:mxroute.com -all"}
+		b, err := json.Marshal(ri)
+		assert.NoError(t, err)
+		assert.Contains(t, string(b), `"content"`)
+
+		empty := RecordIdentifier{Name: "@", Type: "TXT"}
+		b, err = json.Marshal(empty)
+		assert.NoError(t, err)
+		assert.NotContains(t, string(b), "content")
 	})
 }
 

--- a/internal/service/dns/dns_helpers.go
+++ b/internal/service/dns/dns_helpers.go
@@ -2,7 +2,11 @@ package dns
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/base64"
 	"fmt"
+	"io"
+	"strconv"
 	"strings"
 
 	"github.com/bwesterb/go-zonefile"
@@ -203,17 +207,37 @@ func buildRRSet(name, recordType string, changetype powerdns.RRSetChangetype, tt
 	}
 }
 
+// recordID returns a compact, deterministic identifier for a DNS record value,
+// stable within a zone and across TTL/disabled edits. It is computed over the
+// DTO form of the record (the Name as returned by stripDomain, the uppercased
+// Type, and the Content as returned by stripTXTQuotes), so the id a caller sees
+// in dns records list is the same id they can use to target the record for
+// deletion. The id is 8 bytes of a SHA-256, base64url-encoded (11 chars), to
+// stay short for CLI use.
+//
+// Limits (documented): two byte-identical (name, type, content) values within
+// one RRSet hash to the same id; changing the content changes the id.
+func recordID(zoneID uint, name, recordType, content string) string {
+	h := sha256.New()
+	_, _ = io.WriteString(h, strconv.FormatUint(uint64(zoneID), 10))
+	_, _ = io.WriteString(h, "\x00"+name+"\x00"+strings.ToUpper(recordType)+"\x00"+content)
+	return base64.RawURLEncoding.EncodeToString(h.Sum(nil)[:8])
+}
+
 // recordToDTOWithZoneID converts a PowerDNS RRSet and Record to an API DNSRecord DTO
 // It strips the domain from the record name and extracts TTL and disabled status
 // It populates all fields including ZoneID and timestamps
 func recordToDTOWithZoneID(rrset powerdns.RRSet, record powerdns.Record, zoneDomain string, zoneID uint) *apiDTO.DNSRecord {
+	name := stripDomain(rrset.Name, zoneDomain)
+	content := stripTXTQuotes(rrset.Type, record.Content)
 	return &apiDTO.DNSRecord{
 		ZoneID:   zoneID,
-		Name:     stripDomain(rrset.Name, zoneDomain),
+		Name:     name,
 		Type:     rrset.Type,
-		Content:  stripTXTQuotes(rrset.Type, record.Content),
+		Content:  content,
 		TTL:      uint(getTTL(rrset.Ttl)),
 		Disabled: getDisabled(record.Disabled),
+		ID:       recordID(zoneID, name, rrset.Type, content),
 	}
 }
 

--- a/internal/service/dns/dns_helpers_test.go
+++ b/internal/service/dns/dns_helpers_test.go
@@ -648,8 +648,9 @@ func TestRecordID(t *testing.T) {
 
 // TestRecordIDStableAcrossSurfaces guards that the same logical record hashes
 // to the same id whether surfaced through the read path (recordToDTOWithZoneID,
-// which uses stripDomain(buildFullName(name, domain))) or the update response
-// (UpdateRecord, which previously used the raw caller-supplied name).
+// which uses stripDomain(buildFullName(name, domain)) and stripTXTQuotes) or
+// the update response (UpdateRecord, which previously used the raw
+// caller-supplied name and content).
 func TestRecordIDStableAcrossSurfaces(t *testing.T) {
 	const zone = 12345
 	const domain = "example.com."
@@ -676,4 +677,13 @@ func TestRecordIDStableAcrossSurfaces(t *testing.T) {
 			assert.Equal(t, "www", dtoName)
 		}
 	}
+
+	// Id is stable across TXT quoting: UpdateRecord must normalize content with
+	// stripTXTQuotes before hashing, matching the read path, so a caller that
+	// passes an already-quoted TXT value still gets the same id as a read.
+	// Quoted and unquoted forms of the same TXT value collide onto one id.
+	const raw = "v=spf1 include:mxroute.com -all"
+	unquoted := recordID(zone, "www", "TXT", stripTXTQuotes("TXT", raw))
+	quoted := recordID(zone, "www", "TXT", stripTXTQuotes("TXT", "\""+raw+"\""))
+	assert.Equal(t, unquoted, quoted)
 }

--- a/internal/service/dns/dns_helpers_test.go
+++ b/internal/service/dns/dns_helpers_test.go
@@ -601,3 +601,47 @@ func TestFormatRecordContent(t *testing.T) {
 		})
 	}
 }
+
+func TestRecordID(t *testing.T) {
+	c := []struct {
+		name           string
+		zone           uint
+		n, ty, content string
+	}{
+		{"spf at apex", 12345, "@", "TXT", "v=spf1 include:mxroute.com -all"},
+		{"google verify", 12345, "@", "TXT", "google-site-verification=abc123xyz"},
+		{"mx 10", 12345, "@", "MX", "10 mail.example.com"},
+		{"mx 20", 12345, "@", "MX", "20 backup.example.com"},
+		{"a www 10", 12345, "www", "A", "192.0.2.10"},
+		{"a www 11", 12345, "www", "A", "192.0.2.11"},
+		{"same content different zone", 99999, "@", "TXT", "v=spf1 include:mxroute.com -all"},
+	}
+	// Distinct inputs must yield distinct ids where expected.
+	distinct := [][2]string{
+		{c[0].name, c[1].name},
+		{c[1].name, c[2].name},
+		{c[2].name, c[3].name},
+		{c[4].name, c[5].name},
+		{c[0].name, c[6].name}, // same content+name+type, different zone scope
+	}
+	ids := map[string]string{}
+	for _, tc := range c {
+		id := recordID(tc.zone, tc.n, tc.ty, tc.content)
+		// 11 chars, URL-safe base64.
+		assert.Len(t, id, 11, tc.name)
+		assert.Regexp(t, `^[A-Za-z0-9_-]{11}$`, id, tc.name)
+		ids[tc.name] = id
+		// Deterministic.
+		assert.Equal(t, id, recordID(tc.zone, tc.n, tc.ty, tc.content), tc.name)
+	}
+	for _, pair := range distinct {
+		assert.NotEqual(t, ids[pair[0]], ids[pair[1]], "%s vs %s", pair[0], pair[1])
+	}
+
+	// Type is case-insensitive in the hash: txt vs TXT yield the same id.
+	assert.Equal(t, ids["spf at apex"], recordID(12345, "@", "txt", "v=spf1 include:mxroute.com -all"))
+
+	// TTL/disabled are not part of the hash: recomputing with a different TTL
+	// is impossible via the signature (it only takes zone,name,type,content),
+	// so assert id is stable across a content-identical call (already above).
+}

--- a/internal/service/dns/dns_helpers_test.go
+++ b/internal/service/dns/dns_helpers_test.go
@@ -645,3 +645,35 @@ func TestRecordID(t *testing.T) {
 	// is impossible via the signature (it only takes zone,name,type,content),
 	// so assert id is stable across a content-identical call (already above).
 }
+
+// TestRecordIDStableAcrossSurfaces guards that the same logical record hashes
+// to the same id whether surfaced through the read path (recordToDTOWithZoneID,
+// which uses stripDomain(buildFullName(name, domain))) or the update response
+// (UpdateRecord, which previously used the raw caller-supplied name).
+func TestRecordIDStableAcrossSurfaces(t *testing.T) {
+	const zone = 12345
+	const domain = "example.com."
+
+	cases := []struct{ name string }{
+		{"@"}, {"www"},
+	}
+
+	for _, tc := range cases {
+		fullName, err := buildFullName(tc.name, domain)
+		assert.NoError(t, err)
+		dtoName := stripDomain(fullName, domain)
+
+		// Same id whether computed from the caller-supplied name (through the
+		// normalized DTO form) or from the read-back full RRSet name.
+		idFromUpdate := recordID(zone, dtoName, "TXT", "v=spf1 include:mxroute.com -all")
+		idFromRead := recordID(zone, stripDomain(fullName, domain), "TXT", "v=spf1 include:mxroute.com -all")
+		assert.Equal(t, idFromUpdate, idFromRead, "name=%q", tc.name)
+
+		// The normalized DTO name matches what recordToDTOWithZoneID exposes.
+		if tc.name == "@" {
+			assert.Equal(t, "", dtoName)
+		} else {
+			assert.Equal(t, "www", dtoName)
+		}
+	}
+}

--- a/internal/service/dns/dns_service_record.go
+++ b/internal/service/dns/dns_service_record.go
@@ -180,12 +180,13 @@ func (s *DNSServiceDefault) UpdateRecord(ctx context.Context, zoneID uint, name 
 		zap.String("type", recordType))
 
 	result := lo.Map(records, func(r string, _ int) *apiDTO.DNSRecord {
+		content := stripTXTQuotes(recordType, r)
 		return &apiDTO.DNSRecord{
 			ZoneID:   zoneID,
-			ID:       recordID(zoneID, dtoName, recordType, r),
+			ID:       recordID(zoneID, dtoName, recordType, content),
 			Name:     dtoName,
 			Type:     recordType,
-			Content:  r,
+			Content:  content,
 			TTL:      ttl,
 			Disabled: false,
 		}

--- a/internal/service/dns/dns_service_record.go
+++ b/internal/service/dns/dns_service_record.go
@@ -176,6 +176,8 @@ func (s *DNSServiceDefault) UpdateRecord(ctx context.Context, zoneID uint, name 
 
 	result := lo.Map(records, func(r string, _ int) *apiDTO.DNSRecord {
 		return &apiDTO.DNSRecord{
+			ZoneID:   zoneID,
+			ID:       recordID(zoneID, name, recordType, r),
 			Name:     name,
 			Type:     recordType,
 			Content:  r,
@@ -187,8 +189,11 @@ func (s *DNSServiceDefault) UpdateRecord(ctx context.Context, zoneID uint, name 
 	return result, nil
 }
 
-// DeleteRecord deletes a DNS RRSet from PowerDNS
-func (s *DNSServiceDefault) DeleteRecord(ctx context.Context, zoneID uint, name string, recordType string) error {
+// DeleteRecord deletes DNS records from PowerDNS. When no contents are given it
+// removes the entire RRSet (all records with the name+type). When one or more
+// contents are given it removes only the records whose content matches, leaving
+// sibling records untouched.
+func (s *DNSServiceDefault) DeleteRecord(ctx context.Context, zoneID uint, name string, recordType string, contents ...string) error {
 	ctx, span := core.TraceMethod(ctx, "DNSService.DeleteRecord")
 	defer span.End()
 
@@ -202,7 +207,14 @@ func (s *DNSServiceDefault) DeleteRecord(ctx context.Context, zoneID uint, name 
 		return fmt.Errorf("invalid record name: %w", err)
 	}
 
-	rrset := buildRRSet(fullName, recordType, powerdns.DELETE, nil, nil)
+	var records []powerdns.Record
+	if len(contents) > 0 {
+		records = lo.Map(contents, func(c string, _ int) powerdns.Record {
+			return powerdns.Record{Content: formatRecordContent(recordType, c)}
+		})
+	}
+
+	rrset := buildRRSet(fullName, recordType, powerdns.DELETE, nil, records)
 
 	err = s.pdnsClient.UpdateZoneRRSets(ctx, zone.PowerDNSZoneID, []powerdns.RRSet{rrset})
 	if err != nil {
@@ -216,7 +228,8 @@ func (s *DNSServiceDefault) DeleteRecord(ctx context.Context, zoneID uint, name 
 	s.Logger().Debug("DNS record deleted",
 		zap.Uint("zone_id", zoneID),
 		zap.String("name", name),
-		zap.String("type", recordType))
+		zap.String("type", recordType),
+		zap.Int("content_count", len(contents)))
 
 	return nil
 }
@@ -231,14 +244,20 @@ func (s *DNSServiceDefault) BulkDeleteRecords(ctx context.Context, zoneID uint, 
 		return nil, err
 	}
 
-	// Convert RecordIdentifiers to PowerDNS DELETE RRSet operations
+	// Convert RecordIdentifiers to PowerDNS DELETE RRSet operations. A
+	// RecordIdentifier with an optional Content removes only that value; one
+	// without Content removes the entire RRSet (all records for the name+type).
 	rrsets := make([]powerdns.RRSet, 0, len(records))
 	for _, r := range records {
 		fullName, err := buildFullName(r.Name, zone.Domain)
 		if err != nil {
 			return nil, fmt.Errorf("invalid record name %q: %w", r.Name, err)
 		}
-		rrsets = append(rrsets, buildRRSet(fullName, r.Type, powerdns.DELETE, nil, nil))
+		var recs []powerdns.Record
+		if r.Content != "" {
+			recs = []powerdns.Record{{Content: formatRecordContent(r.Type, r.Content)}}
+		}
+		rrsets = append(rrsets, buildRRSet(fullName, r.Type, powerdns.DELETE, nil, recs))
 	}
 
 	// If dryRun is true, return success results without actually deleting

--- a/internal/service/dns/dns_service_record.go
+++ b/internal/service/dns/dns_service_record.go
@@ -154,6 +154,11 @@ func (s *DNSServiceDefault) UpdateRecord(ctx context.Context, zoneID uint, name 
 		return nil, fmt.Errorf("invalid record name: %w", err)
 	}
 
+	// Normalize to the DTO form used by the list/GetRRSet read paths so a
+	// record surfaces with the same Name and ID whether it comes from an
+	// update response or a subsequent read (e.g. "www" / "" for apex).
+	dtoName := stripDomain(fullName, zone.Domain)
+
 	pdnsRecords := lo.Map(records, func(r string, _ int) powerdns.Record {
 		return powerdns.Record{Content: formatRecordContent(recordType, r)}
 	})
@@ -177,8 +182,8 @@ func (s *DNSServiceDefault) UpdateRecord(ctx context.Context, zoneID uint, name 
 	result := lo.Map(records, func(r string, _ int) *apiDTO.DNSRecord {
 		return &apiDTO.DNSRecord{
 			ZoneID:   zoneID,
-			ID:       recordID(zoneID, name, recordType, r),
-			Name:     name,
+			ID:       recordID(zoneID, dtoName, recordType, r),
+			Name:     dtoName,
 			Type:     recordType,
 			Content:  r,
 			TTL:      ttl,

--- a/internal/service/dns/dns_service_test.go
+++ b/internal/service/dns/dns_service_test.go
@@ -1286,3 +1286,174 @@ func TestDNSServiceEnableDNSSEC(t *testing.T) {
 		}, testOptions)
 	})
 }
+
+// TestDNSServiceDeleteRecordContentScoped guards that DeleteRecord with one or
+// more contents sends a content-scoped PowerDNS DELETE RRSet (only those
+// values listed), while DeleteRecord with no contents sends an empty-records
+// DELETE RRSet (the whole RRSet).
+func TestDNSServiceDeleteRecordContentScoped(t *testing.T) {
+	mux := http.NewServeMux()
+
+	// Zone creation.
+	mux.HandleFunc("POST /servers/localhost/zones", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(powerdns.Zone{
+			Id:   new("example.com."),
+			Name: new("example.com."),
+			Kind: (*powerdns.ZoneKind)(new("Native")),
+		})
+	})
+
+	// Zone retrieval (needed by CreateRecord's post-create fetch).
+	mux.HandleFunc("GET /servers/localhost/zones/example.com.", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(powerdns.Zone{
+			Id:     new("example.com."),
+			Name:   new("example.com."),
+			Kind:   (*powerdns.ZoneKind)(new("Native")),
+			Rrsets: &[]powerdns.RRSet{},
+		})
+	})
+
+	var captured []powerdns.RRSet
+	// Capture the rrsets from a PATCH (used by UpdateZoneRRSets).
+	mux.HandleFunc("PATCH /servers/localhost/zones/example.com.", func(w http.ResponseWriter, r *http.Request) {
+		var patch powerdns.ZonePatch
+		if err := json.NewDecoder(r.Body).Decode(&patch); err != nil {
+			t.Errorf("failed to decode PATCH body: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if patch.Rrsets != nil {
+			captured = append(captured, *patch.Rrsets...)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	testOptions := createTestOptionsWithServer(server)
+
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		svc := core.GetService[*DNSServiceDefault](ctx, pluginCore.DNS_SERVICE)
+		require.NotNil(tb, svc)
+
+		zone, err := svc.CreateZone(ctx, "example.com.", 1)
+		require.NoError(tb, err)
+		require.NotNil(tb, zone)
+
+		t.Run("no content deletes whole RRSet", func(t *testing.T) {
+			captured = nil
+			err := svc.DeleteRecord(ctx, zone.ID, "www", "A")
+			require.NoError(tb, err)
+			require.Len(tb, captured, 1)
+			rrset := captured[0]
+			require.Equal(t, "DELETE", string(rrset.Changetype))
+			require.Equal(t, "www.example.com.", rrset.Name)
+			require.Equal(t, "A", rrset.Type)
+			require.Len(tb, rrset.Records, 0)
+		})
+
+		t.Run("content deletes only that value", func(t *testing.T) {
+			captured = nil
+			err := svc.DeleteRecord(ctx, zone.ID, "www", "TXT", "v=spf1 include:mxroute.com -all")
+			require.NoError(tb, err)
+			require.Len(tb, captured, 1)
+			rrset := captured[0]
+			require.Equal(t, "DELETE", string(rrset.Changetype))
+			require.Len(tb, rrset.Records, 1)
+			// TXT content is quoted for the PowerDNS wire.
+			require.Equal(t, `"v=spf1 include:mxroute.com -all"`, rrset.Records[0].Content)
+		})
+
+		t.Run("multiple contents delete each value", func(t *testing.T) {
+			captured = nil
+			err := svc.DeleteRecord(ctx, zone.ID, "@", "MX",
+				"10 mail.example.com", "20 backup.example.com")
+			require.NoError(tb, err)
+			require.Len(tb, captured, 1)
+			rrset := captured[0]
+			require.Equal(t, "DELETE", string(rrset.Changetype))
+			require.Len(tb, rrset.Records, 2)
+		})
+	}, testOptions)
+}
+
+// TestDNSServiceBulkDeleteRecordsContentScoped guards that BulkDeleteRecords
+// sends a content-scoped PowerDNS DELETE RRSet when a RecordIdentifier carries
+// Content, and a whole-RRSet DELETE when it does not.
+func TestDNSServiceBulkDeleteRecordsContentScoped(t *testing.T) {
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("POST /servers/localhost/zones", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(powerdns.Zone{
+			Id:   new("example.com."),
+			Name: new("example.com."),
+			Kind: (*powerdns.ZoneKind)(new("Native")),
+		})
+	})
+	mux.HandleFunc("GET /servers/localhost/zones/example.com.", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(powerdns.Zone{
+			Id:     new("example.com."),
+			Name:   new("example.com."),
+			Kind:   (*powerdns.ZoneKind)(new("Native")),
+			Rrsets: &[]powerdns.RRSet{},
+		})
+	})
+
+	var captured []powerdns.RRSet
+	mux.HandleFunc("PATCH /servers/localhost/zones/example.com.", func(w http.ResponseWriter, r *http.Request) {
+		var patch powerdns.ZonePatch
+		if err := json.NewDecoder(r.Body).Decode(&patch); err != nil {
+			t.Errorf("failed to decode PATCH body: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if patch.Rrsets != nil {
+			captured = append(captured, *patch.Rrsets...)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	testOptions := createTestOptionsWithServer(server)
+
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		svc := core.GetService[*DNSServiceDefault](ctx, pluginCore.DNS_SERVICE)
+		require.NotNil(tb, svc)
+
+		zone, err := svc.CreateZone(ctx, "example.com.", 1)
+		require.NoError(tb, err)
+		require.NotNil(tb, zone)
+
+		captured = nil
+		records := []apiDTO.RecordIdentifier{
+			{Name: "@", Type: "TXT"}, // whole RRSet
+			{Name: "@", Type: "TXT", Content: "v=spf1 include:mxroute.com -all"}, // content-scoped
+		}
+		response, err := svc.BulkDeleteRecords(ctx, zone.ID, 1, records, false)
+		require.NoError(tb, err)
+		require.NotNil(tb, response)
+		require.Len(tb, response.Results, 2)
+
+		require.Len(tb, captured, 2)
+
+		// First: no content -> whole RRSet (no records listed).
+		require.Equal(t, "DELETE", string(captured[0].Changetype))
+		require.Len(tb, captured[0].Records, 0)
+
+		// Second: content -> only that value listed (TXT quoted on the wire).
+		require.Equal(t, "DELETE", string(captured[1].Changetype))
+		require.Len(tb, captured[1].Records, 1)
+		require.Equal(t, `"v=spf1 include:mxroute.com -all"`, captured[1].Records[0].Content)
+	}, testOptions)
+}

--- a/internal/testing/mocks/MockDNSService.go
+++ b/internal/testing/mocks/MockDNSService.go
@@ -83,7 +83,7 @@ type MockDNSService_BulkDeleteRecords_Call struct {
 //   - userID uint
 //   - records []dto.RecordIdentifier
 //   - dryRun bool
-func (_e *MockDNSService_Expecter) BulkDeleteRecords(ctx any, zoneID any, userID any, records any, dryRun any) *MockDNSService_BulkDeleteRecords_Call {
+func (_e *MockDNSService_Expecter) BulkDeleteRecords(ctx interface{}, zoneID interface{}, userID interface{}, records interface{}, dryRun interface{}) *MockDNSService_BulkDeleteRecords_Call {
 	return &MockDNSService_BulkDeleteRecords_Call{Call: _e.mock.On("BulkDeleteRecords", ctx, zoneID, userID, records, dryRun)}
 }
 
@@ -250,7 +250,7 @@ type MockDNSService_CreateApexRecord_Call struct {
 //   - domain string
 //   - recordType core0.RecordType
 //   - content string
-func (_e *MockDNSService_Expecter) CreateApexRecord(ctx any, zoneID any, domain any, recordType any, content any) *MockDNSService_CreateApexRecord_Call {
+func (_e *MockDNSService_Expecter) CreateApexRecord(ctx interface{}, zoneID interface{}, domain interface{}, recordType interface{}, content interface{}) *MockDNSService_CreateApexRecord_Call {
 	return &MockDNSService_CreateApexRecord_Call{Call: _e.mock.On("CreateApexRecord", ctx, zoneID, domain, recordType, content)}
 }
 
@@ -324,7 +324,7 @@ type MockDNSService_CreateDNSLinkRecord_Call struct {
 //   - zoneID uint
 //   - domain string
 //   - target string
-func (_e *MockDNSService_Expecter) CreateDNSLinkRecord(ctx any, zoneID any, domain any, target any) *MockDNSService_CreateDNSLinkRecord_Call {
+func (_e *MockDNSService_Expecter) CreateDNSLinkRecord(ctx interface{}, zoneID interface{}, domain interface{}, target interface{}) *MockDNSService_CreateDNSLinkRecord_Call {
 	return &MockDNSService_CreateDNSLinkRecord_Call{Call: _e.mock.On("CreateDNSLinkRecord", ctx, zoneID, domain, target)}
 }
 
@@ -406,7 +406,7 @@ type MockDNSService_CreateRecord_Call struct {
 //   - recordType string
 //   - content string
 //   - ttl uint
-func (_e *MockDNSService_Expecter) CreateRecord(ctx any, zoneID any, name any, recordType any, content any, ttl any) *MockDNSService_CreateRecord_Call {
+func (_e *MockDNSService_Expecter) CreateRecord(ctx interface{}, zoneID interface{}, name interface{}, recordType interface{}, content interface{}, ttl interface{}) *MockDNSService_CreateRecord_Call {
 	return &MockDNSService_CreateRecord_Call{Call: _e.mock.On("CreateRecord", ctx, zoneID, name, recordType, content, ttl)}
 }
 
@@ -487,7 +487,7 @@ type MockDNSService_CreateWebsiteDNSRecords_Call struct {
 //   - targetHash string
 //   - targetType db.WebsiteTargetType
 //   - validationToken string
-func (_e *MockDNSService_Expecter) CreateWebsiteDNSRecords(ctx any, zoneID any, websiteDomain any, targetHash any, targetType any, validationToken any) *MockDNSService_CreateWebsiteDNSRecords_Call {
+func (_e *MockDNSService_Expecter) CreateWebsiteDNSRecords(ctx interface{}, zoneID interface{}, websiteDomain interface{}, targetHash interface{}, targetType interface{}, validationToken interface{}) *MockDNSService_CreateWebsiteDNSRecords_Call {
 	return &MockDNSService_CreateWebsiteDNSRecords_Call{Call: _e.mock.On("CreateWebsiteDNSRecords", ctx, zoneID, websiteDomain, targetHash, targetType, validationToken)}
 }
 
@@ -566,7 +566,7 @@ type MockDNSService_CreateWebsiteValidationRecord_Call struct {
 //   - zoneID uint
 //   - websiteDomain string
 //   - validationToken string
-func (_e *MockDNSService_Expecter) CreateWebsiteValidationRecord(ctx any, zoneID any, websiteDomain any, validationToken any) *MockDNSService_CreateWebsiteValidationRecord_Call {
+func (_e *MockDNSService_Expecter) CreateWebsiteValidationRecord(ctx interface{}, zoneID interface{}, websiteDomain interface{}, validationToken interface{}) *MockDNSService_CreateWebsiteValidationRecord_Call {
 	return &MockDNSService_CreateWebsiteValidationRecord_Call{Call: _e.mock.On("CreateWebsiteValidationRecord", ctx, zoneID, websiteDomain, validationToken)}
 }
 
@@ -645,7 +645,7 @@ type MockDNSService_CreateZone_Call struct {
 //   - ctx context.Context
 //   - domain string
 //   - userID uint
-func (_e *MockDNSService_Expecter) CreateZone(ctx any, domain any, userID any) *MockDNSService_CreateZone_Call {
+func (_e *MockDNSService_Expecter) CreateZone(ctx interface{}, domain interface{}, userID interface{}) *MockDNSService_CreateZone_Call {
 	return &MockDNSService_CreateZone_Call{Call: _e.mock.On("CreateZone", ctx, domain, userID)}
 }
 
@@ -762,8 +762,9 @@ type MockDNSService_DeleteRecord_Call struct {
 //   - name string
 //   - recordType string
 //   - contents ...string
-func (_e *MockDNSService_Expecter) DeleteRecord(ctx any, zoneID any, name any, recordType any, contents ...any) *MockDNSService_DeleteRecord_Call {
-	return &MockDNSService_DeleteRecord_Call{Call: _e.mock.On("DeleteRecord", append([]any{ctx, zoneID, name, recordType}, contents...)...)}
+func (_e *MockDNSService_Expecter) DeleteRecord(ctx interface{}, zoneID interface{}, name interface{}, recordType interface{}, contents ...interface{}) *MockDNSService_DeleteRecord_Call {
+	return &MockDNSService_DeleteRecord_Call{Call: _e.mock.On("DeleteRecord",
+		append([]interface{}{ctx, zoneID, name, recordType}, contents...)...)}
 }
 
 func (_c *MockDNSService_DeleteRecord_Call) Run(run func(ctx context.Context, zoneID uint, name string, recordType string, contents ...string)) *MockDNSService_DeleteRecord_Call {
@@ -785,9 +786,11 @@ func (_c *MockDNSService_DeleteRecord_Call) Run(run func(ctx context.Context, zo
 			arg3 = args[3].(string)
 		}
 		var arg4 []string
-		if args[4] != nil {
-			arg4 = args[4].([]string)
+		var variadicArgs []string
+		if len(args) > 4 {
+			variadicArgs = args[4].([]string)
 		}
+		arg4 = variadicArgs
 		run(
 			arg0,
 			arg1,
@@ -835,7 +838,7 @@ type MockDNSService_DeleteWebsiteDNSRecords_Call struct {
 //   - ctx context.Context
 //   - zoneID uint
 //   - websiteDomain string
-func (_e *MockDNSService_Expecter) DeleteWebsiteDNSRecords(ctx any, zoneID any, websiteDomain any) *MockDNSService_DeleteWebsiteDNSRecords_Call {
+func (_e *MockDNSService_Expecter) DeleteWebsiteDNSRecords(ctx interface{}, zoneID interface{}, websiteDomain interface{}) *MockDNSService_DeleteWebsiteDNSRecords_Call {
 	return &MockDNSService_DeleteWebsiteDNSRecords_Call{Call: _e.mock.On("DeleteWebsiteDNSRecords", ctx, zoneID, websiteDomain)}
 }
 
@@ -898,7 +901,7 @@ type MockDNSService_DeleteWebsiteValidationRecord_Call struct {
 //   - ctx context.Context
 //   - zoneID uint
 //   - websiteDomain string
-func (_e *MockDNSService_Expecter) DeleteWebsiteValidationRecord(ctx any, zoneID any, websiteDomain any) *MockDNSService_DeleteWebsiteValidationRecord_Call {
+func (_e *MockDNSService_Expecter) DeleteWebsiteValidationRecord(ctx interface{}, zoneID interface{}, websiteDomain interface{}) *MockDNSService_DeleteWebsiteValidationRecord_Call {
 	return &MockDNSService_DeleteWebsiteValidationRecord_Call{Call: _e.mock.On("DeleteWebsiteValidationRecord", ctx, zoneID, websiteDomain)}
 }
 
@@ -960,7 +963,7 @@ type MockDNSService_DeleteZone_Call struct {
 // DeleteZone is a helper method to define mock.On call
 //   - ctx context.Context
 //   - zoneID uint
-func (_e *MockDNSService_Expecter) DeleteZone(ctx any, zoneID any) *MockDNSService_DeleteZone_Call {
+func (_e *MockDNSService_Expecter) DeleteZone(ctx interface{}, zoneID interface{}) *MockDNSService_DeleteZone_Call {
 	return &MockDNSService_DeleteZone_Call{Call: _e.mock.On("DeleteZone", ctx, zoneID)}
 }
 
@@ -1026,7 +1029,7 @@ type MockDNSService_EnableDNSSEC_Call struct {
 // EnableDNSSEC is a helper method to define mock.On call
 //   - ctx context.Context
 //   - zoneID uint
-func (_e *MockDNSService_Expecter) EnableDNSSEC(ctx any, zoneID any) *MockDNSService_EnableDNSSEC_Call {
+func (_e *MockDNSService_Expecter) EnableDNSSEC(ctx interface{}, zoneID interface{}) *MockDNSService_EnableDNSSEC_Call {
 	return &MockDNSService_EnableDNSSEC_Call{Call: _e.mock.On("EnableDNSSEC", ctx, zoneID)}
 }
 
@@ -1085,7 +1088,7 @@ type MockDNSService_EnsureSOAMNAME_Call struct {
 //   - zoneID uint
 //   - domain string
 //   - nameservers []string
-func (_e *MockDNSService_Expecter) EnsureSOAMNAME(ctx any, zoneID any, domain any, nameservers any) *MockDNSService_EnsureSOAMNAME_Call {
+func (_e *MockDNSService_Expecter) EnsureSOAMNAME(ctx interface{}, zoneID interface{}, domain interface{}, nameservers interface{}) *MockDNSService_EnsureSOAMNAME_Call {
 	return &MockDNSService_EnsureSOAMNAME_Call{Call: _e.mock.On("EnsureSOAMNAME", ctx, zoneID, domain, nameservers)}
 }
 
@@ -1161,7 +1164,7 @@ type MockDNSService_GetActiveDNSSECDS_Call struct {
 // GetActiveDNSSECDS is a helper method to define mock.On call
 //   - ctx context.Context
 //   - zoneID uint
-func (_e *MockDNSService_Expecter) GetActiveDNSSECDS(ctx any, zoneID any) *MockDNSService_GetActiveDNSSECDS_Call {
+func (_e *MockDNSService_Expecter) GetActiveDNSSECDS(ctx interface{}, zoneID interface{}) *MockDNSService_GetActiveDNSSECDS_Call {
 	return &MockDNSService_GetActiveDNSSECDS_Call{Call: _e.mock.On("GetActiveDNSSECDS", ctx, zoneID)}
 }
 
@@ -1286,7 +1289,7 @@ type MockDNSService_GetRRSet_Call struct {
 //   - zoneID uint
 //   - name string
 //   - recordType string
-func (_e *MockDNSService_Expecter) GetRRSet(ctx any, zoneID any, name any, recordType any) *MockDNSService_GetRRSet_Call {
+func (_e *MockDNSService_Expecter) GetRRSet(ctx interface{}, zoneID interface{}, name interface{}, recordType interface{}) *MockDNSService_GetRRSet_Call {
 	return &MockDNSService_GetRRSet_Call{Call: _e.mock.On("GetRRSet", ctx, zoneID, name, recordType)}
 }
 
@@ -1364,7 +1367,7 @@ type MockDNSService_GetZone_Call struct {
 // GetZone is a helper method to define mock.On call
 //   - ctx context.Context
 //   - zoneID uint
-func (_e *MockDNSService_Expecter) GetZone(ctx any, zoneID any) *MockDNSService_GetZone_Call {
+func (_e *MockDNSService_Expecter) GetZone(ctx interface{}, zoneID interface{}) *MockDNSService_GetZone_Call {
 	return &MockDNSService_GetZone_Call{Call: _e.mock.On("GetZone", ctx, zoneID)}
 }
 
@@ -1432,7 +1435,7 @@ type MockDNSService_GetZoneByDomain_Call struct {
 // GetZoneByDomain is a helper method to define mock.On call
 //   - ctx context.Context
 //   - domain string
-func (_e *MockDNSService_Expecter) GetZoneByDomain(ctx any, domain any) *MockDNSService_GetZoneByDomain_Call {
+func (_e *MockDNSService_Expecter) GetZoneByDomain(ctx interface{}, domain interface{}) *MockDNSService_GetZoneByDomain_Call {
 	return &MockDNSService_GetZoneByDomain_Call{Call: _e.mock.On("GetZoneByDomain", ctx, domain)}
 }
 
@@ -1509,7 +1512,7 @@ type MockDNSService_GetZoneRecords_Call struct {
 //   - filters []queryutil.CrudFilter
 //   - sorts []queryutil.Sort
 //   - pagination queryutil.Pagination
-func (_e *MockDNSService_Expecter) GetZoneRecords(ctx any, zoneID any, filters any, sorts any, pagination any) *MockDNSService_GetZoneRecords_Call {
+func (_e *MockDNSService_Expecter) GetZoneRecords(ctx interface{}, zoneID interface{}, filters interface{}, sorts interface{}, pagination interface{}) *MockDNSService_GetZoneRecords_Call {
 	return &MockDNSService_GetZoneRecords_Call{Call: _e.mock.On("GetZoneRecords", ctx, zoneID, filters, sorts, pagination)}
 }
 
@@ -1644,7 +1647,7 @@ type MockDNSService_ListZones_Call struct {
 //   - filters []queryutil.CrudFilter
 //   - sorts []queryutil.Sort
 //   - pagination queryutil.Pagination
-func (_e *MockDNSService_Expecter) ListZones(ctx any, filters any, sorts any, pagination any) *MockDNSService_ListZones_Call {
+func (_e *MockDNSService_Expecter) ListZones(ctx interface{}, filters interface{}, sorts interface{}, pagination interface{}) *MockDNSService_ListZones_Call {
 	return &MockDNSService_ListZones_Call{Call: _e.mock.On("ListZones", ctx, filters, sorts, pagination)}
 }
 
@@ -1745,7 +1748,7 @@ type MockDNSService_SetConfig_Call struct {
 
 // SetConfig is a helper method to define mock.On call
 //   - cfg config.Manager
-func (_e *MockDNSService_Expecter) SetConfig(cfg any) *MockDNSService_SetConfig_Call {
+func (_e *MockDNSService_Expecter) SetConfig(cfg interface{}) *MockDNSService_SetConfig_Call {
 	return &MockDNSService_SetConfig_Call{Call: _e.mock.On("SetConfig", cfg)}
 }
 
@@ -1785,7 +1788,7 @@ type MockDNSService_SetContext_Call struct {
 
 // SetContext is a helper method to define mock.On call
 //   - ctx core.Context
-func (_e *MockDNSService_Expecter) SetContext(ctx any) *MockDNSService_SetContext_Call {
+func (_e *MockDNSService_Expecter) SetContext(ctx interface{}) *MockDNSService_SetContext_Call {
 	return &MockDNSService_SetContext_Call{Call: _e.mock.On("SetContext", ctx)}
 }
 
@@ -1825,7 +1828,7 @@ type MockDNSService_SetDB_Call struct {
 
 // SetDB is a helper method to define mock.On call
 //   - db1 *gorm.DB
-func (_e *MockDNSService_Expecter) SetDB(db1 any) *MockDNSService_SetDB_Call {
+func (_e *MockDNSService_Expecter) SetDB(db1 interface{}) *MockDNSService_SetDB_Call {
 	return &MockDNSService_SetDB_Call{Call: _e.mock.On("SetDB", db1)}
 }
 
@@ -1865,7 +1868,7 @@ type MockDNSService_SetLogger_Call struct {
 
 // SetLogger is a helper method to define mock.On call
 //   - logger *core.Logger
-func (_e *MockDNSService_Expecter) SetLogger(logger any) *MockDNSService_SetLogger_Call {
+func (_e *MockDNSService_Expecter) SetLogger(logger interface{}) *MockDNSService_SetLogger_Call {
 	return &MockDNSService_SetLogger_Call{Call: _e.mock.On("SetLogger", logger)}
 }
 
@@ -1919,7 +1922,7 @@ type MockDNSService_SetTLSARecord_Call struct {
 //   - zoneID uint
 //   - domain string
 //   - content string
-func (_e *MockDNSService_Expecter) SetTLSARecord(ctx any, zoneID any, domain any, content any) *MockDNSService_SetTLSARecord_Call {
+func (_e *MockDNSService_Expecter) SetTLSARecord(ctx interface{}, zoneID interface{}, domain interface{}, content interface{}) *MockDNSService_SetTLSARecord_Call {
 	return &MockDNSService_SetTLSARecord_Call{Call: _e.mock.On("SetTLSARecord", ctx, zoneID, domain, content)}
 }
 
@@ -2001,7 +2004,7 @@ type MockDNSService_UpdateRecord_Call struct {
 //   - recordType string
 //   - records []string
 //   - ttl uint
-func (_e *MockDNSService_Expecter) UpdateRecord(ctx any, zoneID any, name any, recordType any, records any, ttl any) *MockDNSService_UpdateRecord_Call {
+func (_e *MockDNSService_Expecter) UpdateRecord(ctx interface{}, zoneID interface{}, name interface{}, recordType interface{}, records interface{}, ttl interface{}) *MockDNSService_UpdateRecord_Call {
 	return &MockDNSService_UpdateRecord_Call{Call: _e.mock.On("UpdateRecord", ctx, zoneID, name, recordType, records, ttl)}
 }
 
@@ -2081,7 +2084,7 @@ type MockDNSService_UpdateWebsiteDNSRecords_Call struct {
 //   - websiteDomain string
 //   - targetHash string
 //   - targetType db.WebsiteTargetType
-func (_e *MockDNSService_Expecter) UpdateWebsiteDNSRecords(ctx any, zoneID any, websiteDomain any, targetHash any, targetType any) *MockDNSService_UpdateWebsiteDNSRecords_Call {
+func (_e *MockDNSService_Expecter) UpdateWebsiteDNSRecords(ctx interface{}, zoneID interface{}, websiteDomain interface{}, targetHash interface{}, targetType interface{}) *MockDNSService_UpdateWebsiteDNSRecords_Call {
 	return &MockDNSService_UpdateWebsiteDNSRecords_Call{Call: _e.mock.On("UpdateWebsiteDNSRecords", ctx, zoneID, websiteDomain, targetHash, targetType)}
 }
 
@@ -2154,7 +2157,7 @@ type MockDNSService_UpdateZone_Call struct {
 //   - ctx context.Context
 //   - zoneID uint
 //   - status db.DNSZoneStatus
-func (_e *MockDNSService_Expecter) UpdateZone(ctx any, zoneID any, status any) *MockDNSService_UpdateZone_Call {
+func (_e *MockDNSService_Expecter) UpdateZone(ctx interface{}, zoneID interface{}, status interface{}) *MockDNSService_UpdateZone_Call {
 	return &MockDNSService_UpdateZone_Call{Call: _e.mock.On("UpdateZone", ctx, zoneID, status)}
 }
 
@@ -2225,7 +2228,7 @@ type MockDNSService_ValidateNameservers_Call struct {
 // ValidateNameservers is a helper method to define mock.On call
 //   - ctx context.Context
 //   - zoneID uint
-func (_e *MockDNSService_Expecter) ValidateNameservers(ctx any, zoneID any) *MockDNSService_ValidateNameservers_Call {
+func (_e *MockDNSService_Expecter) ValidateNameservers(ctx interface{}, zoneID interface{}) *MockDNSService_ValidateNameservers_Call {
 	return &MockDNSService_ValidateNameservers_Call{Call: _e.mock.On("ValidateNameservers", ctx, zoneID)}
 }
 

--- a/internal/testing/mocks/MockDNSService.go
+++ b/internal/testing/mocks/MockDNSService.go
@@ -729,16 +729,22 @@ func (_c *MockDNSService_DB_Call) RunAndReturn(run func() *gorm.DB) *MockDNSServ
 }
 
 // DeleteRecord provides a mock function for the type MockDNSService
-func (_mock *MockDNSService) DeleteRecord(ctx context.Context, zoneID uint, name string, recordType string) error {
-	ret := _mock.Called(ctx, zoneID, name, recordType)
+func (_mock *MockDNSService) DeleteRecord(ctx context.Context, zoneID uint, name string, recordType string, contents ...string) error {
+	var tmpRet mock.Arguments
+	if len(contents) > 0 {
+		tmpRet = _mock.Called(ctx, zoneID, name, recordType, contents)
+	} else {
+		tmpRet = _mock.Called(ctx, zoneID, name, recordType)
+	}
+	ret := tmpRet
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteRecord")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, uint, string, string) error); ok {
-		r0 = returnFunc(ctx, zoneID, name, recordType)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uint, string, string, ...string) error); ok {
+		r0 = returnFunc(ctx, zoneID, name, recordType, contents...)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -755,11 +761,12 @@ type MockDNSService_DeleteRecord_Call struct {
 //   - zoneID uint
 //   - name string
 //   - recordType string
-func (_e *MockDNSService_Expecter) DeleteRecord(ctx any, zoneID any, name any, recordType any) *MockDNSService_DeleteRecord_Call {
-	return &MockDNSService_DeleteRecord_Call{Call: _e.mock.On("DeleteRecord", ctx, zoneID, name, recordType)}
+//   - contents ...string
+func (_e *MockDNSService_Expecter) DeleteRecord(ctx any, zoneID any, name any, recordType any, contents ...any) *MockDNSService_DeleteRecord_Call {
+	return &MockDNSService_DeleteRecord_Call{Call: _e.mock.On("DeleteRecord", append([]any{ctx, zoneID, name, recordType}, contents...)...)}
 }
 
-func (_c *MockDNSService_DeleteRecord_Call) Run(run func(ctx context.Context, zoneID uint, name string, recordType string)) *MockDNSService_DeleteRecord_Call {
+func (_c *MockDNSService_DeleteRecord_Call) Run(run func(ctx context.Context, zoneID uint, name string, recordType string, contents ...string)) *MockDNSService_DeleteRecord_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -777,11 +784,16 @@ func (_c *MockDNSService_DeleteRecord_Call) Run(run func(ctx context.Context, zo
 		if args[3] != nil {
 			arg3 = args[3].(string)
 		}
+		var arg4 []string
+		if args[4] != nil {
+			arg4 = args[4].([]string)
+		}
 		run(
 			arg0,
 			arg1,
 			arg2,
 			arg3,
+			arg4...,
 		)
 	})
 	return _c
@@ -792,7 +804,7 @@ func (_c *MockDNSService_DeleteRecord_Call) Return(err error) *MockDNSService_De
 	return _c
 }
 
-func (_c *MockDNSService_DeleteRecord_Call) RunAndReturn(run func(ctx context.Context, zoneID uint, name string, recordType string) error) *MockDNSService_DeleteRecord_Call {
+func (_c *MockDNSService_DeleteRecord_Call) RunAndReturn(run func(ctx context.Context, zoneID uint, name string, recordType string, contents ...string) error) *MockDNSService_DeleteRecord_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
## Summary

Makes DNS record deletion content-scoped so a caller can remove a single record among several sharing the same name+type (e.g. one TXT/SPF/MX value), instead of always deleting the entire RRSet.

### What changed

- **Synthesized record ID**: each record value in a zone now has a compact, deterministic `id` (11 base64url chars, a hash of `zone + name + type + content`), surfaced on the `DNSRecord` DTO. It lets a caller target one record among duplicates and is stable across TTL/disabled edits.
- **`DeleteRecord` accepts optional content(s)**: when contents are supplied it sends a PowerDNS `DELETE` RRSet listing only those values (removing just them); with no contents it retains the existing whole-RRSet delete. Backward compatible.
- **`RecordIdentifier` carries optional `Content`** for bulk-delete, so bulk delete can also be content-scoped.
- **API wiring**: `DELETE .../records/{name}/{type}` accepts an optional `{ "content": "..." }` body; bulk delete passes `RecordIdentifier.Content` through.

### Files

- `core/dns.go` — `DNSService.DeleteRecord` interface accepts content(s)
- `internal/service/dns/dns_helpers.go` — `recordID`, DTO id population
- `internal/service/dns/dns_service_record.go` — content-scoped `DeleteRecord` / `BulkDeleteRecords`
- `internal/api/api_dns.go` — delete route binds optional body
- `internal/api/dto/dns.go` — `DNSRecord.id`, `RecordIdentifier.Content`, `RecordDeleteRequest`

### Tests

- `recordID`: 11-char URL-safe output, determinism, distinct inputs → distinct ids, type case-insensitivity, zone scoping
- `DeleteRecord`: no content → whole RRSet; content → only that value (TXT quoted on the wire); multiple contents → each value
- `BulkDeleteRecords`: content-scoped vs whole-RRSet identifiers build the right RRSets

### Notes

- Implemented PowerDNS partial delete via a `DELETE` RRSet carrying the specific records, which PowerDNS supports; the API base delete path (`DeleteZone`, etc.) is unchanged.
- The pre-existing `internal/api` test-suite failure is an unrelated protobuf namespace conflict (`go-libp2p-pubsub` vs `go.etcd.io/etcd`) present on develop; `internal/service/dns` and `internal/api/dto` pass.

* `develop` <!-- branch-stack -->
  - **feat(dns): content-scoped record delete** :point\_left:

***

<!-- kody-pr-summary:start -->

## Summary

This pull request introduces content-scoped DNS record deletion, allowing users to selectively delete individual DNS records (e.g., a single TXT value among several at the same hostname) instead of only being able to delete the entire RRSet (all records with the same name and type).

## Key Changes

### 1. Content-Scoped Deletion Support

- **`DeleteRecord` interface/service method** now accepts optional `contents ...string` parameters:
  - When no contents are provided, the entire RRSet for a given (name, type) is deleted (existing behavior).
  - When one or more contents are provided, only those specific record values are deleted, leaving sibling records untouched.
- **`BulkDeleteRecords`** similarly supports an optional `Content` field on `RecordIdentifier` to narrow deletion to a specific record value.

### 2. API DTO Updates

- **`DNSRecord` DTO** now includes an `ID` field.
- **`RecordIdentifier`** now has an optional `Content` field (omitted when empty in JSON).
- New **`RecordDeleteRequest`** DTO with schema validation allows passing an optional body to the single-record delete endpoint to narrow deletion to specific record content.

### 3. Record ID Generation

- New `recordID` function generates a compact, deterministic identifier (11 chars, base64url-encoded SHA-256 hash) for each DNS record value.
- The ID is based on zone ID, record name, type, and content — stable within a zone and across TTL/disabled edits.
- The ID is now included in API responses (`DNSRecord.ID`) so callers can target a specific record among multiple with the same name+type.
- **Limitation documented**: two byte-identical (name, type, content) values within one RRSet hash to the same ID.

### 4. API Endpoint Behavior

- The single-record delete endpoint now optionally reads the request body:
  - Empty/absent body → deletes the whole RRSet.
  - Body with content → deletes only that specific record value.

## Tests Added

- Test verifying content-scoped `DeleteRecord` sends a DELETE RRSet with only the listed values, while no-content deletes the whole RRSet (empty records list).
- Test for `BulkDeleteRecords` content-scoped behavior.
- Test for `RecordIdentifier` JSON serialization (content included/omitted).
- Tests for `recordID` determinism, uniqueness, length, character set, and case-insensitivity of record type.

<!-- kody-pr-summary:end -->
