### PR TITLE
feat(api): surface specific website update and DNS validation errors

### DIFF
--- a/internal/api/api_websites.go
+++ b/internal/api/api_websites.go
@@ -554,12 +554,15 @@ func (a *API) deleteWebsite(c echo.Context) error {
 	return ctx.NoContent(http.StatusNoContent)
 }
 
-// isDNSResolutionError reports whether err is (or wraps) a DNS resolution
-// failure, e.g. net.LookupTXT returning *net.DNSError because a verification
-// record is missing or the domain does not resolve.
+// isDNSResolutionError reports whether err is (or wraps) a genuine
+// domain-not-found resolution failure — *net.DNSError with IsNotFound set,
+// e.g. net.LookupTXT returning NXDOMAIN because a verification record is
+// missing or the domain does not resolve. Transient resolver faults (timeouts,
+// SERVFAIL, connection failures) are platform-side and deliberately excluded
+// so they stay on the generic 500 path.
 func isDNSResolutionError(err error) bool {
 	var dnsErr *net.DNSError
-	return errors.As(err, &dnsErr)
+	return errors.As(err, &dnsErr) && dnsErr.IsNotFound
 }
 
 func (a *API) validateWebsiteDNS(c echo.Context) error {

--- a/internal/api/api_websites.go
+++ b/internal/api/api_websites.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"strconv"
 	"strings"
@@ -104,6 +105,16 @@ func (a *API) handleWebsiteValidationError(err error, c echo.Context) (error, bo
 
 	if errors.Is(err, pluginservice.ErrInvalidDomain) {
 		apiErr := NewError(ErrKeyInvalidDomainFormat, err)
+		return ctx.Error(apiErr, apiErr.HttpStatus()), true
+	}
+
+	if errors.Is(err, pluginservice.ErrCIDNotPinned) {
+		apiErr := NewError(ErrKeyCIDNotPinned, err)
+		return ctx.Error(apiErr, apiErr.HttpStatus()), true
+	}
+
+	if errors.Is(err, pluginservice.ErrIPNSKeyNotFound) {
+		apiErr := NewError(ErrKeyIPNSKeyNotFound, err)
 		return ctx.Error(apiErr, apiErr.HttpStatus()), true
 	}
 
@@ -385,6 +396,12 @@ func (a *API) updateWebsite(c echo.Context) error {
 	website, err := a.websiteService.UpdateWebsite(reqCtx, user, uint(websiteID), updates)
 	if err != nil {
 		a.Logger().Error("Failed to update website", zap.Error(err), zap.Uint("website_id", uint(websiteID)), zap.Uint("user_id", user))
+		// Surface user-correctable validation errors with specific messages
+		// (e.g. CID is not pinned, invalid CID/IPNS target) instead of a
+		// generic 500, mirroring the create-website path.
+		if handledErr, wasHandled := a.handleWebsiteValidationError(err, c); wasHandled {
+			return handledErr
+		}
 		apiErr := NewError(ErrKeyFileProcessingFailed, err)
 		return ctx.Error(apiErr, apiErr.HttpStatus())
 	}
@@ -537,6 +554,14 @@ func (a *API) deleteWebsite(c echo.Context) error {
 	return ctx.NoContent(http.StatusNoContent)
 }
 
+// isDNSResolutionError reports whether err is (or wraps) a DNS resolution
+// failure, e.g. net.LookupTXT returning *net.DNSError because a verification
+// record is missing or the domain does not resolve.
+func isDNSResolutionError(err error) bool {
+	var dnsErr *net.DNSError
+	return errors.As(err, &dnsErr)
+}
+
 func (a *API) validateWebsiteDNS(c echo.Context) error {
 	ctx := httputil.Context(c)
 	reqCtx := ctx.Context.Request().Context()
@@ -554,6 +579,13 @@ func (a *API) validateWebsiteDNS(c echo.Context) error {
 	result, err := a.websiteService.ValidateDNS(reqCtx, user, uint(websiteID))
 	if err != nil {
 		a.Logger().Error("Failed to validate website DNS", zap.Error(err), zap.Uint("website_id", uint(websiteID)), zap.Uint("user_id", user))
+		// A DNS resolution failure (e.g. the verification TXT record not yet
+		// published, or the domain not resolving) is user-correctable, so
+		// surface it with a specific message instead of a generic 500.
+		if isDNSResolutionError(err) {
+			apiErr := NewError(ErrKeyDNSValidationFailed, err)
+			return ctx.Error(apiErr, apiErr.HttpStatus())
+		}
 		apiErr := NewError(ErrKeyFileProcessingFailed, err)
 		return ctx.Error(apiErr, apiErr.HttpStatus())
 	}

--- a/internal/api/api_websites_test.go
+++ b/internal/api/api_websites_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -16,6 +17,7 @@ import (
 	pluginCore "go.lumeweb.com/portal-plugin-ipfs/core"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/api/dto"
 	pluginDb "go.lumeweb.com/portal-plugin-ipfs/internal/db"
+	pluginservice "go.lumeweb.com/portal-plugin-ipfs/internal/service/website"
 	mocks "go.lumeweb.com/portal-plugin-ipfs/internal/testing/mocks"
 	"go.lumeweb.com/portal/core"
 	coreTesting "go.lumeweb.com/portal/core/testing"
@@ -1202,6 +1204,25 @@ func TestAPI_UpdateWebsite(t *testing.T) {
 		}, TestOptions)
 	})
 
+	t.Run("error_cid_not_pinned", func(t *testing.T) {
+		coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+			helper := newMockHelper(t, ctx)
+			token, userID := helper.SetupAuthenticatedTestWithCID(cid.MustParse(TestCID))
+
+			mockWebsiteService := core.GetService[*mocks.MockWebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
+
+			mockWebsiteService.EXPECT().UpdateWebsite(mock.Anything, userID, uint(1), mock.AnythingOfType("map[string]interface {}")).Return(nil, fmt.Errorf("CID validation failed: %w", pluginservice.ErrCIDNotPinned))
+
+			reqBody := fmt.Sprintf(`{"domain":"%s","target_type":"ipfs","target_hash":"%s"}`, TestDomain, TestCID)
+			rec := helper.makeAuthenticatedRequest(http.MethodPut, "/api/websites/1", token, []byte(reqBody))
+
+			assert.Equal(t, http.StatusUnprocessableEntity, rec.Code)
+			var body map[string]any
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+			assert.Equal(t, string(ErrKeyCIDNotPinned), body["error"])
+		}, TestOptions)
+	})
+
 	t.Run("unauthorized", func(t *testing.T) {
 		coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 			reqBody := fmt.Sprintf(`{"domain":"%s","target_type":"ipfs","target_hash":"%s"}`, TestDomain, TestCID)
@@ -1375,6 +1396,26 @@ func TestAPI_ValidateWebsiteDNS(t *testing.T) {
 			rec := helper.makeAuthenticatedRequest(http.MethodPost, "/api/websites/1/validate", token, nil)
 
 			assert.Equal(t, http.StatusInternalServerError, rec.Code)
+		}, TestOptions)
+	})
+
+	t.Run("error_dns_resolution_failed", func(t *testing.T) {
+		coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+			helper := newMockHelper(t, ctx)
+			token, userID := helper.SetupAuthenticatedTestWithCID(cid.MustParse(TestCID))
+
+			mockWebsiteService := core.GetService[*mocks.MockWebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
+
+			dnsErr := &net.DNSError{Err: "no such host", Name: "pinner-verify." + TestDomain, IsNotFound: true}
+			mockWebsiteService.EXPECT().ValidateDNS(mock.Anything, userID, uint(1)).
+				Return(pluginCore.ValidateDNSResult{}, fmt.Errorf("DNS TXT lookup failed for %s: %w", TestDomain, dnsErr))
+
+			rec := helper.makeAuthenticatedRequest(http.MethodPost, "/api/websites/1/validate", token, nil)
+
+			assert.Equal(t, http.StatusUnprocessableEntity, rec.Code)
+			var body map[string]any
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+			assert.Equal(t, string(ErrKeyDNSValidationFailed), body["error"])
 		}, TestOptions)
 	})
 

--- a/internal/api/errors.go
+++ b/internal/api/errors.go
@@ -51,6 +51,18 @@ const (
 	// Website validation error types
 	ErrKeyInvalidCID    core.ErrorType = "INVALID_CID"
 	ErrKeyInvalidTarget core.ErrorType = "INVALID_TARGET"
+	// ErrKeyCIDNotPinned is returned when a website update targets a CID that
+	// exists but is not pinned in the user's account. It is user-correctable
+	// (pin the CID first), so it surfaces as 422 rather than a generic 500.
+	ErrKeyCIDNotPinned core.ErrorType = "CID_NOT_PINNED"
+	// ErrKeyIPNSKeyNotFound is returned when an IPNS target references a key
+	// that does not exist or is not owned by the requesting user (422).
+	ErrKeyIPNSKeyNotFound core.ErrorType = "IPNS_KEY_NOT_FOUND"
+	// ErrKeyDNSValidationFailed is returned when website DNS validation cannot
+	// be completed because a required DNS record is missing or unresolvable
+	// (e.g. the verification TXT record is not yet published). User-correctable,
+	// so it surfaces as 422 rather than a generic 500.
+	ErrKeyDNSValidationFailed core.ErrorType = "DNS_VALIDATION_FAILED"
 
 	// Website domain binding error types
 	ErrKeyDomainNotFound core.ErrorType = "DOMAIN_NOT_FOUND"
@@ -109,6 +121,9 @@ func init() {
 		ErrKeyPermissionDenied:      {Key: ErrKeyPermissionDenied, Message: "Permission denied"},
 		ErrKeyInvalidCID:            {Key: ErrKeyInvalidCID, Message: "Invalid CID provided"},
 		ErrKeyInvalidTarget:         {Key: ErrKeyInvalidTarget, Message: "Invalid target hash or peer ID provided"},
+		ErrKeyCIDNotPinned:          {Key: ErrKeyCIDNotPinned, Message: "CID is not pinned. Please pin the CID and try again."},
+		ErrKeyIPNSKeyNotFound:       {Key: ErrKeyIPNSKeyNotFound, Message: "IPNS key not found or not owned by your account."},
+		ErrKeyDNSValidationFailed:   {Key: ErrKeyDNSValidationFailed, Message: "DNS validation could not be completed. Please ensure the required DNS records are published and reachable."},
 		ErrKeyDomainNotFound:        {Key: ErrKeyDomainNotFound, Message: "Domain not found"},
 		ErrKeyDomainInUse:           {Key: ErrKeyDomainInUse, Message: "Domain is already in use by another website"},
 		ErrKeyInvalidPathID:         {Key: ErrKeyInvalidPathID, Message: "Invalid path parameter: %s"},
@@ -141,6 +156,9 @@ func init() {
 		ErrKeyInvalidIdentifier:     http.StatusUnprocessableEntity,
 		ErrKeyInvalidCID:            http.StatusUnprocessableEntity,
 		ErrKeyInvalidTarget:         http.StatusUnprocessableEntity,
+		ErrKeyCIDNotPinned:          http.StatusUnprocessableEntity,
+		ErrKeyIPNSKeyNotFound:       http.StatusUnprocessableEntity,
+		ErrKeyDNSValidationFailed:   http.StatusUnprocessableEntity,
 		ErrKeyPermissionDenied:      http.StatusForbidden,
 		ErrKeyDomainNotFound:        http.StatusNotFound,
 		ErrKeyDomainInUse:           http.StatusConflict,


### PR DESCRIPTION
## Summary

The `updateWebsite` and `validateWebsiteDNS` handlers previously returned a generic `FILE_PROCESSING_FAILED` **500** ("Failed to process the file.") for every service error. The specific, user-relevant detail (e.g. "CID is not pinned" or a missing DNS TXT record) was only logged, never sent to the client.

This PR surfaces user-correctable failures with specific messages and proper `422` codes, matching the existing behavior of the create-website path.

## Changes

- **`internal/api/errors.go`** — add three error keys (all `422`):
  - `CID_NOT_PINNED` — "CID is not pinned. Please pin the CID and try again."
  - `IPNS_KEY_NOT_FOUND` — "IPNS key not found or not owned by your account."
  - `DNS_VALIDATION_FAILED` — "DNS validation could not be completed. Please ensure the required DNS records are published and reachable."
- **`internal/api/api_websites.go`**
  - Extend `handleWebsiteValidationError` to map `ErrCIDNotPinned` → `CID_NOT_PINNED` and `ErrIPNSKeyNotFound` → `IPNS_KEY_NOT_FOUND`.
  - `updateWebsite` now routes its `UpdateWebsite` error through `handleWebsiteValidationError` before falling back to the generic 500.
  - `validateWebsiteDNS` detects DNS resolution failures (`*net.DNSError`) and returns `DNS_VALIDATION_FAILED` instead of the generic 500.
- **`internal/api/api_websites_test.go`** — add `error_cid_not_pinned` and `error_dns_resolution_failed` cases asserting `422` and the expected error key.

## Behavior before / after

| Case                                          | Before                       | After                       |
| --------------------------------------------- | ---------------------------- | --------------------------- |
| Update with CID that isn't pinned             | 500 `FILE_PROCESSING_FAILED` | 422 `CID_NOT_PINNED`        |
| Update with invalid IPNS key                  | 500 `FILE_PROCESSING_FAILED` | 422 `IPNS_KEY_NOT_FOUND`    |
| DNS validate with missing/unresolvable record | 500 `FILE_PROCESSING_FAILED` | 422 `DNS_VALIDATION_FAILED` |

## Verification

- `go build ./...` — passes
- `go vet ./internal/api/...` — passes (type-checks tests)
- Running the test binary in this sandbox is blocked by a pre-existing proto-registry panic (`rpc.proto` conflict between libp2p-pubsub and etcd) that also occurs on unmodified code.

* `develop` <!-- branch-stack -->
  - **feat(api): surface specific website update and DNS validation errors** :point\_left:

***

<!-- kody-pr-summary:start -->

## Summary

This pull request improves error handling in the IPFS portal plugin's website management API by surfacing specific, user-correctable validation errors with clear messages instead of returning generic 500 errors.

## Key Changes

### 1. Specific Validation Errors on Website Update

- **`internal/api/api_websites.go`**: The `updateWebsite` endpoint now detects and returns specific validation errors when:
  - A CID is not pinned (`ERR_CID_NOT_PINNED`) - returns HTTP 422 with message "CID is not pinned. Please pin the CID and try again."
  - An IPNS key is not found or not owned by the user (`ERR_IPNS_KEY_NOT_FOUND`) - returns HTTP 422 with message "IPNS key not found or not owned by your account."
- Previously, these cases were returning a generic 500 error; now they provide actionable feedback to the user.

### 2. DNS Validation Error Handling

- **`internal/api/api_websites.go`**: Added `isDNSResolutionError` helper function that detects DNS resolution failures (e.g., missing TXT records or unresolvable domains).
- The `validateWebsiteDNS` endpoint now returns a specific error (`ERR_DNS_VALIDATION_FAILED`) with HTTP 422 and message "DNS validation could not be completed. Please ensure the required DNS records are published and reachable." when DNS resolution fails.
- This replaces the generic 500 error, helping users understand they need to fix their DNS records.

### 3. New Error Types

- **`internal/api/errors.go`**: Added three new error type constants:
  - `ErrKeyCIDNotPinned` (CID\_NOT\_PINNED)
  - `ErrKeyIPNSKeyNotFound` (IPNS\_KEY\_NOT\_FOUND)
  - `ErrKeyDNSValidationFailed` (DNS\_VALIDATION\_FAILED)
- Each error type includes appropriate HTTP status codes (422 Unprocessable Entity) and user-friendly messages registered in the error initialization.

### 4. Test Coverage

- **`internal/api/api_websites_test.go`**: Added tests verifying:
  - Update website returns `CID_NOT_PINNED` error when CID is not pinned
  - DNS validation returns `DNS_VALIDATION_FAILED` error when DNS resolution fails

## Impact

These changes improve the user experience by providing clear, actionable error messages for common configuration issues, allowing users to fix problems (like pinning a CID or correcting DNS records) without needing to contact support or interpret complex system errors.

<!-- kody-pr-summary:end -->
