### PR TITLE
fix(api): return 409 when creating a website binds a domain owned by another website

### DIFF
--- a/internal/api/api_websites.go
+++ b/internal/api/api_websites.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-sql-driver/mysql"
 	"github.com/labstack/echo/v4"
 	"go.lumeweb.com/httputil"
 	mcontext "go.lumeweb.com/portal-middleware/context"
@@ -138,6 +139,47 @@ func (a *API) createWebsite(c echo.Context) error {
 	// Set user ID
 	model.UserID = user
 
+	// Domain ownership guard: a given (domain, namespace) can be live-bound to
+	// only one website. CreateDomain is create-only and would otherwise surface
+	// a raw MySQL 1062 duplicate-key as a 500 (and, because the website is
+	// persisted below before the binding, leave a dangling website row behind).
+	// Mirror the update path: refuse up front with a 409 ownership conflict
+	// instead. Soft-deleted tombstones still occupy the unique key but are
+	// purged by CreateDomain, so they fall through to a fresh binding.
+	namespace := string(pluginDb.DomainNamespaceICANN)
+	if req.Namespace != nil {
+		namespace = string(*req.Namespace)
+	}
+	// Guard on the delegated domain service's DB availability: the lookup
+	// runs against GetWebsiteDomainByDomainAndNamespace, which (unlike
+	// CreateDomain) dereferences s.DB() without an internal nil guard. Gate on
+	// that service's DB, not the API's own, so the exact "service not wired to
+	// a DB" scenario is skipped rather than crashing with a nil-pointer.
+	if a.delegatedDomainSvc != nil && a.delegatedDomainSvc.DB() != nil {
+		// Normalize before the lookup: CreateDomain persists the canonical apex
+		// form, so a www.-prefixed or mixed-case request for an already
+		// live-bound domain must still hit the ownership guard (otherwise the
+		// raw 1062 duplicate-key 500 this guard replaces would surface).
+		domain := pluginDb.NormalizeDomain(req.Domain)
+		existing, eerr := a.delegatedDomainSvc.GetWebsiteDomainByDomainAndNamespace(reqCtx, domain, pluginDb.DomainNamespace(namespace))
+		switch {
+		case eerr == nil && !existing.DeletedAt.Valid:
+			// Domain is live-bound to another website — refuse to rebind.
+			a.Logger().Warn("Refusing to bind domain owned by another website",
+				zap.String("domain", req.Domain), zap.Uint("domain_owner_website_id", existing.WebsiteID))
+			apiErr := NewError(ErrKeyDomainInUse, fmt.Errorf("domain %q is already in use by another website", req.Domain))
+			return ctx.Error(apiErr, http.StatusConflict)
+		case eerr == nil:
+			// Soft-deleted tombstone: fall through so CreateDomain purges it.
+		default:
+			if !errors.Is(eerr, gorm.ErrRecordNotFound) {
+				a.Logger().Error("Failed to look up existing domain binding", zap.String("domain", req.Domain), zap.Error(eerr))
+				apiErr := NewError(ErrKeyFileProcessingFailed, eerr)
+				return ctx.Error(apiErr, apiErr.HttpStatus())
+			}
+		}
+	}
+
 	website, err := a.websiteService.CreateWebsite(reqCtx, model)
 	if err != nil {
 		a.Logger().Error("Failed to create website", zap.Error(err), zap.Uint("user_id", user), zap.String("domain", req.Domain))
@@ -156,12 +198,25 @@ func (a *API) createWebsite(c echo.Context) error {
 		dnsEnabled = *req.DNSEnabled
 	}
 	if a.delegatedDomainSvc != nil {
-		namespace := string(pluginDb.DomainNamespaceICANN)
-		if req.Namespace != nil {
-			namespace = string(*req.Namespace)
-		}
 		var cfgRaw json.RawMessage
 		if _, err := a.delegatedDomainSvc.CreateDomain(reqCtx, namespace, req.Domain, website.ID, user, dnsEnabled, true, cfgRaw); err != nil {
+			// A concurrent create may have won the (domain, namespace) unique key
+			// race after this request's pre-check passed. The guard is not atomic,
+			// so on a duplicate-key violation roll back the just-persisted website
+			// (which has no primary domain binding) before surfacing a clean 409,
+			// leaving no dangling website row behind.
+			if isDuplicateKeyError(err) {
+				if a.delegatedDomainSvc.DB() != nil {
+					if derr := a.delegatedDomainSvc.DB().WithContext(reqCtx).Unscoped().Delete(&pluginDb.Website{}, website.ID).Error; derr != nil {
+						a.Logger().Error("Failed to roll back website after duplicate domain conflict",
+							zap.Uint("website_id", website.ID), zap.Error(derr))
+					}
+				}
+				a.Logger().Warn("Refusing to bind domain raced/owned by another website",
+					zap.String("domain", req.Domain), zap.Uint("website_id", website.ID))
+				apiErr := NewError(ErrKeyDomainInUse, fmt.Errorf("domain %q is already in use by another website", req.Domain))
+				return ctx.Error(apiErr, http.StatusConflict)
+			}
 			a.Logger().Error("Failed to create primary domain for website",
 				zap.Uint("website_id", website.ID), zap.String("domain", req.Domain), zap.Error(err))
 			apiErr := NewError(ErrKeyFileProcessingFailed, err)
@@ -214,6 +269,31 @@ func (a *API) createWebsite(c echo.Context) error {
 	})
 
 	return httputil.EncodeResponse(ctx, website, &resp)
+}
+
+// isDuplicateKeyError reports whether err is a database unique-key (duplicate)
+// violation. GORM only returns gorm.ErrDuplicatedKey when gorm.Config{
+// TranslateError:true} is set — this deployment does not enable it — so on
+// MySQL a duplicate surfaces as a raw *mysql.MySQLError with code 1062 that
+// errors.Is cannot match. Mirror the portal core detection (see
+// go.lumeweb.com/portal/service/user.go isDuplicateKeyError): check the GORM
+// sentinel, the structured MySQL error, and fall back to driver-agnostic
+// string matching.
+func isDuplicateKeyError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, gorm.ErrDuplicatedKey) {
+		return true
+	}
+	var mysqlErr *mysql.MySQLError
+	if errors.As(err, &mysqlErr) && mysqlErr != nil && mysqlErr.Number == 1062 {
+		return true
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "UNIQUE constraint failed") ||
+		strings.Contains(msg, "Duplicate entry") ||
+		strings.Contains(msg, "duplicate key value")
 }
 
 func (a *API) listWebsites(c echo.Context) error {
@@ -435,8 +515,11 @@ func (a *API) updateWebsite(c echo.Context) error {
 		// Reuse an existing live binding for this (domain, namespace) when it
 		// already belongs to the website; otherwise fall through to a genuine
 		// create (change-primary). A binding owned by a different website is
-		// surfaced as an explicit ownership conflict.
-		existing, eerr := a.delegatedDomainSvc.GetWebsiteDomainByDomainAndNamespace(reqCtx, *req.Domain, pluginDb.DomainNamespace(namespace))
+		// surfaced as an explicit ownership conflict. The lookup compares the
+		// canonical apex form (lowercased, www.-stripped) that CreateDomain
+		// stores, so a www.-prefixed or mixed-case request resolves correctly.
+		domain := pluginDb.NormalizeDomain(*req.Domain)
+		existing, eerr := a.delegatedDomainSvc.GetWebsiteDomainByDomainAndNamespace(reqCtx, domain, pluginDb.DomainNamespace(namespace))
 		switch {
 		case eerr == nil && !existing.DeletedAt.Valid && existing.WebsiteID == website.ID:
 			// Re-deploy to an already-bound primary: reuse, don't re-create.

--- a/internal/api/api_websites_test.go
+++ b/internal/api/api_websites_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-sql-driver/mysql"
 	"github.com/ipfs/go-cid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -217,6 +218,41 @@ func TestAPI_CreateWebsite(t *testing.T) {
 			rec := helper.makeAuthenticatedRequest(http.MethodPost, "/api/websites", token, []byte(reqBody))
 
 			assert.Equal(t, http.StatusInternalServerError, rec.Code)
+		}, TestOptions)
+	})
+
+	t.Run("error_domain_owned_by_another_website_conflict", func(t *testing.T) {
+		coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+			helper := newMockHelper(t, ctx)
+			token, userID := helper.SetupAuthenticatedTestWithCID(cid.MustParse(TestCID))
+
+			// A domain live-bound to a DIFFERENT website must be refused as an
+			// ownership conflict (409) during create, not surface a raw MySQL
+			// 1062 duplicate-key ("Duplicate entry 'example.org-icann' for key
+			// 'website_domains.uk_domain_namespace'") as a 500. The guard runs
+			// before the website is persisted, so CreateWebsite is not called,
+			// leaving no dangling website row behind.
+			require.NoError(tb, ctx.DB().Create(&pluginDb.WebsiteDomain{
+				ID:        1,
+				WebsiteID: 99, // owned by another website
+				UserID:    userID,
+				Domain:    "example.org",
+				Namespace: pluginDb.DomainNamespaceICANN,
+				Status:    pluginDb.DomainStatusActive,
+			}).Error)
+
+			mockWebsiteService := core.GetService[*mocks.MockWebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
+			mockWebsiteService.AssertNotCalled(tb, "CreateWebsite", mock.Anything, mock.Anything)
+
+			// Request the domain as a www.-prefixed, mixed-case variant: the
+			// guard must normalize it to the stored apex ("example.org") before
+			// the ownership lookup, still returning 409 rather than leaking a
+			// raw 1062 duplicate-key 500 from CreateDomain.
+			reqBody := fmt.Sprintf(`{"domain":"WWW.Example.org","target_type":"ipfs","target_hash":"%s"}`, TestCID)
+			rec := helper.makeAuthenticatedRequest(http.MethodPost, "/api/websites", token, []byte(reqBody))
+
+			// The normalized lookup finds a live binding owned by website 99 → 409, not 500.
+			assert.Equal(t, http.StatusConflict, rec.Code)
 		}, TestOptions)
 	})
 
@@ -1443,4 +1479,21 @@ func TestAPI_ValidateWebsiteDNS(t *testing.T) {
 			assert.Equal(t, http.StatusUnauthorized, rec.Code)
 		}, TestOptions)
 	})
+}
+
+func TestIsDuplicateKeyError(t *testing.T) {
+	// GORM sentinel — only returned when gorm.Config{TranslateError:true} is set.
+	assert.True(t, isDuplicateKeyError(gorm.ErrDuplicatedKey))
+
+	// Raw MySQL 1062 — the actual production path when TranslateError is off.
+	assert.True(t, isDuplicateKeyError(&mysql.MySQLError{Number: 1062}))
+	assert.False(t, isDuplicateKeyError(&mysql.MySQLError{Number: 1146})) // table missing
+
+	// Driver-agnostic string fallback (as surfaced on real MySQL / SQLite).
+	assert.True(t, isDuplicateKeyError(errors.New("Error 1062 (23000): Duplicate entry 'test2.web3ready.org-icann' for key 'website_domains.uk_domain_namespace'")))
+	assert.True(t, isDuplicateKeyError(errors.New("UNIQUE constraint failed: website_domains.domain, website_domains.namespace")))
+
+	// Non-duplicate / nil errors are not flagged.
+	assert.False(t, isDuplicateKeyError(errors.New("some other database error")))
+	assert.False(t, isDuplicateKeyError(nil))
 }

--- a/internal/service/domain/delegated_domain_service_test.go
+++ b/internal/service/domain/delegated_domain_service_test.go
@@ -157,6 +157,34 @@ func TestDelegatedDomainService_CreateDomain_SelfHosted(t *testing.T) {
 	}, TestOptions)
 }
 
+func TestDelegatedDomainService_CreateDomain_DuplicateKey(t *testing.T) {
+	// Re-binding a domain that is already live-bound (the create-time race) must
+	// fail on the (domain, namespace) unique key. On MySQL this surfaces as
+	// gorm.ErrDuplicatedKey (translated from 1062) so the API rolls back the
+	// just-created website and returns 409 instead of leaking a dangling row and
+	// raw 500; the SQLite test driver reports it as a generic UNIQUE constraint
+	// error, so we assert only that the duplicate bind is rejected.
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		db := ctx.DB()
+		website := createTestWebsite(tb, db, 1, "example.com")
+
+		svc := core.GetService[*DelegatedDomainService](ctx, pluginCore.DELEGATED_DOMAIN_SERVICE)
+		require.NotNil(tb, svc)
+
+		// First bind succeeds (self-hosted to avoid DNS provisioning) and fires
+		// the created notification.
+		mockWebsite := core.GetService[*mocks.MockWebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
+		mockWebsite.EXPECT().NotifyAdminWebsiteCreated(mock.Anything, website.ID).Return(nil).Once()
+
+		_, err := svc.CreateDomain(context.Background(), "icann", "example.com", website.ID, 1, false, true, nil)
+		require.NoError(tb, err)
+
+		// A second bind of the same (domain, namespace) hits the unique key.
+		_, err = svc.CreateDomain(context.Background(), "icann", "example.com", website.ID, 1, false, true, nil)
+		require.Error(tb, err)
+	}, TestOptions)
+}
+
 func TestDelegatedDomainService_CreateDomain_SelfHostedDANEFailurePurgesBinding(t *testing.T) {
 	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 		db := ctx.DB()


### PR DESCRIPTION
## Summary

When `POST /api/websites` creates a website whose primary domain is already live-bound to another website (same `(domain, namespace)`), the create-only `CreateDomain` path surfaced the raw MySQL duplicate-key error:

> `Persist failed: Error 1062 (23000): Duplicate entry 'example.org-icann' for key 'website_domains.uk_domain_namespace'`

as a generic **500** — and, because the website row is persisted before the domain binding, it also left a dangling website behind with no primary domain.

The `updateWebsite` path already handled this correctly (409 `DOMAIN_IN_USE`). This PR gives `createWebsite` the same guard.

## Changes

- `internal/api/api_websites.go` — `createWebsite` now pre-checks `GetWebsiteDomainByDomainAndNamespace` before persisting the website:
  - Live binding owned by another website → **409** `ErrKeyDomainInUse` (clear ownership conflict, and no orphaned website row since the check runs before `CreateWebsite`).
  - Soft-deleted tombstone → falls through so `CreateDomain` purges it and re-binds (unchanged behavior).
  - Skips the pre-check when no DB is wired (matches `CreateDomain`'s own DB guard).
- `internal/api/api_websites_test.go` — regression test `error_domain_owned_by_another_website_conflict` asserting the create path returns **409** (not 500) and never calls `CreateWebsite`.
- `.changeset/lucky-websites-confirm.md` — changeset (`patch`).

## Test

`GOLANG_PROTOBUF_REGISTRATION_CONFLICT=warn go test ./internal/api/ -run 'TestAPI_CreateWebsite' -count=1` → **ok**

(Note: `TestAPI_UpdateWebsite/error_cid_not_pinned` and `TestAPI_ValidateWebsiteDNS/error_dns_resolution_failed` fail in this environment due to external state — real DNS lookups / CID pinning — and fail identically on `develop` without this change.)

- `develop` <!-- branch-stack -->
  - **fix(api): return 409 when creating a website binds a domain owned by another website** :point\_left:

***

<!-- kody-pr-summary:start -->

This pull request fixes an issue in the website creation API where attempting to create a website with a domain already owned by another website would result in a raw MySQL duplicate-key error (500 status) instead of a proper ownership conflict response.

## Key Changes

1. **Domain ownership guard**: Added a pre-check in the `createWebsite` function that queries the DelegatedDomainService to verify whether the requested domain is already live-bound to another website before proceeding with website creation.

2. **Proper error handling**:
   - Returns a `409 Conflict` with a clear "domain is already in use by another website" error message when the domain is found to be owned by another website
   - Handles soft-deleted domain records by allowing them to fall through, since `CreateDomain` purges these tombstones
   - Skips the guard when the DB or DelegatedDomainService is unavailable, falling back to the existing error handling inside `CreateDomain`

3. **Prevents dangling website records**: The guard runs before the website is persisted to the database, ensuring no orphaned website rows are left when domain binding fails

4. **Test coverage**: Added a new test case verifying that creating a website with a domain owned by another website (website ID 99) returns a 409 Conflict status and does not invoke the website creation service

5. **Changeset**: Added a patch changeset documenting this bug fix

This change aligns the create path behavior with the existing update path, providing consistent, user-friendly error responses instead of exposing raw database errors while maintaining data integrity.

<!-- kody-pr-summary:end -->
