### PR TITLE
chore: add debug logging for upload/pin workflow diagnostics

### DIFF
--- a/internal/protocol/op_file_path.go
+++ b/internal/protocol/op_file_path.go
@@ -119,8 +119,13 @@ func (h *FilePathOperationHandler) Execute(ctx context.Context, req *models.Requ
 		}
 
 		if len(cids) > 0 {
+			h.Logger().Debug("processing missing UnixFS names",
+				zap.Int("cidCount", len(cids)),
+				zap.NamedError("ctxErr", ctx.Err()))
 			if err := metadataStore.ProcessMissingUnixFSNames(ctx, cids); err != nil {
-				h.Logger().Warn("Failed to process missing UnixFS names", zap.Error(err))
+				h.Logger().Warn("Failed to process missing UnixFS names",
+					zap.Error(err),
+					zap.NamedError("ctxErr", ctx.Err()))
 			}
 		}
 	}

--- a/internal/protocol/op_post_upload.go
+++ b/internal/protocol/op_post_upload.go
@@ -48,6 +48,10 @@ func (h *PostUploadOperationHandler) Execute(ctx context.Context, req *models.Re
 	ctx, span := core.TraceMethod(ctx, "PostUploadOperationHandler.Execute")
 	defer span.End()
 
+	h.Logger().Debug("upload operation started",
+		zap.Uint("requestID", req.ID),
+		zap.Uint("userID", lo.FromPtrOr(req.UserID, 0)))
+
 	// Initialize progress tracker with manual mode for simple milestones
 	tracker, err := InitializeManualProgressTracker(h, req.ID, core.OpTypeUpload, 10)
 	if err != nil {
@@ -208,6 +212,22 @@ func (h *PostUploadOperationHandler) Execute(ctx context.Context, req *models.Re
 	}
 
 	h.logProcessingResult(allCids, rootCids)
+
+	// Check if context was cancelled during processing — this would cause
+	// the cron job to fail before CompleteWorkflowStep can run, leaving
+	// the operation stuck in "Processing" with progress=100.
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		h.Logger().Warn("upload operation completed with cancelled context",
+			zap.Uint("requestID", req.ID),
+			zap.Int("numCids", len(allCids)),
+			zap.Int("numRoots", len(rootCids)),
+			zap.Error(ctxErr))
+	} else {
+		h.Logger().Debug("upload operation completed successfully",
+			zap.Uint("requestID", req.ID),
+			zap.Int("numCids", len(allCids)),
+			zap.Int("numRoots", len(rootCids)))
+	}
 
 	// Complete
 	if err := tracker.SetProgress(100); err != nil {

--- a/internal/protocol/store/downloader/downloader.go
+++ b/internal/protocol/store/downloader/downloader.go
@@ -201,15 +201,32 @@ func (bd *BlockDownloaderDefault) queueRelated(ctx context.Context, c cid.Cid) {
 	defer span.End()
 
 	log := bd.log.Named("queueRelated").With(zap.Stringer("cid", c))
+
+	// Log context state before DB queries. ctx is created via DetachContext
+	// (context.WithoutCancel) and should never be cancelled. If ctx.Err() is
+	// non-nil here, the detached context was somehow cancelled before we
+	// even started — indicating a bug in context propagation. If ctx.Err()
+	// is nil but BlockSiblings returns context.Canceled below, it points to
+	// a GORM PrepareStmt race condition cross-contaminating the error from
+	// a different goroutine's cancelled context.
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		log.Warn("queueRelated called with already-cancelled detached context",
+			zap.Error(ctxErr))
+	}
+
 	siblings, err := bd.store.BlockSiblings(ctx, c, 64)
 	if err != nil {
-		log.Error("failed to get block siblings", zap.Error(err))
+		log.Error("failed to get block siblings",
+			zap.Error(err),
+			zap.NamedError("ctxErr", ctx.Err()))
 		return
 	}
 
 	children, err := bd.store.BlockChildren(ctx, c, lo.ToPtr(64))
 	if err != nil {
-		log.Error("failed to get block children", zap.Error(err))
+		log.Error("failed to get block children",
+			zap.Error(err),
+			zap.NamedError("ctxErr", ctx.Err()))
 		return
 	}
 


### PR DESCRIPTION
Add targeted debug and warn-level log lines at key diagnostic points in
the upload/pin pipeline to help identify context cancellation and stuck
operation issues:

- op\_post\_upload.go: log operation start (requestID, userID) and exit
  (distinguishing cancelled vs successful completion)
- downloader.go: log ctx.Err() state before BlockSiblings/BlockChildren
  queries to detect GORM PrepareStmt cache context cross-propagation
- op\_file\_path.go: log ctx.Err() around ProcessMissingUnixFSNames calls

These logs directly target the root cause identified in production where
operations get stuck in Processing state due to context cancellation
propagating through detached contexts.

- `develop` <!-- branch-stack -->
  - **chore: add debug logging for upload/pin workflow diagnostics** :point\_left:

---

<!-- kody-pr-summary:start -->
This pull request adds debug logging for upload/pin workflow diagnostics across multiple components:

1. **Upload operation logging** (`op_post_upload.go`): Added debug logging to track upload lifecycle:
   - Logs when an upload operation starts with request/user IDs
   - After processing, logs whether the operation completed successfully or if the context was cancelled during processing (which would cause the workflow to get stuck in "Processing" state with progress=100)
   - On success, includes count of CIDs and root CIDs processed

2. **Missing UnixFS names processing** (`op_file_path.go`): Enhanced logging in the file path handler:
   - Added debug log when processing missing UnixFS names, including the CID count and current context state
   - Updated the warning log on failure to also include the context error state

3. **Block downloader diagnostics** (`downloader.go`): Added context state logging in the `queueRelated` function:
   - Warns if the detached context is already cancelled before database queries begin
   - Enhanced error logs for sibling and children block retrieval failures to include both the original error and current context state
   - This helps diagnose potential GORM PrepareStmt race conditions where cancelled context errors from one goroutine may cross-contaminate database operations in another

The changes focus on providing better visibility into context cancellation issues that could cause workflows to hang or fail silently, particularly around upload processing and block downloading operations.
<!-- kody-pr-summary:end -->