### PR TITLE
fix(filepath): relay parent protocol and CID to Update File System workflow

### DIFF
--- a/internal/protocol/op_confirm.go
+++ b/internal/protocol/op_confirm.go
@@ -188,12 +188,11 @@ func (h *ConfirmOperationHandler) startFilePathWorkflow(
 
 	_, err := h.StartWorkflow(
 		FILE_PATH_WORKFLOW,
-		core.WithWorkflowStructData(FilePathWorkflowInputData{
+		filePathWorkflowOptions(req, userID, FilePathWorkflowInputData{
 			CIDs:         cids,
 			RelatedCIDs: relatedCIDs,
 			UserID:       userID,
-		}, "json"),
-		core.WithWorkflowUserID(userID),
+		})...,
 	)
 	return err
 }

--- a/internal/protocol/op_file_path.go
+++ b/internal/protocol/op_file_path.go
@@ -769,7 +769,7 @@ func filePathWorkflowOptions(
 		opts = append(opts, core.WithWorkflowProtocol(req.Protocol))
 	}
 
-	if len(req.Hash) > 0 {
+	if len(req.Hash) > 0 && req.CIDType != 0 {
 		opts = append(opts, core.WithWorkflowStorageHash(
 			core.NewStorageHashFromMultihash(req.Hash, req.CIDType, nil),
 		))

--- a/internal/protocol/op_file_path.go
+++ b/internal/protocol/op_file_path.go
@@ -751,6 +751,33 @@ func (h *FilePathOperationHandler) walkDAGForTotalSize(ctx context.Context, c ci
 	return totalSize, nil
 }
 
+// filePathWorkflowOptions builds the StartWorkflow options for the
+// FILE_PATH_WORKFLOW ("Update File System") request. It relays the parent
+// request's protocol and CID onto the new workflow request so downstream
+// tooling (e.g. operation listings) can display them.
+func filePathWorkflowOptions(
+	req *models.Request,
+	userID uint,
+	input FilePathWorkflowInputData,
+) []core.WorkflowOption {
+	opts := []core.WorkflowOption{
+		core.WithWorkflowStructData(input, "json"),
+		core.WithWorkflowUserID(userID),
+	}
+
+	if len(req.Protocol) > 0 {
+		opts = append(opts, core.WithWorkflowProtocol(req.Protocol))
+	}
+
+	if len(req.Hash) > 0 {
+		opts = append(opts, core.WithWorkflowStorageHash(
+			core.NewStorageHashFromMultihash(req.Hash, req.CIDType, nil),
+		))
+	}
+
+	return opts
+}
+
 func NewFilePathOperation(ctx core.Context) core.Operation {
 	return core.NewNamedOperation(
 		FilePathOperationName(),

--- a/internal/protocol/op_post_upload.go
+++ b/internal/protocol/op_post_upload.go
@@ -461,12 +461,11 @@ func (h *PostUploadOperationHandler) startFilePathWorkflow(
 
 	_, err := h.StartWorkflow(
 		FILE_PATH_WORKFLOW,
-		core.WithWorkflowStructData(FilePathWorkflowInputData{
+		filePathWorkflowOptions(req, userID, FilePathWorkflowInputData{
 			CIDs:        cids,
 			RelatedCIDs: relatedCIDs,
 			UserID:      userID,
-		}, "json"),
-		core.WithWorkflowUserID(userID),
+		})...,
 	)
 	return err
 }

--- a/internal/protocol/op_tus_upload.go
+++ b/internal/protocol/op_tus_upload.go
@@ -323,12 +323,11 @@ func startTUSFilePathWorkflow(
 
 	_, err := helper.StartWorkflow(
 		FILE_PATH_WORKFLOW,
-		core.WithWorkflowStructData(FilePathWorkflowInputData{
+		filePathWorkflowOptions(request, userID, FilePathWorkflowInputData{
 			CIDs:        cids,
 			RelatedCIDs: relatedCIDs,
 			UserID:      userID,
-		}, "json"),
-		core.WithWorkflowUserID(userID),
+		})...,
 	)
 	return err
 }

--- a/internal/protocol/tests/op_file_path_regression_test.go
+++ b/internal/protocol/tests/op_file_path_regression_test.go
@@ -169,6 +169,38 @@ func TestPostUpload_StartsFilePathWorkflow(t *testing.T) {
 	}, GetStandardTestOptions()...)
 }
 
+// TestPostUpload_StartsFilePathWorkflow_RelaysParentProtoAndCID is a regression
+// test verifying that the FILE_PATH_WORKFLOW ("Update File System") request
+// relays the parent request's protocol and CID so operation listings show them.
+func TestPostUpload_StartsFilePathWorkflow_RelaysParentProtoAndCID(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		root, wfTest := testPostUploadWorkflow(
+			t, ctx,
+			pluginUpload.NewUniversalReader(bytes.NewReader([]byte("filepath proto/cid relay test"))),
+			contentArchive.FormatFile, pluginUpload.ArchiveConvert,
+			withProtocol(internal.ProtocolName),
+		)
+
+		inst := wfTest.WaitForWorkflowInstance(
+			protocol.FILE_PATH_WORKFLOW,
+			core.RequestFilter{},
+			10*time.Second,
+		)
+		require.NotNil(tb, inst, "FILE_PATH_WORKFLOW instance should be found")
+		require.NotNil(tb, inst.Request, "FILE_PATH_WORKFLOW request should be found")
+
+		// Parent request protocol should be relayed onto the child.
+		assert.Equal(tb, internal.ProtocolName, inst.Request.Protocol)
+
+		// Parent request CID should be relayed onto the child.
+		childCID, err := internal.CIDFromHash(inst.Request.Hash, inst.Request.CIDType)
+		require.NoError(tb, err, "child request CID should be reconstructable")
+		assert.Equal(tb, root, childCID)
+
+		assertRootBlockFetchable(t, ctx, root)
+	}, GetStandardTestOptions()...)
+}
+
 // TestTUSUpload_StartsFilePathWorkflow verifies that after a TUS upload
 // workflow completes, a FILE_PATH_WORKFLOW request has been started.
 func TestTUSUpload_StartsFilePathWorkflow(t *testing.T) {

--- a/internal/protocol/tests/tests_test.go
+++ b/internal/protocol/tests/tests_test.go
@@ -183,11 +183,18 @@ type uploadWorkflowOption func(*uploadWorkflowConfig)
 type uploadWorkflowConfig struct {
 	existingUser *models.User
 	existingWf   *coreTesting.WorkflowTest
+	protocol     string
 }
 
 func withExistingUser(user *models.User) uploadWorkflowOption {
 	return func(cfg *uploadWorkflowConfig) {
 		cfg.existingUser = user
+	}
+}
+
+func withProtocol(protocol string) uploadWorkflowOption {
+	return func(cfg *uploadWorkflowConfig) {
+		cfg.protocol = protocol
 	}
 }
 
@@ -228,6 +235,10 @@ func testUploadWorkflow(t *testing.T, ctx coreTesting.TestContext, universalRead
 		core.WithWorkflowUserID(testUser.ID),
 		core.WithWorkflowSourceIP("127.0.0.1"),
 	)
+
+	if cfg.protocol != "" {
+		workflowOptions = append(workflowOptions, core.WithWorkflowProtocol(cfg.protocol))
+	}
 
 	if workflowDataBuilder != nil {
 		workflowData := workflowDataBuilder(uploadId)


### PR DESCRIPTION
## Problem

When a **Update File System** (`FILE_PATH_WORKFLOW`) operation is created from
a parent handler (post-upload, confirm, TUS upload), the parent request's
**protocol** and **CID** were not relayed onto the new workflow request. As a
result downstream tooling such as `pinner operations list` displayed a blank
`PROTOCOL` and no `CID` for these operations.

## Root cause

The three `startFilePathWorkflow` / `startTUSFilePathWorkflow` call sites
started the workflow with only struct-data and user-ID options. The portal
workflow coordinator only sets `Protocol`/`Hash`/`CIDType` on a new request
when `WithWorkflowProtocol`/`WithWorkflowStorageHash` are provided, so the
child request ended up without them.

## Change

- Added a shared `filePathWorkflowOptions` helper in `op_file_path.go` that
  relays the parent request's `Protocol` and storage hash (from `req.Hash` +
  `req.CIDType`) onto the new workflow request.
- Updated the three call sites (`op_post_upload.go`, `op_confirm.go`,
  `op_tus_upload.go`) to use the helper.
- Added a regression test
  `TestPostUpload_StartsFilePathWorkflow_RelaysParentProtoAndCID` verifying the
  child request carries the parent's protocol and root CID.

## Verification

- `go build ./...` passes
- New regression test + existing `Test*StartsFilePathWorkflow` and
  `TestFilePath*` tests pass

* `develop` <!-- branch-stack -->
  - **fix(filepath): relay parent protocol and CID to Update File System workflow** :point\_left:

***

<!-- kody-pr-summary:start -->

## Summary

This pull request fixes an issue where the "Update File System" workflow (FILE\_PATH\_WORKFLOW) was not relaying the parent request's protocol and CID information when started from upload workflows. This resulted in missing protocol and CID details in operation listings for these child workflows.

## Changes

### Core Fix

- Introduced a new helper function `filePathWorkflowOptions` in `internal/protocol/op_file_path.go` that:
  - Builds the workflow start options with the standard input data and user ID
  - Relays the parent request's protocol information to the new workflow when available
  - Relays the parent request's CID (storage hash) to the new workflow when available

### Updated Callers

Updated three locations where the FILE\_PATH\_WORKFLOW was being started to use the new `filePathWorkflowOptions` helper instead of manually constructing the workflow options:

- **Confirm Operation handler** (`internal/protocol/op_confirm.go`) - When confirming operations
- **Post-Upload handler** (`internal/protocol/op_post_upload.go`) - After upload completion
- **TUS Upload handler** (`internal/protocol/op_tus_upload.go`) - For TUS-based uploads

### Tests

- Added a regression test `TestPostUpload_StartsFilePathWorkflow_RelaysParentProtoAndCID` in `internal/protocol/tests/op_file_path_regression_test.go` that verifies:
  - The FILE\_PATH\_WORKFLOW request inherits the parent request's protocol
  - The FILE\_PATH\_WORKFLOW request inherits the parent request's CID
  - The root block remains fetchable after workflow completion
- Added test infrastructure support in `tests_test.go` with a new `withProtocol` option to configure protocol settings in test workflows

## Impact

This fix ensures that when "Update File System" workflow requests are triggered from upload flows, they retain the protocol and CID information from their parent requests. This makes operation listings and traceability more accurate, as downstream consumers can now see which protocol and content the child workflow is associated with.

<!-- kody-pr-summary:end -->
