### PR TITLE
fix(website): stop janitor from marking pending_validation sites as broken

### DIFF
--- a/internal/service/website/janitor.go
+++ b/internal/service/website/janitor.go
@@ -8,19 +8,19 @@ import (
 	"github.com/gammazero/workerpool"
 	"github.com/google/uuid"
 	"github.com/ipfs/go-cid"
-	"go.lumeweb.com/portal/core"
-	"go.uber.org/zap"
-	"gorm.io/gorm"
 	pluginCore "go.lumeweb.com/portal-plugin-ipfs/core"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/config"
 	pluginDb "go.lumeweb.com/portal-plugin-ipfs/internal/db"
-	domsvc "go.lumeweb.com/portal-plugin-ipfs/internal/service/domain"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/protocol/encoding"
+	domsvc "go.lumeweb.com/portal-plugin-ipfs/internal/service/domain"
+	"go.lumeweb.com/portal/core"
+	"go.uber.org/zap"
+	"gorm.io/gorm"
 )
 
 const (
 	JanitorJobSourceID = "ipfs"
-JanitorJobType     = "plugin.ipfs.website_janitor"
+	JanitorJobType     = "plugin.ipfs.website_janitor"
 )
 
 // WebsiteJanitorJob implements core.CronJob for periodic website validation
@@ -98,6 +98,7 @@ func (j *WebsiteJanitorJob) Run(ctx core.Context, eventCtx context.Context) erro
 	var websites []*pluginDb.Website
 	err := j.db.WithContext(eventCtx).
 		Where("deleted_at IS NULL").
+		Where("status != ?", string(pluginDb.WebsiteStatusPendingValidation)).
 		Where("last_checked_at IS NULL OR last_checked_at < ?", time.Now().Add(-j.config.CheckInterval)).
 		Find(&websites).Error
 
@@ -167,6 +168,15 @@ func (j *WebsiteJanitorJob) Run(ctx core.Context, eventCtx context.Context) erro
 func (j *WebsiteJanitorJob) validateWebsite(ctx context.Context, website *pluginDb.Website) error {
 	ctx, span := core.TraceMethod(ctx, "WebsiteJanitorJob.validateWebsite")
 	defer span.End()
+
+	// Websites awaiting DNS validation must not be subjected to CID-only
+	// liveness checks. They transition to active solely via ValidateDNS.
+	// Skip them here (refreshing last_checked_at so they aren't re-picked
+	// every minute) instead of risking an incorrect broken status.
+	if website.Status == string(pluginDb.WebsiteStatusPendingValidation) {
+		website.LastCheckedAt = new(time.Now())
+		return j.db.WithContext(ctx).Save(website).Error
+	}
 
 	oldStatus := website.Status
 	newStatus := pluginDb.WebsiteStatusActive

--- a/internal/service/website/janitor_test.go
+++ b/internal/service/website/janitor_test.go
@@ -6,10 +6,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ipfs/go-cid"
+	mh "github.com/multiformats/go-multihash"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	pluginCore "go.lumeweb.com/portal-plugin-ipfs/core"
 	pluginConfig "go.lumeweb.com/portal-plugin-ipfs/internal/config"
+	pluginDb "go.lumeweb.com/portal-plugin-ipfs/internal/db"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/db/migrations"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/testing/testopts"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/testing/util"
@@ -76,6 +79,51 @@ func TestWebsiteJanitorJob_Run_NoWebsites(t *testing.T) {
 		err := job.Run(ctx, context.Background())
 
 		require.NoError(tb, err)
+	}, JanitorTestOptions)
+}
+
+func TestWebsiteJanitorJob_validateWebsite_SkipsPendingValidation(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		job := NewWebsiteJanitorJob()
+
+		websiteConfig := &pluginConfig.WebsiteConfig{
+			JanitorEnabled:     true,
+			CheckInterval:      30 * time.Minute,
+			JanitorWorkerCount: 2,
+			JanitorBatchSize:   10,
+		}
+
+		janitorJob := job.(*WebsiteJanitorJob)
+		janitorJob.config = websiteConfig
+		janitorJob.db = ctx.DB()
+		janitorJob.logger = nil
+
+		// Build an IPFS website in pending_validation state whose CID is NOT
+		// pinned. Before the fix, the janitor would mark it broken.
+		mhBytes, err := mh.Sum([]byte("unpinned-cid"), mh.SHA2_256, -1)
+		require.NoError(tb, err)
+		cidVersion := uint8(1)
+		cidType := uint8(cid.Raw)
+
+		website := &pluginDb.Website{
+			TargetType:      string(pluginDb.WebsiteTargetTypeIPFS),
+			TargetMultihash: mhBytes,
+			CIDVersion:      &cidVersion,
+			CIDType:         &cidType,
+			Status:          string(pluginDb.WebsiteStatusPendingValidation),
+			ValidationToken: "test-token",
+		}
+		require.NoError(tb, ctx.DB().Create(website).Error)
+		require.Equal(tb, string(pluginDb.WebsiteStatusPendingValidation), website.Status)
+
+		// Act: run the janitor validation over this website.
+		require.NoError(tb, janitorJob.validateWebsite(context.Background(), website))
+
+		// Assert: still pending_validation (not broken), and last_checked_at refreshed.
+		var persisted pluginDb.Website
+		require.NoError(tb, ctx.DB().First(&persisted, website.ID).Error)
+		assert.Equal(tb, string(pluginDb.WebsiteStatusPendingValidation), persisted.Status)
+		assert.NotNil(tb, persisted.LastCheckedAt)
 	}, JanitorTestOptions)
 }
 


### PR DESCRIPTION
## Summary

The website janitor (`internal/service/website/janitor.go`) runs a CID-only liveness check every minute against every stale website. A website still in `pending_validation` (awaiting DNS validation) was being subjected to this check. If its CID pin was not yet queryable (common within \~seconds of upload), the janitor marked it `broken` — a terminal state with no automatic recovery path.

Websites in `pending_validation` should only ever transition to `active` via the `ValidateDNS` flow, never via the janitor's CID check.

## Changes

- **`janitor.go` — `validateWebsite`**: Added a guard that skips `pending_validation` websites (leaving status unchanged, refreshing `last_checked_at` so they aren't re-picked every minute).
- **`janitor.go` — `Run` pickup query**: Excluded `pending_validation` websites from the selection for defense in depth.
- **`janitor_test.go`**: Added `TestWebsiteJanitorJob_validateWebsite_SkipsPendingValidation` covering a pending\_validation site with an unpinned CID.

## Verification

- `go build ./...` — passes
- `go vet ./internal/service/website/` — passes
- `gofmt` applied

> Note: `go test` for this package can't execute in this environment due to a pre-existing protobuf registry conflict (`rpc.proto` registered by both `libp2p-pubsub` and `etcd`) that panics during package init. Confirmed unrelated by reproducing on the base code.

- `develop` <!-- branch-stack -->
  - **fix(website): stop janitor from marking pending\_validation sites as broken** :point\_left:

***

<!-- kody-pr-summary:start -->

Based on the code changes, this pull request implements a major new feature: **Platform-Provided Subdomains**.

The core functionality added is the ability for users to claim subdomains on platform-owned root domains (e.g., `user-site.pinner.site`) for their IPFS websites. This is implemented through several key components:

1. **New `PlatformDomain` Data Model**: Introduces a new database table (`platform_domains`) as a registry of platform-owned roots that users can claim subdomains under. This includes a nullable foreign key on the existing `website_domains` table to mark bindings as platform subdomains.

2. **Admin API for Managing Platform Roots**: New admin-only API endpoints to register, list, enable/disable, and delete platform root domains. Registration requires a provisioned DNS zone, enforcing that platform roots are operator-vouched.

3. **User-Facing Subdomain Claims**: Users can now claim platform subdomains when creating domains for their websites by specifying either an explicit label or requesting a generated one (adjective-noun-number format). Claims are exclusive with user-owned domain bindings.

4. **Availability Endpoint**: An authenticated endpoint to check whether a candidate label is available across registered platform roots.

5. **Zone Resolution Changes**: The domain resolution logic now allows subdomains under platform roots to reuse the platform's DNS zone, even though the user binding differs from the zone owner. This relaxation is strictly gated on genuine platform claims.

6. **Verification and Lifecycle Management**: Platform subdomains skip user-side TXT verification (the platform controls both ends of the DNS check) and transition directly to active status.

7. **Label Generation Utility**: A new `GenerateDNSSlug` function creates pronounceable, DNS-safe labels with concurrency safety.

**Bug Fix**: Additionally, the pull request fixes an issue where the website janitor was marking websites in `pending_validation` status as broken. The janitor now skips these websites for CID liveness checks and only transitions them to active via proper DNS validation.

The change includes comprehensive tests covering admin CRUD, availability checks, subdomain claims (including collision retries), and the janitor fix.

<!-- kody-pr-summary:end -->
