### PR TITLE
refactor(website): drive website status transitions through a state machine

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -238,7 +238,7 @@ require (
 	github.com/libp2p/go-netroute v0.4.0 // indirect
 	github.com/libp2p/go-reuseport v0.4.0 // indirect
 	github.com/libp2p/go-yamux/v5 v5.1.0 // indirect
-	github.com/looplab/fsm v1.0.3 // indirect
+	github.com/looplab/fsm v1.0.3
 	github.com/mailru/easyjson v0.9.1 // indirect
 	github.com/markbates/going v1.0.3 // indirect
 	github.com/markbates/goth v1.82.0 // indirect

--- a/internal/service/website/fsm.go
+++ b/internal/service/website/fsm.go
@@ -1,0 +1,126 @@
+package website
+
+import (
+	"context"
+
+	"github.com/looplab/fsm"
+	pluginDb "go.lumeweb.com/portal-plugin-ipfs/internal/db"
+)
+
+// Events that drive a website's lifecycle state machine. These are the only
+// ways a Website may move between statuses; every status mutation in the code
+// base should be routed through WebsiteStateMachine so illegal transitions are
+// rejected instead of being silently written to the database.
+const (
+	// EventWebsiteCreate initializes a freshly created website to
+	// pending_validation, overriding whatever status the caller may have
+	// pre-set (a new website must pass DNS validation before it can be served).
+	// NewWebsiteStateMachine keeps the empty state as-is so this is a real
+	// transition; firing from an already-pending website is a guarded no-op.
+	EventWebsiteCreate = "create"
+	// EventWebsiteValidate activates a website whose DNS validation succeeded.
+	// It is legal from pending_validation (first validation) and broken
+	// (re-validation recovers a broken site). An already-active website needs
+	// no transition (guard with Can()).
+	EventWebsiteValidate = "validate"
+	// EventWebsiteRevalidateOK is fired when the janitor confirms the target is
+	// still pinned, recovering a broken website back to active. A website that
+	// is already active and valid needs no transition (guard with Can()).
+	EventWebsiteRevalidateOK = "revalidate_ok"
+	// EventWebsiteCIDUnpinned is fired when an active website's target is no
+	// longer pinned, flipping it to broken.
+	EventWebsiteCIDUnpinned = "cid_unpinned"
+	// EventWebsiteTargetChanged resets a website to pending_validation because
+	// its target hash changed and must be re-validated. Only meaningful for
+	// websites that were active/broken; an already-pending website is a no-op
+	// (guard with Can()).
+	EventWebsiteTargetChanged = "target_changed"
+	// EventWebsiteBlock is an admin action that blocks serving the website.
+	EventWebsiteBlock = "block"
+	// EventWebsiteUnblock lifts an admin block, returning the website to
+	// pending_validation so it must pass validation before being served again.
+	EventWebsiteUnblock = "unblock"
+)
+
+// websiteStateMachineEvents is the authoritative transition table for website
+// lifecycle statuses. Keep this in sync with the WebsiteStatus enum in
+// internal/db/website.go.
+// websiteStateMachineEvents is the authoritative transition table for website
+// lifecycle statuses. Keep this in sync with the WebsiteStatus enum in
+// internal/db/website.go.
+//
+// Note: looplab/fsm v1.0.3 treats a self-transition (Src == Dst) as an error
+// (NoTransitionError). This table therefore contains only *real* transitions.
+// Call sites that want a no-op "stay in the same state" outcome (e.g. the
+// janitor confirming an already-active website, or forcing an already-pending
+// website back to pending) must guard with Can() rather than firing the event.
+var websiteStateMachineEvents = fsm.Events{
+	// Fresh website (empty status) or one pre-set by the caller (e.g. active in
+	// an API/test fixture) → pending_validation. A brand-new website must be
+	// validated; CreateWebsite never inherits a prior/pre-set status. Firing
+	// from an already-pending website is a self-transition and is guarded with
+	// Can() by the caller, so it is omitted from the legal sources.
+	{Name: EventWebsiteCreate, Src: []string{"", string(pluginDb.WebsiteStatusActive), string(pluginDb.WebsiteStatusBroken)}, Dst: string(pluginDb.WebsiteStatusPendingValidation)},
+	// DNS validation succeeded (first validation or recovery of a broken site).
+	{Name: EventWebsiteValidate, Src: []string{string(pluginDb.WebsiteStatusPendingValidation), string(pluginDb.WebsiteStatusBroken)}, Dst: string(pluginDb.WebsiteStatusActive)},
+	// Janitor liveness check passed; recovers broken back to active.
+	{Name: EventWebsiteRevalidateOK, Src: []string{string(pluginDb.WebsiteStatusBroken)}, Dst: string(pluginDb.WebsiteStatusActive)},
+	// Janitor liveness check failed for an active website.
+	{Name: EventWebsiteCIDUnpinned, Src: []string{string(pluginDb.WebsiteStatusActive)}, Dst: string(pluginDb.WebsiteStatusBroken)},
+	// Target hash change invalidates a previously active/broken website.
+	{Name: EventWebsiteTargetChanged, Src: []string{string(pluginDb.WebsiteStatusActive), string(pluginDb.WebsiteStatusBroken)}, Dst: string(pluginDb.WebsiteStatusPendingValidation)},
+	// Admin blocking; not valid from an already-blocked website.
+	{Name: EventWebsiteBlock, Src: []string{string(pluginDb.WebsiteStatusPendingValidation), string(pluginDb.WebsiteStatusActive), string(pluginDb.WebsiteStatusBroken)}, Dst: string(pluginDb.WebsiteStatusBlocked)},
+	// Admin unblock returns the website to pending_validation.
+	{Name: EventWebsiteUnblock, Src: []string{string(pluginDb.WebsiteStatusBlocked)}, Dst: string(pluginDb.WebsiteStatusPendingValidation)},
+}
+
+// WebsiteStateMachine wraps a looplab/fsm state machine bound to a single
+// Website. It is constructed from the website's current status, fired to
+// perform a legal transition (which updates the Website.Status field in place
+// via the after_event callback), and the caller persists the change within the
+// surrounding transaction.
+type WebsiteStateMachine struct {
+	fsm     *fsm.FSM
+	website *pluginDb.Website
+}
+
+// NewWebsiteStateMachine builds a state machine initialized to the given
+// website's current status. An empty status is kept as-is: it represents the
+// pre-creation state from which the create event fires. This keeps create a
+// real (non-self) transition under looplab/fsm.
+func NewWebsiteStateMachine(website *pluginDb.Website) *WebsiteStateMachine {
+	initial := website.Status
+
+	m := &WebsiteStateMachine{
+		website: website,
+		fsm:     fsm.NewFSM(initial, websiteStateMachineEvents, fsm.Callbacks{
+			// Persist the destination status back onto the website so callers
+			// don't have to derive it from the event themselves.
+			"after_event": func(_ context.Context, e *fsm.Event) {
+				website.Status = e.Dst
+			},
+		}),
+	}
+
+	return m
+}
+
+// Fire performs a transition if it is legal for the website's current state.
+// On success it mutates website.Status to the destination state. It returns an
+// error (fsm.ErrNotInSource) when the transition is not allowed.
+func (w *WebsiteStateMachine) Fire(ctx context.Context, event string) error {
+	return w.fsm.Event(ctx, event)
+}
+
+// Can reports whether the given event is a legal transition from the website's
+// current state. Use it to guard transitions that are only meaningful from a
+// subset of states (e.g. a janitor marking an already-broken website broken).
+func (w *WebsiteStateMachine) Can(event string) bool {
+	return w.fsm.Can(event)
+}
+
+// Current returns the website's current status.
+func (w *WebsiteStateMachine) Current() pluginDb.WebsiteStatus {
+	return pluginDb.WebsiteStatus(w.fsm.Current())
+}

--- a/internal/service/website/fsm_test.go
+++ b/internal/service/website/fsm_test.go
@@ -1,0 +1,138 @@
+package website
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	pluginDb "go.lumeweb.com/portal-plugin-ipfs/internal/db"
+)
+
+// emptyState represents the pre-creation status ("" in the DB).
+const emptyState = pluginDb.WebsiteStatus("")
+
+// legalTransitions is the expectation matrix for the website state machine:
+// event → source statuses that may legally fire it, and the resulting status.
+// create is only legal from the empty pre-creation state (initialEmpty).
+var legalTransitions = []struct {
+	name         string
+	event        string
+	sources      []pluginDb.WebsiteStatus
+	dest         pluginDb.WebsiteStatus
+	initialEmpty bool // allow firing from the empty (pre-creation) status
+}{
+	{name: "create", event: EventWebsiteCreate, sources: []pluginDb.WebsiteStatus{pluginDb.WebsiteStatusActive, pluginDb.WebsiteStatusBroken}, dest: pluginDb.WebsiteStatusPendingValidation, initialEmpty: true},
+	{name: "validate", event: EventWebsiteValidate, sources: []pluginDb.WebsiteStatus{pluginDb.WebsiteStatusPendingValidation, pluginDb.WebsiteStatusBroken}, dest: pluginDb.WebsiteStatusActive},
+	{name: "revalidate_ok", event: EventWebsiteRevalidateOK, sources: []pluginDb.WebsiteStatus{pluginDb.WebsiteStatusBroken}, dest: pluginDb.WebsiteStatusActive},
+	{name: "cid_unpinned", event: EventWebsiteCIDUnpinned, sources: []pluginDb.WebsiteStatus{pluginDb.WebsiteStatusActive}, dest: pluginDb.WebsiteStatusBroken},
+	{name: "target_changed", event: EventWebsiteTargetChanged, sources: []pluginDb.WebsiteStatus{pluginDb.WebsiteStatusActive, pluginDb.WebsiteStatusBroken}, dest: pluginDb.WebsiteStatusPendingValidation},
+	{name: "block", event: EventWebsiteBlock, sources: []pluginDb.WebsiteStatus{pluginDb.WebsiteStatusPendingValidation, pluginDb.WebsiteStatusActive, pluginDb.WebsiteStatusBroken}, dest: pluginDb.WebsiteStatusBlocked},
+	{name: "unblock", event: EventWebsiteUnblock, sources: []pluginDb.WebsiteStatus{pluginDb.WebsiteStatusBlocked}, dest: pluginDb.WebsiteStatusPendingValidation},
+}
+
+// allStatuses lists every known status, used to assert illegal transitions
+// from every non-source state. The empty pre-creation state is included so the
+// create event is asserted illegal from any real status.
+var allStatuses = []pluginDb.WebsiteStatus{
+	emptyState,
+	pluginDb.WebsiteStatusPendingValidation,
+	pluginDb.WebsiteStatusActive,
+	pluginDb.WebsiteStatusBroken,
+	pluginDb.WebsiteStatusBlocked,
+}
+
+func containsStatus(list []pluginDb.WebsiteStatus, s pluginDb.WebsiteStatus) bool {
+	for _, v := range list {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}
+
+func TestWebsiteStateMachine_LegalTransitions(t *testing.T) {
+	for _, tc := range legalTransitions {
+		for _, src := range tc.sources {
+			t.Run(tc.name+"_from_"+string(src), func(t *testing.T) {
+				website := &pluginDb.Website{Status: string(src)}
+				sm := NewWebsiteStateMachine(website)
+
+				assert.True(t, sm.Can(tc.event), "expected %s to be legal from %s", tc.event, src)
+				err := sm.Fire(context.Background(), tc.event)
+				assert.NoError(t, err, "expected %s to succeed from %s", tc.event, src)
+				assert.Equal(t, tc.dest, sm.Current(), "unexpected destination after %s", tc.event)
+				assert.Equal(t, string(tc.dest), website.Status, "fire should update website.Status")
+			})
+		}
+
+		if tc.initialEmpty {
+			t.Run(tc.name+"_from_empty", func(t *testing.T) {
+				website := &pluginDb.Website{Status: ""}
+				sm := NewWebsiteStateMachine(website)
+				assert.True(t, sm.Can(tc.event))
+				assert.NoError(t, sm.Fire(context.Background(), tc.event))
+				assert.Equal(t, tc.dest, sm.Current())
+				assert.Equal(t, string(tc.dest), website.Status)
+			})
+		}
+	}
+}
+
+func TestWebsiteStateMachine_IllegalTransitions(t *testing.T) {
+	for _, tc := range legalTransitions {
+		for _, src := range allStatuses {
+			if containsStatus(tc.sources, src) || (src == emptyState && tc.initialEmpty) {
+				continue
+			}
+
+			t.Run(tc.name+"_from_"+string(src)+"_rejected", func(t *testing.T) {
+				website := &pluginDb.Website{Status: string(src)}
+				sm := NewWebsiteStateMachine(website)
+
+				assert.False(t, sm.Can(tc.event), "expected %s to be illegal from %s", tc.event, src)
+				err := sm.Fire(context.Background(), tc.event)
+				assert.Error(t, err, "expected %s to be rejected from %s", tc.event, src)
+				// Status must be untouched on a rejected transition.
+				assert.Equal(t, string(src), website.Status)
+				assert.Equal(t, src, sm.Current())
+			})
+		}
+	}
+}
+
+// TestWebsiteStateMachine_NoSelfTransitions documents that looplab/fsm v1.0.3
+// rejects self-transitions (Src == Dst), so call sites keep a website in the
+// same state via Can() guards rather than firing an event that would error.
+func TestWebsiteStateMachine_NoSelfTransitions(t *testing.T) {
+	// An already-active website is a no-op for revalidate_ok (no self-
+	// transition); it stays active without firing an event.
+	active := &pluginDb.Website{Status: string(pluginDb.WebsiteStatusActive)}
+	smActive := NewWebsiteStateMachine(active)
+	assert.False(t, smActive.Can(EventWebsiteRevalidateOK))
+	// But target_changed is a real transition that forces re-validation.
+	assert.True(t, smActive.Can(EventWebsiteTargetChanged))
+
+	// An already-pending website is a no-op for create (only legal from "") and
+	// target_changed (only legal from active/broken).
+	pending := &pluginDb.Website{Status: string(pluginDb.WebsiteStatusPendingValidation)}
+	smPending := NewWebsiteStateMachine(pending)
+	assert.False(t, smPending.Can(EventWebsiteCreate))
+	assert.False(t, smPending.Can(EventWebsiteTargetChanged))
+	// But it can still be validated.
+	assert.True(t, smPending.Can(EventWebsiteValidate))
+}
+
+func TestWebsiteStateMachine_BlockedIsTerminalForHealthEvents(t *testing.T) {
+	// A blocked website must not be flipped to broken/active by janitor health
+	// events, nor be re-validated directly.
+	website := &pluginDb.Website{Status: string(pluginDb.WebsiteStatusBlocked)}
+	sm := NewWebsiteStateMachine(website)
+
+	for _, ev := range []string{EventWebsiteValidate, EventWebsiteRevalidateOK, EventWebsiteCIDUnpinned, EventWebsiteCreate, EventWebsiteBlock} {
+		assert.False(t, sm.Can(ev), "expected %s to be illegal from blocked", ev)
+	}
+
+	assert.True(t, sm.Can(EventWebsiteUnblock))
+	assert.NoError(t, sm.Fire(context.Background(), EventWebsiteUnblock))
+	assert.Equal(t, pluginDb.WebsiteStatusPendingValidation, sm.Current())
+}

--- a/internal/service/website/janitor.go
+++ b/internal/service/website/janitor.go
@@ -169,19 +169,25 @@ func (j *WebsiteJanitorJob) validateWebsite(ctx context.Context, website *plugin
 	ctx, span := core.TraceMethod(ctx, "WebsiteJanitorJob.validateWebsite")
 	defer span.End()
 
+	sm := NewWebsiteStateMachine(website)
+
 	// Websites awaiting DNS validation must not be subjected to CID-only
-	// liveness checks. They transition to active solely via ValidateDNS.
-	// Skip them here (refreshing last_checked_at so they aren't re-picked
-	// every minute) instead of risking an incorrect broken status.
+	// liveness checks. They transition to active solely via ValidateDNS. Skip
+	// them here (refreshing last_checked_at so they aren't re-picked every
+	// minute) instead of risking an incorrect broken status. The FSM also
+	// enforces this: revalidate_ok/cid_unpinned are not legal from
+	// pending_validation.
 	if website.Status == string(pluginDb.WebsiteStatusPendingValidation) {
 		website.LastCheckedAt = new(time.Now())
 		return j.db.WithContext(ctx).Save(website).Error
 	}
 
 	oldStatus := website.Status
-	newStatus := pluginDb.WebsiteStatusActive
 
-	// Check target based on type
+	// Determine the health-driven outcome for the target. The FSM turns this
+	// into a legal status transition (and is a no-op when the website is
+	// already in the target state).
+	var targetStatus pluginDb.WebsiteStatus
 	switch website.TargetType {
 	case string(pluginDb.WebsiteTargetTypeIPFS):
 		valid, err := j.validateCIDTarget(ctx, website.TargetHash())
@@ -189,11 +195,13 @@ func (j *WebsiteJanitorJob) validateWebsite(ctx context.Context, website *plugin
 			j.logger.Warn("Failed to validate CID target",
 				zap.Error(err),
 				zap.String("target", website.TargetHash()))
-			newStatus = pluginDb.WebsiteStatusBroken
+			targetStatus = pluginDb.WebsiteStatusBroken
 		} else if !valid {
 			j.logger.Debug("CID target is not valid or not pinned",
 				zap.String("target", website.TargetHash()))
-			newStatus = pluginDb.WebsiteStatusBroken
+			targetStatus = pluginDb.WebsiteStatusBroken
+		} else {
+			targetStatus = pluginDb.WebsiteStatusActive
 		}
 
 	case string(pluginDb.WebsiteTargetTypeIPNS):
@@ -202,10 +210,12 @@ func (j *WebsiteJanitorJob) validateWebsite(ctx context.Context, website *plugin
 			j.logger.Warn("Failed to validate IPNS target",
 				zap.Error(err),
 				zap.String("target", website.TargetHash()))
-			newStatus = pluginDb.WebsiteStatusBroken
+			targetStatus = pluginDb.WebsiteStatusBroken
+		} else {
+			targetStatus = pluginDb.WebsiteStatusActive
 		}
-		// validateIPNSTarget handles status and LastCheckedAt updates internally
-		// Save the changes immediately
+		// validateIPNSTarget handles status and LastCheckedAt updates internally.
+		// Save the changes immediately.
 		if err := j.db.WithContext(ctx).Save(website).Error; err != nil {
 			return fmt.Errorf("failed to update website: %w", err)
 		}
@@ -213,27 +223,38 @@ func (j *WebsiteJanitorJob) validateWebsite(ctx context.Context, website *plugin
 
 	default:
 		j.logger.Warn("Unknown target type", zap.String("target_type", website.TargetType))
-		newStatus = pluginDb.WebsiteStatusBroken
+		targetStatus = pluginDb.WebsiteStatusBroken
 	}
 
-	// Update website status if changed
-	if string(newStatus) != oldStatus {
+	// Fire the health-driven transition via the FSM (a no-op when the website
+	// is already in the desired state):
+	//   valid   → revalidate_ok (broken → active; already-active is a no-op
+	//              guarded by Can)
+	//   invalid → cid_unpinned  (active → broken; an already-broken website
+	//              that fails again is a no-op, still refreshing the timestamp)
+	var transitionErr error
+	if targetStatus == pluginDb.WebsiteStatusActive {
+		if sm.Can(EventWebsiteRevalidateOK) {
+			transitionErr = sm.Fire(ctx, EventWebsiteRevalidateOK)
+		}
+	} else if sm.Can(EventWebsiteCIDUnpinned) {
+		transitionErr = sm.Fire(ctx, EventWebsiteCIDUnpinned)
+	}
+	if transitionErr != nil {
+		j.logger.Warn("Failed to apply website status transition",
+			zap.Error(transitionErr),
+			zap.Uint("website_id", website.ID),
+			zap.String("event", "revalidate_ok/cid_unpinned"))
+		return fmt.Errorf("failed to transition website status: %w", transitionErr)
+	}
+
+	// Log status changes
+	if website.Status != oldStatus {
 		j.logger.Info("Website status changed",
 			zap.Uint("website_id", website.ID),
 			zap.String("domain", j.primaryDomainName(ctx, website)),
 			zap.String("old_status", oldStatus),
-			zap.String("new_status", string(newStatus)))
-
-		website.Status = string(newStatus)
-
-		// Trigger notification if status changed to broken
-		if newStatus == pluginDb.WebsiteStatusBroken {
-			// Note: notifyStatusChange requires core.Context, but we have context.Context here
-			// Skip notification in janitor context - notifications will be handled in user-facing operations
-			j.logger.Debug("Status changed to broken, skipping notification in janitor context",
-				zap.Uint("website_id", website.ID),
-				zap.String("domain", j.primaryDomainName(ctx, website)))
-		}
+			zap.String("new_status", website.Status))
 	}
 
 	// Update last_checked_at timestamp
@@ -283,6 +304,7 @@ func (j *WebsiteJanitorJob) validateIPNSTarget(ctx context.Context, website *plu
 	ctx, span := core.TraceMethod(ctx, "WebsiteJanitorJob.validateIPNSTarget")
 	defer span.End()
 
+	sm := NewWebsiteStateMachine(website)
 	peerID := website.TargetHash()
 
 	privKey, userID, err := j.ipnsKeyService.GetPrivateKeyByPeerID(ctx, peerID)
@@ -293,8 +315,7 @@ func (j *WebsiteJanitorJob) validateIPNSTarget(ctx context.Context, website *plu
 			zap.String("domain", j.primaryDomainName(ctx, website)),
 			zap.String("peer_id", peerID),
 		)
-		website.Status = string(pluginDb.WebsiteStatusBroken)
-		website.LastCheckedAt = new(time.Now())
+		j.markBroken(ctx, sm, website)
 		return nil
 	}
 
@@ -307,8 +328,7 @@ func (j *WebsiteJanitorJob) validateIPNSTarget(ctx context.Context, website *plu
 			zap.Uint("website_user_id", website.UserID),
 			zap.Uint("key_user_id", userID),
 		)
-		website.Status = string(pluginDb.WebsiteStatusBroken)
-		website.LastCheckedAt = new(time.Now())
+		j.markBroken(ctx, sm, website)
 		return nil
 	}
 
@@ -320,8 +340,7 @@ func (j *WebsiteJanitorJob) validateIPNSTarget(ctx context.Context, website *plu
 			zap.String("domain", j.primaryDomainName(ctx, website)),
 			zap.String("peer_id", peerID),
 		)
-		website.Status = string(pluginDb.WebsiteStatusBroken)
-		website.LastCheckedAt = new(time.Now())
+		j.markBroken(ctx, sm, website)
 		return nil
 	}
 
@@ -331,8 +350,7 @@ func (j *WebsiteJanitorJob) validateIPNSTarget(ctx context.Context, website *plu
 			zap.String("domain", j.primaryDomainName(ctx, website)),
 			zap.String("peer_id", peerID),
 		)
-		website.Status = string(pluginDb.WebsiteStatusBroken)
-		website.LastCheckedAt = new(time.Now())
+		j.markBroken(ctx, sm, website)
 		return nil
 	}
 
@@ -344,8 +362,7 @@ func (j *WebsiteJanitorJob) validateIPNSTarget(ctx context.Context, website *plu
 			zap.String("domain", j.primaryDomainName(ctx, website)),
 			zap.String("cid", key.LastPublishedCID),
 		)
-		website.Status = string(pluginDb.WebsiteStatusBroken)
-		website.LastCheckedAt = new(time.Now())
+		j.markBroken(ctx, sm, website)
 		return nil
 	}
 
@@ -355,13 +372,11 @@ func (j *WebsiteJanitorJob) validateIPNSTarget(ctx context.Context, website *plu
 			zap.String("domain", j.primaryDomainName(ctx, website)),
 			zap.String("cid", key.LastPublishedCID),
 		)
-		website.Status = string(pluginDb.WebsiteStatusBroken)
-		website.LastCheckedAt = new(time.Now())
+		j.markBroken(ctx, sm, website)
 		return nil
 	}
 
-	website.Status = string(pluginDb.WebsiteStatusActive)
-	website.LastCheckedAt = new(time.Now())
+	j.markActive(ctx, sm, website)
 
 	j.logger.Debug("IPNS target validated successfully",
 		zap.Uint("website_id", website.ID),
@@ -371,6 +386,33 @@ func (j *WebsiteJanitorJob) validateIPNSTarget(ctx context.Context, website *plu
 	)
 
 	return nil
+}
+
+// markBroken transitions the website to broken via the state machine when that
+// transition is legal, and refreshes its last_checked_at. It is a no-op for a
+// website already in broken state.
+func (j *WebsiteJanitorJob) markBroken(ctx context.Context, sm *WebsiteStateMachine, website *pluginDb.Website) {
+	if sm.Can(EventWebsiteCIDUnpinned) {
+		if err := sm.Fire(ctx, EventWebsiteCIDUnpinned); err != nil {
+			j.logger.Warn("failed to mark website broken",
+				zap.Error(err),
+				zap.Uint("website_id", website.ID))
+		}
+	}
+	website.LastCheckedAt = new(time.Now())
+}
+
+// markActive transitions the website to active via the state machine when that
+// transition is legal, and refreshes its last_checked_at.
+func (j *WebsiteJanitorJob) markActive(ctx context.Context, sm *WebsiteStateMachine, website *pluginDb.Website) {
+	if sm.Can(EventWebsiteRevalidateOK) {
+		if err := sm.Fire(ctx, EventWebsiteRevalidateOK); err != nil {
+			j.logger.Warn("failed to mark website active",
+				zap.Error(err),
+				zap.Uint("website_id", website.ID))
+		}
+	}
+	website.LastCheckedAt = new(time.Now())
 }
 
 // validateDNSZones validates DNS zones that are pending nameserver verification

--- a/internal/service/website/website.go
+++ b/internal/service/website/website.go
@@ -1057,8 +1057,10 @@ func (s *WebsiteServiceDefault) handleDNSEnabledTransition(ctx context.Context, 
 			return fmt.Errorf("failed to create DNS records: %w", err)
 		}
 
-		// Update website with new token and status (reset to pending_validation
-		// via the state machine — a change in DNS records forces re-validation).
+		// Update website with new token and status. Active/broken websites are
+		// reset to pending_validation via target_changed (a change in DNS
+		// records forces re-validation). A blocked website keeps its status —
+		// an admin block is lifted only via UnblockWebsite, not by a DNS toggle.
 		expiresAt := time.Now().Add(s.config.ValidationTokenTTL)
 		sm := NewWebsiteStateMachine(&website)
 		if sm.Can(EventWebsiteTargetChanged) {
@@ -1205,9 +1207,10 @@ func (s *WebsiteServiceDefault) handleDNSDisabledTransition(ctx context.Context,
 // after DNS-hosting teardown. It is the part of handleDNSDisabledTransition
 // that also applies when the zone is delegation-owned and must be preserved.
 func (s *WebsiteServiceDefault) resetWebsiteValidationState(ctx context.Context, website pluginDb.Website) error {
-	// Reset to pending_validation via the state machine; the website must be
-	// re-validated before it can be served again. An already-pending website
-	// needs no transition.
+	// Reset active/broken websites to pending_validation via target_changed so
+	// they must be re-validated before being served again. A blocked website is
+	// left blocked — an admin block is only lifted via UnblockWebsite. An
+	// already-pending website needs no transition.
 	sm := NewWebsiteStateMachine(&website)
 	if sm.Can(EventWebsiteTargetChanged) {
 		if err := sm.Fire(ctx, EventWebsiteTargetChanged); err != nil {

--- a/internal/service/website/website.go
+++ b/internal/service/website/website.go
@@ -222,8 +222,16 @@ func (s *WebsiteServiceDefault) CreateWebsite(ctx context.Context, website *plug
 			expiresAt := time.Now().Add(s.config.ValidationTokenTTL)
 			website.ValidationExpiresAt = &expiresAt
 
-			// Set initial status
-			website.Status = string(pluginDb.WebsiteStatusPendingValidation)
+			// Set initial status via the website state machine. Only a fresh
+			// website (empty status) transitions to pending_validation; an
+			// already-statused website (e.g. the API layer pre-sets active) is
+			// left untouched.
+			createSM := NewWebsiteStateMachine(website)
+			if createSM.Can(EventWebsiteCreate) {
+				if err := createSM.Fire(ctx, EventWebsiteCreate); err != nil {
+					return nil, fmt.Errorf("failed to set initial website status: %w", err)
+				}
+			}
 
 			// Resolve the primary (apex) WebsiteDomain, which owns the DNS hosting
 			// state for this site. The primary domain may have been bound before
@@ -1049,13 +1057,20 @@ func (s *WebsiteServiceDefault) handleDNSEnabledTransition(ctx context.Context, 
 			return fmt.Errorf("failed to create DNS records: %w", err)
 		}
 
-		// Update website with new token and status
+		// Update website with new token and status (reset to pending_validation
+		// via the state machine — a change in DNS records forces re-validation).
 		expiresAt := time.Now().Add(s.config.ValidationTokenTTL)
+		sm := NewWebsiteStateMachine(&website)
+		if sm.Can(EventWebsiteTargetChanged) {
+			if err := sm.Fire(ctx, EventWebsiteTargetChanged); err != nil {
+				return fmt.Errorf("failed to reset website validation status: %w", err)
+			}
+		}
 		err = db.RetryableComponentTransaction(s, ctx, func(tx *gorm.DB) *gorm.DB {
 			return tx.Model(&website).Updates(map[string]interface{}{
 				"validation_token":      newToken,
 				"validation_expires_at": expiresAt,
-				"status":                string(pluginDb.WebsiteStatusPendingValidation),
+				"status":                website.Status,
 			})
 		})
 		if err != nil {
@@ -1190,11 +1205,17 @@ func (s *WebsiteServiceDefault) handleDNSDisabledTransition(ctx context.Context,
 // after DNS-hosting teardown. It is the part of handleDNSDisabledTransition
 // that also applies when the zone is delegation-owned and must be preserved.
 func (s *WebsiteServiceDefault) resetWebsiteValidationState(ctx context.Context, website pluginDb.Website) error {
-	updates := map[string]interface{}{
-		"status": string(pluginDb.WebsiteStatusPendingValidation),
+	// Reset to pending_validation via the state machine; the website must be
+	// re-validated before it can be served again. An already-pending website
+	// needs no transition.
+	sm := NewWebsiteStateMachine(&website)
+	if sm.Can(EventWebsiteTargetChanged) {
+		if err := sm.Fire(ctx, EventWebsiteTargetChanged); err != nil {
+			return fmt.Errorf("failed to reset website validation state: %w", err)
+		}
 	}
 	err := db.RetryableComponentTransaction(s, ctx, func(tx *gorm.DB) *gorm.DB {
-		return tx.Model(&website).Updates(updates)
+		return tx.Save(&website)
 	})
 	if err != nil {
 		s.Logger().Error("Failed to update website",
@@ -1334,8 +1355,15 @@ func (s *WebsiteServiceDefault) BlockWebsite(ctx context.Context, websiteID uint
 					return tx
 				}
 
-				// Update the status
-				website.Status = string(pluginDb.WebsiteStatusBlocked)
+				// Update the status via the state machine (idempotent if already
+				// blocked).
+				sm := NewWebsiteStateMachine(&website)
+				if sm.Can(EventWebsiteBlock) {
+					if err := sm.Fire(ctx, EventWebsiteBlock); err != nil {
+						_ = tx.AddError(fmt.Errorf("failed to block website: %w", err))
+						return tx
+					}
+				}
 				if err := tx.Save(&website).Error; err != nil {
 					_ = tx.AddError(fmt.Errorf("failed to block website: %w", err))
 					return tx
@@ -1378,8 +1406,13 @@ func (s *WebsiteServiceDefault) UnblockWebsite(ctx context.Context, websiteID ui
 					return tx
 				}
 
-				// Update the status
-				website.Status = string(pluginDb.WebsiteStatusActive)
+				// Update the status via the state machine. Unblocking returns the
+				// website to pending_validation so it must re-validate before
+				// being served again.
+				if err := NewWebsiteStateMachine(&website).Fire(ctx, EventWebsiteUnblock); err != nil {
+					_ = tx.AddError(fmt.Errorf("failed to unblock website: %w", err))
+					return tx
+				}
 				if err := tx.Save(&website).Error; err != nil {
 					_ = tx.AddError(fmt.Errorf("failed to unblock website: %w", err))
 					return tx
@@ -1675,7 +1708,14 @@ func (s *WebsiteServiceDefault) regenerateExpiredToken(ctx context.Context, webs
 
 func (s *WebsiteServiceDefault) activateValidatedWebsite(ctx context.Context, website *pluginDb.Website) error {
 	return db.RetryableComponentTransaction(s, ctx, func(tx *gorm.DB) *gorm.DB {
-		website.Status = string(pluginDb.WebsiteStatusActive)
+		// Activate from pending_validation. A website that is already active
+		// (e.g. a re-validation) needs no transition.
+		sm := NewWebsiteStateMachine(website)
+		if sm.Can(EventWebsiteValidate) {
+			if err := sm.Fire(ctx, EventWebsiteValidate); err != nil {
+				_ = tx.AddError(fmt.Errorf("failed to activate website: %w", err))
+			}
+		}
 		newExpiry := time.Now().Add(s.config.ValidationTokenTTL)
 		website.ValidationExpiresAt = &newExpiry
 		return tx.Save(website)

--- a/internal/service/website/website_test.go
+++ b/internal/service/website/website_test.go
@@ -969,11 +969,12 @@ func TestWebsiteService_UnblockWebsite(t *testing.T) {
 		// Assert
 		require.NoError(tb, err)
 
-		// Verify website is now active
+		// Verify website is now pending_validation (must re-validate before
+		// being served again).
 		retrievedWebsite, err := websiteService.GetWebsite(context.Background(), testUserID1, createdWebsite.ID)
 		require.NoError(tb, err)
 		assert.NotNil(tb, retrievedWebsite)
-		assert.Equal(t, string(pluginDb.WebsiteStatusActive), retrievedWebsite.Status)
+		assert.Equal(t, string(pluginDb.WebsiteStatusPendingValidation), retrievedWebsite.Status)
 	}, TestOptions)
 }
 


### PR DESCRIPTION
FSM refactor for website status transitions.

- `develop` <!-- branch-stack -->
  - **refactor(website): drive website status transitions through a state machine** :point\_left:

***

<!-- kody-pr-summary:start -->

## Summary

This pull request introduces a formal state machine to govern website status transitions in the IPFS portal plugin. Previously, website status changes were applied directly across multiple code paths, which risked illegal status transitions (e.g., a blocked website being marked active) and inconsistent behavior. The change centralizes all status mutations through a single, authoritative transition table.

## Key Changes

### New State Machine (FSM)

- Added a state machine (`WebsiteStateMachine`) implemented with the `looplab/fsm` library, defined in `internal/service/website/fsm.go`
- The state machine defines 8 legal events:
  - **Create**: Initializes a new website to `pending_validation`
  - **Validate**: Activates a website after DNS validation succeeds
  - **RevalidateOK**: Recovers a broken website back to active (janitor liveness check)
  - **CIDUnpinned**: Marks an active website as broken when its target is no longer pinned
  - **TargetChanged**: Resets a website to `pending_validation` when its target hash changes
  - **Block**: Admin action to block serving a website
  - **Unblock**: Lifts an admin block and returns the website to `pending_validation`
- Each event has a defined set of valid source states, and illegal transitions are rejected with an error
- The state machine automatically updates the website's status in memory upon a successful transition

### Route All Status Changes Through the FSM

Updated all website service operations to use the state machine instead of directly assigning status:

- **CreateWebsite**: Initial status is set via the `create` event (only from the empty pre-creation state)
- **activateValidatedWebsite**: Uses the `validate` event to transition from `pending_validation` to `active`
- **BlockWebsite/UnblockWebsite**: Use `block`/`unblock` events
- **handleDNSEnabledTransition / resetWebsiteValidationState**: Use `target_changed` event to force re-validation when DNS records change
- **Janitor validation** (`validateWebsite`, `validateIPNSTarget`): Uses `revalidate_ok` (to mark active) and `cid_unpinned` (to mark broken) events, replacing direct status writes

### Behavioral Change

The most notable behavior change is in **unblocking**: Previously, unblocking a website set its status directly to `active`. Now, unblocking returns the website to `pending_validation`, requiring it to pass DNS validation again before it can be served. This is consistent with the new state machine's `unblock` event definition.

### Tests

Added comprehensive unit tests (`internal/service/website/fsm_test.go`) that verify:

- All legal transitions are permitted and update the website status correctly
- All illegal transitions are rejected without modifying the website status
- Self-transitions (e.g., re-validating an already-active website) are treated as no-ops rather than errors
- A blocked website is effectively terminal for health-related events (only `unblock` is legal)
- Updated existing unblock test to reflect the new expected status (`pending_validation` instead of `active`)

<!-- kody-pr-summary:end -->
