### PR TITLE
fix: swagger nil pointer crash on delete platform domain

### DIFF
--- a/internal/api/admin_extension.go
+++ b/internal/api/admin_extension.go
@@ -348,7 +348,8 @@ See also: GET /platform-domains (list), PATCH /platform-domains/:id (enable/disa
 				router.WithDescription(`Removes a registered platform root. Existing subdomain bindings remain but can no longer be reconciled as platform subdomains.`),
 				router.WithTags("Admin", "PlatformDomains"),
 				router.WithPathParam("id", "Platform domain ID", ""),
-				router.WithSuccessResponse(http.StatusOK, "Platform domain deleted", router.WithJSONContent(nil)),
+				router.WithSuccessResponse(http.StatusNoContent, "Platform domain deleted"),
+			router.WithoutDefaultSuccessResponse(),
 			),
 		),
 	)
@@ -463,5 +464,5 @@ func (e *AdminExtension) deletePlatformDomain(c echo.Context) error {
 		return ctx.Error(apiErr, apiErr.HttpStatus())
 	}
 
-	return ctx.NoContent(http.StatusOK)
+	return ctx.NoContent(http.StatusNoContent)
 }


### PR DESCRIPTION
The delete platform domain route used WithJSONContent(nil) in its swagger definition, creating a SchemaRef with both Ref and Value nil. This caused a nil pointer dereference panic when kin-openapi marshaled the swagger spec at startup. Fixed by using WithSuccessResponse(http.StatusNoContent) with WithoutDefaultSuccessResponse(), matching the handler NoContent return.

- **fix: swagger nil pointer crash on delete platform domain** :point\_left: <!-- branch-stack -->
  - \#945

***

<!-- kody-pr-summary:start -->

This pull request fixes a swagger documentation crash that occurs when deleting a platform domain. The changes modify the delete platform domain endpoint in two ways:

1. **Updated API documentation**: Changed the success response from HTTP 200 (OK) with a JSON content type of `nil` to HTTP 204 (No Content) without specifying a response body, which properly reflects that the operation returns no content.

2. **Corrected the actual HTTP status code**: Changed the actual response from `http.StatusOK` (200) to `http.StatusNoContent` (204) to match the updated documentation and align with REST API best practices where DELETE operations return 204 when no response body is needed.

These changes fix the nil pointer crash in swagger documentation generation and ensure the API behaves consistently with its documented contract.

<!-- kody-pr-summary:end -->
