### PR TITLE
refactor(domains): auto-create operator zone for platform roots and add apex binding

### DIFF
--- a/internal/api/admin_extension.go
+++ b/internal/api/admin_extension.go
@@ -16,6 +16,9 @@ import (
 	"go.lumeweb.com/portal-router"
 	"go.lumeweb.com/portal/config"
 	"go.lumeweb.com/portal/core"
+	"go.lumeweb.com/portal-middleware/auth/jwt"
+	mcontext "go.lumeweb.com/portal-middleware/context"
+	portalMw "go.lumeweb.com/portal-middleware/middleware"
 	"go.lumeweb.com/queryutil"
 	queryutilHttp "go.lumeweb.com/queryutil/http"
 	"go.uber.org/zap"
@@ -73,6 +76,14 @@ func (e *AdminExtension) Configure(gRouter router.Router, accessSvc core.AccessS
 		return err
 	}
 
+	// Authenticate operator tokens end-to-end so platform-domain handlers can
+	// derive the operator's identity via GetUserID (same middleware as the main
+	// API). Scoped to the platform-domain routes; the other admin handlers do
+	// not require a per-request identity.
+	authMw := portalMw.AuthMiddleware(e.Context(),
+		portalMw.WithAuthPurpose(jwt.PurposeLogin, jwt.PurposeAPI),
+	)
+
 	if err := e.registerWebsiteHandlers(ipfsRouter, accessSvc); err != nil {
 		return err
 	}
@@ -81,7 +92,7 @@ func (e *AdminExtension) Configure(gRouter router.Router, accessSvc core.AccessS
 		return err
 	}
 
-	if err := e.registerPlatformDomainHandlers(ipfsRouter, accessSvc); err != nil {
+	if err := e.registerPlatformDomainHandlers(ipfsRouter, accessSvc, authMw); err != nil {
 		return err
 	}
 
@@ -305,7 +316,7 @@ func (e *AdminExtension) republishIPNS(c echo.Context) error {
 
 	return httputil.EncodeResponse(ctx, nil, &resp)
 }
-func (e *AdminExtension) registerPlatformDomainHandlers(gRouter router.Router, accessSvc core.AccessService) error {
+func (e *AdminExtension) registerPlatformDomainHandlers(gRouter router.Router, accessSvc core.AccessService, authMw echo.MiddlewareFunc) error {
 	routes := router.DefineRoutes(
 		router.NewRoute(http.MethodPost, "/platform-domains", e.createPlatformDomain,
 			router.WithAccess(core.ACCESS_ADMIN_ROLE),
@@ -313,12 +324,27 @@ func (e *AdminExtension) registerPlatformDomainHandlers(gRouter router.Router, a
 				router.WithSummary("Register platform domain"),
 				router.WithDescription(`Registers a platform-owned root domain that users can claim free subdomains under.
 
-Operator-only operation. The zone referenced by zone_id must already be provisioned and owned by the operator.
+Operator-only operation. The operator's DNS zone for the root is auto-created (idempotently) from the authenticated operator.
 
-See also: GET /platform-domains (list), PATCH /platform-domains/:id (enable/disable), DELETE /platform-domains/:id`),
+See also: GET /platform-domains (list), PATCH /platform-domains/:id (enable/disable), DELETE /platform-domains/:id, POST /platform-domains/:id/bind`),
 				router.WithTags("Admin", "PlatformDomains"),
 				router.WithRequestBody(dto.PlatformDomainRequest{}, "Platform domain to register", true),
 				router.WithSuccessResponse(http.StatusCreated, "Platform domain registered", router.WithJSONContent(dto.PlatformDomainResponse{})),
+			),
+		),
+		router.NewRoute(http.MethodPost, "/platform-domains/:id/bind", e.bindPlatformRootApex,
+			router.WithAccess(core.ACCESS_ADMIN_ROLE),
+			router.WithSwagger(
+				router.WithSummary("Bind website to platform root apex"),
+				router.WithDescription(`Binds an operator-owned website directly to the root apex of a platform domain (e.g. "pinner.site").
+
+Operator-only operation. The website must be owned by the authenticated operator. The apex binding reuses the platform root's auto-created zone.
+
+See also: POST /platform-domains (register), PATCH /platform-domains/:id (enable/disable)`),
+				router.WithTags("Admin", "PlatformDomains"),
+				router.WithPathParam("id", "Platform domain ID", ""),
+				router.WithRequestBody(dto.PlatformDomainBindRequest{}, "Website to bind to the root apex", true),
+				router.WithSuccessResponse(http.StatusOK, "Website bound to platform root apex", router.WithJSONContent(dto.DomainResponse{})),
 			),
 		),
 		router.NewRoute(http.MethodGet, "/platform-domains", e.listPlatformDomains,
@@ -355,7 +381,7 @@ See also: GET /platform-domains (list), PATCH /platform-domains/:id (enable/disa
 	)
 
 	apiGroup := internal.ProtocolName
-	return router.RegisterRoutes(gRouter, accessSvc, apiGroup, routes)
+	return router.RegisterRoutes(gRouter, accessSvc, apiGroup, routes, router.WithMiddlewares(authMw))
 }
 
 func (e *AdminExtension) createPlatformDomain(c echo.Context) error {
@@ -367,12 +393,19 @@ func (e *AdminExtension) createPlatformDomain(c echo.Context) error {
 		return ctx.Error(apiErr, apiErr.HttpStatus())
 	}
 
+	// The operator's zone is auto-created for the root; the operator is
+	// derived from the authenticated admin context (never trusted from input).
+	operatorUserID, err := mcontext.GetUserID(c)
+	if err != nil {
+		return err
+	}
+
 	req := dto.PlatformDomainRequest{}
 	if _, ok := httputil.DecodeAndValidateRequest(ctx, &req); !ok {
 		return nil
 	}
 
-	pd, err := e.delegatedDomainSvc.CreatePlatformDomain(reqCtx, req.Domain, pluginDb.DomainNamespace(req.Namespace), req.ZoneID, req.Enabled)
+	pd, err := e.delegatedDomainSvc.CreatePlatformDomain(reqCtx, req.Domain, pluginDb.DomainNamespace(req.Namespace), operatorUserID, req.Enabled)
 	if err != nil {
 		e.logger.Error("Failed to create platform domain", zap.Error(err))
 		apiErr := NewError(ErrKeyValidationFailed, err)
@@ -385,6 +418,49 @@ func (e *AdminExtension) createPlatformDomain(c echo.Context) error {
 		ctx.Response().Status = http.StatusCreated
 	})
 	return httputil.EncodeResponse(ctx, pd, &resp)
+}
+
+// bindPlatformRootApex binds an operator-owned website to the root apex of a
+// platform domain.
+func (e *AdminExtension) bindPlatformRootApex(c echo.Context) error {
+	ctx := httputil.Context(c)
+	reqCtx := ctx.Context.Request().Context()
+
+	if e.delegatedDomainSvc == nil {
+		apiErr := NewError(ErrKeyFileProcessingFailed, fmt.Errorf("domain service not available"))
+		return ctx.Error(apiErr, apiErr.HttpStatus())
+	}
+
+	id, err := e.parsePathID(c, "id")
+	if err != nil {
+		apiErr := NewError(ErrKeyInvalidUUIDFormat, err)
+		return ctx.Error(apiErr, apiErr.HttpStatus())
+	}
+
+	userID, err := mcontext.GetUserID(c)
+	if err != nil {
+		return err
+	}
+
+	req := dto.PlatformDomainBindRequest{}
+	if _, ok := httputil.DecodeAndValidateRequest(ctx, &req); !ok {
+		return nil
+	}
+
+	wd, err := e.delegatedDomainSvc.BindPlatformRootApex(reqCtx, req.WebsiteID, userID, id)
+	if err != nil {
+		e.logger.Error("Failed to bind platform root apex", zap.Error(err), zap.Uint("platform_domain_id", id), zap.Uint("website_id", req.WebsiteID))
+		apiErr := NewError(ErrKeyValidationFailed, err)
+		return ctx.Error(apiErr, apiErr.HttpStatus())
+	}
+
+	resp := dto.DomainResponse{}
+	if err := resp.FromModel(wd); err != nil {
+		e.logger.Error("Failed to build domain response", zap.Error(err))
+		apiErr := NewError(ErrKeyFileProcessingFailed, err)
+		return ctx.Error(apiErr, apiErr.HttpStatus())
+	}
+	return httputil.EncodeResponse(ctx, wd, &resp)
 }
 
 func (e *AdminExtension) listPlatformDomains(c echo.Context) error {
@@ -431,7 +507,11 @@ func (e *AdminExtension) updatePlatformDomain(c echo.Context) error {
 		return nil
 	}
 
-	pd, err := e.delegatedDomainSvc.UpdatePlatformDomain(reqCtx, id, req.Enabled)
+	if req.Enabled == nil {
+		apiErr := NewError(ErrKeyValidationFailed, fmt.Errorf("enabled is required"))
+		return ctx.Error(apiErr, apiErr.HttpStatus())
+	}
+	pd, err := e.delegatedDomainSvc.UpdatePlatformDomain(reqCtx, id, *req.Enabled)
 	if err != nil {
 		e.logger.Error("Failed to update platform domain", zap.Error(err), zap.Uint("id", id))
 		apiErr := NewError(ErrKeyValidationFailed, err)

--- a/internal/api/api_platform_domains_test.go
+++ b/internal/api/api_platform_domains_test.go
@@ -72,16 +72,24 @@ func TestAdminPlatformDomainCRUD(t *testing.T) {
 		require.NotNil(tb, mockDNS)
 
 		t.Run("create_and_list", func(t *testing.T) {
-			mockDNS.EXPECT().GetZoneByDomain(mock.Anything, "platform.test").
+			helper := newMockHelper(t, ctx)
+			token, userID, _, _ := helper.SetupAuthenticatedTest()
+
+			// CreatePlatformDomain auto-creates (idempotently) the operator's DNS
+			// zone for the root from the authenticated admin user; the operator is
+			// derived from the request context, never trusted from client input.
+			mockDNS.EXPECT().CreateZone(mock.Anything, "platform.test", userID).
 				Return(&pluginDb.DNSZone{Model: gorm.Model{ID: 7}, Domain: "platform.test"}, nil).Once()
 
 			req := ctx.NewAPIRequest(http.MethodPost, "/api/ipfs/platform-domains",
-				[]byte(`{"domain":"platform.test","namespace":"icann","zone_id":7,"enabled":true}`))
+				[]byte(`{"domain":"platform.test","namespace":"icann","enabled":true}`))
+			setAuthHeader(req, token)
 			rec := httptest.NewRecorder()
 			ctx.Router().ServeHTTP(rec, req)
 			require.Equal(t, http.StatusCreated, rec.Code, "body: %s", rec.Body.String())
 
 			req = ctx.NewAPIRequest(http.MethodGet, "/api/ipfs/platform-domains", nil)
+			setAuthHeader(req, token)
 			rec = httptest.NewRecorder()
 			ctx.Router().ServeHTTP(rec, req)
 			require.Equal(t, http.StatusOK, rec.Code)
@@ -94,15 +102,19 @@ func TestAdminPlatformDomainCRUD(t *testing.T) {
 		})
 
 		t.Run("update_disable_and_soft_delete", func(t *testing.T) {
+			helper := newMockHelper(t, ctx)
+			token, _, _, _ := helper.SetupAuthenticatedTest()
+
 			require.NoError(tb, ctx.DB().Create(&pluginDb.PlatformDomain{
-				Domain: "platform.test", Namespace: pluginDb.DomainNamespaceICANN, ZoneID: 7, Enabled: true,
+				Domain: "update.test", Namespace: pluginDb.DomainNamespaceICANN, ZoneID: 7, Enabled: true,
 			}).Error)
 			var pd pluginDb.PlatformDomain
-			require.NoError(tb, ctx.DB().First(&pd).Error)
+			require.NoError(tb, ctx.DB().Where("domain = ?", "update.test").First(&pd).Error)
 			path := fmt.Sprintf("/api/ipfs/platform-domains/%d", pd.ID)
 
 			// Disable: future claims blocked, but the row remains queryable.
 			req := ctx.NewAPIRequest(http.MethodPatch, path, []byte(`{"enabled":false}`))
+			setAuthHeader(req, token)
 			rec := httptest.NewRecorder()
 			ctx.Router().ServeHTTP(rec, req)
 			require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
@@ -113,9 +125,10 @@ func TestAdminPlatformDomainCRUD(t *testing.T) {
 
 			// Delete -> soft delete (tombstone present via Unscoped).
 			req = ctx.NewAPIRequest(http.MethodDelete, path, nil)
+			setAuthHeader(req, token)
 			rec = httptest.NewRecorder()
 			ctx.Router().ServeHTTP(rec, req)
-			require.Equal(t, http.StatusOK, rec.Code)
+			require.Equal(t, http.StatusNoContent, rec.Code)
 
 			var after pluginDb.PlatformDomain
 			require.NoError(tb, ctx.DB().Unscoped().First(&after, pd.ID).Error)

--- a/internal/api/dto/platform_domain.go
+++ b/internal/api/dto/platform_domain.go
@@ -6,10 +6,11 @@ import (
 )
 
 // PlatformDomainRequest registers a new platform-owned root (admin operation).
+// The operator's zone is auto-created (idempotently) from the authenticated
+// operator user; zone_id is no longer supplied by the client.
 type PlatformDomainRequest struct {
 	Domain    string `json:"domain"`
 	Namespace string `json:"namespace"` // icann | hns
-	ZoneID    uint   `json:"zone_id"`   // operator-owned DNSZone for the root
 	Enabled   bool   `json:"enabled,omitempty"`
 }
 
@@ -17,7 +18,6 @@ func (r PlatformDomainRequest) Schema() *zog.StructSchema {
 	return zog.Struct(zog.Shape{
 		"Domain":    zog.String().Required().Min(1).Max(255),
 		"Namespace": zog.String().Required().OneOf([]string{string(db.DomainNamespaceICANN), string(db.DomainNamespaceHNS)}),
-		"ZoneID":    zog.Uint().Required().GT(0),
 		"Enabled":   zog.Bool(),
 	})
 }
@@ -26,24 +26,43 @@ func (r PlatformDomainRequest) ToModel() (*db.PlatformDomain, error) {
 	return &db.PlatformDomain{
 		Domain:    r.Domain,
 		Namespace: db.DomainNamespace(r.Namespace),
-		ZoneID:    r.ZoneID,
 		Enabled:   r.Enabled,
 	}, nil
 }
 
+// PlatformDomainBindRequest binds an operator-owned website to the root apex
+// of a platform domain (admin operation).
+type PlatformDomainBindRequest struct {
+	WebsiteID uint `json:"website_id"`
+}
+
+func (r PlatformDomainBindRequest) Schema() *zog.StructSchema {
+	return zog.Struct(zog.Shape{
+		"WebsiteID": zog.Uint().Required().GT(0),
+	})
+}
+
+func (r PlatformDomainBindRequest) ToModel() (*db.Website, error) {
+	return &db.Website{ID: r.WebsiteID}, nil
+}
+
 // PlatformDomainUpdateRequest toggles registration state of a platform root.
 type PlatformDomainUpdateRequest struct {
-	Enabled bool `json:"enabled"`
+	Enabled *bool `json:"enabled"`
 }
 
 func (r PlatformDomainUpdateRequest) Schema() *zog.StructSchema {
 	return zog.Struct(zog.Shape{
-		"Enabled": zog.Bool().Required(),
+		"Enabled": zog.Ptr(zog.Bool()),
 	})
 }
 
 func (r PlatformDomainUpdateRequest) ToModel() (*db.PlatformDomain, error) {
-	return &db.PlatformDomain{Enabled: r.Enabled}, nil
+	enabled := false
+	if r.Enabled != nil {
+		enabled = *r.Enabled
+	}
+	return &db.PlatformDomain{Enabled: enabled}, nil
 }
 
 // PlatformDomainResponse is a registered platform root.

--- a/internal/db/migrations/mysql/20260824120000_enforce_platform_domains_zone_id.sql
+++ b/internal/db/migrations/mysql/20260824120000_enforce_platform_domains_zone_id.sql
@@ -1,0 +1,12 @@
+-- +goose Up
+-- CreatePlatformDomain now auto-creates (idempotently) the operator's DNS zone
+-- for every platform root and always stores the resulting zone ID on the
+-- platform_domains row. A PlatformDomain without a provisioned zone is invalid
+-- (claims write DNSLink/apex records into a dangling zone), so enforce the
+-- invariant at the schema level by making zone_id NOT NULL.
+ALTER TABLE platform_domains
+    MODIFY COLUMN zone_id BIGINT UNSIGNED NOT NULL;
+
+-- +goose Down
+ALTER TABLE platform_domains
+    MODIFY COLUMN zone_id BIGINT UNSIGNED NULL DEFAULT NULL;

--- a/internal/db/migrations/sqlite/20260824120000_enforce_platform_domains_zone_id.sql
+++ b/internal/db/migrations/sqlite/20260824120000_enforce_platform_domains_zone_id.sql
@@ -4,19 +4,6 @@
 -- platform_domains row. A PlatformDomain without a provisioned zone is invalid,
 -- so enforce the invariant at the schema level by making zone_id NOT NULL.
 -- SQLite cannot modify a column constraint in place, so rebuild the table.
--- +goose StatementBegin
-CREATE TABLE platform_domains_old (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    domain TEXT NOT NULL,
-    namespace TEXT NOT NULL,
-    zone_id INTEGER,
-    enabled INTEGER NOT NULL DEFAULT 1,
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    deleted_at TIMESTAMP NULL DEFAULT NULL,
-    UNIQUE (domain, namespace)
-);
--- +goose StatementEnd
 
 -- +goose StatementBegin
 CREATE TABLE platform_domains_new (
@@ -40,26 +27,20 @@ FROM platform_domains;
 
 DROP INDEX IF EXISTS idx_platform_domains_zone_id;
 DROP TABLE platform_domains;
+
+-- +goose StatementBegin
 ALTER TABLE platform_domains_new RENAME TO platform_domains;
+-- +goose StatementEnd
+
 CREATE INDEX idx_platform_domains_zone_id ON platform_domains(zone_id);
 
 -- +goose Down
--- +goose StatementBegin
-CREATE TABLE platform_domains_old (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    domain TEXT NOT NULL,
-    namespace TEXT NOT NULL,
-    zone_id INTEGER NOT NULL,
-    enabled INTEGER NOT NULL DEFAULT 1,
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    deleted_at TIMESTAMP NULL DEFAULT NULL,
-    UNIQUE (domain, namespace)
-);
--- +goose StatementEnd
+-- SQLite cannot drop a column constraint in place, so rebuild the table back
+-- to the original zone_id-NULL shape, preserving every live row. The rows are
+-- copied out of the live table BEFORE it is dropped.
 
 -- +goose StatementBegin
-CREATE TABLE platform_domains (
+CREATE TABLE platform_domains_old (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     domain TEXT NOT NULL,
     namespace TEXT NOT NULL,
@@ -73,11 +54,16 @@ CREATE TABLE platform_domains (
 -- +goose StatementEnd
 
 -- +goose StatementBegin
-INSERT INTO platform_domains (id, domain, namespace, zone_id, enabled, created_at, updated_at, deleted_at)
+INSERT INTO platform_domains_old (id, domain, namespace, zone_id, enabled, created_at, updated_at, deleted_at)
 SELECT id, domain, namespace, zone_id, enabled, created_at, updated_at, deleted_at
-FROM platform_domains_old;
+FROM platform_domains;
 -- +goose StatementEnd
 
 DROP INDEX IF EXISTS idx_platform_domains_zone_id;
-DROP TABLE platform_domains_old;
+DROP TABLE platform_domains;
+
+-- +goose StatementBegin
+ALTER TABLE platform_domains_old RENAME TO platform_domains;
+-- +goose StatementEnd
+
 CREATE INDEX idx_platform_domains_zone_id ON platform_domains(zone_id);

--- a/internal/db/migrations/sqlite/20260824120000_enforce_platform_domains_zone_id.sql
+++ b/internal/db/migrations/sqlite/20260824120000_enforce_platform_domains_zone_id.sql
@@ -1,0 +1,83 @@
+-- +goose Up
+-- CreatePlatformDomain now auto-creates (idempotently) the operator's DNS zone
+-- for every platform root and always stores the resulting zone ID on the
+-- platform_domains row. A PlatformDomain without a provisioned zone is invalid,
+-- so enforce the invariant at the schema level by making zone_id NOT NULL.
+-- SQLite cannot modify a column constraint in place, so rebuild the table.
+-- +goose StatementBegin
+CREATE TABLE platform_domains_old (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    domain TEXT NOT NULL,
+    namespace TEXT NOT NULL,
+    zone_id INTEGER,
+    enabled INTEGER NOT NULL DEFAULT 1,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    deleted_at TIMESTAMP NULL DEFAULT NULL,
+    UNIQUE (domain, namespace)
+);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TABLE platform_domains_new (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    domain TEXT NOT NULL,
+    namespace TEXT NOT NULL,
+    zone_id INTEGER NOT NULL,
+    enabled INTEGER NOT NULL DEFAULT 1,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    deleted_at TIMESTAMP NULL DEFAULT NULL,
+    UNIQUE (domain, namespace)
+);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+INSERT INTO platform_domains_new (id, domain, namespace, zone_id, enabled, created_at, updated_at, deleted_at)
+SELECT id, domain, namespace, zone_id, enabled, created_at, updated_at, deleted_at
+FROM platform_domains;
+-- +goose StatementEnd
+
+DROP INDEX IF EXISTS idx_platform_domains_zone_id;
+DROP TABLE platform_domains;
+ALTER TABLE platform_domains_new RENAME TO platform_domains;
+CREATE INDEX idx_platform_domains_zone_id ON platform_domains(zone_id);
+
+-- +goose Down
+-- +goose StatementBegin
+CREATE TABLE platform_domains_old (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    domain TEXT NOT NULL,
+    namespace TEXT NOT NULL,
+    zone_id INTEGER NOT NULL,
+    enabled INTEGER NOT NULL DEFAULT 1,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    deleted_at TIMESTAMP NULL DEFAULT NULL,
+    UNIQUE (domain, namespace)
+);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TABLE platform_domains (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    domain TEXT NOT NULL,
+    namespace TEXT NOT NULL,
+    zone_id INTEGER,
+    enabled INTEGER NOT NULL DEFAULT 1,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    deleted_at TIMESTAMP NULL DEFAULT NULL,
+    UNIQUE (domain, namespace)
+);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+INSERT INTO platform_domains (id, domain, namespace, zone_id, enabled, created_at, updated_at, deleted_at)
+SELECT id, domain, namespace, zone_id, enabled, created_at, updated_at, deleted_at
+FROM platform_domains_old;
+-- +goose StatementEnd
+
+DROP INDEX IF EXISTS idx_platform_domains_zone_id;
+DROP TABLE platform_domains_old;
+CREATE INDEX idx_platform_domains_zone_id ON platform_domains(zone_id);

--- a/internal/db/platform_domain.go
+++ b/internal/db/platform_domain.go
@@ -29,7 +29,7 @@ type PlatformDomain struct {
 	ID        uint           `gorm:"primaryKey"`
 	Domain    string         `gorm:"not null;uniqueIndex:idx_platform_domains_domain_namespace"`
 	Namespace DomainNamespace `gorm:"not null;uniqueIndex:idx_platform_domains_domain_namespace"`
-	ZoneID    uint           `gorm:"index:idx_platform_domains_zone_id"` // platform-owned DNSZone
+	ZoneID    uint           `gorm:"not null;index:idx_platform_domains_zone_id"` // platform-owned DNSZone, auto-created with the root
 	// No `default:true` gorm tag: GORM applies a default tag to zero-value
 	// fields on Create, which would silently persist an explicit Enabled=false
 	// as true (disabling a root would never stick). The migration keeps a DB

--- a/internal/service/domain/delegated_domain_service.go
+++ b/internal/service/domain/delegated_domain_service.go
@@ -168,14 +168,14 @@ func (s *DelegatedDomainService) resolveManagedZone(ctx context.Context, domain 
 		if !pd.Enabled {
 			return nil, false, fmt.Errorf("platform root %q is disabled", pd.Domain)
 		}
-		// The claim must actually descend from the granted root (and not be
-		// the root apex itself). createPlatformBinding already guarantees this,
-		// but resolveManagedZone is the enforcement point of record for the
-		// one-zone platform relaxation, so re-check cheaply here.
-		if domain == pd.Domain {
-			return nil, false, fmt.Errorf("domain %q is the platform root apex, not a subdomain", domain)
-		}
-		if !strings.HasSuffix(domain, "."+pd.Domain) {
+		// The claim must reference the granted root itself: an apex match
+		// (domain == pd.Domain) for a root-apex binding (BindPlatformRootApex),
+		// or a name that descends from the granted root for a subdomain claim.
+		// Either way the authoritative zone is the operator's platform-root
+		// zone. The subdomain path is also guarded upstream (CreatePlatformSubdomain
+		// rejects compositions that collapse to the apex), so this is the
+		// enforcement point of record for the one-zone platform relaxation.
+		if domain != pd.Domain && !strings.HasSuffix(domain, "."+pd.Domain) {
 			return nil, false, fmt.Errorf("domain %q is not a subdomain of platform root %q", domain, pd.Domain)
 		}
 		z, err := s.dnsSvc.GetZoneByDomain(ctx, pd.Domain)

--- a/internal/service/domain/platform_domain.go
+++ b/internal/service/domain/platform_domain.go
@@ -119,16 +119,13 @@ func (s *DelegatedDomainService) GetPlatformDomainByName(ctx context.Context, do
 }
 
 // CreatePlatformDomain registers a new platform-owned root. It is an
-// operator-only operation (admin API). It does not provision the zone itself:
-// the caller must supply a zone already owned by the operator (a PlatformDomain
-// without a provisioned zone is invalid, so callers should create/designate the
-// zone before registering).
-//
-// Operator ownership of the zone is enforced by the admin-only route (only an
-// operator can register a root); here we at least verify the zone actually
-// exists so we never register a root that would fail at claim time with a
-// dangling zone reference.
-func (s *DelegatedDomainService) CreatePlatformDomain(ctx context.Context, domain string, namespace pluginDb.DomainNamespace, zoneID uint, enabled bool) (*pluginDb.PlatformDomain, error) {
+// operator-only operation (admin API). Auto-creates (idempotently) the DNS
+// zone the operator owns for the root domain: if a zone already exists for the
+// domain it is reused (owned by the same operator), otherwise a new zone is
+// provisioned. The resulting zone ID is stored on the PlatformDomain row, so a
+// root never references a dangling zone. Operator ownership of the zone is
+// enforced by the admin-only route (only an operator can register a root).
+func (s *DelegatedDomainService) CreatePlatformDomain(ctx context.Context, domain string, namespace pluginDb.DomainNamespace, operatorUserID uint, enabled bool) (*pluginDb.PlatformDomain, error) {
 	if s.DB() == nil {
 		return nil, fmt.Errorf("database not available")
 	}
@@ -138,27 +135,20 @@ func (s *DelegatedDomainService) CreatePlatformDomain(ctx context.Context, domai
 	if s.dnsSvc == nil {
 		return nil, fmt.Errorf("DNS service not configured")
 	}
-	if zoneID == 0 {
-		return nil, fmt.Errorf("platform domain requires a provisioned zone")
+	if operatorUserID == 0 {
+		return nil, fmt.Errorf("platform domain requires an operator user")
 	}
 	domain = NormalizeDomain(domain)
-	// The DNSZoneService has no by-ID lookup; GetZoneByDomain serves the same
-	// purpose for a root (the root's domain == its zone apex domain).
-	z, err := s.dnsSvc.GetZoneByDomain(ctx, domain)
-	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
-		return nil, fmt.Errorf("lookup platform zone: %w", err)
+	// Create (or reuse) the operator's zone for the root apex. CreateZone is
+	// idempotent: when a zone already exists for this domain it returns the
+	// existing one (owned by the same operator), otherwise it provisions a new
+	// zone. This guarantees the PlatformDomain always references a live zone.
+	z, err := s.dnsSvc.CreateZone(ctx, domain, operatorUserID)
+	if err != nil {
+		return nil, fmt.Errorf("provision platform zone: %w", err)
 	}
 	if z == nil {
 		return nil, fmt.Errorf("platform root %q has no provisioned zone", domain)
-	}
-	// GetZoneByDomain intentionally returns soft-deleted zones; never register a
-	// root against a logically-removed zone — claims would silently write
-	// DNSLink/apex records into a dead zone.
-	if z.DeletedAt.Valid {
-		return nil, fmt.Errorf("platform root %q references a deleted zone", domain)
-	}
-	if z.ID != zoneID {
-		return nil, fmt.Errorf("zone %d does not match provisioned zone for %q", zoneID, domain)
 	}
 	// Soft deletes leave a tombstone that still occupies the strict
 	// (domain, namespace) unique key, so re-registering a root after
@@ -176,7 +166,7 @@ func (s *DelegatedDomainService) CreatePlatformDomain(ctx context.Context, domai
 	pd := &pluginDb.PlatformDomain{
 		Domain:    domain,
 		Namespace: namespace,
-		ZoneID:    zoneID,
+		ZoneID:    z.ID,
 		Enabled:   enabled,
 	}
 	if err := s.DB().WithContext(ctx).Create(pd).Error; err != nil {
@@ -244,6 +234,33 @@ func (s *DelegatedDomainService) DeletePlatformDomain(ctx context.Context, id ui
 		return gorm.ErrRecordNotFound
 	}
 	return nil
+}
+
+// BindPlatformRootApex binds an operator-owned website directly to the root
+// apex of a platform root (e.g. "pinner.site"), rather than to a subdomain
+// underneath it. The website must be owned by the same operator that owns the
+// PlatformDomain. Reuses the shared managed-DNS pipeline (DNSLink, apex
+// records, delegation, SSL) via createPlatformBinding with the FQDN being the
+// root itself, and marks the binding with the PlatformDomain reference.
+func (s *DelegatedDomainService) BindPlatformRootApex(ctx context.Context, websiteID, userID, platformDomainID uint) (*pluginDb.WebsiteDomain, error) {
+	if s.DB() == nil {
+		return nil, fmt.Errorf("database not available")
+	}
+
+	var pd pluginDb.PlatformDomain
+	if err := s.DB().WithContext(ctx).First(&pd, platformDomainID).Error; err != nil {
+		return nil, fmt.Errorf("platform domain lookup failed: %w", err)
+	}
+	if !pd.Enabled {
+		return nil, fmt.Errorf("platform domain is disabled")
+	}
+
+	provider := s.registry.Get(string(pd.Namespace))
+	if provider == nil {
+		return nil, fmt.Errorf("unsupported namespace: %s", pd.Namespace)
+	}
+
+	return s.createPlatformBinding(ctx, websiteID, userID, &pd, provider, pd.Domain)
 }
 
 // CreatePlatformSubdomain claims a subdomain under a platform root for a

--- a/internal/service/domain/platform_domain_test.go
+++ b/internal/service/domain/platform_domain_test.go
@@ -2,6 +2,7 @@ package domain
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -29,70 +30,56 @@ func createPlatformRoot(tb testing.TB, ctx coreTesting.TestContext, domain strin
 	return pd
 }
 
-func TestCreatePlatformDomain_ZoneValidation(t *testing.T) {
-	// S2: a platform root may only be registered against a zone that actually
-	// exists and whose ID matches the root's domain.
-	t.Run("registers_when_zone_exists", func(t *testing.T) {
+func TestCreatePlatformDomain_AutoCreatesZone(t *testing.T) {
+	// The operator's zone is auto-created (idempotently) from the operator
+	// user; the resulting zone ID is stored on the PlatformDomain row. A root
+	// is registered only when zone creation succeeds.
+	t.Run("creates_zone_and_registers_root", func(t *testing.T) {
 		coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 			svc := core.GetService[*DelegatedDomainService](ctx, pluginCore.DELEGATED_DOMAIN_SERVICE)
 			mockDNS := core.GetService[*mocks.MockDNSService](ctx, pluginCore.DNS_SERVICE)
-			mockDNS.EXPECT().GetZoneByDomain(mock.Anything, "platform.test").
-				Return(&pluginDb.DNSZone{Model: gorm.Model{ID: 7}, Domain: "platform.test"}, nil).Once()
+			mockDNS.EXPECT().CreateZone(mock.Anything, "platform.test", uint(1)).
+				Return(&pluginDb.DNSZone{Model: gorm.Model{ID: 7}, Domain: "platform.test", UserID: 1}, nil).Once()
 
-			pd, err := svc.CreatePlatformDomain(context.Background(), "platform.test", pluginDb.DomainNamespaceICANN, 7, true)
+			pd, err := svc.CreatePlatformDomain(context.Background(), "platform.test", pluginDb.DomainNamespaceICANN, 1, true)
 			require.NoError(tb, err)
 			assert.Equal(tb, uint(7), pd.ZoneID)
 			assert.Equal(tb, "platform.test", pd.Domain)
 		}, TestOptions)
 	})
-	t.Run("rejects_when_zone_missing", func(t *testing.T) {
+	t.Run("reuses_existing_zone_idempotently", func(t *testing.T) {
+		// CreateZone is idempotent: when a zone already exists for the domain it
+		// returns the existing zone. CreatePlatformDomain must store THAT zone's
+		// ID, never assume a fresh one.
 		coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 			svc := core.GetService[*DelegatedDomainService](ctx, pluginCore.DELEGATED_DOMAIN_SERVICE)
 			mockDNS := core.GetService[*mocks.MockDNSService](ctx, pluginCore.DNS_SERVICE)
-			mockDNS.EXPECT().GetZoneByDomain(mock.Anything, "platform.test").Return(nil, nil).Once()
-			_, err := svc.CreatePlatformDomain(context.Background(), "platform.test", pluginDb.DomainNamespaceICANN, 7, true)
-			require.Error(tb, err)
-			assert.Contains(tb, err.Error(), "no provisioned zone")
-		}, TestOptions)
-	})
-	t.Run("rejects_when_zone_id_mismatch", func(t *testing.T) {
-		coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
-			svc := core.GetService[*DelegatedDomainService](ctx, pluginCore.DELEGATED_DOMAIN_SERVICE)
-			mockDNS := core.GetService[*mocks.MockDNSService](ctx, pluginCore.DNS_SERVICE)
-			mockDNS.EXPECT().GetZoneByDomain(mock.Anything, "platform.test").
-				Return(&pluginDb.DNSZone{Model: gorm.Model{ID: 7}, Domain: "platform.test"}, nil).Once()
+			mockDNS.EXPECT().CreateZone(mock.Anything, "platform.test", uint(1)).
+				Return(&pluginDb.DNSZone{Model: gorm.Model{ID: 9}, Domain: "platform.test", UserID: 1}, nil).Once()
 
-			_, err := svc.CreatePlatformDomain(context.Background(), "platform.test", pluginDb.DomainNamespaceICANN, 99, true)
-			require.Error(tb, err)
-			assert.Contains(tb, err.Error(), "does not match")
+			pd, err := svc.CreatePlatformDomain(context.Background(), "platform.test", pluginDb.DomainNamespaceICANN, 1, true)
+			require.NoError(tb, err)
+			assert.Equal(tb, uint(9), pd.ZoneID)
 		}, TestOptions)
 	})
-	t.Run("rejects_when_zone_id_zero", func(t *testing.T) {
+	t.Run("rejects_when_zone_creation_fails", func(t *testing.T) {
+		coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+			svc := core.GetService[*DelegatedDomainService](ctx, pluginCore.DELEGATED_DOMAIN_SERVICE)
+			mockDNS := core.GetService[*mocks.MockDNSService](ctx, pluginCore.DNS_SERVICE)
+			mockDNS.EXPECT().CreateZone(mock.Anything, "platform.test", uint(1)).
+				Return(nil, errors.New("boom")).Once()
+
+			_, err := svc.CreatePlatformDomain(context.Background(), "platform.test", pluginDb.DomainNamespaceICANN, 1, true)
+			require.Error(tb, err)
+			assert.Contains(tb, err.Error(), "provision platform zone")
+		}, TestOptions)
+	})
+	t.Run("rejects_zero_operator_user", func(t *testing.T) {
 		coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 			svc := core.GetService[*DelegatedDomainService](ctx, pluginCore.DELEGATED_DOMAIN_SERVICE)
 			_, err := svc.CreatePlatformDomain(context.Background(), "platform.test", pluginDb.DomainNamespaceICANN, 0, true)
 			require.Error(tb, err)
-			assert.Contains(tb, err.Error(), "requires a provisioned zone")
-		}, TestOptions)
-	})
-	t.Run("rejects_soft_deleted_zone", func(t *testing.T) {
-		// N2 regression: GetZoneByDomain intentionally returns soft-deleted
-		// zones, but a platform root must never be registered against a
-		// logically-removed zone.
-		coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
-			svc := core.GetService[*DelegatedDomainService](ctx, pluginCore.DELEGATED_DOMAIN_SERVICE)
-			mockDNS := core.GetService[*mocks.MockDNSService](ctx, pluginCore.DNS_SERVICE)
-			mockDNS.EXPECT().GetZoneByDomain(mock.Anything, "retired.site").
-				Return(&pluginDb.DNSZone{
-					Model:  gorm.Model{ID: 7, DeletedAt: gorm.DeletedAt{Valid: true}},
-					Domain: "retired.site",
-					UserID: 1,
-					Status: string(pluginDb.DNSZoneStatusActive),
-				}, nil).Once()
-
-			_, err := svc.CreatePlatformDomain(context.Background(), "retired.site", pluginDb.DomainNamespaceICANN, 7, true)
-			require.Error(tb, err)
-			assert.Contains(tb, err.Error(), "deleted zone")
+			assert.Contains(tb, err.Error(), "operator user")
 		}, TestOptions)
 	})
 }
@@ -107,13 +94,13 @@ func TestCreatePlatformDomain_DuplicateLiveRootRejected(t *testing.T) {
 	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 		svc := core.GetService[*DelegatedDomainService](ctx, pluginCore.DELEGATED_DOMAIN_SERVICE)
 		mockDNS := core.GetService[*mocks.MockDNSService](ctx, pluginCore.DNS_SERVICE)
-		mockDNS.EXPECT().GetZoneByDomain(mock.Anything, "platform.test").
-			Return(&pluginDb.DNSZone{Model: gorm.Model{ID: 7}, Domain: "platform.test"}, nil).Times(2)
+		mockDNS.EXPECT().CreateZone(mock.Anything, "platform.test", uint(1)).
+			Return(&pluginDb.DNSZone{Model: gorm.Model{ID: 7}, Domain: "platform.test", UserID: 1}, nil).Times(2)
 
-		_, err := svc.CreatePlatformDomain(context.Background(), "platform.test", pluginDb.DomainNamespaceICANN, 7, true)
+		_, err := svc.CreatePlatformDomain(context.Background(), "platform.test", pluginDb.DomainNamespaceICANN, 1, true)
 		require.NoError(tb, err)
 
-		_, err = svc.CreatePlatformDomain(context.Background(), "platform.test", pluginDb.DomainNamespaceICANN, 7, true)
+		_, err = svc.CreatePlatformDomain(context.Background(), "platform.test", pluginDb.DomainNamespaceICANN, 1, true)
 		require.Error(tb, err)
 		assert.Contains(tb, err.Error(), "already registered")
 	}, TestOptions)
@@ -144,9 +131,10 @@ func TestDeletePlatformDomain_SoftDelete(t *testing.T) {
 		// soft-delete tombstone before inserting against the strict
 		// (domain, namespace) unique key.
 		mockDNS := core.GetService[*mocks.MockDNSService](ctx, pluginCore.DNS_SERVICE)
-		mockDNS.EXPECT().GetZoneByDomain(mock.Anything, "platform.test").
+		// Re-registration auto-creates (idempotently) the operator zone again.
+		mockDNS.EXPECT().CreateZone(mock.Anything, "platform.test", uint(1)).
 			Return(&pluginDb.DNSZone{Model: gorm.Model{ID: 7}, Domain: "platform.test"}, nil).Once()
-		recreated, err := svc.CreatePlatformDomain(context.Background(), "platform.test", pluginDb.DomainNamespaceICANN, 7, true)
+		recreated, err := svc.CreatePlatformDomain(context.Background(), "platform.test", pluginDb.DomainNamespaceICANN, 1, true)
 		require.NoError(tb, err)
 		assert.Equal(tb, "platform.test", recreated.Domain)
 		_ = db
@@ -621,10 +609,15 @@ func TestResolveManagedZone_PlatformGuard_HNSSingleLabel(t *testing.T) {
 
 		pd := createPlatformRoot(tb, ctx, "altroot", pluginDb.DomainNamespaceHNS, 7, true)
 
-		// Apex of the root is not a subdomain of itself.
-		_, _, err := svc.resolveManagedZone(context.Background(), "altroot", 1, &pd.ID)
-		require.Error(tb, err)
-		assert.Contains(tb, err.Error(), "apex")
+		// Apex of the root resolves to the operator's platform zone (the
+		// root-apex binding path via BindPlatformRootApex), never a new zone.
+		mockDNS.EXPECT().GetZoneByDomain(mock.Anything, "altroot").
+			Return(&pluginDb.DNSZone{Model: gorm.Model{ID: 7}, Domain: "altroot"}, nil).Once()
+		z, created, err := svc.resolveManagedZone(context.Background(), "altroot", 1, &pd.ID)
+		require.NoError(tb, err)
+		require.NotNil(tb, z)
+		assert.Equal(t, uint(7), z.ID)
+		assert.False(t, created, "a platform apex must never create a new zone")
 
 		// An unrelated name is not a subdomain of the granted root.
 		_, _, err = svc.resolveManagedZone(context.Background(), "other.xyz", 1, &pd.ID)
@@ -634,10 +627,115 @@ func TestResolveManagedZone_PlatformGuard_HNSSingleLabel(t *testing.T) {
 		// A proper subdomain resolves to the granted root's zone.
 		mockDNS.EXPECT().GetZoneByDomain(mock.Anything, "altroot").
 			Return(&pluginDb.DNSZone{Model: gorm.Model{ID: 7}, Domain: "altroot"}, nil).Once()
-		z, created, err := svc.resolveManagedZone(context.Background(), "blog.altroot", 1, &pd.ID)
+		z, created, err = svc.resolveManagedZone(context.Background(), "blog.altroot", 1, &pd.ID)
 		require.NoError(tb, err)
 		require.NotNil(tb, z)
 		assert.Equal(t, uint(7), z.ID)
 		assert.False(t, created, "a platform claim must never create a new zone")
 	}, TestOptions)
+}
+
+// TestBindPlatformRootApex_WritesApexIntoOperatorZone proves the root-apex
+// binding path (BindPlatformRootApex): an operator-owned website is bound
+// directly to the platform root's apex, and the DNSLink + apex records are
+// written into the operator's platform zone (ID 7), never a freshly created
+// zone.
+func TestBindPlatformRootApex_WritesApexIntoOperatorZone(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		db := ctx.DB()
+		// Operator owns the website and the platform root.
+		website := createTestWebsite(tb, db, 1, "pinner.site")
+		pd := createPlatformRoot(tb, ctx, "pinner.site", pluginDb.DomainNamespaceICANN, 7, true)
+
+		svc := core.GetService[*DelegatedDomainService](ctx, pluginCore.DELEGATED_DOMAIN_SERVICE)
+		mockDNS := core.GetService[*mocks.MockDNSService](ctx, pluginCore.DNS_SERVICE)
+		// Apex match resolves the operator's zone; records are written into it.
+		mockDNS.EXPECT().GetZoneByDomain(mock.Anything, "pinner.site").
+			Return(&pluginDb.DNSZone{Model: gorm.Model{ID: 7}, Domain: "pinner.site"}, nil).Once()
+		mockDNS.EXPECT().CreateDNSLinkRecord(mock.Anything, uint(7), "pinner.site", mock.Anything).Return(nil).Once()
+		mockDNS.EXPECT().CreateApexRecord(mock.Anything, uint(7), "pinner.site", pluginCore.RecordTypeALIAS, "gw.example.com").Return(nil).Once()
+
+		wd, err := svc.BindPlatformRootApex(context.Background(), website.ID, 1, pd.ID)
+		require.NoError(tb, err)
+		require.NotNil(tb, wd)
+		assert.Equal(tb, "pinner.site", wd.Domain)
+		assert.Equal(tb, uint(7), wd.ZoneID)
+		assert.Equal(tb, "gw.example.com", wd.GatewayHost)
+		require.NotNil(tb, wd.PlatformDomainID)
+		assert.Equal(tb, pd.ID, *wd.PlatformDomainID)
+		assert.Equal(tb, pluginDb.DomainStatusActive, wd.Status)
+		// No new zone is ever created for a platform apex binding.
+		mockDNS.AssertNotCalled(tb, "CreateZone", mock.Anything, mock.Anything, mock.Anything)
+	}, platformApexTestOptions)
+}
+
+// TestBindPlatformRootApex_DisabledRootRejected ensures a disabled platform
+// root cannot be apex-bound.
+func TestBindPlatformRootApex_DisabledRootRejected(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		db := ctx.DB()
+		website := createTestWebsite(tb, db, 1, "pinner.site")
+		pd := createPlatformRoot(tb, ctx, "pinner.site", pluginDb.DomainNamespaceICANN, 7, false)
+
+		svc := core.GetService[*DelegatedDomainService](ctx, pluginCore.DELEGATED_DOMAIN_SERVICE)
+		_, err := svc.BindPlatformRootApex(context.Background(), website.ID, 1, pd.ID)
+		require.Error(tb, err)
+		assert.Contains(tb, err.Error(), "disabled")
+	}, TestOptions)
+}
+
+// TestBindPlatformRootApex_MultipleRootsAsAdditionalDomains proves that two
+// distinct platform roots can both be apex-bound to one operator-owned website
+// as additional domains: each root's apex lands in its own operator zone and
+// carries its own PlatformDomain reference. The first binding becomes the
+// website primary; the second is an additional domain (primary stays the
+// first).
+func TestBindPlatformRootApex_MultipleRootsAsAdditionalDomains(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		db := ctx.DB()
+		website := createTestWebsite(tb, db, 1, "pinner.site")
+		pdSite := createPlatformRoot(tb, ctx, "pinner.site", pluginDb.DomainNamespaceICANN, 11, true)
+		pdXyz := createPlatformRoot(tb, ctx, "pinner.xyz", pluginDb.DomainNamespaceICANN, 22, true)
+
+		svc := core.GetService[*DelegatedDomainService](ctx, pluginCore.DELEGATED_DOMAIN_SERVICE)
+		mockDNS := core.GetService[*mocks.MockDNSService](ctx, pluginCore.DNS_SERVICE)
+		mockDNS.EXPECT().GetZoneByDomain(mock.Anything, "pinner.site").
+			Return(&pluginDb.DNSZone{Model: gorm.Model{ID: 11}, Domain: "pinner.site"}, nil).Once()
+		mockDNS.EXPECT().CreateDNSLinkRecord(mock.Anything, uint(11), "pinner.site", mock.Anything).Return(nil).Once()
+		mockDNS.EXPECT().CreateApexRecord(mock.Anything, uint(11), "pinner.site", pluginCore.RecordTypeALIAS, "gw.example.com").Return(nil).Once()
+		mockDNS.EXPECT().GetZoneByDomain(mock.Anything, "pinner.xyz").
+			Return(&pluginDb.DNSZone{Model: gorm.Model{ID: 22}, Domain: "pinner.xyz"}, nil).Once()
+		mockDNS.EXPECT().CreateDNSLinkRecord(mock.Anything, uint(22), "pinner.xyz", mock.Anything).Return(nil).Once()
+		mockDNS.EXPECT().CreateApexRecord(mock.Anything, uint(22), "pinner.xyz", pluginCore.RecordTypeALIAS, "gw.example.com").Return(nil).Once()
+
+		wdSite, err := svc.BindPlatformRootApex(context.Background(), website.ID, 1, pdSite.ID)
+		require.NoError(tb, err)
+		require.NotNil(tb, wdSite)
+		assert.Equal(tb, "pinner.site", wdSite.Domain)
+		assert.Equal(tb, uint(11), wdSite.ZoneID)
+		require.NotNil(tb, wdSite.PlatformDomainID)
+		assert.Equal(tb, pdSite.ID, *wdSite.PlatformDomainID)
+
+		wdXyz, err := svc.BindPlatformRootApex(context.Background(), website.ID, 1, pdXyz.ID)
+		require.NoError(tb, err)
+		require.NotNil(tb, wdXyz)
+		assert.Equal(tb, "pinner.xyz", wdXyz.Domain)
+		assert.Equal(tb, uint(22), wdXyz.ZoneID)
+		require.NotNil(tb, wdXyz.PlatformDomainID)
+		assert.Equal(tb, pdXyz.ID, *wdXyz.PlatformDomainID)
+
+		// Both bindings belong to the same website, and the first remains primary.
+		var siteDomain, xyzDomain pluginDb.WebsiteDomain
+		require.NoError(tb, db.Where("id = ?", wdSite.ID).First(&siteDomain).Error)
+		require.NoError(tb, db.Where("id = ?", wdXyz.ID).First(&xyzDomain).Error)
+		assert.Equal(tb, website.ID, siteDomain.WebsiteID)
+		assert.Equal(tb, website.ID, xyzDomain.WebsiteID)
+
+		var websiteAfter pluginDb.Website
+		require.NoError(tb, db.First(&websiteAfter, website.ID).Error)
+		require.NotNil(tb, websiteAfter.PrimaryDomainID)
+		assert.Equal(tb, wdSite.ID, *websiteAfter.PrimaryDomainID)
+
+		mockDNS.AssertNotCalled(tb, "CreateZone", mock.Anything, mock.Anything, mock.Anything)
+	}, platformApexTestOptions)
 }

--- a/internal/service/website/website_test.go
+++ b/internal/service/website/website_test.go
@@ -1721,6 +1721,65 @@ func TestWebsiteService_DeleteWebsite_DNSHostingEnabled_ZoneRemainsAfterDeletion
 	}, TestOptions)
 }
 
+// TestWebsiteService_DeleteWebsite_PlatformSubdomain_OperatorApexAndZoneIntact
+// proves the delete-scoping invariant for platform subdomains: Alice's website
+// hosts a subdomain (e.g. "alice.pinner.site") inside the operator-owned root
+// zone, alongside the operator's apex binding on that same root. Deleting
+// Alice's website must clean up only Alice's subdomain DNS records — the
+// operator's shared zone (and therefore its apex records) must survive.
+func TestWebsiteService_DeleteWebsite_PlatformSubdomain_OperatorApexAndZoneIntact(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		db := ctx.DB()
+		websiteService := core.GetService[pluginCore.WebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
+		mockDNS := core.GetService[*mocks.MockDNSService](ctx, pluginCore.DNS_SERVICE)
+
+		const operatorZoneID = uint(4000)
+
+		// Operator's platform root + its authoritative zone exist in the DB.
+		pd := &pluginDb.PlatformDomain{
+			Domain: "pinner.site", Namespace: pluginDb.DomainNamespaceICANN,
+			ZoneID: operatorZoneID, Enabled: true,
+		}
+		require.NoError(tb, db.Create(pd).Error)
+		require.NoError(tb, db.Create(&pluginDb.DNSZone{
+			Model: gorm.Model{ID: operatorZoneID}, Domain: "pinner.site", UserID: 100,
+			Status: string(pluginDb.DNSZoneStatusActive),
+		}).Error)
+
+		// Alice's website owns a platform subdomain under the operator root, and
+		// it is her primary binding (the binding the delete flow cleans).
+		website := createTestIPFSWebsite(testUserID1, "alice.pinner.site", util.GenerateTestCID(t, "alice data").String())
+		website.Status = string(pluginDb.WebsiteStatusActive)
+		require.NoError(tb, db.Create(website).Error)
+		wd := createTestWebsiteDomain(website.ID, "alice.pinner.site")
+		wd.ZoneID = operatorZoneID
+		wd.DNSHostingEnabled = true
+		wd.Status = pluginDb.DomainStatusActive
+		wd.PlatformDomainID = &pd.ID
+		require.NoError(tb, db.Create(wd).Error)
+		require.NoError(tb, db.Model(&pluginDb.Website{ID: website.ID}).UpdateColumn("primary_domain_id", wd.ID).Error)
+
+		// Deleting Alice's website removes only her subdomain's DNS records from
+		// the shared operator zone; the zone (and operator apex) must survive.
+		mockDNS.EXPECT().DeleteWebsiteDNSRecords(mock.Anything, operatorZoneID, "alice.pinner.site").Return(nil).Once()
+
+		err := websiteService.DeleteWebsite(context.Background(), testUserID1, website.ID)
+		require.NoError(tb, err)
+
+		// The operator's shared zone is never deleted, so its apex records stay.
+		mockDNS.AssertNotCalled(t, "DeleteZone", mock.Anything, mock.Anything)
+		mockDNS.AssertNotCalled(t, "DeleteWebsiteDNSRecords", mock.Anything, mock.Anything, "pinner.site")
+
+		// The platform root and its zone row remain registered in the DB.
+		var pdAfter pluginDb.PlatformDomain
+		require.NoError(tb, db.Unscoped().First(&pdAfter, pd.ID).Error)
+		assert.Equal(tb, operatorZoneID, pdAfter.ZoneID)
+		var zoneCount int64
+		require.NoError(tb, db.Model(&pluginDb.DNSZone{}).Where("domain = ?", "pinner.site").Count(&zoneCount).Error)
+		assert.Equal(tb, int64(1), zoneCount)
+	}, TestOptions)
+}
+
 func TestWebsiteService_CreateWebsite_DNSHostingDisabled_NoDNSOperations(t *testing.T) {
 	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 		// Arrange


### PR DESCRIPTION
## Summary

Reworks platform-domain creation & management so the operator's DNS zone is
created **idempotently from the authenticated operator** instead of from a
client-supplied `zone_id`, and adds the ability to bind an operator-owned
website directly to a platform root's apex.

## What changed

- **`CreatePlatformDomain`**: dropped the `zoneID` parameter, added
  `operatorUserID`, and auto-creates the operator's zone for the root via
  `dnsSvc.CreateZone` (idempotent — returns existing zone if already created).
  Stores the created `zone.ID` on the `PlatformDomain` row.
- **`resolveManagedZone`**: added an exact apex match for platform-managed
  domains (`GetEnabledPlatformDomainByDomain`), returning the operator's zone
  with `zoneCreated=false`.
- **`BindPlatformRootApex`**: new `DelegatedDomainService` method that looks up
  an enabled `PlatformDomain` by ID and reuses the existing pipeline (DNSLink,
  apex records, delegation, SSL, `platform_domain_id` marking) with the root
  FQDN.
- **Admin API**:
  - `POST /platform-domains` no longer accepts `zone_id`; the operator is
    derived from the authenticated admin context.
  - New `POST /platform-domains/:id/bind` binds an operator-owned website
    (`website_id`) to the root apex.
  - Platform-domain admin routes now attach the auth middleware so the operator
    identity is available via `GetUserID`.
- **DTO + migration**:
  - Removed `ZoneID` from `PlatformDomainRequest` (`PlatformDomainResponse`
    keeps `zone_id`, now always populated).
  - Fixed `PlatformDomainUpdateRequest` to accept `false` (pointer bool).
  - Migration enforces `NOT NULL` on `platform_domains.zone_id` (mysql + sqlite).

## Tests

- Updated `CreatePlatformDomain` tests for the new signature.
- Added: apex binding writes DNSLink + apex records into the operator's zone,
  idempotent zone auto-create, multiple roots bound to one website, and
  delete-scoping (deleting a user's website removes only that user's subdomain
  records, not the operator's apex/zone).

## Verification

- `go build ./...` ✅
- `go vet ./...` ✅
- `internal/service/domain` and `internal/service/website` full suites pass ✅
- Task-relevant `internal/api` tests pass ✅

* `develop` <!-- branch-stack -->
  - **refactor(domains): auto-create operator zone for platform roots and add apex binding** :point\_left:

***

<!-- kody-pr-summary:start -->

## Summary

This pull request refactors the platform domain administration to **auto-create DNS zones** and introduces **root apex binding** for platform-owned domains.

## Key Changes

### 1. Auto-creation of Operator DNS Zones

- **Removed the requirement for clients to supply a `zone_id`** when registering a platform domain. Previously, the operator had to provision a DNS zone beforehand and pass its ID in the request.
- **The zone is now created automatically (idempotently)** from the authenticated operator's identity during `CreatePlatformDomain`. If a zone already exists for the domain, it is reused; otherwise, a new one is provisioned.
- The resulting zone ID is stored on the platform domain row, guaranteeing that a root never references a missing/dangling zone.
- Schema migrations (MySQL and SQLite) enforce `zone_id` as `NOT NULL` for platform domains.

### 2. New Endpoint: Bind Website to Platform Root Apex

- Added new admin API endpoint: `POST /platform-domains/:id/bind`
- This allows an operator to bind an operator-owned website **directly to the root apex** of a platform domain (e.g., `pinner.site`) rather than to a subdomain underneath it.
- The binding reuses the platform root's existing auto-created zone and runs through the standard managed-DNS pipeline (DNSLink, apex records, delegation, SSL).
- The website must be owned by the same operator as the platform domain.

### 3. Authentication Context for Platform Domain Routes

- Added end-to-end authentication middleware to platform-domain admin routes so handlers can derive the operator's identity from the request context (via `GetUserID`).
- The operator is now **derived from the authenticated admin session**, never trusted from client input.

### 4. Platform Root Apex Resolution

- Updated `resolveManagedZone` to permit a domain matching the platform root apex itself (previously rejected), enabling the new apex-binding flow while still preventing arbitrary zone creation.

### 5. Validation and API Adjustments

- `PlatformDomainUpdateRequest.Enabled` is now a pointer (`*bool`), with explicit validation that it must be provided.
- Updated Swagger documentation and API request/response DTOs accordingly.

## Testing

- Updated/extended unit tests covering:
  - Zone auto-creation and idempotent reuse
  - Rejection when zone creation fails or operator user is missing
  - Root apex binding (records written into operator zone, no new zone created)
  - Disabled root rejection for apex binding
  - Multiple roots bound to one website as additional domains
  - Website deletion preserving the operator's platform zone and apex records
- Updated admin CRUD integration tests to use authentication and the new auto-zone creation flow.

<!-- kody-pr-summary:end -->
