### PR TITLE
fix(domains): reject direct claim of platform root apex

### DIFF
--- a/internal/api/api_domains.go
+++ b/internal/api/api_domains.go
@@ -86,6 +86,19 @@ func (a *API) createDomain(c echo.Context) error {
 			apiErr := NewError(ErrKeyValidationFailed, fmt.Errorf("either domain+namespace or platform_domain must be provided"))
 			return ctx.Error(apiErr, apiErr.HttpStatus())
 		}
+		// Platform root apex guard: mirror the website-create check. An end user
+		// must never bind a platform root apex as a custom domain; that apex is
+		// operator-owned and reachable only via the admin apex-binding flow.
+		isRoot, rerr := a.delegatedDomainSvc.IsPlatformRootDomain(reqCtx, req.Domain)
+		if rerr != nil {
+			apiErr := NewError(ErrKeyInvalidRequest, rerr)
+			return ctx.Error(apiErr, apiErr.HttpStatus())
+		}
+		if isRoot {
+			apiErr := NewError(ErrKeyInvalidRequest,
+				fmt.Errorf("domain %q is a platform root and cannot be claimed directly; request a subdomain under it instead", req.Domain))
+			return ctx.Error(apiErr, apiErr.HttpStatus())
+		}
 		wd, err = a.delegatedDomainSvc.CreateDomain(reqCtx, req.Namespace, req.Domain, uint(websiteID), userID, dnsHostingEnabled, false, configRaw, nil)
 	}
 

--- a/internal/api/api_websites.go
+++ b/internal/api/api_websites.go
@@ -150,6 +150,24 @@ func (a *API) createWebsite(c echo.Context) error {
 	if req.Namespace != nil {
 		namespace = string(*req.Namespace)
 	}
+	// Platform root apex guard: the apex of a platform root (e.g. "pinner.site")
+	// is operator-owned and must never be claimed by an end user as a custom
+	// domain. A request that names a platform root as its primary domain must go
+	// through the platform-subdomain claim flow (or omit the domain so a
+	// subdomain is minted); otherwise the site would silently sit on the
+	// operator's apex.
+	if a.delegatedDomainSvc != nil {
+		isRoot, rerr := a.delegatedDomainSvc.IsPlatformRootDomain(reqCtx, req.Domain)
+		if rerr != nil {
+			apiErr := NewError(ErrKeyInvalidRequest, rerr)
+			return ctx.Error(apiErr, apiErr.HttpStatus())
+		}
+		if isRoot {
+			apiErr := NewError(ErrKeyInvalidRequest,
+				fmt.Errorf("domain %q is a platform root and cannot be claimed directly; request a subdomain under it instead", req.Domain))
+			return ctx.Error(apiErr, apiErr.HttpStatus())
+		}
+	}
 	// Guard on the delegated domain service's DB availability: the lookup
 	// runs against GetWebsiteDomainByDomainAndNamespace, which (unlike
 	// CreateDomain) dereferences s.DB() without an internal nil guard. Gate on

--- a/internal/api/api_websites.go
+++ b/internal/api/api_websites.go
@@ -523,6 +523,20 @@ func (a *API) updateWebsite(c echo.Context) error {
 		if req.Namespace != nil {
 			namespace = string(*req.Namespace)
 		}
+		// Platform root apex guard: mirror the website-create check. An end user
+		// must never bind a platform root apex (e.g. "pinner.site") as their
+		// primary domain via update — that apex is operator-owned and reachable
+		// only through the admin apex-binding flow.
+		isRoot, rerr := a.delegatedDomainSvc.IsPlatformRootDomain(reqCtx, *req.Domain)
+		if rerr != nil {
+			apiErr := NewError(ErrKeyInvalidRequest, rerr)
+			return ctx.Error(apiErr, apiErr.HttpStatus())
+		}
+		if isRoot {
+			apiErr := NewError(ErrKeyInvalidRequest,
+				fmt.Errorf("domain %q is a platform root and cannot be claimed directly; request a subdomain under it instead", *req.Domain))
+			return ctx.Error(apiErr, apiErr.HttpStatus())
+		}
 		var cfgRaw json.RawMessage
 		// Managed-DNS by default; explicit DNSEnabled override flows through.
 		newDomainDNS := true

--- a/internal/api/api_websites.go
+++ b/internal/api/api_websites.go
@@ -523,20 +523,6 @@ func (a *API) updateWebsite(c echo.Context) error {
 		if req.Namespace != nil {
 			namespace = string(*req.Namespace)
 		}
-		// Platform root apex guard: mirror the website-create check. An end user
-		// must never bind a platform root apex (e.g. "pinner.site") as their
-		// primary domain via update — that apex is operator-owned and reachable
-		// only through the admin apex-binding flow.
-		isRoot, rerr := a.delegatedDomainSvc.IsPlatformRootDomain(reqCtx, *req.Domain)
-		if rerr != nil {
-			apiErr := NewError(ErrKeyInvalidRequest, rerr)
-			return ctx.Error(apiErr, apiErr.HttpStatus())
-		}
-		if isRoot {
-			apiErr := NewError(ErrKeyInvalidRequest,
-				fmt.Errorf("domain %q is a platform root and cannot be claimed directly; request a subdomain under it instead", *req.Domain))
-			return ctx.Error(apiErr, apiErr.HttpStatus())
-		}
 		var cfgRaw json.RawMessage
 		// Managed-DNS by default; explicit DNSEnabled override flows through.
 		newDomainDNS := true
@@ -578,6 +564,21 @@ func (a *API) updateWebsite(c echo.Context) error {
 			if !errors.Is(eerr, gorm.ErrRecordNotFound) {
 				a.Logger().Error("Failed to look up existing domain binding", zap.String("domain", *req.Domain), zap.Error(eerr))
 				apiErr := NewError(ErrKeyFileProcessingFailed, eerr)
+				return ctx.Error(apiErr, apiErr.HttpStatus())
+			}
+			// Platform root apex guard: an end user must never bind a platform
+			// root apex (e.g. "pinner.site") as a NEW primary domain via update.
+			// It only runs when no live binding already owns the domain — a
+			// legitimate re-deploy of an apex the website already owns (handled
+			// by the reuse branch above) is preserved.
+			isRoot, rerr := a.delegatedDomainSvc.IsPlatformRootDomain(reqCtx, *req.Domain)
+			if rerr != nil {
+				apiErr := NewError(ErrKeyInvalidRequest, rerr)
+				return ctx.Error(apiErr, apiErr.HttpStatus())
+			}
+			if isRoot {
+				apiErr := NewError(ErrKeyInvalidRequest,
+					fmt.Errorf("domain %q is a platform root and cannot be claimed directly; request a subdomain under it instead", *req.Domain))
 				return ctx.Error(apiErr, apiErr.HttpStatus())
 			}
 			wd, derr := a.delegatedDomainSvc.CreateDomain(reqCtx, namespace, *req.Domain, website.ID, user, newDomainDNS, false, cfgRaw, nil)

--- a/internal/api/api_websites_test.go
+++ b/internal/api/api_websites_test.go
@@ -972,6 +972,34 @@ func TestAPI_UpdateWebsite(t *testing.T) {
 		}, TestOptions)
 	})
 
+	t.Run("error_platform_root_domain_rejected_on_update", func(t *testing.T) {
+		// Regression: the update path (PUT /websites/:id with domain=...) must
+		// reject a platform root apex just like createWebsite/createDomain.
+		// Otherwise an end user could create a website, then re-point its
+		// primary domain onto the operator-owned apex to bypass the guard.
+		coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+			helper := newMockHelper(t, ctx)
+			token, userID := helper.SetupAuthenticatedTestWithCID(cid.MustParse(TestCID))
+
+			// Persist a real website row so the update handler reaches the
+			// domain-change branch before the guard rejects it.
+			require.NoError(tb, ctx.DB().Create(createTestIPFSGatewayWebsite(1, userID, "example.com", cid.MustParse(TestCID), pluginDb.WebsiteStatusActive)).Error)
+
+			// Register an enabled platform root (as the admin flow would).
+			require.NoError(tb, ctx.DB().Create(&pluginDb.PlatformDomain{
+				Domain:    "platform.test",
+				Namespace: pluginDb.DomainNamespaceICANN,
+				ZoneID:    1,
+				Enabled:   true,
+			}).Error)
+
+			reqBody := fmt.Sprintf(`{"domain":"platform.test","target_type":"ipfs","target_hash":"%s"}`, TestCID)
+			rec := helper.makeAuthenticatedRequest(http.MethodPut, "/api/websites/1", token, []byte(reqBody))
+
+			assert.Equal(t, http.StatusUnprocessableEntity, rec.Code)
+		}, TestOptions)
+	})
+
 	t.Run("success_redeploy_existing_primary_reuses_binding", func(t *testing.T) {
 		coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 			helper := newMockHelper(t, ctx)

--- a/internal/api/api_websites_test.go
+++ b/internal/api/api_websites_test.go
@@ -169,6 +169,34 @@ func TestAPI_CreateWebsite(t *testing.T) {
 		}, TestOptions)
 	})
 
+	t.Run("error_platform_root_domain_rejected", func(t *testing.T) {
+		// Regression: a user must never be able to claim a platform root apex
+		// (e.g. "pinner.site") as a custom domain for their website — the apex is
+		// operator-owned. This is the exact leak that let the wizard create a
+		// website with domain = the platform root and no subdomain name.
+		coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+			helper := newMockHelper(t, ctx)
+			token, _ := helper.SetupAuthenticatedTestWithCID(cid.MustParse(TestCID))
+
+			// Register an enabled platform root (as the admin flow would).
+			pd := &pluginDb.PlatformDomain{
+				Domain:    "platform.test",
+				Namespace: pluginDb.DomainNamespaceICANN,
+				ZoneID:    1,
+				Enabled:   true,
+			}
+			require.NoError(tb, ctx.DB().Create(pd).Error)
+
+			// Creating a website that names the platform root as its primary
+			// domain must be rejected up front (422), before any Website is
+			// persisted.
+			reqBody := fmt.Sprintf(`{"domain":"platform.test","target_type":"ipfs","target_hash":"%s"}`, TestCID)
+			rec := helper.makeAuthenticatedRequest(http.MethodPost, "/api/websites", token, []byte(reqBody))
+
+			assert.Equal(t, http.StatusUnprocessableEntity, rec.Code)
+		}, TestOptions)
+	})
+
 	t.Run("error_invalid_target_type", func(t *testing.T) {
 		coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 			helper := newMockHelper(t, ctx)

--- a/internal/service/domain/platform_domain.go
+++ b/internal/service/domain/platform_domain.go
@@ -91,6 +91,27 @@ func (s *DelegatedDomainService) GetEnabledPlatformDomainByDomain(ctx context.Co
 	return s.GetEnabledPlatformDomain(ctx, domain, "")
 }
 
+// IsPlatformRootDomain reports whether the given domain (case/format
+// normalized) is an enabled platform root apex. The apex of a platform root is
+// operator-owned: it may only be bound to the operator's own site via the
+// admin apex-binding flow, never claimed by an end user through the normal
+// create/bind endpoints. Returns (false, nil) when the domain is not an
+// enabled platform root, or when the delegated-domain service has no DB wired.
+func (s *DelegatedDomainService) IsPlatformRootDomain(ctx context.Context, domain string) (bool, error) {
+	if s.DB() == nil {
+		return false, nil
+	}
+	var count int64
+	err := s.DB().WithContext(ctx).
+		Model(&pluginDb.PlatformDomain{}).
+		Where("domain = ? AND enabled = ?", NormalizeDomain(domain), true).
+		Count(&count).Error
+	if err != nil {
+		return false, err
+	}
+	return count > 0, nil
+}
+
 // labelFor returns the fully-qualified subdomain for a label on a platform root.
 // It deliberately does NOT call NormalizeDomain, which strips a leading "www."
 // prefix — that would map the label "www" to the bare root apex, bypassing

--- a/internal/service/domain/platform_domain_test.go
+++ b/internal/service/domain/platform_domain_test.go
@@ -170,6 +170,56 @@ func TestGetEnabledPlatformDomain_NamespaceAmbiguity(t *testing.T) {
 	}, TestOptions)
 }
 
+func TestIsPlatformRootDomain(t *testing.T) {
+	// The apex of a platform root is operator-owned and may not be claimed by
+	// end users as a custom domain. IsPlatformRootDomain must return true for
+	// an enabled root apex (in any normalized form) and false for a subdomain,
+	// a disabled/soft-deleted root, or a non-platform domain.
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		svc := core.GetService[*DelegatedDomainService](ctx, pluginCore.DELEGATED_DOMAIN_SERVICE)
+
+		createPlatformRoot(tb, ctx, "platform.test", pluginDb.DomainNamespaceICANN, 1, true)
+		createPlatformRoot(tb, ctx, "disabled.test", pluginDb.DomainNamespaceICANN, 1, false)
+		pd := createPlatformRoot(tb, ctx, "deleted.test", pluginDb.DomainNamespaceICANN, 1, true)
+		require.NoError(tb, svc.DeletePlatformDomain(context.Background(), pd.ID))
+
+		// Enabled apex is detected in its canonical form.
+		isRoot, err := svc.IsPlatformRootDomain(context.Background(), "platform.test")
+		require.NoError(tb, err)
+		assert.True(tb, isRoot)
+
+		// Normalization (www. prefix, case, whitespace) still detects the apex.
+		isRoot, err = svc.IsPlatformRootDomain(context.Background(), "  WWW.PLATFORM.TEST  ")
+		require.NoError(tb, err)
+		assert.True(tb, isRoot)
+
+		// Disabled and soft-deleted roots are not claimable apexes.
+		isRoot, err = svc.IsPlatformRootDomain(context.Background(), "disabled.test")
+		require.NoError(tb, err)
+		assert.False(tb, isRoot)
+
+		isRoot, err = svc.IsPlatformRootDomain(context.Background(), "deleted.test")
+		require.NoError(tb, err)
+		assert.False(tb, isRoot)
+
+		// A subdomain of a platform root is NOT the apex — it must be allowed
+		// through to the platform-subdomain claim flow.
+		isRoot, err = svc.IsPlatformRootDomain(context.Background(), "blog.platform.test")
+		require.NoError(tb, err)
+		assert.False(tb, isRoot)
+
+		// A completely unrelated domain is not a platform root.
+		isRoot, err = svc.IsPlatformRootDomain(context.Background(), "example.com")
+		require.NoError(tb, err)
+		assert.False(tb, isRoot)
+
+		// Empty domain (auto-generate path) is not a platform root.
+		isRoot, err = svc.IsPlatformRootDomain(context.Background(), "")
+		require.NoError(tb, err)
+		assert.False(tb, isRoot)
+	}, TestOptions)
+}
+
 func TestGetEnabledPlatformDomain_DisabledAndDeletedExcluded(t *testing.T) {
 	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 		svc := core.GetService[*DelegatedDomainService](ctx, pluginCore.DELEGATED_DOMAIN_SERVICE)


### PR DESCRIPTION
Prevents end users from binding a website or domain directly to the apex of an
enabled platform root (e.g. "pinner.site"), which is operator-owned and only
reachable via the admin apex-binding flow.

Adds `DelegatedDomainService.IsPlatformRootDomain` and enforces it in the
website-create and domain-bind endpoints, returning 422 with a message that
directs callers to request a subdomain instead.

- `develop` <!-- branch-stack -->
  - **fix(domains): reject direct claim of platform root apex** :point\_left:

***

<!-- kody-pr-summary:start -->

## Summary

This pull request fixes a security/ownership issue where end users could directly claim a platform root apex domain (e.g., "pinner.site") as a custom domain for their website. Platform root apex domains are operator-owned and should only be accessible through the admin apex-binding flow.

## Changes

### Domain Service Enhancement

Added a new `IsPlatformRootDomain` method to the `DelegatedDomainService` that checks whether a given domain corresponds to an enabled platform root apex. The check:

- Normalizes the domain format before comparison
- Only considers enabled platform roots as claimable apexes
- Ignores disabled or soft-deleted roots
- Returns `false` when no database is configured

### API Guards

Added validation guards in two API endpoints to reject direct claims of platform root apex domains:

1. **`POST /api/websites`** (website creation): Rejects requests where the primary domain is a platform root apex, returning a 422 error. This specifically addresses a vulnerability where users could create a website claiming the platform's root domain as their own without a subdomain.

2. **`POST /api/domains`** (domain creation): Rejects attempts to bind a platform root apex as a custom domain, also returning a 422 error with a clear message instructing users to request a subdomain instead.

### Test Coverage

Added regression tests for both the service layer and the API endpoints to ensure:

- Enabled platform root apex domains are correctly identified
- Disabled/deleted roots and subdomains are not incorrectly blocked
- The API properly rejects claims of platform root apexes with HTTP 422
- Normalization (case, whitespace, "[www](http://www)." prefix) works correctly in the detection

## Impact

This fix prevents unauthorized claiming of operator-owned platform root domains by regular users, ensuring that only the admin apex-binding flow can attach a platform root apex to a website. Users attempting to claim such domains will receive clear error messages directing them to use subdomains instead.

<!-- kody-pr-summary:end -->
