### PR TITLE
fix(domains): correct invalid ID message for path-ID parsing errors

### DIFF
--- a/internal/api/errors.go
+++ b/internal/api/errors.go
@@ -95,7 +95,7 @@ func init() {
 		ErrKeyFileUploadAPIFailed:   {Key: ErrKeyFileUploadAPIFailed, Message: "File upload failed due to an internal error."},
 		ErrKeyMetadataFetchFailed:   {Key: ErrKeyMetadataFetchFailed, Message: "Failed to fetch metadata."},
 		ErrKeyPinFetchFailed:        {Key: ErrKeyPinFetchFailed, Message: "Failed to fetch pin."},
-		ErrKeyInvalidUUIDFormat:     {Key: ErrKeyInvalidUUIDFormat, Message: "Invalid UUID format provided: %s"},
+		ErrKeyInvalidUUIDFormat:     {Key: ErrKeyInvalidUUIDFormat, Message: "Invalid ID format provided: %s"},
 		ErrKeyFileProcessingFailed:  {Key: ErrKeyFileProcessingFailed, Message: "Failed to process the file."},
 		ErrKeyCIDParseFailed:        {Key: ErrKeyCIDParseFailed, Message: "Failed to parse CID."},
 		ErrKeyBlockNotFound:         {Key: ErrKeyBlockNotFound, Message: "Block not found."},


### PR DESCRIPTION
Corrects the shared ID-error message from `Invalid UUID format` to `Invalid ID format` so platform-domain path-ID parsing errors for non-numeric values report accurately.

- `develop` <!-- branch-stack -->
  - **fix(domains): correct invalid ID message for path-ID parsing errors** :point\_left:

---

<!-- kody-pr-summary:start -->
## Summary

This pull request fixes an incorrect error message for domain operations when parsing path-based IDs.

## Changes

- **Updated error message text** in `internal/api/errors.go`:
  - Changed the message for `ErrKeyInvalidUUIDFormat` from **"Invalid UUID format provided: %s"** to **"Invalid ID format provided: %s"**

## Impact

The error message previously referenced "UUID format" even though the domain feature uses path-based ID parsing. This correction ensures users see an accurate and contextually appropriate error message when an invalid ID is provided, avoiding confusion about the expected ID format.
<!-- kody-pr-summary:end -->