### PR TITLE
feat(website): support advanced pagination on website list endpoint

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -655,6 +655,9 @@ Prerequisites: User must own the specified IPNS key.`),
 		return fmt.Errorf("failed to register ipns operation routes: %w", err)
 	}
 
+	websiteFilterSchema := queryutil.NewSchemaProvider().ForType(dto.WebsiteFilter{})
+	websiteListSchema := queryutil.NewSchemaProvider().ForType(dto.WebsiteItem{})
+
 	websiteRoutes := router.DefineRoutes(
 		router.NewRoute(http.MethodPost, "/websites", a.createWebsite,
 			router.WithAccess(core.ACCESS_USER_ROLE),
@@ -688,13 +691,18 @@ Returns paginated list of website configurations with status, domain, and target
 
 See also:.*`),
 				router.WithTags("Websites"),
-					router.WithSuccessResponse(http.StatusOK, "List of websites", router.WithJSONContent(dto.WebsiteItemResponse{})),
-					router.WithErrorResponses(router.DefineSwaggerErrorResponses(
-						DefineErrorResponse(http.StatusUnauthorized, "Authentication required"),
-						DefineErrorResponse(http.StatusInternalServerError, "Internal server error occurred"),
-					)),
-					),
+				router.WithPaginationParams(),
+				router.WithSortParams(websiteListSchema.SortableFields()),
+				router.WithFilterParamsFromSchema(websiteFilterSchema),
+				router.WithSuccessResponse(http.StatusOK, "List of websites",
+					router.WithJSONContent(dto.WebsiteItemResponse{}),
+					router.WithTotalCountHeader()),
+				router.WithErrorResponses(router.DefineSwaggerErrorResponses(
+					DefineErrorResponse(http.StatusUnauthorized, "Authentication required"),
+					DefineErrorResponse(http.StatusInternalServerError, "Internal server error occurred"),
+				)),
 				),
+			),
 				router.NewRoute(http.MethodGet, "/websites/:id", a.getWebsite,
 			router.WithAccess(core.ACCESS_USER_ROLE),
 			router.WithSwagger(

--- a/internal/api/api_websites.go
+++ b/internal/api/api_websites.go
@@ -21,7 +21,7 @@ import (
 	pluginEvents "go.lumeweb.com/portal-plugin-ipfs/internal/errors"
 	pluginservice "go.lumeweb.com/portal-plugin-ipfs/internal/service/website"
 	"go.lumeweb.com/queryutil"
-	"go.lumeweb.com/queryutil/filter"
+	queryUtilHttp "go.lumeweb.com/queryutil/http"
 	"go.uber.org/zap"
 	"gorm.io/gorm"
 )
@@ -304,67 +304,55 @@ func (a *API) listWebsites(c echo.Context) error {
 		return err
 	}
 
-	websiteFilter := dto.WebsiteFilter{}
-	if _, ok := httputil.DecodeAndValidateQueryRequest(ctx, &websiteFilter); !ok {
-		return nil
-	}
+	return queryUtilHttp.ProcessListRequest[*dto.WebsiteItem, dto.WebsiteItem](
+		c.Response(),
+		c.Request(),
+		"websites",
+		func(filters []queryutil.CrudFilter, sorts []queryutil.Sort, pagination queryutil.Pagination) ([]*dto.WebsiteItem, int64, error) {
+			// The website service always scopes queries to the authenticated
+			// user, so drop any client-supplied user_id filter to prevent
+			// conflicting access conditions.
+			scopedFilters := make([]queryutil.CrudFilter, 0, len(filters))
+			for _, f := range filters {
+				if f.GetField() != "user_id" {
+					scopedFilters = append(scopedFilters, f)
+				}
+			}
 
-	// Build filters from request
-	var filters []queryutil.CrudFilter
-	if websiteFilter.Domain != nil {
-		filters = append(filters, queryutil.NewLogicalFilter("domain", filter.OpEq, *websiteFilter.Domain))
-	}
-	if websiteFilter.TargetType != nil {
-		filters = append(filters, queryutil.NewLogicalFilter("target_type", filter.OpEq, *websiteFilter.TargetType))
-	}
-	if websiteFilter.Status != nil {
-		filters = append(filters, queryutil.NewLogicalFilter("status", filter.OpEq, *websiteFilter.Status))
-	}
+			websites, total, err := a.websiteService.ListWebsites(reqCtx, user, scopedFilters, sorts, pagination)
+			if err != nil {
+				return nil, 0, err
+			}
 
-	// Add user filter
-	filters = append(filters, queryutil.NewLogicalFilter("user_id", filter.OpEq, user))
+			items := make([]*dto.WebsiteItem, len(websites))
+			for i, website := range websites {
+				var resp dto.WebsiteResponse
+				if err := resp.FromModel(website); err != nil {
+					return nil, 0, err
+				}
+				primary, perr := a.websiteService.GetApexDomainBinding(reqCtx, website.ID)
+				if perr != nil {
+					a.Logger().Warn("website has no primary domain binding", zap.Uint("website_id", website.ID), zap.Error(perr))
+				}
+				resp.SetPrimaryDomain(primary)
+				resp.GatewayDomain = a.gatewayDomain()
+				if primary != nil {
+					resp.SetSubdomainInfo(a.zoneDomain(reqCtx, primary.ZoneID))
+				} else {
+					resp.SetSubdomainInfo("")
+				}
+				resp.SetValidationRecordInfo(a.verificationTokenKey())
+				resp.EnrichActiveCID(ipnsKeyCIDResolver{svc: a.ipnsKeyService, ctx: reqCtx}, user, website)
+				item := dto.WebsiteItem(resp)
+				items[i] = &item
+			}
 
-	// Default pagination
-	pagination := filter.DefaultPagination
-
-	websites, total, err := a.websiteService.ListWebsites(reqCtx, user, filters, []queryutil.Sort{}, pagination)
-	if err != nil {
-		a.Logger().Error("Failed to list websites", zap.Error(err), zap.Uint("user_id", user))
-		apiErr := NewError(ErrKeyFileProcessingFailed, err)
-		return ctx.Error(apiErr, apiErr.HttpStatus())
-	}
-
-	responses := make([]dto.WebsiteResponse, len(websites))
-	for i, website := range websites {
-		if err := responses[i].FromModel(website); err != nil {
-			a.Logger().Error("Failed to convert website to response", zap.Error(err))
-			apiErr := NewError(ErrKeyFileProcessingFailed, err)
-			return ctx.Error(apiErr, apiErr.HttpStatus())
-		}
-		primary, perr := a.websiteService.GetApexDomainBinding(reqCtx, website.ID)
-		if perr != nil {
-			a.Logger().Warn("website has no primary domain binding", zap.Uint("website_id", website.ID), zap.Error(perr))
-		}
-		responses[i].SetPrimaryDomain(primary)
-		responses[i].GatewayDomain = a.gatewayDomain()
-		if primary != nil {
-			responses[i].SetSubdomainInfo(a.zoneDomain(reqCtx, primary.ZoneID))
-		} else {
-			responses[i].SetSubdomainInfo("")
-		}
-		responses[i].SetValidationRecordInfo(a.verificationTokenKey())
-		responses[i].EnrichActiveCID(ipnsKeyCIDResolver{svc: a.ipnsKeyService, ctx: reqCtx}, user, website)
-	}
-
-	// Convert to WebsiteItem for list response
-	items := make([]dto.WebsiteItem, len(responses))
-	for i := range responses {
-		items[i] = dto.WebsiteItem(responses[i])
-	}
-
-	result := queryutil.BuildResponse(items, total)
-
-	return ctx.JSON(http.StatusOK, result)
+			return items, total, nil
+		},
+		func(item *dto.WebsiteItem) dto.WebsiteItem {
+			return *item
+		},
+	)
 }
 
 func (a *API) getWebsite(c echo.Context) error {

--- a/internal/api/api_websites_test.go
+++ b/internal/api/api_websites_test.go
@@ -761,7 +761,7 @@ func TestAPI_ListWebsites(t *testing.T) {
 			mockWebsiteService.EXPECT().GetApexDomainBinding(mock.Anything, uint(1)).Return(nil, nil)
 			mockWebsiteService.EXPECT().GetApexDomainBinding(mock.Anything, uint(2)).Return(nil, nil)
 
-			rec := helper.makeAuthenticatedRequest(http.MethodGet, "/api/websites?page=1&limit=2", token, nil)
+			rec := helper.makeAuthenticatedRequest(http.MethodGet, "/api/websites?_start=0&_end=2", token, nil)
 
 			assert.Equal(t, http.StatusOK, rec.Code)
 
@@ -769,6 +769,7 @@ func TestAPI_ListWebsites(t *testing.T) {
 			err := json.Unmarshal(rec.Body.Bytes(), &response)
 			require.NoError(t, err)
 			assert.Equal(t, float64(5), response["total"])
+			assert.Equal(t, "5", rec.Header().Get("X-Total-Count"))
 			items, ok := response["data"].([]interface{})
 			require.True(t, ok, "data should be a slice")
 			assert.Len(t, items, 2)

--- a/internal/api/dto/website.go
+++ b/internal/api/dto/website.go
@@ -370,14 +370,14 @@ type WebsiteResponse struct {
 	ID     uint   `json:"id"`
 	Domain string `json:"domain"`
 	// IPFS or IPNS
-	TargetType string `json:"target_type"`
+	TargetType string `json:"target_type" sort:"true"`
 	// CID (IPFS) or peer ID (IPNS)
-	TargetHash string `json:"target_hash"`
+	TargetHash string `json:"target_hash" sort:"true"`
 	// FK to the linked IPNS key (set when DNS hosting auto-creates a key)
 	IPNSKeyID *uint `json:"ipns_key_id,omitempty"`
 	// The currently-published IPFS content CID (distinct from target_hash when target is IPNS)
 	ActiveCID string `json:"active_cid,omitempty"`
-	Status    string `json:"status"`
+	Status    string `json:"status" sort:"true"`
 	// The full TXT record value (e.g. "lumeweb-verify=abc123...")
 	ValidationToken string `json:"validation_token"`
 	// The DNS hostname for the TXT record (e.g. "lumeweb-verify.example.com")
@@ -392,8 +392,8 @@ type WebsiteResponse struct {
 	IsSubdomain bool `json:"is_subdomain"`
 	// Gateway domain for constructing public URLs (e.g. ipfs.example.com)
 	GatewayDomain string    `json:"gateway_domain,omitempty"`
-	Created       time.Time `json:"created"`
-	Updated       time.Time `json:"updated"`
+	Created       time.Time `json:"created" sort:"true"`
+	Updated       time.Time `json:"updated" sort:"true"`
 	// Whether validation token has expired
 	Expired bool           `json:"expired"`
 	SSL     *SSLStatusInfo `json:"ssl,omitempty"`
@@ -520,9 +520,9 @@ type WebsiteItemResponse struct {
 
 // WebsiteFilter represents filtering options for website listings
 type WebsiteFilter struct {
-	Domain     *string               `json:"domain,omitempty" query:"domain"`
-	TargetType *db.WebsiteTargetType `json:"target_type,omitempty" query:"target_type"`
-	Status     *db.WebsiteStatus     `json:"status,omitempty" query:"status"`
+	Domain     *string               `json:"domain,omitempty" filter:"true"`
+	TargetType *db.WebsiteTargetType `json:"target_type,omitempty" filter:"true"`
+	Status     *db.WebsiteStatus     `json:"status,omitempty" filter:"true"`
 }
 
 func (f WebsiteFilter) Schema() *zog.StructSchema {

--- a/internal/api/dto/website.go
+++ b/internal/api/dto/website.go
@@ -372,7 +372,8 @@ type WebsiteResponse struct {
 	// IPFS or IPNS
 	TargetType string `json:"target_type" sort:"true"`
 	// CID (IPFS) or peer ID (IPNS)
-	TargetHash string `json:"target_hash" sort:"true"`
+	// Not sortable: derived from target_multihash (no matching column).
+	TargetHash string `json:"target_hash"`
 	// FK to the linked IPNS key (set when DNS hosting auto-creates a key)
 	IPNSKeyID *uint `json:"ipns_key_id,omitempty"`
 	// The currently-published IPFS content CID (distinct from target_hash when target is IPNS)
@@ -392,8 +393,9 @@ type WebsiteResponse struct {
 	IsSubdomain bool `json:"is_subdomain"`
 	// Gateway domain for constructing public URLs (e.g. ipfs.example.com)
 	GatewayDomain string    `json:"gateway_domain,omitempty"`
-	Created       time.Time `json:"created" sort:"true"`
-	Updated       time.Time `json:"updated" sort:"true"`
+	// Created/Updated are not sortable: columns are created_at/updated_at.
+	Created time.Time `json:"created"`
+	Updated time.Time `json:"updated"`
 	// Whether validation token has expired
 	Expired bool           `json:"expired"`
 	SSL     *SSLStatusInfo `json:"ssl,omitempty"`


### PR DESCRIPTION
Switches the `GET /websites` list endpoint to the shared `ProcessListRequest` handler, exposing pagination (`_start`/`_end`), sorting, and filter parameters in the swagger/OpenAPI spec, plus a `Content-Range`/`X-Total-Count` response header.

Queries are scoped to the authenticated user; client-supplied `user_id` filters are discarded.

- `develop` <!-- branch-stack -->
  - **feat(website): support advanced pagination on website list endpoint** :point\_left:

***

<!-- kody-pr-summary:start -->

## Summary

This pull request enhances the website list endpoint to support advanced pagination, sorting, and filtering capabilities using the queryutil framework.

## Key Changes

### Advanced Pagination Support

- **API Route Configuration** (`internal/api/api.go`): The `GET /websites` endpoint now registers:
  - Pagination parameters (`_start`, `_end`)
  - Sortable fields (target\_type, target\_hash, status, created, updated) derived from the `WebsiteItem` DTO schema
  - Filter parameters derived from the `WebsiteFilter` DTO schema
  - A total count response header (`X-Total-Count`)

### Simplified List Processing

- **Request Handling** (`internal/api/api_websites.go`): Replaced manual query parsing and response building with the generic `queryUtilHttp.ProcessListRequest` helper. This provides:
  - Automatic pagination, sorting, and filtering support
  - Consistent response format with total count headers
  - Removal of previously hardcoded filter logic and pagination defaults

### Security Enhancement

- **User Scoping Protection**: Client-supplied `user_id` filters are now stripped before querying the database to prevent conflicting access conditions, as the website service always applies its own user-based scoping.

### DTO Metadata Updates

- **Sortable Fields** (`internal/api/dto/website.go`): Added `sort:"true"` tags to sortable fields (target\_type, target\_hash, status, created, updated)
- **Filterable Fields**: Changed filter tags from `query` to `filter` format for proper schema-based filter registration

### Test Updates

- Updated the list endpoint test to use the new pagination format (`_start=0&_end=2` instead of `page=1&limit=2`)
- Added assertion for the new `X-Total-Count` response header

<!-- kody-pr-summary:end -->
