### PR TITLE
fix(domains): default platform domain registration namespace to hns

### DIFF
--- a/internal/api/admin_extension.go
+++ b/internal/api/admin_extension.go
@@ -405,7 +405,12 @@ func (e *AdminExtension) createPlatformDomain(c echo.Context) error {
 		return nil
 	}
 
-	pd, err := e.delegatedDomainSvc.CreatePlatformDomain(reqCtx, req.Domain, pluginDb.DomainNamespace(req.Namespace), operatorUserID, req.Enabled)
+	namespace := string(pluginDb.DomainNamespaceHNS)
+	if req.Namespace != nil {
+		namespace = *req.Namespace
+	}
+
+	pd, err := e.delegatedDomainSvc.CreatePlatformDomain(reqCtx, req.Domain, pluginDb.DomainNamespace(namespace), operatorUserID, req.Enabled)
 	if err != nil {
 		e.logger.Error("Failed to create platform domain", zap.Error(err))
 		apiErr := NewError(ErrKeyValidationFailed, err)

--- a/internal/api/dto/platform_domain.go
+++ b/internal/api/dto/platform_domain.go
@@ -9,23 +9,27 @@ import (
 // The operator's zone is auto-created (idempotently) from the authenticated
 // operator user; zone_id is no longer supplied by the client.
 type PlatformDomainRequest struct {
-	Domain    string `json:"domain"`
-	Namespace string `json:"namespace"` // icann | hns
-	Enabled   bool   `json:"enabled,omitempty"`
+	Domain    string  `json:"domain"`
+	Namespace *string `json:"namespace,omitempty"` // hns (default) or icann
+	Enabled   bool    `json:"enabled,omitempty"`
 }
 
 func (r PlatformDomainRequest) Schema() *zog.StructSchema {
 	return zog.Struct(zog.Shape{
 		"Domain":    zog.String().Required().Min(1).Max(255),
-		"Namespace": zog.String().Required().OneOf([]string{string(db.DomainNamespaceICANN), string(db.DomainNamespaceHNS)}),
+		"Namespace": zog.Ptr(zog.String().OneOf([]string{string(db.DomainNamespaceHNS), string(db.DomainNamespaceICANN)})),
 		"Enabled":   zog.Bool(),
 	})
 }
 
 func (r PlatformDomainRequest) ToModel() (*db.PlatformDomain, error) {
+	namespace := string(db.DomainNamespaceHNS)
+	if r.Namespace != nil {
+		namespace = *r.Namespace
+	}
 	return &db.PlatformDomain{
 		Domain:    r.Domain,
-		Namespace: db.DomainNamespace(r.Namespace),
+		Namespace: db.DomainNamespace(namespace),
 		Enabled:   r.Enabled,
 	}, nil
 }


### PR DESCRIPTION
POST /platform-domains registers a namespace that defaults to hns when omitted, mirroring the website-create optional-namespace pattern. Explicit icann continues to be honored.

- `develop` <!-- branch-stack -->
  - **fix(domains): default platform domain registration namespace to hns** :point\_left:

---

<!-- kody-pr-summary:start -->
## Summary

This pull request modifies the platform domain registration API to default the namespace to `hns` (Handshake) when not explicitly specified by the client.

## Changes

### Default namespace behavior
- **`internal/api/dto/platform_domain.go`**: The `Namespace` field in the `PlatformDomainRequest` is now optional (changed from `string` to `*string`). When the namespace is not provided, the system defaults to `hns` in both the request validation schema (now allows nil) and the `ToModel()` conversion method.

### API endpoint handling
- **`internal/api/admin_extension.go`**: The `createPlatformDomain` handler now applies the same default logic—if the namespace is not supplied in the request, it uses `hns` instead of requiring an explicit value.

## Impact

This change simplifies the API for clients creating platform domains, as they no longer need to explicitly specify the namespace—the system will automatically use `hns` as the default. The `icann` namespace remains available as an explicit alternative.
<!-- kody-pr-summary:end -->