### PR TITLE
fix(website): make domain omittable on website create for platform claims

### DIFF
--- a/internal/api/dto/website.go
+++ b/internal/api/dto/website.go
@@ -185,7 +185,7 @@ func (r *IPNSRepublishResponse) FromModel(any) error {
 //     a computed label). The namespace and DNS hosting are derived from the
 //     platform root, mirroring the domain-bind flow.
 type WebsiteRequest struct {
-	Domain     string               `json:"domain"`                        // primary domain (transparently created as a WebsiteDomain binding)
+	Domain     string               `json:"domain,omitempty"`               // primary domain (transparently created as a WebsiteDomain binding); omitted when claiming a platform subdomain
 	Namespace  *db.DomainNamespace  `json:"namespace,omitempty"`           // icann (default) or hns
 	TargetType db.WebsiteTargetType `json:"target_type"`                   // db.WebsiteTargetTypeIPFS or db.WebsiteTargetTypeIPNS
 	TargetHash string               `json:"target_hash"`                   // CID or IPNS peer ID


### PR DESCRIPTION
Makes `WebsiteRequest.Domain` omittable (adds `omitempty`) so platform-subdomain claims (label/generate) can omit `domain` on create. An explicit empty `"domain":""` is rejected by the zog schema, so without this the generated create request can't send platform-generate claims.

- `develop` <!-- branch-stack -->
  - **fix(website): make domain omittable on website create for platform claims** :point\_left:

---

<!-- kody-pr-summary:start -->
This pull request makes the `domain` field optional when creating a website for platform claims. Specifically:

- The `Domain` field in the `WebsiteRequest` DTO now uses the `omitempty` JSON tag, meaning it can be omitted from the request payload.
- This change enables creating websites without specifying a primary domain when claiming a platform subdomain, where the namespace and DNS hosting are automatically derived from the platform root (similar to the domain-bind flow).
<!-- kody-pr-summary:end -->