### PR TITLE
fix(website): skip DNS verify check on platform subdomains

### DIFF
--- a/internal/api/dto/website.go
+++ b/internal/api/dto/website.go
@@ -201,9 +201,11 @@ type WebsiteRequest struct {
 }
 
 // IsPlatformClaim reports whether this request claims a platform subdomain
-// rather than a user-owned domain.
+// rather than a user-owned domain. A claim is expressed by naming a platform
+// root (PlatformDomain), requesting an auto-generated subdomain (Generate), or
+// supplying an explicit label (Label) — any of which selects the platform path.
 func (r WebsiteRequest) IsPlatformClaim() bool {
-	return r.PlatformDomain != ""
+	return r.PlatformDomain != "" || r.Generate || r.Label != ""
 }
 
 func (r WebsiteRequest) Schema() *zog.StructSchema {

--- a/internal/api/dto/website_test.go
+++ b/internal/api/dto/website_test.go
@@ -395,6 +395,26 @@ func TestWebsiteResponse_FromModel_DoesNotSetSSL(t *testing.T) {
 	})
 }
 
+func TestWebsiteRequest_IsPlatformClaim(t *testing.T) {
+	tests := []struct {
+		name string
+		req  WebsiteRequest
+		want bool
+	}{
+		{name: "platform domain set", req: WebsiteRequest{PlatformDomain: "pinned.site"}, want: true},
+		{name: "generate set", req: WebsiteRequest{Generate: true}, want: true},
+		{name: "label set", req: WebsiteRequest{Label: "myapp"}, want: true},
+		{name: "custom domain only", req: WebsiteRequest{Domain: "example.com"}, want: false},
+		{name: "empty request", req: WebsiteRequest{}, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, tt.req.IsPlatformClaim())
+		})
+	}
+}
+
 func TestWebsiteRequest_ToModel_IPNS_WithValidPeerID(t *testing.T) {
 	targetType := db.WebsiteTargetTypeIPNS
 	req := WebsiteRequest{

--- a/internal/service/website/validate_dns_test.go
+++ b/internal/service/website/validate_dns_test.go
@@ -592,6 +592,51 @@ func TestValidateDNS_PendingDelegated_SkipsTokenCheck(t *testing.T) {
 	}, TestOptions)
 }
 
+func TestValidateDNS_PlatformSubdomain_SkipsTokenCheck(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		ws := core.GetService[pluginCore.WebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
+		require.NotNil(tb, ws)
+
+		testCID := util.GenerateTestCID(t, "platform-skip-token")
+		website := createTestIPFSWebsite(testUserID1, "platform-skip.com", testCID.String())
+		created, err := ws.CreateWebsite(context.Background(), website)
+		require.NoError(tb, err)
+		wd := bindPrimaryDomain(tb, ctx, created.ID, "platform-skip.com", true)
+
+		// Mark the binding as a platform subdomain (ICANN namespace): the
+		// platform controls both ends of the DNS check, so no user TXT token
+		// exists and the token check must be skipped purely on this pointer.
+		pdID := uint(7)
+		wd.PlatformDomainID = &pdID
+		require.NoError(tb, ctx.DB().Model(wd).Update("platform_domain_id", pdID).Error)
+
+		mockResolver := mocks.NewMockDNSResolver(t)
+		// Only DNSLink expected: the token check (TXT lookup) must NOT run.
+		mockResolver.EXPECT().ResolveDNSLink("platform-skip.com").Return(dnslink.Result{
+			Links: map[string]dnslink.NamespaceEntries{
+				"ipfs": {{Identifier: created.TargetHash()}},
+			},
+		}, nil)
+		setMockResolver(ws, mockResolver)
+
+		// UsesDelegationForOwnership returns false (ICANN), proving the skip is
+		// triggered by the platform-subdomain path, not the delegation path.
+		mockDelegated := &testDelegatedDomainService{
+			uses: func(d string) bool { return false },
+		}
+		setMockDelegatedDomainSvc(ws, mockDelegated)
+
+		result, err := ws.ValidateDNS(context.Background(), testUserID1, created.ID)
+		require.NoError(tb, err)
+		assert.True(tb, result.Valid)
+		assert.Equal(tb, pluginCore.ValidationReasonValidated, result.Reason)
+
+		final, err := ws.GetWebsite(context.Background(), testUserID1, created.ID)
+		require.NoError(tb, err)
+		assert.Equal(tb, string(pluginDb.WebsiteStatusActive), final.Status)
+	}, TestOptions)
+}
+
 func TestValidateDNS_DelegatedAttached_Success(t *testing.T) {
 	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 		ws := core.GetService[pluginCore.WebsiteService](ctx, pluginCore.WEBSITE_SERVICE)

--- a/internal/service/website/website.go
+++ b/internal/service/website/website.go
@@ -1449,14 +1449,25 @@ func (s *WebsiteServiceDefault) loadWebsite(ctx context.Context, userID, website
 	return website, nil
 }
 
-// ValidateDNS validates the DNS TXT record for a website's primary domain
-func (s *WebsiteServiceDefault) shouldPerformTokenCheck(website *pluginDb.Website, primaryDomain string) bool {
+// shouldPerformTokenCheck reports whether the user-side TXT verification token
+// must be checked for a website awaiting DNS validation. It is skipped for
+// platform subdomains (minted under an operator-owned root, where the platform
+// controls both ends of the DNS check and no verification record exists) and
+// for namespaces that prove ownership via delegation (e.g. HNS).
+func (s *WebsiteServiceDefault) shouldPerformTokenCheck(website *pluginDb.Website, primaryWD *pluginDb.WebsiteDomain) bool {
 	needs := website.Status == string(pluginDb.WebsiteStatusPendingValidation)
-	if needs && s.delegatedDomainSvc != nil && s.delegatedDomainSvc.UsesDelegationForOwnership(primaryDomain) {
-		s.Logger().Debug("skipping TXT token (ownership proven via delegation verification)", zap.String("domain", primaryDomain))
+	if !needs {
 		return false
 	}
-	return needs
+	if primaryWD.PlatformDomainID != nil {
+		s.Logger().Debug("skipping TXT token (platform subdomain, operator-controlled DNS)", zap.String("domain", primaryWD.Domain))
+		return false
+	}
+	if s.delegatedDomainSvc != nil && s.delegatedDomainSvc.UsesDelegationForOwnership(primaryWD.Domain) {
+		s.Logger().Debug("skipping TXT token (ownership proven via delegation verification)", zap.String("domain", primaryWD.Domain))
+		return false
+	}
+	return true
 }
 
 func (s *WebsiteServiceDefault) ValidateDNS(ctx context.Context, userID uint, websiteID uint) (pluginCore.ValidateDNSResult, error) {
@@ -1480,7 +1491,7 @@ func (s *WebsiteServiceDefault) ValidateDNS(ctx context.Context, userID uint, we
 			}
 			primaryDomain := primaryWD.Domain
 
-			needsTokenCheck := s.shouldPerformTokenCheck(&website, primaryDomain)
+			needsTokenCheck := s.shouldPerformTokenCheck(&website, primaryWD)
 
 			if needsTokenCheck && website.IsExpired() {
 				if err := s.regenerateExpiredToken(ctx, &website, primaryWD); err != nil {


### PR DESCRIPTION
Fixes two platform-subdomain issues in the website flow.

Detects platform claims from `Generate`/`Label` (not just `PlatformDomain`) so a create sent with `generate: true` and no `platform_domain` is no longer rejected with a 422 "domain is required".

Skips the user-side TXT verification token check for platform subdomains. They are minted under an operator-owned root where the platform controls both ends of the DNS check, so no pinner-verify record exists; the token check previously failed with no such host and left the site stuck in pending\_validation. Validation now reaches the delegation gate, which auto-activates the site.

- `develop` <!-- branch-stack -->
  - **fix(website): skip DNS verify check on platform subdomains** :point\_left:
