### PR TITLE
fix(website): resolve default platform root for subdomain mint, guard domain/claim conflict

### DIFF
--- a/internal/api/api_websites.go
+++ b/internal/api/api_websites.go
@@ -185,6 +185,13 @@ func (a *API) createWebsite(c echo.Context) error {
 		namespace = string(*req.Namespace)
 	}
 
+	// A user-owned domain and a platform-subdomain claim are mutually exclusive
+	// destinations. Supplying both is ambiguous, so reject it rather than
+	// silently ignoring one and persisting a website bound to the wrong target.
+	if req.Domain != "" && req.IsPlatformClaim() {
+		apiErr := NewError(ErrKeyInvalidRequest, fmt.Errorf("supply a custom domain OR claim a platform subdomain, not both"))
+		return ctx.Error(apiErr, apiErr.HttpStatus())
+	}
 	// A website needs a destination: either a user-owned domain (non-empty
 	// Domain) or an explicit platform-subdomain claim. An empty domain with no
 	// platform claim would otherwise persist an orphan website with no binding,
@@ -299,13 +306,13 @@ func (a *API) claimPlatformSubdomain(ctx httputil.RequestContext, reqCtx context
 	if req.PlatformNamespace != "" {
 		platformNS = pluginDb.DomainNamespace(req.PlatformNamespace)
 	}
-	pd, perr := a.delegatedDomainSvc.GetEnabledPlatformDomain(reqCtx, req.PlatformDomain, platformNS)
+	pd, perr := a.resolvePlatformDomainForClaim(reqCtx, req, platformNS)
 	if perr != nil {
 		a.Logger().Error("Failed to resolve platform domain", zap.String("platform_domain", req.PlatformDomain), zap.Error(perr))
 		return a.rollbackAndFail(ctx, reqCtx, user, websiteID, ErrKeyInvalidRequest, perr)
 	}
 	if pd == nil {
-		return a.rollbackAndFail(ctx, reqCtx, user, websiteID, ErrKeyInvalidRequest, fmt.Errorf("platform domain %q not found or disabled", req.PlatformDomain))
+		return a.rollbackAndFail(ctx, reqCtx, user, websiteID, ErrKeyInvalidRequest, fmt.Errorf("no enabled platform domain configured; specify platform_domain or label"))
 	}
 	if _, cerr := a.delegatedDomainSvc.CreatePlatformSubdomain(reqCtx, websiteID, user, pd.ID, req.Label, req.Generate); cerr != nil {
 		if isDuplicateKeyError(cerr) || strings.Contains(cerr.Error(), "already taken") {
@@ -318,6 +325,37 @@ func (a *API) claimPlatformSubdomain(ctx httputil.RequestContext, reqCtx context
 		return a.rollbackAndFail(ctx, reqCtx, user, websiteID, ErrKeyPlatformSubdomainRequired, cerr)
 	}
 	return nil
+}
+
+// resolvePlatformDomainForClaim returns the platform root under which a
+// subdomain is claimed. An explicit PlatformDomain is honored via the standard
+// lookup; when omitted (the auto-mint path — generate/label with no root), it
+// falls back to the single enabled platform root matching the namespace so a
+// bare `generate: true` request can mint a free subdomain. It returns
+// (nil, nil) when no enabled root applies, so callers surface a clear message.
+func (a *API) resolvePlatformDomainForClaim(ctx context.Context, req dto.WebsiteRequest, platformNS pluginDb.DomainNamespace) (*pluginDb.PlatformDomain, error) {
+	if req.PlatformDomain != "" {
+		return a.delegatedDomainSvc.GetEnabledPlatformDomain(ctx, req.PlatformDomain, platformNS)
+	}
+	domains, _, err := a.delegatedDomainSvc.ListEnabledPlatformDomains(ctx, queryutil.LargePagination)
+	if err != nil {
+		return nil, err
+	}
+	var candidates []*pluginDb.PlatformDomain
+	for _, pd := range domains {
+		if platformNS != "" && pd.Namespace != platformNS {
+			continue
+		}
+		candidates = append(candidates, pd)
+	}
+	switch {
+	case len(candidates) == 0:
+		return nil, nil
+	case len(candidates) > 1:
+		return nil, fmt.Errorf("multiple enabled platform domains; specify platform_domain")
+	default:
+		return candidates[0], nil
+	}
 }
 
 // bindCustomDomain attaches a user-owned custom domain as the primary binding

--- a/internal/api/api_websites_test.go
+++ b/internal/api/api_websites_test.go
@@ -220,6 +220,50 @@ func TestAPI_CreateWebsite(t *testing.T) {
 		}, TestOptions)
 	})
 
+	t.Run("error_mint_without_configured_platform_domain", func(t *testing.T) {
+		// Regression: a `generate: true` mint (no platform_domain, no domain)
+		// must be treated as a platform-subdomain claim and reach the claim
+		// path — not be rejected with the misleading "domain is required". With
+		// no enabled platform root configured, the claim resolves no root and
+		// rolls back the website, so CreateWebsite runs and DeleteWebsite is
+		// called exactly once.
+		coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+			helper := newMockHelper(t, ctx)
+			token, userID := helper.SetupAuthenticatedTestWithCID(cid.MustParse(TestCID))
+
+			mockWebsiteService := core.GetService[*mocks.MockWebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
+
+			mockWebsite := createMockIPFSWebsite(1, userID, "", TestCID, pluginDb.WebsiteStatusPendingValidation, "test-token")
+			mockWebsiteService.EXPECT().CreateWebsite(mock.Anything, mock.AnythingOfType("*db.Website")).Return(mockWebsite, nil)
+			mockWebsiteService.EXPECT().DeleteWebsite(mock.Anything, userID, uint(1)).Return(nil)
+
+			reqBody := fmt.Sprintf(`{"generate":true,"target_type":"ipfs","target_hash":"%s"}`, TestCID)
+			rec := helper.makeAuthenticatedRequest(http.MethodPost, "/api/websites", token, []byte(reqBody))
+
+			assert.Equal(t, http.StatusUnprocessableEntity, rec.Code)
+			mockWebsiteService.AssertNumberOfCalls(tb, "CreateWebsite", 1)
+			mockWebsiteService.AssertNumberOfCalls(tb, "DeleteWebsite", 1)
+		}, TestOptions)
+	})
+
+	t.Run("error_domain_and_platform_claim_conflict", func(t *testing.T) {
+		// A custom domain and a platform-subdomain claim are mutually exclusive
+		// destinations. Supplying both is ambiguous and must be rejected up
+		// front (422) without persisting a website.
+		coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+			helper := newMockHelper(t, ctx)
+			token, _ := helper.SetupAuthenticatedTestWithCID(cid.MustParse(TestCID))
+
+			mockWebsiteService := core.GetService[*mocks.MockWebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
+			mockWebsiteService.AssertNotCalled(tb, "CreateWebsite", mock.Anything, mock.Anything)
+
+			reqBody := fmt.Sprintf(`{"domain":"example.com","generate":true,"target_type":"ipfs","target_hash":"%s"}`, TestCID)
+			rec := helper.makeAuthenticatedRequest(http.MethodPost, "/api/websites", token, []byte(reqBody))
+
+			assert.Equal(t, http.StatusUnprocessableEntity, rec.Code)
+		}, TestOptions)
+	})
+
 	t.Run("error_invalid_target_type", func(t *testing.T) {
 		coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 			helper := newMockHelper(t, ctx)


### PR DESCRIPTION
Completes the platform-subdomain mint so `websites_create` with only a cid works end-to-end.

`claimPlatformSubdomain` now resolves a single enabled platform root matching the namespace when `platform_domain` is omitted (the auto-mint path), instead of querying an empty domain and failing with "platform domain not found or disabled". Also rejects supplying both a custom domain and a platform claim as ambiguous. Adds handler tests covering the mint path and the conflict guard.

- `develop` <!-- branch-stack -->
  - **fix(website): resolve default platform root for subdomain mint, guard domain/claim conflict** :point\_left:

---

<!-- kody-pr-summary:start -->
## Summary

This pull request fixes the default platform root resolution for subdomain minting and adds validation to prevent ambiguous website creation requests in the IPFS website API.

## Key Changes

### 1. Resolve default platform domain for subdomain claims
When a request uses `generate: true` (auto-mint) without specifying a `platform_domain`, the API now automatically resolves the single enabled platform root associated with the namespace. Previously, such requests would fail with a misleading "domain is required" error. The new `resolvePlatformDomainForClaim` function:
- Uses an explicitly provided `platform_domain` when available
- Falls back to the sole enabled platform root matching the namespace for bare mint requests
- Returns a clear error if multiple platform domains exist and require disambiguation
- Returns `nil` (with a user-friendly message) when no enabled platform root exists

### 2. Reject conflicting destination specifications
A new validation check rejects requests that supply both a custom user-owned domain and a platform-subdomain claim (`platform_domain`, `generate`, or `label`). These are mutually exclusive destination types, and silently ignoring one could result in a website bound to the wrong target. Such requests now fail with HTTP 422 (Unprocessable Entity) before any website is persisted.

### 3. Improved error messaging
The error message when no platform domain is found is now more helpful, indicating that the user should specify a `platform_domain` or `label` rather than just reporting the domain as "not found or disabled".

## Tests Added
- **Regression test**: Confirms `generate: true` mint requests without a platform domain correctly reach the claim path and roll back cleanly when no root is configured
- **Conflict test**: Verifies that combining a custom domain with a platform claim is rejected with 422 without creating a website
<!-- kody-pr-summary:end -->