### PR TITLE
feat(website): add configurable grace period for new sites

### DIFF
--- a/internal/config/website.go
+++ b/internal/config/website.go
@@ -32,10 +32,15 @@ var _ config.Defaults = (*WebsiteConfig)(nil)
 // WebsiteConfig contains the configuration for the website hosting feature
 type WebsiteConfig struct {
 	// Janitor configuration
-	JanitorEnabled      bool          `config:"janitor_enabled"`
-	CheckInterval       time.Duration `config:"check_interval"` // How often to re-validate individual websites
-	JanitorWorkerCount  int           `config:"janitor_worker_count"`
-	JanitorBatchSize    int           `config:"janitor_batch_size"`
+	JanitorEnabled     bool          `config:"janitor_enabled"`
+	CheckInterval      time.Duration `config:"check_interval"` // How often to re-validate individual websites
+	JanitorWorkerCount int           `config:"janitor_worker_count"`
+	JanitorBatchSize   int           `config:"janitor_batch_size"`
+	// JanitorGracePeriod is how long after a website is created the janitor
+	// waits before it may mark the site broken. It gives deployments time to
+	// finish pinning / publishing the target so we don't flag freshly created
+	// sites as bad. A value <= 0 disables the grace period.
+	JanitorGracePeriod time.Duration `config:"janitor_grace_period"`
 
 	// Validation configuration
 	ValidationTokenTTL time.Duration `config:"validation_token_ttl"`
@@ -47,10 +52,11 @@ type WebsiteConfig struct {
 
 func (c WebsiteConfig) Defaults() map[string]any {
 	return map[string]any{
-		"JanitorEnabled":  true,
-		"CheckInterval":   30 * time.Minute,
-		"JanitorWorkerCount": 10,
-		"JanitorBatchSize":   500,
+		"JanitorEnabled":       true,
+		"CheckInterval":        30 * time.Minute,
+		"JanitorWorkerCount":   10,
+		"JanitorBatchSize":     500,
+		"JanitorGracePeriod":   1 * time.Hour,
 		"ValidationTokenTTL":   24 * time.Hour,
 		"NotificationsEnabled": true,
 		"AdminEmail":           "",

--- a/internal/service/website/janitor.go
+++ b/internal/service/website/janitor.go
@@ -226,6 +226,18 @@ func (j *WebsiteJanitorJob) validateWebsite(ctx context.Context, website *plugin
 		targetStatus = pluginDb.WebsiteStatusBroken
 	}
 
+	// Grace period: a freshly created website may still be deploying (pinning
+	// the CID / publishing the IPNS record). Don't declare it broken during the
+	// grace period — just refresh last_checked_at so it is reconsidered on the
+	// next run instead of being left in a wrong state.
+	if targetStatus == pluginDb.WebsiteStatusBroken && j.withinGracePeriod(ctx, website) {
+		j.logger.Debug("Website within creation grace period; deferring broken status",
+			zap.Uint("website_id", website.ID),
+			zap.Time("created_at", website.CreatedAt))
+		website.LastCheckedAt = new(time.Now())
+		return j.db.WithContext(ctx).Save(website).Error
+	}
+
 	// Fire the health-driven transition via the FSM (a no-op when the website
 	// is already in the desired state):
 	//   valid   → revalidate_ok (broken → active; already-active is a no-op
@@ -388,10 +400,29 @@ func (j *WebsiteJanitorJob) validateIPNSTarget(ctx context.Context, website *plu
 	return nil
 }
 
+// withinGracePeriod reports whether the website is still inside the configured
+// creation grace period. It returns false when the grace period is disabled
+// (<= 0) so that behavior is unchanged unless explicitly configured.
+func (j *WebsiteJanitorJob) withinGracePeriod(_ context.Context, website *pluginDb.Website) bool {
+	if j.config == nil || j.config.JanitorGracePeriod <= 0 || website == nil {
+		return false
+	}
+	return time.Since(website.CreatedAt) < j.config.JanitorGracePeriod
+}
+
 // markBroken transitions the website to broken via the state machine when that
 // transition is legal, and refreshes its last_checked_at. It is a no-op for a
-// website already in broken state.
+// website already in broken state. If the website is still inside the creation
+// grace period, the transition is skipped (only last_checked_at is refreshed)
+// so freshly deployed sites aren't flagged as bad prematurely.
 func (j *WebsiteJanitorJob) markBroken(ctx context.Context, sm *WebsiteStateMachine, website *pluginDb.Website) {
+	if j.withinGracePeriod(ctx, website) {
+		j.logger.Debug("Website within creation grace period; deferring broken status",
+			zap.Uint("website_id", website.ID),
+			zap.Time("created_at", website.CreatedAt))
+		website.LastCheckedAt = new(time.Now())
+		return
+	}
 	if sm.Can(EventWebsiteCIDUnpinned) {
 		if err := sm.Fire(ctx, EventWebsiteCIDUnpinned); err != nil {
 			j.logger.Warn("failed to mark website broken",

--- a/internal/service/website/janitor_test.go
+++ b/internal/service/website/janitor_test.go
@@ -127,6 +127,139 @@ func TestWebsiteJanitorJob_validateWebsite_SkipsPendingValidation(t *testing.T) 
 	}, JanitorTestOptions)
 }
 
+func TestWebsiteJanitorJob_validateWebsite_GracePeriodDefersBroken(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		job := NewWebsiteJanitorJob()
+
+		websiteConfig := &pluginConfig.WebsiteConfig{
+			JanitorEnabled:     true,
+			CheckInterval:      30 * time.Minute,
+			JanitorWorkerCount: 2,
+			JanitorBatchSize:   10,
+			JanitorGracePeriod: 1 * time.Hour,
+		}
+
+		janitorJob := job.(*WebsiteJanitorJob)
+		janitorJob.config = websiteConfig
+		janitorJob.db = ctx.DB()
+		janitorJob.logger = nil
+
+		// An active website whose CID is NOT pinned, created just now (within
+		// the grace period).
+		mhBytes, err := mh.Sum([]byte("unpinned-within-grace"), mh.SHA2_256, -1)
+		require.NoError(tb, err)
+		cidVersion := uint8(1)
+		cidType := uint8(cid.Raw)
+
+		website := &pluginDb.Website{
+			TargetType:      string(pluginDb.WebsiteTargetTypeIPFS),
+			TargetMultihash: mhBytes,
+			CIDVersion:      &cidVersion,
+			CIDType:         &cidType,
+			Status:          string(pluginDb.WebsiteStatusActive),
+			ValidationToken: "test-token",
+		}
+		require.NoError(tb, ctx.DB().Create(website).Error)
+		require.Equal(tb, string(pluginDb.WebsiteStatusActive), website.Status)
+
+		// Act
+		require.NoError(tb, janitorJob.validateWebsite(context.Background(), website))
+
+		// Assert: not broken during the grace period, last_checked_at refreshed.
+		var persisted pluginDb.Website
+		require.NoError(tb, ctx.DB().First(&persisted, website.ID).Error)
+		assert.Equal(tb, string(pluginDb.WebsiteStatusActive), persisted.Status)
+		assert.NotNil(tb, persisted.LastCheckedAt)
+	}, JanitorTestOptions)
+}
+
+func TestWebsiteJanitorJob_validateWebsite_GracePeriodDisabledMarksBroken(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		job := NewWebsiteJanitorJob()
+
+		// Grace period explicitly disabled (0) preserves legacy behavior.
+		websiteConfig := &pluginConfig.WebsiteConfig{
+			JanitorEnabled:     true,
+			CheckInterval:      30 * time.Minute,
+			JanitorWorkerCount: 2,
+			JanitorBatchSize:   10,
+			JanitorGracePeriod: 0,
+		}
+
+		janitorJob := job.(*WebsiteJanitorJob)
+		janitorJob.config = websiteConfig
+		janitorJob.db = ctx.DB()
+		janitorJob.logger = nil
+
+		mhBytes, err := mh.Sum([]byte("unpinned-no-grace"), mh.SHA2_256, -1)
+		require.NoError(tb, err)
+		cidVersion := uint8(1)
+		cidType := uint8(cid.Raw)
+
+		website := &pluginDb.Website{
+			TargetType:      string(pluginDb.WebsiteTargetTypeIPFS),
+			TargetMultihash: mhBytes,
+			CIDVersion:      &cidVersion,
+			CIDType:         &cidType,
+			Status:          string(pluginDb.WebsiteStatusActive),
+			ValidationToken: "test-token",
+		}
+		require.NoError(tb, ctx.DB().Create(website).Error)
+
+		// Act
+		require.NoError(tb, janitorJob.validateWebsite(context.Background(), website))
+
+		// Assert: marked broken when the grace period is disabled.
+		var persisted pluginDb.Website
+		require.NoError(tb, ctx.DB().First(&persisted, website.ID).Error)
+		assert.Equal(tb, string(pluginDb.WebsiteStatusBroken), persisted.Status)
+	}, JanitorTestOptions)
+}
+
+func TestWebsiteJanitorJob_validateWebsite_GracePeriodElapsedMarksBroken(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		job := NewWebsiteJanitorJob()
+
+		websiteConfig := &pluginConfig.WebsiteConfig{
+			JanitorEnabled:     true,
+			CheckInterval:      30 * time.Minute,
+			JanitorWorkerCount: 2,
+			JanitorBatchSize:   10,
+			JanitorGracePeriod: 1 * time.Hour,
+		}
+
+		janitorJob := job.(*WebsiteJanitorJob)
+		janitorJob.config = websiteConfig
+		janitorJob.db = ctx.DB()
+		janitorJob.logger = nil
+
+		mhBytes, err := mh.Sum([]byte("unpinned-grace-elapsed"), mh.SHA2_256, -1)
+		require.NoError(tb, err)
+		cidVersion := uint8(1)
+		cidType := uint8(cid.Raw)
+
+		// Website created well before the grace period.
+		website := &pluginDb.Website{
+			TargetType:      string(pluginDb.WebsiteTargetTypeIPFS),
+			TargetMultihash: mhBytes,
+			CIDVersion:      &cidVersion,
+			CIDType:         &cidType,
+			Status:          string(pluginDb.WebsiteStatusActive),
+			ValidationToken: "test-token",
+			CreatedAt:       time.Now().Add(-2 * time.Hour),
+		}
+		require.NoError(tb, ctx.DB().Create(website).Error)
+
+		// Act
+		require.NoError(tb, janitorJob.validateWebsite(context.Background(), website))
+
+		// Assert: marked broken once the grace period has elapsed.
+		var persisted pluginDb.Website
+		require.NoError(tb, ctx.DB().First(&persisted, website.ID).Error)
+		assert.Equal(tb, string(pluginDb.WebsiteStatusBroken), persisted.Status)
+	}, JanitorTestOptions)
+}
+
 func TestWebsiteJanitorJob_ID(t *testing.T) {
 	job := NewWebsiteJanitorJob()
 	jobID := job.ID()


### PR DESCRIPTION
Adds a configurable `janitor_grace_period` so freshly created websites aren't
declared broken while their deployment is still pinning/publishing the target.

Defers broken status for both IPFS and IPNS targets while the site is within
the grace period, refreshing `last_checked_at` so it's reconsidered on the next
run. A value of `0` disables the grace behavior.

- `develop` <!-- branch-stack -->
  - **feat(website): add configurable grace period for new sites** :point\_left:

---

<!-- kody-pr-summary:start -->
# Pull Request Description

## Summary
This pull request introduces a configurable grace period for newly created websites to prevent the janitor service from prematurely marking fresh sites as "broken" while their deployments are still in progress (e.g., pinning CIDs or publishing IPNS records).

## Changes

### New Configuration Option
- Added a new `JanitorGracePeriod` configuration parameter to the website configuration (`internal/config/website.go`).
- Default value is set to **1 hour**, during which newly created websites are protected from being flagged as broken.
- A value of `<= 0` disables the grace period, preserving the previous behavior.

### Janitor Logic Updates
- Implemented a `withinGracePeriod` helper function that checks whether a website is still within the configured creation grace period based on its `created_at` timestamp.
- When a website is detected as potentially broken (target not pinned) but is still within the grace period:
  - The system **does not transition** the website to "broken" status.
  - Instead, it **refreshes the `last_checked_at` timestamp** so the site is reconsidered on the next janitor cycle.
- This logic is applied in both the website validation flow and the `markBroken` function.

### Test Coverage
Added three new test cases to validate the grace period behavior:
1. **Within grace period**: A newly created website with unpinned CID remains "active" during the grace period.
2. **Grace period disabled** (`= 0`): A website is immediately marked "broken" when the target isn't pinned (legacy behavior).
3. **Grace period elapsed**: A website created before the grace period window is correctly marked "broken" once the period has passed.

## Impact
This change reduces false positives from the janitor service by giving newly created websites time to complete their initial deployment (pinning/publishing) before being flagged as broken, while maintaining flexibility through the new configuration option.
<!-- kody-pr-summary:end -->