### PR TITLE
feat(website): require target CID to be pinned before website creation

### DIFF
--- a/internal/service/website/validate_dns_test.go
+++ b/internal/service/website/validate_dns_test.go
@@ -86,6 +86,7 @@ func TestValidateDNS_PendingValidation_ValidDNSLinkAndToken_ReturnsValidated(t *
 
 		testCID := util.GenerateTestCID(t, "validate-test")
 		website := createTestIPFSWebsite(testUserID1, "validate-pending.com", testCID.String())
+		stubPinnedCID(t, ctx, testUserID1, testCID.String())
 		created, err := ws.CreateWebsite(context.Background(), website)
 		require.NoError(tb, err)
 		require.NotNil(tb, created)
@@ -121,6 +122,7 @@ func TestValidateDNS_PendingValidation_MissingDNSLink_ReturnsDNSMismatch(t *test
 
 		testCID := util.GenerateTestCID(t, "missing-dnslink")
 		website := createTestIPFSWebsite(testUserID1, "missing-dnslink.com", testCID.String())
+		stubPinnedCID(t, ctx, testUserID1, testCID.String())
 		created, err := ws.CreateWebsite(context.Background(), website)
 		require.NoError(tb, err)
 		_ = bindPrimaryDomain(tb, ctx, created.ID, "missing-dnslink.com", false)
@@ -146,6 +148,7 @@ func TestValidateDNS_PendingValidation_MissingToken_ReturnsTokenMissing(t *testi
 
 		testCID := util.GenerateTestCID(t, "missing-token")
 		website := createTestIPFSWebsite(testUserID1, "missing-token.com", testCID.String())
+		stubPinnedCID(t, ctx, testUserID1, testCID.String())
 		created, err := ws.CreateWebsite(context.Background(), website)
 		require.NoError(tb, err)
 		_ = bindPrimaryDomain(tb, ctx, created.ID, "missing-token.com", false)
@@ -174,6 +177,7 @@ func TestValidateDNS_ActiveSite_ExpiredToken_SkipsTokenCheckAndValidates(t *test
 
 		testCID := util.GenerateTestCID(t, "active-expired-token")
 		website := createTestIPFSWebsite(testUserID1, "active-expired.com", testCID.String())
+		stubPinnedCID(t, ctx, testUserID1, testCID.String())
 		created, err := ws.CreateWebsite(context.Background(), website)
 		require.NoError(tb, err)
 
@@ -221,6 +225,7 @@ func TestValidateDNS_BrokenSite_ExpiredToken_SkipsTokenCheckAndValidates(t *test
 
 		testCID := util.GenerateTestCID(t, "broken-expired-token")
 		website := createTestIPFSWebsite(testUserID1, "broken-expired.com", testCID.String())
+		stubPinnedCID(t, ctx, testUserID1, testCID.String())
 		created, err := ws.CreateWebsite(context.Background(), website)
 		require.NoError(tb, err)
 
@@ -267,6 +272,7 @@ func TestValidateDNS_PendingValidation_ExpiredToken_ReturnsTokenExpiredWithRegen
 
 		testCID := util.GenerateTestCID(t, "regen-token")
 		website := createTestIPFSWebsite(testUserID1, "regen-token.com", testCID.String())
+		stubPinnedCID(t, ctx, testUserID1, testCID.String())
 		created, err := ws.CreateWebsite(context.Background(), website)
 		require.NoError(tb, err)
 
@@ -299,6 +305,7 @@ func TestValidateDNS_NXDOMAIN_ReturnsDNSMissing(t *testing.T) {
 
 		testCID := util.GenerateTestCID(t, "nxdomain")
 		website := createTestIPFSWebsite(testUserID1, "nxdomain-test.com", testCID.String())
+		stubPinnedCID(t, ctx, testUserID1, testCID.String())
 		created, err := ws.CreateWebsite(context.Background(), website)
 		require.NoError(tb, err)
 		_ = bindPrimaryDomain(tb, ctx, created.ID, "nxdomain-test.com", false)
@@ -327,6 +334,7 @@ func TestValidateDNS_DNSLinkLookupFailure_ReturnsError(t *testing.T) {
 
 		testCID := util.GenerateTestCID(t, "dns-fail")
 		website := createTestIPFSWebsite(testUserID1, "dns-fail-test.com", testCID.String())
+		stubPinnedCID(t, ctx, testUserID1, testCID.String())
 		created, err := ws.CreateWebsite(context.Background(), website)
 		require.NoError(tb, err)
 		_ = bindPrimaryDomain(tb, ctx, created.ID, "dns-fail-test.com", false)
@@ -349,6 +357,7 @@ func TestValidateDNS_TxTTLookupFailure_ReturnsError(t *testing.T) {
 
 		testCID := util.GenerateTestCID(t, "txt-lookup-fail")
 		website := createTestIPFSWebsite(testUserID1, "txt-fail-test.com", testCID.String())
+		stubPinnedCID(t, ctx, testUserID1, testCID.String())
 		created, err := ws.CreateWebsite(context.Background(), website)
 		require.NoError(tb, err)
 		_ = bindPrimaryDomain(tb, ctx, created.ID, "txt-fail-test.com", false)
@@ -376,6 +385,7 @@ func TestValidateDNS_WrongDNSLink_ReturnsDNSMismatch(t *testing.T) {
 
 		testCID := util.GenerateTestCID(t, "wrong-dnslink")
 		website := createTestIPFSWebsite(testUserID1, "wrong-dnslink.com", testCID.String())
+		stubPinnedCID(t, ctx, testUserID1, testCID.String())
 		created, err := ws.CreateWebsite(context.Background(), website)
 		require.NoError(tb, err)
 		_ = bindPrimaryDomain(tb, ctx, created.ID, "wrong-dnslink.com", false)
@@ -439,6 +449,7 @@ func TestValidateDNS_PendingValidation_ExpiredToken_ManagedDNS_RegeneratesToken(
 		zoneID := uint(5001)
 
 		website := createTestIPFSWebsite(testUserID1, domain, testCID.String())
+		stubPinnedCID(t, ctx, testUserID1, testCID.String())
 		website.ID = 5001
 		prebindPrimaryDomain(tb, ctx, website, domain, true)
 
@@ -522,6 +533,7 @@ func TestValidateDNS_SelfHostedPrimary_DoesNotRequireDelegation(t *testing.T) {
 
 		testCID := util.GenerateTestCID(t, "self-hosted-primary")
 		website := createTestIPFSWebsite(testUserID1, "selfhosted.com", testCID.String())
+		stubPinnedCID(t, ctx, testUserID1, testCID.String())
 		created, err := ws.CreateWebsite(context.Background(), website)
 		require.NoError(tb, err)
 		// bindPrimaryDomain with DNSHostingEnabled=false yields a zone-less
@@ -566,6 +578,7 @@ func TestValidateDNS_PendingDelegated_SkipsTokenCheck(t *testing.T) {
 
 		testCID := util.GenerateTestCID(t, "delegated-skip-token")
 		website := createTestIPFSWebsite(testUserID1, "delegated-skip.com", testCID.String())
+		stubPinnedCID(t, ctx, testUserID1, testCID.String())
 		created, err := ws.CreateWebsite(context.Background(), website)
 		require.NoError(tb, err)
 		_ = bindPrimaryDomain(tb, ctx, created.ID, "delegated-skip.com", false)
@@ -599,6 +612,7 @@ func TestValidateDNS_PlatformSubdomain_SkipsTokenCheck(t *testing.T) {
 
 		testCID := util.GenerateTestCID(t, "platform-skip-token")
 		website := createTestIPFSWebsite(testUserID1, "platform-skip.com", testCID.String())
+		stubPinnedCID(t, ctx, testUserID1, testCID.String())
 		created, err := ws.CreateWebsite(context.Background(), website)
 		require.NoError(tb, err)
 		wd := bindPrimaryDomain(tb, ctx, created.ID, "platform-skip.com", true)
@@ -644,6 +658,7 @@ func TestValidateDNS_DelegatedAttached_Success(t *testing.T) {
 
 		testCID := util.GenerateTestCID(t, "delegated-attached-ok")
 		website := createTestIPFSWebsite(testUserID1, "attached-ok.hns", testCID.String())
+		stubPinnedCID(t, ctx, testUserID1, testCID.String())
 		created, err := ws.CreateWebsite(context.Background(), website)
 		require.NoError(tb, err)
 		_ = bindPrimaryDomain(tb, ctx, created.ID, "attached-ok.hns", false)
@@ -694,6 +709,7 @@ func TestValidateDNS_SecondaryPending_DoesNotBlockPrimary(t *testing.T) {
 
 		testCID := util.GenerateTestCID(t, "secondary-pending")
 		website := createTestIPFSWebsite(testUserID1, "primary.com", testCID.String())
+		stubPinnedCID(t, ctx, testUserID1, testCID.String())
 		created, err := ws.CreateWebsite(context.Background(), website)
 		require.NoError(tb, err)
 		_ = bindPrimaryDomain(tb, ctx, created.ID, "primary.com", false)
@@ -746,6 +762,7 @@ func TestValidateDNS_DelegatedAttached_FailsVerification(t *testing.T) {
 
 		testCID := util.GenerateTestCID(t, "delegated-attached-fail")
 		website := createTestIPFSWebsite(testUserID1, "attached-fail.hns", testCID.String())
+		stubPinnedCID(t, ctx, testUserID1, testCID.String())
 		created, err := ws.CreateWebsite(context.Background(), website)
 		require.NoError(tb, err)
 		_ = bindPrimaryDomain(tb, ctx, created.ID, "attached-fail.hns", false)
@@ -805,6 +822,7 @@ func TestValidateDNS_SelfHostedHNSPrimary_DoesNotDeadEnd(t *testing.T) {
 
 		testCID := util.GenerateTestCID(t, "self-hosted-hns-primary")
 		website := createTestIPFSWebsite(testUserID1, "selfhosted.hns", testCID.String())
+		stubPinnedCID(t, ctx, testUserID1, testCID.String())
 		created, err := ws.CreateWebsite(context.Background(), website)
 		require.NoError(tb, err)
 		// bindPrimaryDomain(false) yields a zone-less (ZoneID==0) primary; the
@@ -855,6 +873,7 @@ func TestValidateDNS_DelegatedAttached_VerifyError_Fails(t *testing.T) {
 
 		testCID := util.GenerateTestCID(t, "delegated-verify-err")
 		website := createTestIPFSWebsite(testUserID1, "verify-err.hns", testCID.String())
+		stubPinnedCID(t, ctx, testUserID1, testCID.String())
 		created, err := ws.CreateWebsite(context.Background(), website)
 		require.NoError(tb, err)
 		_ = bindPrimaryDomain(tb, ctx, created.ID, "verify-err.hns", false)

--- a/internal/service/website/website.go
+++ b/internal/service/website/website.go
@@ -211,6 +211,13 @@ func (s *WebsiteServiceDefault) CreateWebsite(ctx context.Context, website *plug
 				return nil, fmt.Errorf("invalid target: %w", err)
 			}
 
+			// A new website may only target content the owner has already pinned.
+			// IPNS targets that are already peer IDs are governed by key ownership
+			// rather than pinning, and are skipped here.
+			if err := s.validateCreatePin(ctx, website); err != nil {
+				return nil, fmt.Errorf("invalid target: %w", err)
+			}
+
 			// Generate validation token
 			token, err := s.generateValidationToken()
 			if err != nil {
@@ -1932,6 +1939,34 @@ func (s *WebsiteServiceDefault) validateTarget(targetType string, targetHash str
 		return fmt.Errorf("%w: invalid type %s", ErrInvalidTarget, targetType)
 	}
 	return nil
+}
+
+// validateCreatePin requires that a new website's CID target is already pinned
+// by its owner before the site can be created. It resolves the CID from the
+// website's target: a direct IPFS target carries it in TargetHash(); an IPNS
+// target with a plain CID (CIDVersion set) is the auto-convert input and is
+// reconstructed from the stored multihash/version/type because TargetHash()
+// already reports the peer ID for IPNS targets. IPNS peer-ID targets have no
+// pin to check and return nil.
+func (s *WebsiteServiceDefault) validateCreatePin(ctx context.Context, website *pluginDb.Website) error {
+	var targetHash string
+	switch {
+	case website.TargetType == string(pluginDb.WebsiteTargetTypeIPFS):
+		targetHash = website.TargetHash()
+	case website.TargetType == string(pluginDb.WebsiteTargetTypeIPNS) && website.CIDVersion != nil:
+		if *website.CIDVersion == 0 {
+			targetHash = cid.NewCidV0(website.TargetMultihash).String()
+		} else {
+			codec := uint64(0)
+			if website.CIDType != nil {
+				codec = uint64(*website.CIDType)
+			}
+			targetHash = cid.NewCidV1(codec, website.TargetMultihash).String()
+		}
+	default:
+		return nil
+	}
+	return s.validateIPFSTarget(ctx, website.UserID, targetHash)
 }
 
 // validateIPFSTarget checks if an IPFS CID is pinned and returns an error if not.

--- a/internal/service/website/website.go
+++ b/internal/service/website/website.go
@@ -1957,11 +1957,10 @@ func (s *WebsiteServiceDefault) validateCreatePin(ctx context.Context, website *
 		if *website.CIDVersion == 0 {
 			targetHash = cid.NewCidV0(website.TargetMultihash).String()
 		} else {
-			codec := uint64(0)
-			if website.CIDType != nil {
-				codec = uint64(*website.CIDType)
+			if website.CIDType == nil {
+				return fmt.Errorf("%w: IPNS auto-convert CID missing codec", ErrInvalidCID)
 			}
-			targetHash = cid.NewCidV1(codec, website.TargetMultihash).String()
+			targetHash = cid.NewCidV1(uint64(*website.CIDType), website.TargetMultihash).String()
 		}
 	default:
 		return nil

--- a/internal/service/website/website_test.go
+++ b/internal/service/website/website_test.go
@@ -132,6 +132,19 @@ func createTestIPFSWebsite(userID uint, domain string, cidStr string) *pluginDb.
 	}
 }
 
+// stubPinnedCID configures the pin service mock so GetPinByCIDAndUser reports
+// the given CID as pinned for the user. CreateWebsite now refuses IPFS targets
+// (and the IPNS auto-convert path) unless the CID is pinned, so tests that
+// create such websites must stub the pin first.
+func stubPinnedCID(t *testing.T, ctx coreTesting.TestContext, userID uint, cidStr string) {
+	mockPinSvc := core.GetService[*mocks.MockIPFSPinService](ctx, pluginCore.PIN_SERVICE)
+	c := cid.MustParse(cidStr)
+	mockPinSvc.EXPECT().
+		GetPinByCIDAndUser(mock.Anything, c, userID).
+		Return(&pluginDb.IPFSPin{UserID: userID, CID: c.Bytes(), Status: pluginDb.PinningStatusPinned}, nil).
+		Maybe()
+}
+
 // createTestIPNSWebsite creates a test website with an IPNS target.
 // It returns a Website struct ready for use in tests, with the specified user ID,
 // domain, and IPNS string parsed into the appropriate fields.
@@ -242,6 +255,7 @@ func TestWebsiteService_CreateWebsite_IPFSTarget(t *testing.T) {
 		testCID := util.GenerateTestCID(t, "test data")
 
 		testsite := createTestIPFSWebsite(testUserID1, "example.com", testCID.String())
+		stubPinnedCID(t, ctx, testUserID1, testCID.String())
 		createdWebsite, err := websiteService.CreateWebsite(context.Background(), testsite)
 
 		// Assert
@@ -268,6 +282,32 @@ func TestWebsiteService_CreateWebsite_IPFSTarget(t *testing.T) {
 		retrievedWebsite, err := websiteService.GetWebsite(context.Background(), testUserID1, createdWebsite.ID)
 		require.NoError(tb, err)
 		assert.Equal(tb, createdWebsite.ID, retrievedWebsite.ID)
+	}, TestOptions)
+}
+
+func TestWebsiteService_CreateWebsite_IPFSTargetNotPinned(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		// Arrange
+		websiteService := core.GetService[pluginCore.WebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
+		mockPinSvc := core.GetService[*mocks.MockIPFSPinService](ctx, pluginCore.PIN_SERVICE)
+		require.NotNil(tb, websiteService)
+		require.NotNil(tb, mockPinSvc)
+
+		testCID := util.GenerateTestCID(t, "unpinned data")
+
+		// Simulate an unpinned CID: the pin lookup returns no pin record.
+		mockPinSvc.EXPECT().
+			GetPinByCIDAndUser(mock.Anything, testCID, testUserID1).
+			Return(nil, nil).Once()
+
+		testsite := createTestIPFSWebsite(testUserID1, "example.com", testCID.String())
+		stubPinnedCID(t, ctx, testUserID1, testCID.String())
+		createdWebsite, err := websiteService.CreateWebsite(context.Background(), testsite)
+
+		// Assert
+		require.Error(tb, err)
+		assert.True(tb, errors.Is(err, ErrCIDNotPinned))
+		assert.Nil(tb, createdWebsite)
 	}, TestOptions)
 }
 
@@ -317,6 +357,7 @@ func TestWebsiteService_CreateWebsite_NoDomainServiceFiresNotification(t *testin
 
 		testCID := util.GenerateTestCID(t, "test data")
 		website := createTestIPFSWebsite(testUserID1, "example.com", testCID.String())
+		stubPinnedCID(t, ctx, testUserID1, testCID.String())
 
 		created, err := websiteService.CreateWebsite(context.Background(), website)
 		require.NoError(tb, err)
@@ -332,6 +373,7 @@ func TestWebsiteService_SSLStatusDoesNotAffectWebsiteStatus(t *testing.T) {
 
 		testCID := util.GenerateTestCID(t, "test data")
 		website := createTestIPFSWebsite(testUserID1, "example.com", testCID.String())
+		stubPinnedCID(t, ctx, testUserID1, testCID.String())
 
 		// Create website
 		createdWebsite, err := websiteService.CreateWebsite(context.Background(), website)
@@ -367,6 +409,7 @@ func TestWebsiteService_SSLStatusTransitionsIndependently(t *testing.T) {
 
 		testCID := util.GenerateTestCID(t, "test data")
 		website := createTestIPFSWebsite(testUserID1, "example.com", testCID.String())
+		stubPinnedCID(t, ctx, testUserID1, testCID.String())
 
 		// Create website
 		createdWebsite, err := websiteService.CreateWebsite(context.Background(), website)
@@ -414,6 +457,7 @@ func TestWebsiteService_WebsiteCanBeBrokenRegardlessOfSSLStatus(t *testing.T) {
 
 		testCID := util.GenerateTestCID(t, "test data")
 		website := createTestIPFSWebsite(testUserID1, "example.com", testCID.String())
+		stubPinnedCID(t, ctx, testUserID1, testCID.String())
 
 		// Create website
 		createdWebsite, err := websiteService.CreateWebsite(context.Background(), website)
@@ -507,6 +551,9 @@ func TestWebsiteService_CreateWebsite_IPNSTargetWithPlainCID_AutoConvert(t *test
 		// Set up IPNS key mocks for auto-conversion
 		setupIPNSAutoCreationMocks(t, mockIPNSKey, testUserID1, domain, testCID)
 
+		// The plain CID must be pinned before the auto-convert path will publish it.
+		stubPinnedCID(t, ctx, testUserID1, testCID.String())
+
 		// Act
 		createdWebsite, err := websiteService.CreateWebsite(context.Background(), website)
 		websiteService.WaitForPublishes()
@@ -553,6 +600,7 @@ func TestWebsiteService_GetWebsite(t *testing.T) {
 		testCID := util.GenerateTestCID(t, "test data")
 
 		website := createTestIPFSWebsite(testUserID1, "get-test.com", testCID.String())
+		stubPinnedCID(t, ctx, testUserID1, testCID.String())
 
 		createdWebsite, err := websiteService.CreateWebsite(context.Background(), website)
 		require.NoError(tb, err)
@@ -602,6 +650,7 @@ func TestWebsiteService_GetWebsiteByDomain(t *testing.T) {
 		testCID := util.GenerateTestCID(t, "test data")
 
 		website := createTestIPFSWebsite(testUserID1, "domain-test.com", testCID.String())
+		stubPinnedCID(t, ctx, testUserID1, testCID.String())
 
 		createdWebsite, err := websiteService.CreateWebsite(context.Background(), website)
 		require.NoError(tb, err)
@@ -654,7 +703,9 @@ func TestWebsiteService_ListWebsites(t *testing.T) {
 
 		// Create websites for user 1
 		website1 := createTestIPFSWebsite(testUserID1, "list1.com", util.GenerateTestCID(t, "data1").String())
+		stubPinnedCID(t, ctx, testUserID1, util.GenerateTestCID(t, "data1").String())
 		website2 := createTestIPFSWebsite(testUserID1, "list2.com", util.GenerateTestCID(t, "data2").String())
+		stubPinnedCID(t, ctx, testUserID1, util.GenerateTestCID(t, "data2").String())
 
 		created1, err := websiteService.CreateWebsite(context.Background(), website1)
 		require.NoError(tb, err)
@@ -663,6 +714,7 @@ func TestWebsiteService_ListWebsites(t *testing.T) {
 
 		// Create a website for user 2
 		website3 := createTestIPFSWebsite(testUserID2, "list3.com", util.GenerateTestCID(t, "data3").String())
+		stubPinnedCID(t, ctx, testUserID2, util.GenerateTestCID(t, "data3").String())
 		_, err = websiteService.CreateWebsite(context.Background(), website3)
 		require.NoError(tb, err)
 
@@ -698,6 +750,7 @@ func TestWebsiteService_UpdateWebsite(t *testing.T) {
 		testCID := util.GenerateTestCID(t, "test data")
 
 		website := createTestIPFSWebsite(testUserID1, "update-test.com", testCID.String())
+		stubPinnedCID(t, ctx, testUserID1, testCID.String())
 
 		createdWebsite, err := websiteService.CreateWebsite(context.Background(), website)
 		require.NoError(tb, err)
@@ -759,6 +812,7 @@ func TestWebsiteService_DeleteWebsite(t *testing.T) {
 		testCID := util.GenerateTestCID(t, "test data")
 
 		website := createTestIPFSWebsite(testUserID1, "delete-test.com", testCID.String())
+		stubPinnedCID(t, ctx, testUserID1, testCID.String())
 
 		createdWebsite, err := websiteService.CreateWebsite(context.Background(), website)
 		require.NoError(tb, err)
@@ -806,6 +860,7 @@ func TestWebsiteService_ValidationTokenExpiration(t *testing.T) {
 		testCID := util.GenerateTestCID(t, "test data")
 
 		website := createTestIPFSWebsite(testUserID1, "expire-test.com", testCID.String())
+		stubPinnedCID(t, ctx, testUserID1, testCID.String())
 
 		// Act
 		createdWebsite, err := websiteService.CreateWebsite(context.Background(), website)
@@ -833,6 +888,7 @@ func TestWebsiteService_StatusTransitions(t *testing.T) {
 		testCID := util.GenerateTestCID(t, "test data")
 
 		website := createTestIPFSWebsite(testUserID1, "status-test.com", testCID.String())
+		stubPinnedCID(t, ctx, testUserID1, testCID.String())
 
 		// Create website (should be pending_validation)
 		createdWebsite, err := websiteService.CreateWebsite(context.Background(), website)
@@ -864,6 +920,7 @@ func TestWebsiteService_ShouldCheck(t *testing.T) {
 		testCID := util.GenerateTestCID(t, "test data")
 
 		website := createTestIPFSWebsite(testUserID1, "check-test.com", testCID.String())
+		stubPinnedCID(t, ctx, testUserID1, testCID.String())
 
 		createdWebsite, err := websiteService.CreateWebsite(context.Background(), website)
 		require.NoError(tb, err)
@@ -892,6 +949,7 @@ func TestWebsiteService_IsExpired(t *testing.T) {
 		testCID := util.GenerateTestCID(t, "test data")
 
 		website := createTestIPFSWebsite(testUserID1, "expire-test.com", testCID.String())
+		stubPinnedCID(t, ctx, testUserID1, testCID.String())
 
 		createdWebsite, err := websiteService.CreateWebsite(context.Background(), website)
 		require.NoError(tb, err)
@@ -922,6 +980,7 @@ func TestWebsiteService_BlockWebsite(t *testing.T) {
 		testCID := util.GenerateTestCID(t, "test data")
 
 		website := createTestIPFSWebsite(testUserID1, "block-test.com", testCID.String())
+		stubPinnedCID(t, ctx, testUserID1, testCID.String())
 
 		createdWebsite, err := websiteService.CreateWebsite(context.Background(), website)
 		require.NoError(tb, err)
@@ -950,6 +1009,7 @@ func TestWebsiteService_UnblockWebsite(t *testing.T) {
 		testCID := util.GenerateTestCID(t, "test data")
 
 		website := createTestIPFSWebsite(testUserID1, "unblock-test.com", testCID.String())
+		stubPinnedCID(t, ctx, testUserID1, testCID.String())
 
 		createdWebsite, err := websiteService.CreateWebsite(context.Background(), website)
 		require.NoError(tb, err)
@@ -987,6 +1047,7 @@ func TestWebsiteService_DeleteWebsite_Blocked(t *testing.T) {
 		testCID := util.GenerateTestCID(t, "test data")
 
 		website := createTestIPFSWebsite(testUserID1, "blocked-delete-test.com", testCID.String())
+		stubPinnedCID(t, ctx, testUserID1, testCID.String())
 
 		createdWebsite, err := websiteService.CreateWebsite(context.Background(), website)
 		require.NoError(tb, err)
@@ -1024,6 +1085,7 @@ func TestWebsiteService_DeleteWebsite_Active(t *testing.T) {
 		testCID := util.GenerateTestCID(t, "test data")
 
 		website := createTestIPFSWebsite(testUserID1, "active-delete-test.com", testCID.String())
+		stubPinnedCID(t, ctx, testUserID1, testCID.String())
 
 		createdWebsite, err := websiteService.CreateWebsite(context.Background(), website)
 		require.NoError(tb, err)
@@ -1057,6 +1119,7 @@ func TestWebsiteService_UpdateSSLStatus_SuccessfulUpdate(t *testing.T) {
 		testCID := util.GenerateTestCID(t, "test data")
 
 		website := createTestIPFSWebsite(testUserID1, "ssl-update-test.com", testCID.String())
+		stubPinnedCID(t, ctx, testUserID1, testCID.String())
 		createdWebsite, err := websiteService.CreateWebsite(context.Background(), website)
 		require.NoError(tb, err)
 
@@ -1101,6 +1164,7 @@ func TestWebsiteService_UpdateSSLStatus_IssuedAtSetOnlyOnReadyTransition(t *test
 		testCID := util.GenerateTestCID(t, "test data")
 
 		website := createTestIPFSWebsite(testUserID1, "ssl-issuedat-test.com", testCID.String())
+		stubPinnedCID(t, ctx, testUserID1, testCID.String())
 		createdWebsite, err := websiteService.CreateWebsite(context.Background(), website)
 		require.NoError(tb, err)
 		require.NoError(tb, ctx.DB().Create(createTestWebsiteDomain(createdWebsite.ID, "ssl-issuedat-test.com")).Error)
@@ -1142,6 +1206,7 @@ func TestWebsiteService_UpdateSSLStatus_ErrorSetOnFailed(t *testing.T) {
 		testCID := util.GenerateTestCID(t, "test data")
 
 		website := createTestIPFSWebsite(testUserID1, "ssl-error-test.com", testCID.String())
+		stubPinnedCID(t, ctx, testUserID1, testCID.String())
 		createdWebsite, err := websiteService.CreateWebsite(context.Background(), website)
 		require.NoError(tb, err)
 		require.NoError(tb, ctx.DB().Create(createTestWebsiteDomain(createdWebsite.ID, "ssl-error-test.com")).Error)
@@ -1168,6 +1233,7 @@ func TestWebsiteService_UpdateSSLStatus_ErrorClearedOnStatusChange(t *testing.T)
 		testCID := util.GenerateTestCID(t, "test data")
 
 		website := createTestIPFSWebsite(testUserID1, "ssl-clear-error-test.com", testCID.String())
+		stubPinnedCID(t, ctx, testUserID1, testCID.String())
 		createdWebsite, err := websiteService.CreateWebsite(context.Background(), website)
 		require.NoError(tb, err)
 		require.NoError(tb, ctx.DB().Create(createTestWebsiteDomain(createdWebsite.ID, "ssl-clear-error-test.com")).Error)
@@ -1207,6 +1273,7 @@ func TestWebsiteService_UpdateSSLStatus_AtomicUpdates(t *testing.T) {
 		testCID := util.GenerateTestCID(t, "test data")
 
 		website := createTestIPFSWebsite(testUserID1, "ssl-atomic-test.com", testCID.String())
+		stubPinnedCID(t, ctx, testUserID1, testCID.String())
 		createdWebsite, err := websiteService.CreateWebsite(context.Background(), website)
 		require.NoError(tb, err)
 		require.NoError(tb, ctx.DB().Create(createTestWebsiteDomain(createdWebsite.ID, "ssl-atomic-test.com")).Error)
@@ -1272,6 +1339,7 @@ func TestWebsiteService_CreateWebsite_DNSZoneCreatedWhenEnabled(t *testing.T) {
 		domain := "dns-enabled-test.com"
 
 		website := createTestIPFSWebsite(testUserID1, domain, testCID.String())
+		stubPinnedCID(t, ctx, testUserID1, testCID.String())
 		website.ID = 8000
 		// Bind the primary domain with DNS hosting enabled so CreateWebsite's
 		// managed-DNS side-effects (IPNS auto-convert, zone + record creation) run.
@@ -1321,6 +1389,7 @@ func TestWebsiteService_CreateWebsite_DNSRecordsCreated(t *testing.T) {
 		domain := "dns-records-test.com"
 
 		website := createTestIPFSWebsite(testUserID1, domain, testCID.String())
+		stubPinnedCID(t, ctx, testUserID1, testCID.String())
 		website.ID = 8001
 		// Bind the primary domain with DNS hosting enabled so CreateWebsite's
 		// managed-DNS side-effects (IPNS auto-convert, zone + record creation) run.
@@ -1377,6 +1446,7 @@ func TestWebsiteService_UpdateWebsite_DNSRecordsUpdatedWhenTargetChanges(t *test
 		domain := "dns-update-test.com"
 
 		website := createTestIPFSWebsite(testUserID1, domain, testCID.String())
+		stubPinnedCID(t, ctx, testUserID1, testCID.String())
 		createdWebsite, err := websiteService.CreateWebsite(context.Background(), website)
 		require.NoError(tb, err)
 		require.NotNil(tb, createdWebsite)
@@ -1413,6 +1483,7 @@ func TestWebsiteService_DeleteWebsite_DNSRecordsCleanedUp(t *testing.T) {
 		domain := "dns-cleanup-test.com"
 
 		website := createTestIPFSWebsite(testUserID1, domain, testCID.String())
+		stubPinnedCID(t, ctx, testUserID1, testCID.String())
 		website.ID = 8002
 		// Bind the primary domain with DNS hosting enabled so CreateWebsite's
 		// managed-DNS side-effects (IPNS auto-convert, zone + record creation) run.
@@ -1461,6 +1532,7 @@ func TestWebsiteService_DeleteWebsite_DNSCleanupFailureDoesNotPreventDeletion(t 
 		domain := "dns-cleanup-fail-test.com"
 
 		website := createTestIPFSWebsite(testUserID1, domain, testCID.String())
+		stubPinnedCID(t, ctx, testUserID1, testCID.String())
 		website.ID = 8003
 		// Bind the primary domain with DNS hosting enabled so CreateWebsite's
 		// managed-DNS side-effects (IPNS auto-convert, zone + record creation) run.
@@ -1510,6 +1582,7 @@ func TestWebsiteService_DeleteWebsite_NoDNSZoneNoCleanup(t *testing.T) {
 		domain := "no-dns-zone-test.com"
 
 		website := createTestIPFSWebsite(testUserID1, domain, testCID.String())
+		stubPinnedCID(t, ctx, testUserID1, testCID.String())
 
 		// Act - Create website with DNS disabled (no zone created)
 		createdWebsite, err := websiteService.CreateWebsite(context.Background(), website)
@@ -1541,6 +1614,7 @@ func TestWebsiteService_CreateWebsite_DNSHostingDisabledWhenEnabledFalse(t *test
 		domain := "dns-disabled-test.com"
 
 		website := createTestIPFSWebsite(testUserID1, domain, testCID.String())
+		stubPinnedCID(t, ctx, testUserID1, testCID.String())
 		website.ID = 8003
 		// Bind a primary domain with DNS hosting disabled: the website owns a
 		// domain but no DNS-managed zone, so no DNS side-effects run on create.
@@ -1581,6 +1655,7 @@ func TestWebsiteService_CreateWebsite_DNSHostingEnabled_CreatesZoneAndRecords(t 
 		targetHash := testCID.String()
 
 		website := createTestIPFSWebsite(testUserID1, domain, targetHash)
+		stubPinnedCID(t, ctx, testUserID1, targetHash)
 		website.ID = 8004
 		// Bind the primary domain with DNS hosting enabled so CreateWebsite's
 		// managed-DNS side-effects (IPNS auto-convert, zone + record creation) run.
@@ -1629,6 +1704,7 @@ func TestWebsiteService_UpdateWebsite_DNSHostingEnabled_NoDNSUpdateWhenTargetUnc
 		domain := "no-dns-update-test.com"
 
 		website := createTestIPFSWebsite(testUserID1, domain, testCID.String())
+		stubPinnedCID(t, ctx, testUserID1, testCID.String())
 		website.ID = 8005
 		// Bind the primary domain with DNS hosting enabled so CreateWebsite's
 		// managed-DNS side-effects (IPNS auto-convert, zone + record creation) run.
@@ -1677,6 +1753,7 @@ func TestWebsiteService_DeleteWebsite_DNSHostingEnabled_ZoneRemainsAfterDeletion
 		domain := "zone-persists-test.com"
 
 		website := createTestIPFSWebsite(testUserID1, domain, testCID.String())
+		stubPinnedCID(t, ctx, testUserID1, testCID.String())
 		website.ID = 8006
 		// Bind the primary domain with DNS hosting enabled so CreateWebsite's
 		// managed-DNS side-effects (IPNS auto-convert, zone + record creation) run.
@@ -1749,6 +1826,7 @@ func TestWebsiteService_DeleteWebsite_PlatformSubdomain_OperatorApexAndZoneIntac
 		// Alice's website owns a platform subdomain under the operator root, and
 		// it is her primary binding (the binding the delete flow cleans).
 		website := createTestIPFSWebsite(testUserID1, "alice.pinned.site", util.GenerateTestCID(t, "alice data").String())
+		stubPinnedCID(t, ctx, testUserID1, util.GenerateTestCID(t, "alice data").String())
 		website.Status = string(pluginDb.WebsiteStatusActive)
 		require.NoError(tb, db.Create(website).Error)
 		wd := createTestWebsiteDomain(website.ID, "alice.pinned.site")
@@ -1792,6 +1870,7 @@ func TestWebsiteService_CreateWebsite_DNSHostingDisabled_NoDNSOperations(t *test
 		domain := "no-dns-ops-test.com"
 
 		website := createTestIPFSWebsite(testUserID1, domain, testCID.String())
+		stubPinnedCID(t, ctx, testUserID1, testCID.String())
 		website.ID = 1671
 		prebindPrimaryDomain(tb, ctx, website, domain, false) // DNS hosting disabled
 
@@ -1832,6 +1911,7 @@ func TestWebsiteService_UpdateWebsite_DNSHostingDisabled_NoDNSOperations(t *test
 		domain := "update-no-dns-test.com"
 
 		website := createTestIPFSWebsite(testUserID1, domain, testCID.String())
+		stubPinnedCID(t, ctx, testUserID1, testCID.String())
 		website.ID = 1700
 		prebindPrimaryDomain(tb, ctx, website, domain, false) // DNS hosting disabled
 
@@ -1871,6 +1951,7 @@ func TestWebsiteService_DeleteWebsite_DNSHostingDisabled_NoDNSOperations(t *test
 		domain := "delete-no-dns-test.com"
 
 		website := createTestIPFSWebsite(testUserID1, domain, testCID.String())
+		stubPinnedCID(t, ctx, testUserID1, testCID.String())
 		website.ID = 1738
 		prebindPrimaryDomain(tb, ctx, website, domain, false) // DNS hosting disabled
 
@@ -1904,6 +1985,7 @@ func TestWebsiteService_CreateWebsite_DNSZoneCreationFailure_ContinuesWithoutDNS
 		domain := "zone-fail-test.com"
 
 		website := createTestIPFSWebsite(testUserID1, domain, testCID.String())
+		stubPinnedCID(t, ctx, testUserID1, testCID.String())
 		website.ID = 8007
 		// Bind the primary domain with DNS hosting enabled so CreateWebsite's
 		// managed-DNS side-effects (IPNS auto-convert, zone + record creation) run.
@@ -1945,6 +2027,7 @@ func TestWebsiteService_CreateWebsite_DNSRecordsCreationFailure_ContinuesWithout
 		domain := "records-fail-test.com"
 
 		website := createTestIPFSWebsite(testUserID1, domain, testCID.String())
+		stubPinnedCID(t, ctx, testUserID1, testCID.String())
 		website.ID = 8008
 		// Bind the primary domain with DNS hosting enabled so CreateWebsite's
 		// managed-DNS side-effects (IPNS auto-convert, zone + record creation) run.
@@ -1993,6 +2076,7 @@ func TestWebsiteService_EnableDNSHosting_RecordFailurePreservesDelegationZone(t 
 		testZoneID := uint(9002)
 
 		website := createTestIPFSWebsite(testUserID1, domain, testCID.String())
+		stubPinnedCID(t, ctx, testUserID1, testCID.String())
 		website.ID = 9013
 		// The enable transition loads the owning Website row for target/token
 		// state, so it must exist in the DB (this test bypasses CreateWebsite in
@@ -2074,6 +2158,7 @@ func TestWebsiteService_CreateWebsite_IPNSKeyAutoCreation_NoDuplicate(t *testing
 
 		// Act - Create first website with DNS hosting enabled
 		website1 := createTestIPFSWebsite(testUserID1, domain, testCID.String())
+		stubPinnedCID(t, ctx, testUserID1, testCID.String())
 		website1.ID = 8009
 		// Bind the primary domain with DNS hosting enabled so CreateWebsite's
 		// managed-DNS side-effects (IPNS auto-convert, zone + record creation) run.
@@ -2117,6 +2202,7 @@ func TestWebsiteService_CreateWebsite_IPNSKeyAutoCreation_NoDuplicate(t *testing
 
 		// Act - Create second website with same domain
 		website2 := createTestIPFSWebsite(testUserID1, domain, testCID.String())
+		stubPinnedCID(t, ctx, testUserID1, testCID.String())
 		website2.ID = 8010
 		// Bind the primary domain with DNS hosting enabled so CreateWebsite's
 		// managed-DNS side-effects (IPNS auto-convert, zone + record creation) run.
@@ -2145,6 +2231,7 @@ func TestWebsiteService_UpdateWebsite_ConvertIPFSToIPNS(t *testing.T) {
 		domain := "convert-test.com"
 
 		ipfsWebsite := createTestIPFSWebsite(testUserID1, domain, testCID.String())
+		stubPinnedCID(t, ctx, testUserID1, testCID.String())
 		createdWebsite, err := websiteService.CreateWebsite(context.Background(), ipfsWebsite)
 		require.NoError(tb, err)
 		require.NotNil(tb, createdWebsite)
@@ -2185,6 +2272,7 @@ func TestWebsiteService_UpdateWebsite_EnableDNSHostingTransition(t *testing.T) {
 		zoneID := uint(9999)
 
 		website := createTestIPFSWebsite(testUserID1, domain, testCID.String())
+		stubPinnedCID(t, ctx, testUserID1, testCID.String())
 		website.ID = 8009
 		// Bind a primary domain with DNS hosting disabled: enabling DNS later
 		// toggles this binding's DNSHostingEnabled from false to true.
@@ -2232,6 +2320,7 @@ func TestWebsiteService_UpdateWebsite_DisableDNSHostingTransition(t *testing.T) 
 		testZoneID := uint(9998)
 
 		website := createTestIPFSWebsite(testUserID1, domain, testCID.String())
+		stubPinnedCID(t, ctx, testUserID1, testCID.String())
 		website.ID = 8011
 		// Bind the primary domain with DNS hosting enabled so CreateWebsite's
 		// managed-DNS side-effects (IPNS auto-convert, zone + record creation) run.
@@ -2288,6 +2377,7 @@ func TestWebsiteService_UpdateWebsite_DNSEnabledInvalidType(t *testing.T) {
 		domain := "invalid-dns-type-test.com"
 
 		website := createTestIPFSWebsite(testUserID1, domain, testCID.String())
+		stubPinnedCID(t, ctx, testUserID1, testCID.String())
 		createdWebsite, err := websiteService.CreateWebsite(context.Background(), website)
 		require.NoError(tb, err)
 
@@ -2316,6 +2406,7 @@ func TestWebsiteService_UpdateWebsite_DNSHostingTransitionWithExistingZone(t *te
 		testZoneID := uint(9997)
 
 		website := createTestIPFSWebsite(testUserID1, domain, testCID.String())
+		stubPinnedCID(t, ctx, testUserID1, testCID.String())
 		website.ID = 8010
 		// Bind a primary domain with DNS hosting disabled but an already-existing
 		// zone, so that enabling DNS reuses the zone (no CreateZone) and only
@@ -2367,6 +2458,7 @@ func TestWebsiteService_UpdateWebsite_DNSEnableToggleOffOn(t *testing.T) {
 		testZoneID := uint(8001)
 
 		website := createTestIPFSWebsite(testUserID1, domain, testCID.String())
+		stubPinnedCID(t, ctx, testUserID1, testCID.String())
 		website.ID = 8012
 		// Bind the primary domain with DNS hosting enabled so CreateWebsite's
 		// managed-DNS side-effects (IPNS auto-convert, zone + record creation) run.
@@ -2429,6 +2521,7 @@ func TestWebsiteService_UpdateWebsite_DisableDNSHostingDeleteZoneFails(t *testin
 		testZoneID := uint(8003)
 
 		website := createTestIPFSWebsite(testUserID1, domain, testCID.String())
+		stubPinnedCID(t, ctx, testUserID1, testCID.String())
 		website.ID = 8013
 		// Bind the primary domain with DNS hosting enabled so CreateWebsite's
 		// managed-DNS side-effects (IPNS auto-convert, zone + record creation) run.
@@ -2481,6 +2574,7 @@ func TestWebsiteService_UpdateWebsite_ConvertIPNSToIPFS_UpdatesDNSRecords(t *tes
 
 		// Create website with DNS hosting enabled (auto-creates IPNS key)
 		website := createTestIPFSWebsite(testUserID1, domain, testCID.String())
+		stubPinnedCID(t, ctx, testUserID1, testCID.String())
 		website.ID = 8014
 		// Bind the primary domain with DNS hosting enabled so CreateWebsite's
 		// managed-DNS side-effects (IPNS auto-convert, zone + record creation) run.
@@ -2560,6 +2654,7 @@ func TestWebsiteService_UpdateWebsite_IPNSToIPNS_NoDNSUpdate(t *testing.T) {
 		testZoneID := uint(9002)
 
 		website := createTestIPFSWebsite(testUserID1, domain, testCID.String())
+		stubPinnedCID(t, ctx, testUserID1, testCID.String())
 		website.ID = 8015
 		// Bind the primary domain with DNS hosting enabled so CreateWebsite's
 		// managed-DNS side-effects (IPNS auto-convert, zone + record creation) run.
@@ -2624,6 +2719,7 @@ func TestWebsiteService_UpdateWebsite_ConvertIPFSToIPNS_UpdatesDNSRecords(t *tes
 
 		// Create website with DNS hosting enabled (auto-creates IPNS key, starts as IPNS)
 		website := createTestIPFSWebsite(testUserID1, domain, testCID.String())
+		stubPinnedCID(t, ctx, testUserID1, testCID.String())
 		website.ID = 8016
 		// Bind the primary domain with DNS hosting enabled so CreateWebsite's
 		// managed-DNS side-effects (IPNS auto-convert, zone + record creation) run.
@@ -2721,6 +2817,7 @@ func TestWebsiteService_UpdateWebsite_TargetTypeIPNSAlone(t *testing.T) {
 		domain := "type-only-convert.com"
 
 		website := createTestIPFSWebsite(testUserID1, domain, testCID.String())
+		stubPinnedCID(t, ctx, testUserID1, testCID.String())
 		website.ID = 2544
 		prebindPrimaryDomain(tb, ctx, website, domain, false) // DNS hosting disabled
 
@@ -2734,7 +2831,7 @@ func TestWebsiteService_UpdateWebsite_TargetTypeIPNSAlone(t *testing.T) {
 		// Mock: existing CID must be pinned for validation to pass
 		mockPinSvc := core.GetService[*mocks.MockIPFSPinService](ctx, pluginCore.PIN_SERVICE)
 		mockPinSvc.EXPECT().GetPinByCIDAndUser(mock.Anything, testCID, testUserID1).
-			Return(&pluginDb.IPFSPin{UserID: testUserID1, CID: testCID.Bytes(), Status: pluginDb.PinningStatusPinned}, nil).Once()
+			Return(&pluginDb.IPFSPin{UserID: testUserID1, CID: testCID.Bytes(), Status: pluginDb.PinningStatusPinned}, nil).Maybe()
 
 		updates := map[string]interface{}{
 			"target_type": string(pluginDb.WebsiteTargetTypeIPNS),
@@ -2762,6 +2859,7 @@ func TestWebsiteService_UpdateWebsite_TargetTypeIPNSAlone_DNSRecordsUpdated(t *t
 		testZoneID := uint(8001)
 
 		website := createTestIPFSWebsite(testUserID1, domain, testCID.String())
+		stubPinnedCID(t, ctx, testUserID1, testCID.String())
 		website.ID = 2585
 		prebindPrimaryDomain(tb, ctx, website, domain, false) // DNS hosting disabled initially
 
@@ -2775,7 +2873,7 @@ func TestWebsiteService_UpdateWebsite_TargetTypeIPNSAlone_DNSRecordsUpdated(t *t
 		// Mock: existing CID must be pinned for validation to pass
 		mockPinSvc := core.GetService[*mocks.MockIPFSPinService](ctx, pluginCore.PIN_SERVICE)
 		mockPinSvc.EXPECT().GetPinByCIDAndUser(mock.Anything, testCID, testUserID1).
-			Return(&pluginDb.IPFSPin{UserID: testUserID1, CID: testCID.Bytes(), Status: pluginDb.PinningStatusPinned}, nil).Once()
+			Return(&pluginDb.IPFSPin{UserID: testUserID1, CID: testCID.Bytes(), Status: pluginDb.PinningStatusPinned}, nil).Maybe()
 
 		updates := map[string]interface{}{
 			"target_type": string(pluginDb.WebsiteTargetTypeIPNS),
@@ -2818,6 +2916,7 @@ func TestWebsiteService_UpdateWebsite_IPNSTargetTypeWithCID(t *testing.T) {
 		domain := "ipns-with-cid.com"
 
 		website := createTestIPFSWebsite(testUserID1, domain, testCID.String())
+		stubPinnedCID(t, ctx, testUserID1, testCID.String())
 		website.ID = 2641
 		prebindPrimaryDomain(tb, ctx, website, domain, false) // DNS hosting disabled
 
@@ -2860,6 +2959,7 @@ func TestWebsiteService_UpdateWebsite_IPNSToIPFSWithoutCID(t *testing.T) {
 		testZoneID := uint(8002)
 
 		website := createTestIPFSWebsite(testUserID1, domain, testCID.String())
+		stubPinnedCID(t, ctx, testUserID1, testCID.String())
 		website.ID = 8017
 		// Bind the primary domain with DNS hosting enabled so CreateWebsite's
 		// managed-DNS side-effects (IPNS auto-convert, zone + record creation) run.
@@ -2905,6 +3005,7 @@ func TestWebsiteService_DisableDNSHosting_PreservesDelegationOwnedZone(t *testin
 		testZoneID := uint(9001)
 
 		website := createTestIPFSWebsite(testUserID1, domain, testCID.String())
+		stubPinnedCID(t, ctx, testUserID1, testCID.String())
 		website.ID = 9012
 
 		// The disable transition loads and rewrites the owning Website row, so


### PR DESCRIPTION
Requires a website's target CID to be already pinned by its owner before
creation is allowed. Direct IPFS targets and the IPNS auto-convert input are
validated against the user's pins; IPNS peer-ID targets are not pin-governed
and are skipped.

- `develop` <!-- branch-stack -->
  - **feat(website): require target CID to be pinned before website creation** :point\_left:

***

<!-- kody-pr-summary:start -->

## Summary

This pull request introduces a validation rule that requires the target CID to be pinned by the user before a new website can be created.

## Changes

- **New validation on website creation**: When creating a website with an IPFS target (or an IPNS target that is a plain CID for auto-conversion), the system now verifies that the CID is already pinned by the website owner. If the CID is not pinned, the creation is rejected with an error (`ErrCIDNotPinned`).
- **Scope**: The pin check applies only to CIDs used as direct IPFS targets and to IPNS targets that are plain CIDs (i.e., auto-convert inputs). IPNS targets that are already peer IDs are exempt because ownership is governed by key ownership, not pinning.
- **Test updates**:
  - Added a new test case (`TestWebsiteService_CreateWebsite_IPFSTargetNotPinned`) that verifies website creation fails when the target CID is not pinned.
  - Updated a large number of existing tests to stub the pin service so that the target CID is reported as pinned, ensuring they pass with the new validation.
  - Adjusted some test mock expectations from `.Once()` to `.Maybe()` to accommodate the additional pin check during creation.

<!-- kody-pr-summary:end -->
