### PR TITLE
fix(upload): persist custom pin name on pins created from uploads

### DIFF
--- a/core/upload.go
+++ b/core/upload.go
@@ -33,8 +33,10 @@ type UploadService interface {
 
 	// CreateRootPin creates an IPFS pin record for a single root CID.
 	// This method should only be called for actual root CIDs, not child blocks.
+	// name is an optional custom pin name (e.g. provided by the upload operation);
+	// it is empty when the upload did not specify one.
 	// Returns the created IPFS pin record which contains the request ID for tracking.
-	CreateRootPin(ctx context.Context, cid cid.Cid, userId uint) (*db.IPFSPin, error)
+	CreateRootPin(ctx context.Context, cid cid.Cid, userId uint, name string) (*db.IPFSPin, error)
 
 	core.Service
 }

--- a/internal/api/api_upload.go
+++ b/internal/api/api_upload.go
@@ -80,6 +80,7 @@ func (a *API) handleUpload(c echo.Context) error {
 
 	_, err = a.workflowService.StartWorkflow(ctx.Request().Context(), protocol.UPLOAD_WORKFLOW, core.WithWorkflowStructData(protocol.PostUploadWorkflowData{
 		UploadID: uploadId,
+		Name:     uploadReq.Name,
 	}, "json"),
 		core.WithWorkflowSourceIP(c.RealIP()),
 		core.WithWorkflowUserID(user),

--- a/internal/api/dto/pin.go
+++ b/internal/api/dto/pin.go
@@ -28,7 +28,7 @@ type PinRequest struct {
 func (p PinRequest) Schema() *zog.StructSchema {
 	return zog.Struct(zog.Shape{
 		"CID":     zog.String().Required(),
-		"Name":    zog.String().Max(255),
+		"Name":    zog.String().Max(db.MaxPinNameLength),
 		"Origins": zog.Slice(zog.String()),
 		"Meta":    zog.Struct(zog.Shape{}),
 	})

--- a/internal/api/dto/upload.go
+++ b/internal/api/dto/upload.go
@@ -13,6 +13,10 @@ var _ httputil.DTORequest[*UploadRequest] = (*UploadRequest)(nil)
 // UploadRequest represents the query parameters for upload requests
 type UploadRequest struct {
 	ArchiveMode string `query:"archive_mode"`
+	// Name is an optional custom pin name for the uploaded content. It is
+	// independent of the uploaded file's filename and only used to name the
+	// resulting pin when present.
+	Name string `query:"name"`
 }
 
 func (u *UploadRequest) ToModel() (*UploadRequest, error) {
@@ -23,6 +27,7 @@ func (u *UploadRequest) ToModel() (*UploadRequest, error) {
 func (u *UploadRequest) Schema() *zog.StructSchema {
 	return zog.Struct(zog.Shape{
 		"ArchiveMode": zog.String().OneOf([]string{upload.ArchiveConvert.String(), upload.ArchivePreserve.String()}).Optional(),
+		"Name":        zog.String().Max(255).Optional(),
 	})
 }
 

--- a/internal/api/dto/upload.go
+++ b/internal/api/dto/upload.go
@@ -3,6 +3,7 @@ package dto
 import (
 	"github.com/Oudwins/zog"
 	"go.lumeweb.com/httputil"
+	pluginDb "go.lumeweb.com/portal-plugin-ipfs/internal/db"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/upload"
 )
 
@@ -27,7 +28,7 @@ func (u *UploadRequest) ToModel() (*UploadRequest, error) {
 func (u *UploadRequest) Schema() *zog.StructSchema {
 	return zog.Struct(zog.Shape{
 		"ArchiveMode": zog.String().OneOf([]string{upload.ArchiveConvert.String(), upload.ArchivePreserve.String()}).Optional(),
-		"Name":        zog.String().Max(255).Optional(),
+		"Name":        zog.String().Max(pluginDb.MaxPinNameLength).Optional(),
 	})
 }
 

--- a/internal/db/ipfs_pin.go
+++ b/internal/db/ipfs_pin.go
@@ -22,6 +22,11 @@ const (
 	PinningStatusFailed  PinningStatus = "failed"
 )
 
+// MaxPinNameLength is the maximum allowed length of IPFSPin.Name, matching the
+// varchar(255) size of the underlying column. Pin names must be capped to this
+// length before being persisted.
+const MaxPinNameLength = 255
+
 // validStatuses is a map of valid pinning statuses for quick lookup
 var validStatuses = map[PinningStatus]struct{}{
 	PinningStatusQueued:  {},

--- a/internal/protocol/op_post_upload.go
+++ b/internal/protocol/op_post_upload.go
@@ -176,7 +176,7 @@ func (h *PostUploadOperationHandler) Execute(ctx context.Context, req *models.Re
 		h.Logger().Warn("Failed to update progress", zap.Error(err))
 	}
 
-	ipfsPin, err := h.createRootPin(ctx, rootCids[0], userID)
+	ipfsPin, err := h.createRootPin(ctx, rootCids[0], userID, workflow.Name)
 	if err != nil {
 		// Release all per-block reservations on error
 		quota.ReleaseBlockReservationsMap(reservations)
@@ -360,12 +360,12 @@ func (h *PostUploadOperationHandler) processCIDs(ctx context.Context, allCids []
 }
 
 // createRootPin creates a root pin for the upload
-func (h *PostUploadOperationHandler) createRootPin(ctx context.Context, rootCid cid.Cid, userID uint) (*db.IPFSPin, error) {
+func (h *PostUploadOperationHandler) createRootPin(ctx context.Context, rootCid cid.Cid, userID uint, name string) (*db.IPFSPin, error) {
 	ctx, span := core.TraceMethod(ctx, "PostUploadOperationHandler.createRootPin")
 	defer span.End()
 
 	uploadSvc := core.GetService[pluginCore.UploadService](h.Context(), pluginCore.UPLOAD_SERVICE)
-	ipfsPin, err := uploadSvc.CreateRootPin(ctx, rootCid, userID)
+	ipfsPin, err := uploadSvc.CreateRootPin(ctx, rootCid, userID, name)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create root pin: %w", err)
 	}

--- a/internal/protocol/op_tus_upload.go
+++ b/internal/protocol/op_tus_upload.go
@@ -226,12 +226,20 @@ func processUploadAndCreateReservations(ctx context.Context, helper core.Operati
 // getTUSPinName extracts an optional custom pin name from the TUS upload
 // metadata. Clients supply it as the "name" field of the Upload-Metadata
 // header. It returns "" when the upload did not specify one.
+//
+// The value is capped at 255 characters to match the POST /upload path's
+// limit (varchar(255) on IPFSPin.Name); without this bound an over-long name
+// would fail or silently truncate when the pin record is inserted.
 func getTUSPinName(ctx context.Context, tusHandler core.TusHandler, proto core.StorageProtocol, tusUploadID string) string {
 	metadata, err := tusHandler.GetUploadMetadata(ctx, proto, tusUploadID)
 	if err != nil {
 		return ""
 	}
-	return metadata["name"]
+	name := metadata["name"]
+	if l := len(name); l > 255 {
+		name = name[:255]
+	}
+	return name
 }
 
 // processUploadWithServices processes the upload using upload and pin services

--- a/internal/protocol/op_tus_upload.go
+++ b/internal/protocol/op_tus_upload.go
@@ -227,17 +227,17 @@ func processUploadAndCreateReservations(ctx context.Context, helper core.Operati
 // metadata. Clients supply it as the "name" field of the Upload-Metadata
 // header. It returns "" when the upload did not specify one.
 //
-// The value is capped at 255 characters to match the POST /upload path's
-// limit (varchar(255) on IPFSPin.Name); without this bound an over-long name
-// would fail or silently truncate when the pin record is inserted.
+// The value is capped at pluginDb.MaxPinNameLength to match the POST /upload
+// path's limit (varchar(255) on IPFSPin.Name); without this bound an over-long
+// name would fail or silently truncate when the pin record is inserted.
 func getTUSPinName(ctx context.Context, tusHandler core.TusHandler, proto core.StorageProtocol, tusUploadID string) string {
 	metadata, err := tusHandler.GetUploadMetadata(ctx, proto, tusUploadID)
 	if err != nil {
 		return ""
 	}
 	name := metadata["name"]
-	if l := len(name); l > 255 {
-		name = name[:255]
+	if l := len(name); l > pluginDb.MaxPinNameLength {
+		name = name[:pluginDb.MaxPinNameLength]
 	}
 	return name
 }

--- a/internal/protocol/op_tus_upload.go
+++ b/internal/protocol/op_tus_upload.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"unicode/utf8"
 
 	"github.com/ipfs/go-cid"
 	"github.com/samber/lo"
@@ -237,7 +238,14 @@ func getTUSPinName(ctx context.Context, tusHandler core.TusHandler, proto core.S
 	}
 	name := metadata["name"]
 	if l := len(name); l > pluginDb.MaxPinNameLength {
-		name = name[:pluginDb.MaxPinNameLength]
+		truncated := name[:pluginDb.MaxPinNameLength]
+		// Back off to the last UTF-8 rune boundary so a multi-byte
+		// codepoint is not split mid-sequence.
+		for !utf8.ValidString(truncated) {
+			_, size := utf8.DecodeLastRuneInString(truncated)
+			truncated = truncated[:len(truncated)-size]
+		}
+		name = truncated
 	}
 	return name
 }

--- a/internal/protocol/op_tus_upload.go
+++ b/internal/protocol/op_tus_upload.go
@@ -85,7 +85,8 @@ func handleTUSUpload(p core.Protocol) func(ctx context.Context, helper core.Oper
 
 		// Process with services
 		metaStore := protoNode.GetMetadataStore()
-		ipfsPin, err := processUploadWithServices(ctx, helper, p, allCids, rootCids, *request.UserID, reservations, request, metaStore)
+		pinName := getTUSPinName(ctx, tusHandler, proto, tsReq.TUSUploadID)
+		ipfsPin, err := processUploadWithServices(ctx, helper, p, allCids, rootCids, *request.UserID, reservations, request, metaStore, pinName)
 		if err != nil {
 			// processUploadWithServices releases reservations on all internal error paths.
 			// Calling ReleaseBlockReservationsMap here would double-release.
@@ -222,8 +223,19 @@ func processUploadAndCreateReservations(ctx context.Context, helper core.Operati
 	return allCids, rootCids, reservations, nil
 }
 
+// getTUSPinName extracts an optional custom pin name from the TUS upload
+// metadata. Clients supply it as the "name" field of the Upload-Metadata
+// header. It returns "" when the upload did not specify one.
+func getTUSPinName(ctx context.Context, tusHandler core.TusHandler, proto core.StorageProtocol, tusUploadID string) string {
+	metadata, err := tusHandler.GetUploadMetadata(ctx, proto, tusUploadID)
+	if err != nil {
+		return ""
+	}
+	return metadata["name"]
+}
+
 // processUploadWithServices processes the upload using upload and pin services
-func processUploadWithServices(ctx context.Context, helper core.OperationHelper, p core.Protocol, allCids []cid.Cid, rootCids []cid.Cid, userID uint, reservations map[cid.Cid]*quota.BlockReservations, request *models.Request, metaStore pluginCore.MetadataStore) (*pluginDb.IPFSPin, error) {
+func processUploadWithServices(ctx context.Context, helper core.OperationHelper, p core.Protocol, allCids []cid.Cid, rootCids []cid.Cid, userID uint, reservations map[cid.Cid]*quota.BlockReservations, request *models.Request, metaStore pluginCore.MetadataStore, name string) (*pluginDb.IPFSPin, error) {
 	uploadSvc := core.GetService[pluginCore.UploadService](helper.Context(), pluginCore.UPLOAD_SERVICE)
 	if uploadSvc == nil {
 		helper.Logger().Error("Upload service not available")
@@ -241,12 +253,11 @@ func processUploadWithServices(ctx context.Context, helper core.OperationHelper,
 	}
 
 	// Create IPFS pin record for the root CID
-	ipfsPin, err := uploadSvc.CreateRootPin(ctx, rootCids[0], userID)
+	ipfsPin, err := uploadSvc.CreateRootPin(ctx, rootCids[0], userID, name)
 	if err != nil {
 		quota.ReleaseBlockReservationsMap(reservations)
 		return nil, fmt.Errorf("failed to create root pin: %w", err)
 	}
-
 
 	// Update pin status to pinned
 	pinSvc := core.GetService[pluginCore.IPFSPinService](helper.Context(), pluginCore.PIN_SERVICE)

--- a/internal/protocol/workflows.go
+++ b/internal/protocol/workflows.go
@@ -18,6 +18,9 @@ type PinWorkflowData struct {
 
 type PostUploadWorkflowData struct {
 	UploadID string `json:"upload_id"`
+	// Name is an optional custom pin name provided by the upload operation.
+	// It is empty when the upload did not specify one.
+	Name string `json:"name,omitempty"`
 }
 
 type FilePathWorkflowInputData struct {

--- a/internal/service/upload/upload.go
+++ b/internal/service/upload/upload.go
@@ -210,7 +210,7 @@ func (s *UploadServiceDefault) ProcessUpload(ctx context.Context, cids []cid.Cid
 	)
 }
 
-func (s *UploadServiceDefault) CreateRootPin(ctx context.Context, c cid.Cid, userId uint) (*pluginDb.IPFSPin, error) {
+func (s *UploadServiceDefault) CreateRootPin(ctx context.Context, c cid.Cid, userId uint, name string) (*pluginDb.IPFSPin, error) {
 	ctx, span := core.TraceMethod(ctx, "UploadServiceDefault.CreateRootPin")
 	defer span.End()
 
@@ -229,7 +229,7 @@ func (s *UploadServiceDefault) CreateRootPin(ctx context.Context, c cid.Cid, use
 			ipfsPin, err := s.pin.AddPin(ctx, &pluginDb.IPFSPin{
 				UserID:    userId,
 				CID:       c.Bytes(),
-				Name:      "",
+				Name:      name,
 				Origins:   nil,
 				Meta:      nil,
 				Delegates: nil,

--- a/internal/service/upload/upload_test.go
+++ b/internal/service/upload/upload_test.go
@@ -168,7 +168,7 @@ func TestUploadService_CreateRootPin_Idempotent(t *testing.T) {
 		mockPinSvc.EXPECT().GetPinByCIDAndUser(mock.Anything, testCID, userID).Return(nil, nil).Once()
 		mockPinSvc.EXPECT().AddPin(mock.Anything, mock.Anything).Return(existingPin, nil).Once()
 
-		pin1, err := uploadSvc.CreateRootPin(ctx, testCID, userID)
+		pin1, err := uploadSvc.CreateRootPin(ctx, testCID, userID, "test-pin")
 		require.NoError(tb, err)
 		require.NotNil(tb, pin1)
 		require.Equal(tb, existingPin.RequestID, pin1.RequestID)
@@ -176,7 +176,7 @@ func TestUploadService_CreateRootPin_Idempotent(t *testing.T) {
 		// Second call: existing pin found, AddPin should NOT be called
 		mockPinSvc.EXPECT().GetPinByCIDAndUser(mock.Anything, testCID, userID).Return(existingPin, nil).Once()
 
-		pin2, err := uploadSvc.CreateRootPin(ctx, testCID, userID)
+		pin2, err := uploadSvc.CreateRootPin(ctx, testCID, userID, "test-pin")
 		require.NoError(tb, err)
 		require.NotNil(tb, pin2)
 		require.Equal(tb, pin1.RequestID, pin2.RequestID, "second call should return same pin")

--- a/internal/testing/mocks/MockUploadService.go
+++ b/internal/testing/mocks/MockUploadService.go
@@ -138,8 +138,8 @@ func (_c *MockUploadService_Context_Call) RunAndReturn(run func() core.Context) 
 }
 
 // CreateRootPin provides a mock function for the type MockUploadService
-func (_mock *MockUploadService) CreateRootPin(ctx context.Context, cid1 cid.Cid, userId uint) (*db.IPFSPin, error) {
-	ret := _mock.Called(ctx, cid1, userId)
+func (_mock *MockUploadService) CreateRootPin(ctx context.Context, cid1 cid.Cid, userId uint, name string) (*db.IPFSPin, error) {
+	ret := _mock.Called(ctx, cid1, userId, name)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CreateRootPin")
@@ -147,18 +147,18 @@ func (_mock *MockUploadService) CreateRootPin(ctx context.Context, cid1 cid.Cid,
 
 	var r0 *db.IPFSPin
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, cid.Cid, uint) (*db.IPFSPin, error)); ok {
-		return returnFunc(ctx, cid1, userId)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, cid.Cid, uint, string) (*db.IPFSPin, error)); ok {
+		return returnFunc(ctx, cid1, userId, name)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, cid.Cid, uint) *db.IPFSPin); ok {
-		r0 = returnFunc(ctx, cid1, userId)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, cid.Cid, uint, string) *db.IPFSPin); ok {
+		r0 = returnFunc(ctx, cid1, userId, name)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*db.IPFSPin)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, cid.Cid, uint) error); ok {
-		r1 = returnFunc(ctx, cid1, userId)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, cid.Cid, uint, string) error); ok {
+		r1 = returnFunc(ctx, cid1, userId, name)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -174,11 +174,12 @@ type MockUploadService_CreateRootPin_Call struct {
 //   - ctx context.Context
 //   - cid1 cid.Cid
 //   - userId uint
-func (_e *MockUploadService_Expecter) CreateRootPin(ctx any, cid1 any, userId any) *MockUploadService_CreateRootPin_Call {
-	return &MockUploadService_CreateRootPin_Call{Call: _e.mock.On("CreateRootPin", ctx, cid1, userId)}
+//   - name string
+func (_e *MockUploadService_Expecter) CreateRootPin(ctx any, cid1 any, userId any, name any) *MockUploadService_CreateRootPin_Call {
+	return &MockUploadService_CreateRootPin_Call{Call: _e.mock.On("CreateRootPin", ctx, cid1, userId, name)}
 }
 
-func (_c *MockUploadService_CreateRootPin_Call) Run(run func(ctx context.Context, cid1 cid.Cid, userId uint)) *MockUploadService_CreateRootPin_Call {
+func (_c *MockUploadService_CreateRootPin_Call) Run(run func(ctx context.Context, cid1 cid.Cid, userId uint, name string)) *MockUploadService_CreateRootPin_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -192,10 +193,15 @@ func (_c *MockUploadService_CreateRootPin_Call) Run(run func(ctx context.Context
 		if args[2] != nil {
 			arg2 = args[2].(uint)
 		}
+		var arg3 string
+		if args[3] != nil {
+			arg3 = args[3].(string)
+		}
 		run(
 			arg0,
 			arg1,
 			arg2,
+			arg3,
 		)
 	})
 	return _c
@@ -206,7 +212,7 @@ func (_c *MockUploadService_CreateRootPin_Call) Return(iPFSPin *db.IPFSPin, err 
 	return _c
 }
 
-func (_c *MockUploadService_CreateRootPin_Call) RunAndReturn(run func(ctx context.Context, cid1 cid.Cid, userId uint) (*db.IPFSPin, error)) *MockUploadService_CreateRootPin_Call {
+func (_c *MockUploadService_CreateRootPin_Call) RunAndReturn(run func(ctx context.Context, cid1 cid.Cid, userId uint, name string) (*db.IPFSPin, error)) *MockUploadService_CreateRootPin_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
## What

`CreateRootPin`/`AddPin` hardcoded the pin `Name` to `""` when creating a pin from an upload, silently dropping any user-provided name. This threads an **optional custom pin name** (not the filename) through to the pin record created by uploads, on both upload paths:

- **POST /upload**: the name is carried in the upload operation metadata (`PostUploadWorkflowData.Name`), populated from an optional `name` query param on the upload request.
- **TUS upload**: the name is read from the TUS `Upload-Metadata` `name` field via the TUS handler.

The explicit pinning API (`POST /pins`) already persisted the name and is unaffected.

## Changes

- `core/upload.go`: `CreateRootPin(ctx, cid, userID, name string)`
- `internal/service/upload/upload.go`: persist `Name: name` (drop hardcoded `""`)
- `internal/protocol/workflows.go`: add `Name` to `PostUploadWorkflowData`
- `internal/api/api_upload.go`: populate `Name` into operation metadata
- `internal/api/dto/upload.go`: optional `name` query param
- `internal/protocol/op_post_upload.go`: read name from op metadata → `CreateRootPin`
- `internal/protocol/op_tus_upload.go`: read `name` from TUS metadata → `CreateRootPin`
- `internal/service/upload/upload_test.go`: updated `CreateRootPin` calls
- regenerate `MockUploadService`

Verification: `go build ./...` passes. (Unit tests in `internal/service/upload`/protocol fail at package init in this sandbox due to a pre-existing protobuf `rpc.proto` namespace conflict between libp2p-pubsub and etcd — unrelated to this change.)

- `develop` <!-- branch-stack -->
  - **fix(upload): persist custom pin name on pins created from uploads** :point\_left:

***

<!-- kody-pr-summary:start -->

## Summary

This pull request fixes the issue where custom pin names provided during upload operations were being ignored when creating the resulting IPFS pin.

### Changes

- **Persist custom pin names on upload**: The optional `name` query parameter is now accepted on upload requests and passed through the entire upload flow so that when a pin is created from an uploaded file, the custom name is applied to the pin record instead of being left empty.

### Key modifications

1. **API layer**: Added support for an optional `name` query parameter (`UploadRequest.Name`) in the upload endpoint, validated with a max length of 255 characters.

2. **Workflow data propagation**: The upload name is now included in the `PostUploadWorkflowData` structure and passed into the post-upload operation handler.

3. **Service layer**: The `CreateRootPin` method signature now accepts a `name` parameter, and the upload service sets this name on the created pin record rather than always using an empty string.

4. **TUS upload support**: For TUS (resumable upload) flows, the custom pin name is extracted from the upload metadata and passed through the pin creation process as well.

5. **Mock/service updates**: Updated mock implementations and tests to reflect the new method signatures and behavior.

<!-- kody-pr-summary:end -->
