### PR TITLE
fix(reprovider): bound FullRT.Provide calls that ignore context cancellation

### DIFF
--- a/internal/protocol/ipfs/metrics.go
+++ b/internal/protocol/ipfs/metrics.go
@@ -16,6 +16,7 @@ const (
 	MetricReprovideBatchSize     = "reprovide_batch_size"
 	MetricReprovideProviderReady = "reprovide_provider_ready"
 	MetricReprovideCIDLeaks      = "reprovide_cid_leaks_total"
+	MetricReprovideThrottled     = "reprovide_provide_throttled_total"
 
 	// Global pinned-state gauges
 	MetricReprovidePinnedTotal    = "reprovide_pinned_total"
@@ -76,6 +77,9 @@ var (
 
 	// Reprovider leak counter
 	ReprovideCIDLeaks prometheus.Counter
+
+	// Reprovider throttle counter — incremented when too many leaked goroutines prevent starting a new provide
+	ReprovideThrottled prometheus.Counter
 
 	// Reprovider gauges
 	ReprovideProviderReady prometheus.Gauge
@@ -186,6 +190,14 @@ func init() {
 			Subsystem: subSystemReprovider,
 			Name:      MetricReprovideCIDLeaks,
 			Help:      "CIDs where Provide() was abandoned due to context expiry (goroutine may still be running)",
+		},
+	)
+
+	ReprovideThrottled = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Subsystem: subSystemReprovider,
+			Name:      MetricReprovideThrottled,
+			Help:      "Provides refused because the leaked-goroutine semaphore is full",
 		},
 	)
 
@@ -318,6 +330,7 @@ func GetMetricsCollectors() []prometheus.Collector {
 		ReprovideCIDDuration,
 		ReprovideBatchSize,
 		ReprovideCIDLeaks,
+		ReprovideThrottled,
 		ReprovideProviderReady,
 		ReprovidePinnedTotal,
 		ReprovideAnnouncedTotal,

--- a/internal/protocol/ipfs/metrics.go
+++ b/internal/protocol/ipfs/metrics.go
@@ -15,6 +15,7 @@ const (
 	MetricReprovideCIDDuration   = "reprovide_cid_duration_seconds"
 	MetricReprovideBatchSize     = "reprovide_batch_size"
 	MetricReprovideProviderReady = "reprovide_provider_ready"
+	MetricReprovideCIDLeaks      = "reprovide_cid_leaks_total"
 
 	// Global pinned-state gauges
 	MetricReprovidePinnedTotal    = "reprovide_pinned_total"
@@ -71,7 +72,10 @@ var (
 	// Reprovider histograms
 	ReprovideDuration    *prometheus.HistogramVec
 	ReprovideCIDDuration *prometheus.HistogramVec
-	ReprovideBatchSize   *prometheus.HistogramVec
+	ReprovideBatchSize *prometheus.HistogramVec
+
+	// Reprovider leak counter
+	ReprovideCIDLeaks prometheus.Counter
 
 	// Reprovider gauges
 	ReprovideProviderReady prometheus.Gauge
@@ -175,6 +179,14 @@ func init() {
 			Buckets:   batchSizeBuckets,
 		},
 		[]string{},
+	)
+
+	ReprovideCIDLeaks = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Subsystem: subSystemReprovider,
+			Name:      MetricReprovideCIDLeaks,
+			Help:      "CIDs where Provide() was abandoned due to context expiry (goroutine may still be running)",
+		},
 	)
 
 	ReprovideProviderReady = prometheus.NewGauge(
@@ -305,6 +317,7 @@ func GetMetricsCollectors() []prometheus.Collector {
 		ReprovideDuration,
 		ReprovideCIDDuration,
 		ReprovideBatchSize,
+		ReprovideCIDLeaks,
 		ReprovideProviderReady,
 		ReprovidePinnedTotal,
 		ReprovideAnnouncedTotal,

--- a/internal/protocol/ipfs/provide.go
+++ b/internal/protocol/ipfs/provide.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/ipfs/go-cid"
@@ -289,9 +290,16 @@ func boundedProvide(ctx context.Context, provide provideFunc, key multihash.Mult
 		return errTooManyLeaked
 	}
 
+	var released atomic.Bool
+	release := func() {
+		if released.CompareAndSwap(false, true) {
+			<-sem
+		}
+	}
+
 	done := make(chan error, 1)
 	go func() {
-		defer func() { <-sem }()
+		defer release()
 		done <- provide(ctx, cid.NewCidV1(cid.Raw, key), true)
 	}()
 
@@ -306,6 +314,11 @@ func boundedProvide(ctx context.Context, provide provideFunc, key multihash.Mult
 	case err := <-done:
 		return err
 	case <-ctx.Done():
+		// Release the slot immediately so the pool is not exhausted by
+		// goroutines that may never finish. The goroutine's deferred release
+		// is a no-op if we already released here.
+		release()
+
 		// Only count as a genuine leak when the per-CID deadline expired,
 		// not when the parent cycle was cancelled or shut down.
 		if ctx.Err() == context.DeadlineExceeded {

--- a/internal/protocol/ipfs/provide.go
+++ b/internal/protocol/ipfs/provide.go
@@ -52,6 +52,8 @@ func (f *fullrtProvider) Ready() bool {
 }
 
 func (f *fullrtProvider) ProvideMany(ctx context.Context, keys []multihash.Multihash) error {
+	f.lg.resetAbandoned()
+
 	var (
 		mu     sync.Mutex
 		failed []multihash.Multihash
@@ -141,6 +143,8 @@ func (b *basicDHTProvider) Ready() bool {
 }
 
 func (b *basicDHTProvider) ProvideMany(ctx context.Context, keys []multihash.Multihash) error {
+	b.lg.resetAbandoned()
+
 	var (
 		mu     sync.Mutex
 		failed []multihash.Multihash
@@ -274,14 +278,14 @@ var (
 
 type provideFunc func(context.Context, cid.Cid, bool) error
 
-// leakGuard bounds the number of Provide goroutines that have been abandoned
-// (caller gave up on ctx.Done) but may still be running. The semaphore bounds
-// concurrent in-flight provides. The abandoned counter is incremented when the
-// caller abandons and decremented when the goroutine finally returns. New
-// provides are throttled when the abandoned count reaches capacity, preventing
-// unbounded goroutine accumulation across reprovide cycles.
+// leakGuard bounds the number of Provide goroutines abandoned within a single
+// ProvideMany batch. The semaphore bounds concurrent in-flight provides. The
+// abandoned counter is incremented when the caller gives up on ctx.Done and
+// decremented when the goroutine finally returns. It is reset per batch via
+// resetAbandoned so that forever-stuck goroutines from one cycle do not
+// permanently throttle the next.
 type leakGuard struct {
-	sem      chan struct{}
+	sem       chan struct{}
 	abandoned atomic.Int64
 	cap       int64
 }
@@ -294,6 +298,10 @@ func newLeakGuard(capacity int) *leakGuard {
 		sem: make(chan struct{}, capacity),
 		cap: int64(capacity),
 	}
+}
+
+func (lg *leakGuard) resetAbandoned() {
+	lg.abandoned.Store(0)
 }
 
 func boundedProvide(ctx context.Context, provide provideFunc, key multihash.Multihash, lg *leakGuard) error {
@@ -327,17 +335,13 @@ func boundedProvide(ctx context.Context, provide provideFunc, key multihash.Mult
 		<-lg.sem
 		return err
 	case <-ctx.Done():
-		// Release the semaphore so new provides can start, but track this
-		// goroutine in the abandoned counter until it finally returns.
+		// Release the semaphore immediately so new provides can start.
+		// Track this goroutine in the per-batch abandoned counter so we
+		// stop creating new ones if too many are stuck. The counter is
+		// reset at the start of each ProvideMany, so a bad batch does not
+		// permanently disable the reprovider.
 		lg.abandoned.Add(1)
 		<-lg.sem
-
-		// Spawn a reaper that decrements the counter when the goroutine
-		// finally completes, reclaiming the leak budget.
-		go func() {
-			<-done
-			lg.abandoned.Add(-1)
-		}()
 
 		if ctx.Err() == context.DeadlineExceeded {
 			ReprovideCIDLeaks.Inc()

--- a/internal/protocol/ipfs/provide.go
+++ b/internal/protocol/ipfs/provide.go
@@ -40,6 +40,7 @@ type fullrtProvider struct {
 	ready          func() bool
 	perCIDTimeout  time.Duration
 	provideWorkers int
+	leakSem        chan struct{}
 }
 
 func (f *fullrtProvider) Ready() bool {
@@ -80,7 +81,7 @@ func (f *fullrtProvider) ProvideMany(ctx context.Context, keys []multihash.Multi
 			}
 
 			cidStart := time.Now()
-			err := boundedProvide(provideCtx, f.dht.Provide, k)
+			err := boundedProvide(provideCtx, f.dht.Provide, k, f.leakSem)
 			cidElapsed := time.Since(cidStart).Seconds()
 			if cancel != nil {
 				cancel()
@@ -117,7 +118,11 @@ func (f *fullrtProvider) ProvideMany(ctx context.Context, keys []multihash.Multi
 }
 
 func newFullrtProvider(dht provideProvider, ready func() bool, perCIDTimeout time.Duration, provideWorkers int) pluginCore.Provider {
-	return &fullrtProvider{dht: dht, ready: ready, perCIDTimeout: perCIDTimeout, provideWorkers: provideWorkers}
+	cap := provideWorkers * 2
+	if cap < 2 {
+		cap = 2
+	}
+	return &fullrtProvider{dht: dht, ready: ready, perCIDTimeout: perCIDTimeout, provideWorkers: provideWorkers, leakSem: make(chan struct{}, cap)}
 }
 
 // basicDHTProvider wraps a basic DHT that doesn't implement ProvideMany
@@ -128,6 +133,7 @@ type basicDHTProvider struct {
 	ready          func() bool
 	perCIDTimeout  time.Duration
 	provideWorkers int
+	leakSem        chan struct{}
 }
 
 func (b *basicDHTProvider) Ready() bool {
@@ -168,7 +174,7 @@ func (b *basicDHTProvider) ProvideMany(ctx context.Context, keys []multihash.Mul
 			}
 
 			cidStart := time.Now()
-			err := boundedProvide(provideCtx, b.dht.Provide, k)
+			err := boundedProvide(provideCtx, b.dht.Provide, k, b.leakSem)
 			cidElapsed := time.Since(cidStart).Seconds()
 			if cancel != nil {
 				cancel()
@@ -204,7 +210,11 @@ func (b *basicDHTProvider) ProvideMany(ctx context.Context, keys []multihash.Mul
 }
 
 func newBasicDHTProvider(dht routing.ContentRouting, ready func() bool, perCIDTimeout time.Duration, provideWorkers int) pluginCore.Provider {
-	return &basicDHTProvider{dht: dht, ready: ready, perCIDTimeout: perCIDTimeout, provideWorkers: provideWorkers}
+	cap := provideWorkers * 2
+	if cap < 2 {
+		cap = 2
+	}
+	return &basicDHTProvider{dht: dht, ready: ready, perCIDTimeout: perCIDTimeout, provideWorkers: provideWorkers, leakSem: make(chan struct{}, cap)}
 }
 
 // NewDHTProvider is the facade factory for DHT providers. It abstracts the
@@ -264,21 +274,43 @@ func classifyProvideError(err error) string {
 	return "other"
 }
 
-var errProvideLeaked = errors.New("provide abandoned: context expired before Provide returned")
+var (
+	errProvideLeaked    = errors.New("provide abandoned: context expired before Provide returned")
+	errTooManyLeaked    = errors.New("too many outstanding leaked provides")
+)
 
 type provideFunc func(context.Context, cid.Cid, bool) error
 
-func boundedProvide(ctx context.Context, provide provideFunc, key multihash.Multihash) error {
+func boundedProvide(ctx context.Context, provide provideFunc, key multihash.Multihash, sem chan struct{}) error {
+	select {
+	case sem <- struct{}{}:
+	default:
+		ReprovideThrottled.Inc()
+		return errTooManyLeaked
+	}
+
 	done := make(chan error, 1)
 	go func() {
+		defer func() { <-sem }()
 		done <- provide(ctx, cid.NewCidV1(cid.Raw, key), true)
 	}()
+
+	// Non-blocking drain to avoid racing ctx.Done() against a completed result.
+	select {
+	case err := <-done:
+		return err
+	default:
+	}
 
 	select {
 	case err := <-done:
 		return err
 	case <-ctx.Done():
-		ReprovideCIDLeaks.Inc()
+		// Only count as a genuine leak when the per-CID deadline expired,
+		// not when the parent cycle was cancelled or shut down.
+		if ctx.Err() == context.DeadlineExceeded {
+			ReprovideCIDLeaks.Inc()
+		}
 		return fmt.Errorf("%w: %v", errProvideLeaked, ctx.Err())
 	}
 }

--- a/internal/protocol/ipfs/provide.go
+++ b/internal/protocol/ipfs/provide.go
@@ -41,7 +41,7 @@ type fullrtProvider struct {
 	ready          func() bool
 	perCIDTimeout  time.Duration
 	provideWorkers int
-	leakSem        chan struct{}
+	lg             *leakGuard
 }
 
 func (f *fullrtProvider) Ready() bool {
@@ -82,7 +82,7 @@ func (f *fullrtProvider) ProvideMany(ctx context.Context, keys []multihash.Multi
 			}
 
 			cidStart := time.Now()
-			err := boundedProvide(provideCtx, f.dht.Provide, k, f.leakSem)
+			err := boundedProvide(provideCtx, f.dht.Provide, k, f.lg)
 			cidElapsed := time.Since(cidStart).Seconds()
 			if cancel != nil {
 				cancel()
@@ -119,11 +119,7 @@ func (f *fullrtProvider) ProvideMany(ctx context.Context, keys []multihash.Multi
 }
 
 func newFullrtProvider(dht provideProvider, ready func() bool, perCIDTimeout time.Duration, provideWorkers int) pluginCore.Provider {
-	cap := provideWorkers * 2
-	if cap < 2 {
-		cap = 2
-	}
-	return &fullrtProvider{dht: dht, ready: ready, perCIDTimeout: perCIDTimeout, provideWorkers: provideWorkers, leakSem: make(chan struct{}, cap)}
+	return &fullrtProvider{dht: dht, ready: ready, perCIDTimeout: perCIDTimeout, provideWorkers: provideWorkers, lg: newLeakGuard(provideWorkers * 2)}
 }
 
 // basicDHTProvider wraps a basic DHT that doesn't implement ProvideMany
@@ -134,7 +130,7 @@ type basicDHTProvider struct {
 	ready          func() bool
 	perCIDTimeout  time.Duration
 	provideWorkers int
-	leakSem        chan struct{}
+	lg             *leakGuard
 }
 
 func (b *basicDHTProvider) Ready() bool {
@@ -175,7 +171,7 @@ func (b *basicDHTProvider) ProvideMany(ctx context.Context, keys []multihash.Mul
 			}
 
 			cidStart := time.Now()
-			err := boundedProvide(provideCtx, b.dht.Provide, k, b.leakSem)
+			err := boundedProvide(provideCtx, b.dht.Provide, k, b.lg)
 			cidElapsed := time.Since(cidStart).Seconds()
 			if cancel != nil {
 				cancel()
@@ -211,11 +207,7 @@ func (b *basicDHTProvider) ProvideMany(ctx context.Context, keys []multihash.Mul
 }
 
 func newBasicDHTProvider(dht routing.ContentRouting, ready func() bool, perCIDTimeout time.Duration, provideWorkers int) pluginCore.Provider {
-	cap := provideWorkers * 2
-	if cap < 2 {
-		cap = 2
-	}
-	return &basicDHTProvider{dht: dht, ready: ready, perCIDTimeout: perCIDTimeout, provideWorkers: provideWorkers, leakSem: make(chan struct{}, cap)}
+	return &basicDHTProvider{dht: dht, ready: ready, perCIDTimeout: perCIDTimeout, provideWorkers: provideWorkers, lg: newLeakGuard(provideWorkers * 2)}
 }
 
 // NewDHTProvider is the facade factory for DHT providers. It abstracts the
@@ -276,51 +268,77 @@ func classifyProvideError(err error) string {
 }
 
 var (
-	errProvideLeaked    = errors.New("provide abandoned: context expired before Provide returned")
-	errTooManyLeaked    = errors.New("too many outstanding leaked provides")
+	errProvideLeaked = errors.New("provide abandoned: context expired before Provide returned")
+	errTooManyLeaked = errors.New("too many outstanding leaked provides")
 )
 
 type provideFunc func(context.Context, cid.Cid, bool) error
 
-func boundedProvide(ctx context.Context, provide provideFunc, key multihash.Multihash, sem chan struct{}) error {
+// leakGuard bounds the number of Provide goroutines that have been abandoned
+// (caller gave up on ctx.Done) but may still be running. The semaphore bounds
+// concurrent in-flight provides. The abandoned counter is incremented when the
+// caller abandons and decremented when the goroutine finally returns. New
+// provides are throttled when the abandoned count reaches capacity, preventing
+// unbounded goroutine accumulation across reprovide cycles.
+type leakGuard struct {
+	sem      chan struct{}
+	abandoned atomic.Int64
+	cap       int64
+}
+
+func newLeakGuard(capacity int) *leakGuard {
+	if capacity < 2 {
+		capacity = 2
+	}
+	return &leakGuard{
+		sem: make(chan struct{}, capacity),
+		cap: int64(capacity),
+	}
+}
+
+func boundedProvide(ctx context.Context, provide provideFunc, key multihash.Multihash, lg *leakGuard) error {
+	if lg.abandoned.Load() >= lg.cap {
+		ReprovideThrottled.Inc()
+		return errTooManyLeaked
+	}
+
 	select {
-	case sem <- struct{}{}:
+	case lg.sem <- struct{}{}:
 	default:
 		ReprovideThrottled.Inc()
 		return errTooManyLeaked
 	}
 
-	var released atomic.Bool
-	release := func() {
-		if released.CompareAndSwap(false, true) {
-			<-sem
-		}
-	}
-
 	done := make(chan error, 1)
 	go func() {
-		defer release()
 		done <- provide(ctx, cid.NewCidV1(cid.Raw, key), true)
 	}()
 
 	// Non-blocking drain to avoid racing ctx.Done() against a completed result.
 	select {
 	case err := <-done:
+		<-lg.sem
 		return err
 	default:
 	}
 
 	select {
 	case err := <-done:
+		<-lg.sem
 		return err
 	case <-ctx.Done():
-		// Release the slot immediately so the pool is not exhausted by
-		// goroutines that may never finish. The goroutine's deferred release
-		// is a no-op if we already released here.
-		release()
+		// Release the semaphore so new provides can start, but track this
+		// goroutine in the abandoned counter until it finally returns.
+		lg.abandoned.Add(1)
+		<-lg.sem
 
-		// Only count as a genuine leak when the per-CID deadline expired,
-		// not when the parent cycle was cancelled or shut down.
+		// Spawn a reaper that decrements the counter when the goroutine
+		// finally completes, reclaiming the leak budget.
+		go func() {
+			<-done
+			lg.abandoned.Add(-1)
+		}()
+
 		if ctx.Err() == context.DeadlineExceeded {
 			ReprovideCIDLeaks.Inc()
 		}

--- a/internal/protocol/ipfs/provide.go
+++ b/internal/protocol/ipfs/provide.go
@@ -80,7 +80,7 @@ func (f *fullrtProvider) ProvideMany(ctx context.Context, keys []multihash.Multi
 			}
 
 			cidStart := time.Now()
-			err := f.dht.Provide(provideCtx, cid.NewCidV1(cid.Raw, k), true)
+			err := boundedProvide(provideCtx, f.dht.Provide, k)
 			cidElapsed := time.Since(cidStart).Seconds()
 			if cancel != nil {
 				cancel()
@@ -168,7 +168,7 @@ func (b *basicDHTProvider) ProvideMany(ctx context.Context, keys []multihash.Mul
 			}
 
 			cidStart := time.Now()
-			err := b.dht.Provide(provideCtx, cid.NewCidV1(cid.Raw, k), true)
+			err := boundedProvide(provideCtx, b.dht.Provide, k)
 			cidElapsed := time.Since(cidStart).Seconds()
 			if cancel != nil {
 				cancel()
@@ -248,6 +248,9 @@ func (e *provideManyError) FailedKeys() []multihash.Multihash {
 }
 
 func classifyProvideError(err error) string {
+	if errors.Is(err, errProvideLeaked) {
+		return "leaked"
+	}
 	if errors.Is(err, context.DeadlineExceeded) {
 		return "timeout"
 	}
@@ -259,6 +262,25 @@ func classifyProvideError(err error) string {
 		return "routing"
 	}
 	return "other"
+}
+
+var errProvideLeaked = errors.New("provide abandoned: context expired before Provide returned")
+
+type provideFunc func(context.Context, cid.Cid, bool) error
+
+func boundedProvide(ctx context.Context, provide provideFunc, key multihash.Multihash) error {
+	done := make(chan error, 1)
+	go func() {
+		done <- provide(ctx, cid.NewCidV1(cid.Raw, key), true)
+	}()
+
+	select {
+	case err := <-done:
+		return err
+	case <-ctx.Done():
+		ReprovideCIDLeaks.Inc()
+		return fmt.Errorf("%w: %v", errProvideLeaked, ctx.Err())
+	}
 }
 
 // A Reprovider periodically announces CIDs to the IPFS network.

--- a/internal/protocol/ipfs/provide_test.go
+++ b/internal/protocol/ipfs/provide_test.go
@@ -782,3 +782,58 @@ func mustMultihash(t *testing.T, data string) multihash.Multihash {
 	require.NoError(t, err)
 	return h
 }
+
+func TestBoundedProvide_AbortsOnContextExpiry(t *testing.T) {
+	key := mustMultihash(t, "hang-key")
+
+	var (
+		started = make(chan struct{})
+		release = make(chan struct{})
+	)
+
+	stub := &stubProvide{
+		provideFn: func(ctx context.Context, _ cid.Cid) error {
+			close(started)
+			<-release
+			return nil
+		},
+	}
+
+	provider := newFullrtProvider(stub, nil, 50*time.Millisecond, 0)
+
+	keys := []multihash.Multihash{key}
+
+	done := make(chan error, 1)
+	go func() { done <- provider.ProvideMany(context.Background(), keys) }()
+
+	<-started
+
+	select {
+	case <-done:
+		t.Fatal("ProvideMany returned before per-CID timeout fired")
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	select {
+	case err := <-done:
+		require.Error(t, err)
+		var pme *provideManyError
+		require.ErrorAs(t, err, &pme)
+		assert.Equal(t, 1, pme.failed)
+	case <-time.After(2 * time.Second):
+		t.Fatal("ProvideMany did not return after context expiry")
+	}
+
+	close(release)
+}
+
+func TestBoundedProvide_ReturnsOnSuccess(t *testing.T) {
+	key := mustMultihash(t, "fast-key")
+
+	stub := &stubProvide{}
+	provider := newFullrtProvider(stub, nil, 0, 0)
+
+	keys := []multihash.Multihash{key}
+	err := provider.ProvideMany(context.Background(), keys)
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
FullRT's `execOnMany` has no `ctx.Done()` case in its select loop, and the underlying stream `Write` doesn't accept a context. When a peer is half-dead (connected but not reading), `Write` blocks indefinitely. The 15s/5m/15m timeout stack cancels contexts that nobody listens to, so `g.Wait()` never returns and `pending` sticks forever

This wraps each `Provide()` call in a goroutine + `select` on `ctx.Done()`. When the per-CID timeout fires, the worker abandons the call and moves on. The inner goroutine leaks until the stream write unblocks (accepted trade-off). Adds a `reprovide_cid_leaks_total` counter to monitor how often this happens in production.

***

<!-- kody-pr-summary:start -->

## Summary

This pull request addresses a critical issue in the IPFS reprovider where `FullRT.Provide` calls could hang indefinitely without respecting context cancellation, causing goroutine leaks and stalled reprovisioning operations.

## Key Changes

### 1. Bounded Provide Calls with Leak Detection

The main fix introduces a `boundedProvide` wrapper function that runs DHT `Provide` calls in a separate goroutine and monitors context expiration:

- **Before**: Direct calls to `dht.Provide` that could block indefinitely, ignoring context cancellation
- **After**: Calls are wrapped with a timeout mechanism that:
  - Returns immediately when the context expires, even if the underlying `Provide` call is still running
  - Prevents the reprovider from hanging on individual CID announcements
  - Tracks abandoned operations via a new metric

### 2. New Metrics for Monitoring

Added a new Prometheus counter metric `reprovide_cid_leaks_total` to track CIDs where `Provide()` was abandoned due to context expiry, providing visibility into goroutine leak occurrences. The metric help text explicitly notes that the underlying goroutine may still be running.

### 3. Improved Error Classification

Added a new error classification category `"leaked"` for the specific case where a Provide call was abandoned due to context expiration. This allows better observability and distinction between:

- **Timeout errors** (context deadline exceeded)
- **Leaked operations** (Provide abandoned but goroutine may still be running)

### 4. Test Coverage

Added two new test cases to verify:

- **Context expiry behavior**: Confirms that `ProvideMany` returns promptly (within the per-CID timeout) when the underlying Provide call hangs, and reports the failure correctly
- **Success path**: Ensures normal Provide calls still work correctly and return without errors

## Functional Impact

- **Reliability**: Prevents reprovider operations from hanging indefinitely on unresponsive DHT calls
- **Resource Management**: Limits goroutine leaks by bounding the wait time for each Provide call
- **Observability**: Provides clear metrics and error classification for leaked operations
- **Performance**: Ensures reprovider batches continue processing even if individual CID announcements stall

<!-- kody-pr-summary:end -->

- `develop` <!-- branch-stack -->
  - **fix(reprovider): bound FullRT.Provide calls that ignore context cancellation** :point\_left:
