### PR TITLE
fix(website): fire admin notification for platform subdomain creation

### DIFF
--- a/internal/api/api_domains.go
+++ b/internal/api/api_domains.go
@@ -79,7 +79,7 @@ func (a *API) createDomain(c echo.Context) error {
 			apiErr := NewError(ErrKeyValidationFailed, fmt.Errorf("platform domain %q not found or disabled", req.PlatformDomain))
 			return ctx.Error(apiErr, apiErr.HttpStatus())
 		}
-		wd, err = a.delegatedDomainSvc.CreatePlatformSubdomain(reqCtx, uint(websiteID), userID, pd.ID, req.Label, req.Generate)
+		wd, err = a.delegatedDomainSvc.CreatePlatformSubdomain(reqCtx, uint(websiteID), userID, pd.ID, req.Label, req.Generate, false)
 	} else {
 		// User-owned domain binding.
 		if req.Domain == "" || req.Namespace == "" {

--- a/internal/api/api_websites.go
+++ b/internal/api/api_websites.go
@@ -314,7 +314,7 @@ func (a *API) claimPlatformSubdomain(ctx httputil.RequestContext, reqCtx context
 	if pd == nil {
 		return a.rollbackAndFail(ctx, reqCtx, user, websiteID, ErrKeyInvalidRequest, fmt.Errorf("no enabled platform domain configured; specify platform_domain or label"))
 	}
-	if _, cerr := a.delegatedDomainSvc.CreatePlatformSubdomain(reqCtx, websiteID, user, pd.ID, req.Label, req.Generate); cerr != nil {
+	if _, cerr := a.delegatedDomainSvc.CreatePlatformSubdomain(reqCtx, websiteID, user, pd.ID, req.Label, req.Generate, true); cerr != nil {
 		if isDuplicateKeyError(cerr) || strings.Contains(cerr.Error(), "already taken") {
 			a.Logger().Warn("Platform subdomain already claimed",
 				zap.String("platform_domain", req.PlatformDomain), zap.String("label", req.Label), zap.Error(cerr))

--- a/internal/service/domain/platform_domain.go
+++ b/internal/service/domain/platform_domain.go
@@ -325,7 +325,7 @@ func (s *DelegatedDomainService) BindPlatformRootApex(ctx context.Context, websi
 		return nil, fmt.Errorf("unsupported namespace: %s", pd.Namespace)
 	}
 
-	return s.createPlatformBinding(ctx, websiteID, userID, &pd, provider, pd.Domain)
+	return s.createPlatformBinding(ctx, websiteID, userID, &pd, provider, pd.Domain, false)
 }
 
 // CreatePlatformSubdomain claims a subdomain under a platform root for a
@@ -333,8 +333,11 @@ func (s *DelegatedDomainService) BindPlatformRootApex(ctx context.Context, websi
 // (GitHub-style adjective-noun-number); otherwise label is used verbatim.
 // The resulting binding is created through the normal CreateDomain flow
 // (which resolves the platform-owned zone via resolveManagedZone) and then
-// marked with the PlatformDomain reference.
-func (s *DelegatedDomainService) CreatePlatformSubdomain(ctx context.Context, websiteID, userID, platformDomainID uint, label string, generate bool) (*pluginDb.WebsiteDomain, error) {
+// marked with the PlatformDomain reference. notifyCreated is threaded into
+// CreateDomain so a brand-new website minted on a platform subdomain fires the
+// admin "website created" notification (matching the custom-domain create
+// flow); it is false for domain-adds on an existing website.
+func (s *DelegatedDomainService) CreatePlatformSubdomain(ctx context.Context, websiteID, userID, platformDomainID uint, label string, generate, notifyCreated bool) (*pluginDb.WebsiteDomain, error) {
 	if s.DB() == nil {
 		return nil, fmt.Errorf("database not available")
 	}
@@ -383,7 +386,7 @@ func (s *DelegatedDomainService) CreatePlatformSubdomain(ctx context.Context, we
 			} else if !available {
 				continue
 			}
-			wd, err := s.createPlatformBinding(ctx, websiteID, userID, &pd, provider, fqdn)
+			wd, err := s.createPlatformBinding(ctx, websiteID, userID, &pd, provider, fqdn, notifyCreated)
 			if err == nil {
 				return wd, nil
 			}
@@ -424,7 +427,7 @@ func (s *DelegatedDomainService) CreatePlatformSubdomain(ctx context.Context, we
 	if !available {
 		return nil, fmt.Errorf("platform subdomain %q is already taken", fqdn)
 	}
-	wd, err := s.createPlatformBinding(ctx, websiteID, userID, &pd, provider, fqdn)
+	wd, err := s.createPlatformBinding(ctx, websiteID, userID, &pd, provider, fqdn, notifyCreated)
 	if err != nil {
 		if isDuplicateKeyError(err) {
 			return nil, fmt.Errorf("platform subdomain %q is already taken", fqdn)
@@ -440,8 +443,8 @@ func (s *DelegatedDomainService) CreatePlatformSubdomain(ctx context.Context, we
 // resolves the operator zone from this exact root — never by re-deriving via
 // longest suffix-match across registered roots (which could mis-allocate a
 // claim to a differently-registered nested root).
-func (s *DelegatedDomainService) createPlatformBinding(ctx context.Context, websiteID, userID uint, pd *pluginDb.PlatformDomain, provider DomainProvider, fqdn string) (*pluginDb.WebsiteDomain, error) {
-	wd, err := s.CreateDomain(ctx, string(pd.Namespace), fqdn, websiteID, userID, true, false, nil, &pd.ID)
+func (s *DelegatedDomainService) createPlatformBinding(ctx context.Context, websiteID, userID uint, pd *pluginDb.PlatformDomain, provider DomainProvider, fqdn string, notifyCreated bool) (*pluginDb.WebsiteDomain, error) {
+	wd, err := s.CreateDomain(ctx, string(pd.Namespace), fqdn, websiteID, userID, true, notifyCreated, nil, &pd.ID)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/service/domain/platform_domain_test.go
+++ b/internal/service/domain/platform_domain_test.go
@@ -309,7 +309,7 @@ func TestCreatePlatformSubdomain_NestedRoot_UsesGrantedRootZone(t *testing.T) {
 		mockDNS.EXPECT().CreateDNSLinkRecord(mock.Anything, uint(parentZone.ID), mock.Anything, mock.Anything).Return(nil).Once()
 		mockDNS.EXPECT().CreateApexRecord(mock.Anything, uint(parentZone.ID), mock.Anything, pluginCore.RecordTypeALIAS, "gw.example.com").Return(nil).Once()
 
-		wd, err := svc.CreatePlatformSubdomain(context.Background(), website.ID, 1, pd.ID, "blog", false)
+		wd, err := svc.CreatePlatformSubdomain(context.Background(), website.ID, 1, pd.ID, "blog", false, false)
 		require.NoError(tb, err)
 		require.NotNil(tb, wd)
 		assert.Equal(t, "blog.platform.com", wd.Domain)
@@ -374,7 +374,7 @@ func TestCreatePlatformSubdomain_ExplicitLabelAlreadyTaken(t *testing.T) {
 			Return(&pluginDb.DNSZone{Model: gorm.Model{ID: 7}, Domain: "platform.com"}, nil).Maybe()
 		mockDNS.EXPECT().CreateDNSLinkRecord(mock.Anything, uint(7), mock.Anything, mock.Anything).Return(nil).Maybe()
 
-		_, err := svc.CreatePlatformSubdomain(context.Background(), website.ID, 1, pd.ID, "taken", false)
+		_, err := svc.CreatePlatformSubdomain(context.Background(), website.ID, 1, pd.ID, "taken", false, false)
 		require.Error(tb, err)
 		assert.Contains(tb, err.Error(), "already taken")
 	}, TestOptions)
@@ -391,12 +391,12 @@ func TestCreatePlatformSubdomain_LabelWWWRejected(t *testing.T) {
 		pd := createPlatformRoot(tb, ctx, "platform.com", pluginDb.DomainNamespaceICANN, 7, true)
 
 		svc := core.GetService[*DelegatedDomainService](ctx, pluginCore.DELEGATED_DOMAIN_SERVICE)
-		_, err := svc.CreatePlatformSubdomain(context.Background(), website.ID, 1, pd.ID, "www", false)
+		_, err := svc.CreatePlatformSubdomain(context.Background(), website.ID, 1, pd.ID, "www", false, false)
 		require.Error(tb, err)
 		assert.Contains(tb, err.Error(), "reserved")
 
 		// Any www.-prefixed label is likewise rejected.
-		_, err = svc.CreatePlatformSubdomain(context.Background(), website.ID, 1, pd.ID, "www.blog", false)
+		_, err = svc.CreatePlatformSubdomain(context.Background(), website.ID, 1, pd.ID, "www.blog", false, false)
 		require.Error(tb, err)
 		assert.Contains(tb, err.Error(), "reserved")
 	}, TestOptions)
@@ -418,7 +418,7 @@ func TestCreatePlatformSubdomain_Generate_HappyPath(t *testing.T) {
 			Return(&pluginDb.DNSZone{Model: gorm.Model{ID: 7}, Domain: "platform.com"}, nil).Once()
 		mockDNS.EXPECT().CreateDNSLinkRecord(mock.Anything, uint(7), mock.Anything, mock.Anything).Return(nil).Once()
 
-		wd, err := svc.CreatePlatformSubdomain(context.Background(), website.ID, 1, pd.ID, "", true)
+		wd, err := svc.CreatePlatformSubdomain(context.Background(), website.ID, 1, pd.ID, "", true, false)
 		require.NoError(tb, err)
 		require.NotNil(tb, wd)
 		require.NotNil(tb, wd.PlatformDomainID)
@@ -436,7 +436,7 @@ func TestCreatePlatformSubdomain_RequiresLabelWhenNotGenerate(t *testing.T) {
 		pd := createPlatformRoot(tb, ctx, "platform.com", pluginDb.DomainNamespaceICANN, 7, true)
 
 		svc := core.GetService[*DelegatedDomainService](ctx, pluginCore.DELEGATED_DOMAIN_SERVICE)
-		_, err := svc.CreatePlatformSubdomain(context.Background(), website.ID, 1, pd.ID, "", false)
+		_, err := svc.CreatePlatformSubdomain(context.Background(), website.ID, 1, pd.ID, "", false, false)
 		require.Error(tb, err)
 		assert.Contains(tb, err.Error(), "required")
 	}, TestOptions)
@@ -449,7 +449,7 @@ func TestCreatePlatformSubdomain_DisabledRootRejected(t *testing.T) {
 		pd := createPlatformRoot(tb, ctx, "platform.com", pluginDb.DomainNamespaceICANN, 7, false)
 
 		svc := core.GetService[*DelegatedDomainService](ctx, pluginCore.DELEGATED_DOMAIN_SERVICE)
-		_, err := svc.CreatePlatformSubdomain(context.Background(), website.ID, 1, pd.ID, "foo", false)
+		_, err := svc.CreatePlatformSubdomain(context.Background(), website.ID, 1, pd.ID, "foo", false, false)
 		require.Error(tb, err)
 		assert.Contains(tb, err.Error(), "disabled")
 	}, TestOptions)
@@ -536,7 +536,7 @@ func TestCreatePlatformSubdomain_Generate_RetriesOnCollision(t *testing.T) {
 			Return(&pluginDb.DNSZone{Model: gorm.Model{ID: 7}, Domain: "platform.com"}, nil).Once()
 		mockDNS.EXPECT().CreateDNSLinkRecord(mock.Anything, uint(7), mock.Anything, mock.Anything).Return(nil).Once()
 
-		wd, err := svc.CreatePlatformSubdomain(context.Background(), website.ID, 1, pd.ID, "", true)
+		wd, err := svc.CreatePlatformSubdomain(context.Background(), website.ID, 1, pd.ID, "", true, false)
 		require.NoError(tb, err)
 		require.NotNil(tb, wd)
 		assert.Equal(tb, "beta.platform.com", wd.Domain)
@@ -561,7 +561,7 @@ func TestCreatePlatformSubdomain_Generate_WritesApexToOperatorZone(t *testing.T)
 		mockDNS.EXPECT().CreateDNSLinkRecord(mock.Anything, uint(7), mock.Anything, mock.Anything).Return(nil).Once()
 		mockDNS.EXPECT().CreateApexRecord(mock.Anything, uint(7), mock.Anything, pluginCore.RecordTypeALIAS, "gw.example.com").Return(nil).Once()
 
-		wd, err := svc.CreatePlatformSubdomain(context.Background(), website.ID, 1, pd.ID, "blog", false)
+		wd, err := svc.CreatePlatformSubdomain(context.Background(), website.ID, 1, pd.ID, "blog", false, false)
 		require.NoError(tb, err)
 		require.NotNil(tb, wd)
 		assert.Equal(tb, "blog.platform.com", wd.Domain)
@@ -607,7 +607,7 @@ func TestCreatePlatformSubdomain_HNS_HappyPath(t *testing.T) {
 		mockDNS.EXPECT().CreateApexRecord(mock.Anything, uint(7), mock.Anything, pluginCore.RecordTypeA, "127.0.0.1").Return(nil).Once()
 		mockDNS.EXPECT().EnableDNSSEC(mock.Anything, uint(7)).Return("", nil).Maybe()
 
-		wd, err := svc.CreatePlatformSubdomain(context.Background(), website.ID, 1, pd.ID, "blog", false)
+		wd, err := svc.CreatePlatformSubdomain(context.Background(), website.ID, 1, pd.ID, "blog", false, false)
 		require.NoError(tb, err)
 		require.NotNil(tb, wd)
 		assert.Equal(tb, "blog.altroot", wd.Domain)
@@ -637,7 +637,7 @@ func TestCreatePlatformSubdomain_HNS_Generate(t *testing.T) {
 		mockDNS.EXPECT().CreateApexRecord(mock.Anything, uint(7), mock.Anything, pluginCore.RecordTypeA, "127.0.0.1").Return(nil).Once()
 		mockDNS.EXPECT().EnableDNSSEC(mock.Anything, uint(7)).Return("", nil).Maybe()
 
-		wd, err := svc.CreatePlatformSubdomain(context.Background(), website.ID, 1, pd.ID, "", true)
+		wd, err := svc.CreatePlatformSubdomain(context.Background(), website.ID, 1, pd.ID, "", true, false)
 		require.NoError(tb, err)
 		require.NotNil(tb, wd)
 		assert.Contains(tb, wd.Domain, ".altroot")


### PR DESCRIPTION
Adds a notifyCreated flag threaded through platform subdomain creation so a brand-new website minted on a platform subdomain fires the admin "website created" email, matching custom-domain websites. Domain-adds on existing websites keep the notification suppressed.

- `develop` <!-- branch-stack -->
  - **fix(website): fire admin notification for platform subdomain creation** :point\_left:

---

<!-- kody-pr-summary:start -->
## Summary

This pull request fixes an issue where the admin "website created" notification was not being fired when a new website was created via the platform subdomain claim flow.

## Changes

### Core Fix

The `CreatePlatformSubdomain` function now accepts a new `notifyCreated` boolean parameter that is threaded through to `createPlatformBinding` and ultimately to `CreateDomain`. This parameter controls whether the admin notification for website creation should be triggered.

### Callers Updated

Two callers were updated to pass the appropriate value for `notifyCreated`:

1. **`internal/api/api_domains.go`** – In the `createDomain` API handler, platform subdomain creation now passes `false` for `notifyCreated`. This is because domains created through this endpoint are added to an existing website, not creating a new one.

2. **`internal/api/api_websites.go`** – In the `claimPlatformSubdomain` handler, platform subdomain creation now passes `true` for `notifyCreated`. This is because claiming a platform subdomain can create a brand-new website, so the admin "website created" notification should be fired in this case, matching the behavior of the custom-domain create flow.

### Test Updates

All existing tests for `CreatePlatformSubdomain` were updated to include the new `notifyCreated` parameter (passing `false`), maintaining test coverage with the updated function signature.

## Purpose

This change ensures consistency between the platform subdomain creation flow and the custom-domain creation flow regarding admin notifications. Previously, when a new website was minted via the platform subdomain claim endpoint (which can create both a website and its domain), the admin notification wasn't fired—now it is.
<!-- kody-pr-summary:end -->