### PR TITLE
fix(website): auto-activate platform subdomain on deploy

### DIFF
--- a/core/website.go
+++ b/core/website.go
@@ -94,6 +94,14 @@ type WebsiteService interface {
 	// recipient user's email internally. No-op when notifications are disabled.
 	NotifyAdminWebsiteCreated(ctx context.Context, websiteID uint) error
 
+	// ActivatePlatformSubdomainWebsite activates a website whose primary domain
+	// binding is a just-created platform subdomain. The platform controls both
+	// ends of the DNS check for these, so the site requires no external
+	// validation call: it transitions from pending_validation to active as soon
+	// as the binding is live. It returns an error if the website cannot be
+	// loaded or its primary binding is not a platform subdomain.
+	ActivatePlatformSubdomainWebsite(ctx context.Context, websiteID uint) error
+
 	// WaitForPublishes blocks until all in-flight async publish operations complete
 	WaitForPublishes()
 }

--- a/internal/service/domain/delegated_domain_service.go
+++ b/internal/service/domain/delegated_domain_service.go
@@ -25,6 +25,11 @@ type DelegatedDomainService struct {
 	*core.BaseComponent
 	registry *Registry
 	dnsSvc   DNSZoneService
+	// websiteSvc is resolved once at startup for cross-service calls (e.g.
+	// activating a website after a platform subdomain is claimed). It is always
+	// present: the portal registers all service instances before running
+	// startup funcs, and WEBSITE_SERVICE is part of this same plugin.
+	websiteSvc pluginCore.WebsiteService
 	// slugGen produces a DNS-safe label for auto-generated platform
 	// subdomains. It defaults to pluginConfig.GenerateDNSSlug and is
 	// injectable so tests can control the slug sequence.
@@ -1106,6 +1111,12 @@ func NewDelegatedDomainServiceFactory() (core.Service, []core.ContextBuilderOpti
 			svc.registry = reg
 
 			svc.dnsSvc = dns
+
+			// Resolve the website service once for cross-service calls (e.g.
+			// activating a site after a platform subdomain claim). All service
+			// instances are registered before startup funcs run, so this is
+			// always present.
+			svc.websiteSvc = core.GetServiceOptional[pluginCore.WebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
 
 			return nil
 		}),

--- a/internal/service/domain/platform_domain.go
+++ b/internal/service/domain/platform_domain.go
@@ -459,11 +459,14 @@ func (s *DelegatedDomainService) createPlatformBinding(ctx context.Context, webs
 	// are operator-controlled on both ends of the DNS check, so awaiting DNS
 	// validation is moot; without this the site would sit in pending_validation
 	// forever (the janitor skips pending sites by design and nothing server-side
-	// would ever activate it). Activation must not fail the claim: the binding
-	// is already created, so a failure here is logged and swallowed.
-	if aerr := s.websiteSvc.ActivatePlatformSubdomainWebsite(ctx, websiteID); aerr != nil {
-		s.Logger().Warn("Failed to activate platform subdomain website",
-			zap.Uint("website_id", websiteID), zap.String("domain", fqdn), zap.Error(aerr))
+	// would ever activate it). Activation is best-effort: the binding is already
+	// created, so a failure here (or an unavailable website service) is logged
+	// and never fails the claim.
+	if s.websiteSvc != nil {
+		if aerr := s.websiteSvc.ActivatePlatformSubdomainWebsite(ctx, websiteID); aerr != nil {
+			s.Logger().Warn("Failed to activate platform subdomain website",
+				zap.Uint("website_id", websiteID), zap.String("domain", fqdn), zap.Error(aerr))
+		}
 	}
 
 	return wd, nil

--- a/internal/service/domain/platform_domain.go
+++ b/internal/service/domain/platform_domain.go
@@ -11,6 +11,7 @@ import (
 	pluginDb "go.lumeweb.com/portal-plugin-ipfs/internal/db"
 	"go.lumeweb.com/queryutil"
 	"go.lumeweb.com/queryutil/filter"
+	"go.uber.org/zap"
 	"gorm.io/gorm"
 )
 
@@ -453,6 +454,18 @@ func (s *DelegatedDomainService) createPlatformBinding(ctx context.Context, webs
 	}
 	wd.PlatformDomainID = &pd.ID
 	wd.Status = pluginDb.DomainStatusActive
+
+	// The website itself must follow the binding to active. Platform subdomains
+	// are operator-controlled on both ends of the DNS check, so awaiting DNS
+	// validation is moot; without this the site would sit in pending_validation
+	// forever (the janitor skips pending sites by design and nothing server-side
+	// would ever activate it). Activation must not fail the claim: the binding
+	// is already created, so a failure here is logged and swallowed.
+	if aerr := s.websiteSvc.ActivatePlatformSubdomainWebsite(ctx, websiteID); aerr != nil {
+		s.Logger().Warn("Failed to activate platform subdomain website",
+			zap.Uint("website_id", websiteID), zap.String("domain", fqdn), zap.Error(aerr))
+	}
+
 	return wd, nil
 }
 

--- a/internal/service/domain/platform_domain_test.go
+++ b/internal/service/domain/platform_domain_test.go
@@ -413,10 +413,14 @@ func TestCreatePlatformSubdomain_Generate_HappyPath(t *testing.T) {
 
 		svc := core.GetService[*DelegatedDomainService](ctx, pluginCore.DELEGATED_DOMAIN_SERVICE)
 		mockDNS := core.GetService[*mocks.MockDNSService](ctx, pluginCore.DNS_SERVICE)
+		websiteMock := core.GetService[*mocks.MockWebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
 		// resolveManagedZone (platform-managed) resolves the operator zone.
 		mockDNS.EXPECT().GetZoneByDomain(mock.Anything, "platform.com").
 			Return(&pluginDb.DNSZone{Model: gorm.Model{ID: 7}, Domain: "platform.com"}, nil).Once()
 		mockDNS.EXPECT().CreateDNSLinkRecord(mock.Anything, uint(7), mock.Anything, mock.Anything).Return(nil).Once()
+		// Claiming the subdomain must trigger the website activation hook (the
+		// FSM transition itself is exercised by the website-service tests).
+		websiteMock.EXPECT().ActivatePlatformSubdomainWebsite(mock.Anything, website.ID).Return(nil).Once()
 
 		wd, err := svc.CreatePlatformSubdomain(context.Background(), website.ID, 1, pd.ID, "", true)
 		require.NoError(tb, err)
@@ -427,11 +431,9 @@ func TestCreatePlatformSubdomain_Generate_HappyPath(t *testing.T) {
 		assert.True(tb, wd.DNSHostingEnabled)
 		assert.Contains(tb, wd.Domain, ".platform.com")
 
-		// The website must follow the binding to active immediately — no external
+		// The activation hook must fire as part of the claim — no external
 		// websites_validate call should be required for a platform subdomain.
-		var activated pluginDb.Website
-		require.NoError(tb, db.First(&activated, website.ID).Error)
-		assert.Equal(tb, string(pluginDb.WebsiteStatusActive), activated.Status)
+		websiteMock.AssertExpectations(tb)
 	}, TestOptions)
 }
 

--- a/internal/service/domain/platform_domain_test.go
+++ b/internal/service/domain/platform_domain_test.go
@@ -426,6 +426,12 @@ func TestCreatePlatformSubdomain_Generate_HappyPath(t *testing.T) {
 		assert.Equal(tb, pluginDb.DomainStatusActive, wd.Status)
 		assert.True(tb, wd.DNSHostingEnabled)
 		assert.Contains(tb, wd.Domain, ".platform.com")
+
+		// The website must follow the binding to active immediately — no external
+		// websites_validate call should be required for a platform subdomain.
+		var activated pluginDb.Website
+		require.NoError(tb, db.First(&activated, website.ID).Error)
+		assert.Equal(tb, string(pluginDb.WebsiteStatusActive), activated.Status)
 	}, TestOptions)
 }
 

--- a/internal/service/website/website.go
+++ b/internal/service/website/website.go
@@ -2123,6 +2123,16 @@ func (s *WebsiteServiceDefault) ActivatePlatformSubdomainWebsite(ctx context.Con
 		return nil
 	}
 
+	// Verify the target is genuinely valid before auto-activating. A fresh
+	// deploy's target is pinned at create, but a platform subdomain may also be
+	// bound to an existing site whose target is no longer valid — reusing
+	// CheckStatus (which validates both IPFS and IPNS targets) avoids serving
+	// unpinned/invalid content. When the target is not valid, leave the site
+	// pending for the normal validation/janitor handling.
+	if status, err := s.CheckStatus(ctx, &website); err != nil || status != pluginDb.WebsiteStatusActive {
+		return nil
+	}
+
 	if err := s.activateValidatedWebsite(ctx, &website); err != nil {
 		return fmt.Errorf("failed to activate platform subdomain website %d: %w", websiteID, err)
 	}

--- a/internal/service/website/website.go
+++ b/internal/service/website/website.go
@@ -2088,7 +2088,13 @@ func (s *WebsiteServiceDefault) NotifyAdminWebsiteCreated(ctx context.Context, w
 // controls both ends of the DNS check for platform subdomains (no user
 // verification token exists), so a site awaiting DNS validation can move
 // straight to active once the binding is live — no external websites_validate
-// call is required. A blocked website is left unchanged by the FSM.
+// call is required.
+//
+// Activation is gated to the pending_validation state only. A broken website
+// must not be auto-activated by a binding change: its target may be unpinned or
+// otherwise invalid, and activating it would serve content without verification
+// (EventWebsiteValidate is also legal from broken). A blocked website is left
+// unchanged by the FSM.
 func (s *WebsiteServiceDefault) ActivatePlatformSubdomainWebsite(ctx context.Context, websiteID uint) error {
 	ctx, span := core.TraceMethod(ctx, "WebsiteServiceDefault.ActivatePlatformSubdomainWebsite")
 	defer span.End()
@@ -2108,6 +2114,13 @@ func (s *WebsiteServiceDefault) ActivatePlatformSubdomainWebsite(ctx context.Con
 			domain = primaryWD.Domain
 		}
 		return fmt.Errorf("website %d primary domain %q is not a platform subdomain", websiteID, domain)
+	}
+
+	// Only a site awaiting DNS validation (pending_validation) is a fresh
+	// platform-subdomain deploy. Leave broken/blocked/already-active sites
+	// untouched.
+	if website.Status != string(pluginDb.WebsiteStatusPendingValidation) {
+		return nil
 	}
 
 	if err := s.activateValidatedWebsite(ctx, &website); err != nil {

--- a/internal/service/website/website.go
+++ b/internal/service/website/website.go
@@ -2083,6 +2083,39 @@ func (s *WebsiteServiceDefault) NotifyAdminWebsiteCreated(ctx context.Context, w
 	return s.notifyAdminWebsiteCreated(ctx, &website)
 }
 
+// ActivatePlatformSubdomainWebsite activates a website whose primary domain
+// binding is a platform subdomain that has just been created. The platform
+// controls both ends of the DNS check for platform subdomains (no user
+// verification token exists), so a site awaiting DNS validation can move
+// straight to active once the binding is live — no external websites_validate
+// call is required. A blocked website is left unchanged by the FSM.
+func (s *WebsiteServiceDefault) ActivatePlatformSubdomainWebsite(ctx context.Context, websiteID uint) error {
+	ctx, span := core.TraceMethod(ctx, "WebsiteServiceDefault.ActivatePlatformSubdomainWebsite")
+	defer span.End()
+
+	var website pluginDb.Website
+	if err := s.DB().WithContext(ctx).First(&website, websiteID).Error; err != nil {
+		return fmt.Errorf("failed to load website %d: %w", websiteID, err)
+	}
+
+	primaryWD, err := s.primaryWebsiteDomain(ctx, &website)
+	if err != nil {
+		return fmt.Errorf("failed to resolve primary domain for website %d: %w", websiteID, err)
+	}
+	if primaryWD == nil || primaryWD.PlatformDomainID == nil {
+		domain := ""
+		if primaryWD != nil {
+			domain = primaryWD.Domain
+		}
+		return fmt.Errorf("website %d primary domain %q is not a platform subdomain", websiteID, domain)
+	}
+
+	if err := s.activateValidatedWebsite(ctx, &website); err != nil {
+		return fmt.Errorf("failed to activate platform subdomain website %d: %w", websiteID, err)
+	}
+	return nil
+}
+
 // notifyAdminWebsiteUpdated sends an email notification to admin when a website is updated
 func (s *WebsiteServiceDefault) notifyAdminWebsiteUpdated(ctx context.Context, website *pluginDb.Website, changes map[string]interface{}) error {
 	if !s.config.NotificationsEnabled || s.mailerSvc == nil {

--- a/internal/service/website/website_test.go
+++ b/internal/service/website/website_test.go
@@ -1889,6 +1889,35 @@ func TestWebsiteService_ActivatePlatformSubdomainWebsite_FlipsToActive(t *testin
 	}, TestOptions)
 }
 
+// TestWebsiteService_ActivatePlatformSubdomainWebsite_LeavesBrokenUntouched
+// proves a broken website is NOT auto-activated by a platform binding: a
+// binding change must not flip a site whose target is unpinned/invalid to
+// active without content verification.
+func TestWebsiteService_ActivatePlatformSubdomainWebsite_LeavesBrokenUntouched(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		db := ctx.DB()
+		websiteService := core.GetService[pluginCore.WebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
+
+		website := createTestIPFSWebsite(testUserID1, "broken-ridge-9.pinned.site", util.GenerateTestCID(t, "bad data").String())
+		website.Status = string(pluginDb.WebsiteStatusBroken)
+		require.NoError(tb, db.Create(website).Error)
+
+		pdID := uint(7)
+		wd := createTestWebsiteDomain(website.ID, "broken-ridge-9.pinned.site")
+		wd.Status = pluginDb.DomainStatusActive
+		wd.DNSHostingEnabled = true
+		wd.PlatformDomainID = &pdID
+		require.NoError(tb, db.Create(wd).Error)
+		require.NoError(tb, db.Model(&pluginDb.Website{ID: website.ID}).UpdateColumn("primary_domain_id", wd.ID).Error)
+
+		require.NoError(tb, websiteService.ActivatePlatformSubdomainWebsite(context.Background(), website.ID))
+
+		var persisted pluginDb.Website
+		require.NoError(tb, db.First(&persisted, website.ID).Error)
+		assert.Equal(tb, string(pluginDb.WebsiteStatusBroken), persisted.Status)
+	}, TestOptions)
+}
+
 func TestWebsiteService_CreateWebsite_DNSHostingDisabled_NoDNSOperations(t *testing.T) {
 	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 		// Arrange

--- a/internal/service/website/website_test.go
+++ b/internal/service/website/website_test.go
@@ -1868,13 +1868,16 @@ func TestWebsiteService_ActivatePlatformSubdomainWebsite_FlipsToActive(t *testin
 		db := ctx.DB()
 		websiteService := core.GetService[pluginCore.WebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
 
-		// A freshly deployed website awaiting DNS validation.
-		website := createTestIPFSWebsite(testUserID1, "dark-forest-7.pinned.site", util.GenerateTestCID(t, "site data").String())
+		// A freshly deployed website awaiting DNS validation. Its target is
+		// pinned (as CreateWebsite enforces), so the target check passes.
+		cid := util.GenerateTestCID(t, "site data")
+		stubPinnedCID(t, ctx, testUserID1, cid.String())
+		website := createTestIPFSWebsite(testUserID1, "platform-active.example.com", cid.String())
 		website.Status = string(pluginDb.WebsiteStatusPendingValidation)
 		require.NoError(tb, db.Create(website).Error)
 
 		pdID := uint(7)
-		wd := createTestWebsiteDomain(website.ID, "dark-forest-7.pinned.site")
+		wd := createTestWebsiteDomain(website.ID, "platform-active.example.com")
 		wd.Status = pluginDb.DomainStatusActive
 		wd.DNSHostingEnabled = true
 		wd.PlatformDomainID = &pdID
@@ -1898,12 +1901,12 @@ func TestWebsiteService_ActivatePlatformSubdomainWebsite_LeavesBrokenUntouched(t
 		db := ctx.DB()
 		websiteService := core.GetService[pluginCore.WebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
 
-		website := createTestIPFSWebsite(testUserID1, "broken-ridge-9.pinned.site", util.GenerateTestCID(t, "bad data").String())
+		website := createTestIPFSWebsite(testUserID1, "platform-broken.example.com", util.GenerateTestCID(t, "bad data").String())
 		website.Status = string(pluginDb.WebsiteStatusBroken)
 		require.NoError(tb, db.Create(website).Error)
 
 		pdID := uint(7)
-		wd := createTestWebsiteDomain(website.ID, "broken-ridge-9.pinned.site")
+		wd := createTestWebsiteDomain(website.ID, "platform-broken.example.com")
 		wd.Status = pluginDb.DomainStatusActive
 		wd.DNSHostingEnabled = true
 		wd.PlatformDomainID = &pdID
@@ -1915,6 +1918,41 @@ func TestWebsiteService_ActivatePlatformSubdomainWebsite_LeavesBrokenUntouched(t
 		var persisted pluginDb.Website
 		require.NoError(tb, db.First(&persisted, website.ID).Error)
 		assert.Equal(tb, string(pluginDb.WebsiteStatusBroken), persisted.Status)
+	}, TestOptions)
+}
+
+// TestWebsiteService_ActivatePlatformSubdomainWebsite_UnpinnedStaysPending
+// proves an unpinned target is not auto-activated: activation must not serve
+// content the portal does not have pinned, so the site stays pending_validation.
+func TestWebsiteService_ActivatePlatformSubdomainWebsite_UnpinnedStaysPending(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		db := ctx.DB()
+		websiteService := core.GetService[pluginCore.WebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
+
+		cidV := util.GenerateTestCID(t, "unpinned data")
+		// The target is not pinned: the pin lookup yields no pin.
+		mockPinSvc := core.GetService[*mocks.MockIPFSPinService](ctx, pluginCore.PIN_SERVICE)
+		mockPinSvc.EXPECT().
+			GetPinByCIDAndUser(mock.Anything, cid.MustParse(cidV.String()), testUserID1).
+			Return(nil, nil).Maybe()
+
+		website := createTestIPFSWebsite(testUserID1, "platform-unpinned.example.com", cidV.String())
+		website.Status = string(pluginDb.WebsiteStatusPendingValidation)
+		require.NoError(tb, db.Create(website).Error)
+
+		pdID := uint(7)
+		wd := createTestWebsiteDomain(website.ID, "platform-unpinned.example.com")
+		wd.Status = pluginDb.DomainStatusActive
+		wd.DNSHostingEnabled = true
+		wd.PlatformDomainID = &pdID
+		require.NoError(tb, db.Create(wd).Error)
+		require.NoError(tb, db.Model(&pluginDb.Website{ID: website.ID}).UpdateColumn("primary_domain_id", wd.ID).Error)
+
+		require.NoError(tb, websiteService.ActivatePlatformSubdomainWebsite(context.Background(), website.ID))
+
+		var persisted pluginDb.Website
+		require.NoError(tb, db.First(&persisted, website.ID).Error)
+		assert.Equal(tb, string(pluginDb.WebsiteStatusPendingValidation), persisted.Status)
 	}, TestOptions)
 }
 

--- a/internal/service/website/website_test.go
+++ b/internal/service/website/website_test.go
@@ -1858,6 +1858,37 @@ func TestWebsiteService_DeleteWebsite_PlatformSubdomain_OperatorApexAndZoneIntac
 	}, TestOptions)
 }
 
+// TestWebsiteService_ActivatePlatformSubdomainWebsite_FlipsToActive proves
+// that a website whose primary binding is a just-created platform subdomain is
+// activated without any external websites_validate call. The platform controls
+// both ends of the DNS check, so a pending site is safe to activate as soon as
+// the binding is live.
+func TestWebsiteService_ActivatePlatformSubdomainWebsite_FlipsToActive(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		db := ctx.DB()
+		websiteService := core.GetService[pluginCore.WebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
+
+		// A freshly deployed website awaiting DNS validation.
+		website := createTestIPFSWebsite(testUserID1, "dark-forest-7.pinned.site", util.GenerateTestCID(t, "site data").String())
+		website.Status = string(pluginDb.WebsiteStatusPendingValidation)
+		require.NoError(tb, db.Create(website).Error)
+
+		pdID := uint(7)
+		wd := createTestWebsiteDomain(website.ID, "dark-forest-7.pinned.site")
+		wd.Status = pluginDb.DomainStatusActive
+		wd.DNSHostingEnabled = true
+		wd.PlatformDomainID = &pdID
+		require.NoError(tb, db.Create(wd).Error)
+		require.NoError(tb, db.Model(&pluginDb.Website{ID: website.ID}).UpdateColumn("primary_domain_id", wd.ID).Error)
+
+		require.NoError(tb, websiteService.ActivatePlatformSubdomainWebsite(context.Background(), website.ID))
+
+		var activated pluginDb.Website
+		require.NoError(tb, db.First(&activated, website.ID).Error)
+		assert.Equal(tb, string(pluginDb.WebsiteStatusActive), activated.Status)
+	}, TestOptions)
+}
+
 func TestWebsiteService_CreateWebsite_DNSHostingDisabled_NoDNSOperations(t *testing.T) {
 	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 		// Arrange

--- a/internal/testing/mocks/MockWebsiteService.go
+++ b/internal/testing/mocks/MockWebsiteService.go
@@ -1568,6 +1568,63 @@ func (_c *MockWebsiteService_NotifyAdminWebsiteCreated_Call) RunAndReturn(run fu
 	return _c
 }
 
+// ActivatePlatformSubdomainWebsite provides a mock function for the type MockWebsiteService
+func (_mock *MockWebsiteService) ActivatePlatformSubdomainWebsite(ctx context.Context, websiteID uint) error {
+	ret := _mock.Called(ctx, websiteID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ActivatePlatformSubdomainWebsite")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uint) error); ok {
+		r0 = returnFunc(ctx, websiteID)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockWebsiteService_ActivatePlatformSubdomainWebsite_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ActivatePlatformSubdomainWebsite'
+type MockWebsiteService_ActivatePlatformSubdomainWebsite_Call struct {
+	*mock.Call
+}
+
+// ActivatePlatformSubdomainWebsite is a helper method to define mock.On call
+//   - ctx context.Context
+//   - websiteID uint
+func (_e *MockWebsiteService_Expecter) ActivatePlatformSubdomainWebsite(ctx any, websiteID any) *MockWebsiteService_ActivatePlatformSubdomainWebsite_Call {
+	return &MockWebsiteService_ActivatePlatformSubdomainWebsite_Call{Call: _e.mock.On("ActivatePlatformSubdomainWebsite", ctx, websiteID)}
+}
+
+func (_c *MockWebsiteService_ActivatePlatformSubdomainWebsite_Call) Run(run func(ctx context.Context, websiteID uint)) *MockWebsiteService_ActivatePlatformSubdomainWebsite_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 uint
+		if args[1] != nil {
+			arg1 = args[1].(uint)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockWebsiteService_ActivatePlatformSubdomainWebsite_Call) Return(err error) *MockWebsiteService_ActivatePlatformSubdomainWebsite_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockWebsiteService_ActivatePlatformSubdomainWebsite_Call) RunAndReturn(run func(ctx context.Context, websiteID uint) error) *MockWebsiteService_ActivatePlatformSubdomainWebsite_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // WaitForPublishes provides a mock function for the type MockWebsiteService
 func (_mock *MockWebsiteService) WaitForPublishes() {
 	_mock.Called()


### PR DESCRIPTION
Auto-activates a website when its primary domain binding is a freshly-created platform subdomain.

Platform subdomains are operator-controlled on both ends of the DNS check, so no user verification token or external `websites_validate` call is required. Previously the only transitions out of `pending_validation` were the client-driven `POST /websites/:id/validate` endpoint and the janitor, which deliberately skips pending sites — so a platform-subdomain deploy that skipped the validate step stayed stuck in `pending_validation` until the token expired.

Resolves the website service once at startup on the delegated-domain service and, after `createPlatformBinding` marks the binding active, fires the website FSM `EventWebsiteValidate` so the site is active immediately. Adds `WebsiteService.ActivatePlatformSubdomainWebsite` and covers it in the platform-subdomain happy-path test.

- `develop` <!-- branch-stack -->
  - **fix(website): auto-activate platform subdomain on deploy** :point\_left:

***

<!-- kody-pr-summary:start -->

This pull request implements automatic activation of websites when platform subdomains are created during deployment.

**Key changes:**

1. **New service method**: Added `ActivatePlatformSubdomainWebsite` to the website service interface that transitions a website from pending validation to active status when its primary domain binding is a platform subdomain.

2. **Automatic activation on binding creation**: When a platform subdomain binding is created during website deployment, the system now immediately activates the associated website. Previously, websites would remain in a pending validation state indefinitely because platform subdomains are fully controlled by the operator on both ends of the DNS check — no external validation is required.

3. **Service integration**: The delegated domain service now resolves the website service at startup and calls the activation method after creating platform subdomain bindings. If activation fails, the error is logged but doesn't block the binding creation process.

4. **Validation logic**: The new activation method verifies that the website's primary domain is indeed a platform subdomain before activating it. Blocked websites are left unchanged by system logic.

5. **Test coverage**: Updated tests confirm that websites are immediately activated when platform subdomains are created, without requiring external validation calls.

This fix resolves a deployment issue where websites using auto-generated platform subdomains would get stuck in a pending validation state indefinitely.

<!-- kody-pr-summary:end -->
