### PR TITLE
feat(domain): add HIP5 cross-chain on-chain managed domains

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	go.lumeweb.com/dane v0.0.3
 	go.lumeweb.com/httputil v0.5.8
 	go.lumeweb.com/ipfs-content v0.1.18
-	go.lumeweb.com/portal v0.5.2-0.20260829094141-1f089e7c5ab4
+	go.lumeweb.com/portal v0.5.2-0.20260901043913-d57a2e764d6b
 	go.lumeweb.com/portal-middleware v0.3.7
 	go.lumeweb.com/portal-plugin-core v0.1.0
 	go.lumeweb.com/portal-plugin-dashboard v0.3.1-0.20260815204120-fcf90d4324ee
@@ -89,6 +89,7 @@ require (
 	github.com/slok/go-http-metrics v0.13.0 // indirect
 	github.com/woodsbury/decimal128 v1.4.0 // indirect
 	github.com/x-cray/logrus-prefixed-formatter v0.5.2 // indirect
+	go.lumeweb.com/oauth v0.1.6 // indirect
 	go.opentelemetry.io/contrib/instrumentation/github.com/labstack/echo/otelecho v0.70.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.21.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.45.0 // indirect
@@ -113,21 +114,21 @@ require (
 	github.com/andybalholm/brotli v1.2.2 // indirect
 	github.com/aws/aws-sdk-go-v2 v1.45.1 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.19 // indirect
-	github.com/aws/aws-sdk-go-v2/config v1.32.39 // indirect
-	github.com/aws/aws-sdk-go-v2/credentials v1.19.39 // indirect
-	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.40 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.40 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.40 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.41 // indirect
+	github.com/aws/aws-sdk-go-v2/config v1.33.1 // indirect
+	github.com/aws/aws-sdk-go-v2/credentials v1.20.1 // indirect
+	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.19.1 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.5.1 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.8.1 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/v4a v1.5.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.19 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.32 // indirect
-	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.40 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.14.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.40 // indirect
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.107.4 // indirect
-	github.com/aws/aws-sdk-go-v2/service/signin v1.6.0 // indirect
-	github.com/aws/aws-sdk-go-v2/service/sso v1.34.0 // indirect
-	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.39.0 // indirect
-	github.com/aws/aws-sdk-go-v2/service/sts v1.46.0 // indirect
+	github.com/aws/aws-sdk-go-v2/service/signin v1.7.1 // indirect
+	github.com/aws/aws-sdk-go-v2/service/sso v1.35.1 // indirect
+	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.40.1 // indirect
+	github.com/aws/aws-sdk-go-v2/service/sts v1.47.1 // indirect
 	github.com/aws/smithy-go v1.28.1 // indirect
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/benbjohnson/clock v1.3.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -127,6 +127,8 @@ github.com/aws/aws-sdk-go-v2/config v1.32.38 h1:n4yPHBjtQ3BrIIUyk0/LAqf/BL2iv0Tw
 github.com/aws/aws-sdk-go-v2/config v1.32.38/go.mod h1:dencYsOS1R7rBy8zehCvwBYzdxxL4Q/nRK7In03wjN8=
 github.com/aws/aws-sdk-go-v2/config v1.32.39 h1:3TYUWYWawsE9KF02G3dA7vsbwoCphyGOpFFEUugRs/4=
 github.com/aws/aws-sdk-go-v2/config v1.32.39/go.mod h1:/lPP/ciQurgJa6l6mbBX+b5MB1qaLrC9dd3YHtGvrhk=
+github.com/aws/aws-sdk-go-v2/config v1.33.1 h1:bq9jze1hQ5YTCLoVxNnbp0T7rglrlOE7N9YsHqjGkEw=
+github.com/aws/aws-sdk-go-v2/config v1.33.1/go.mod h1:2A3HQwG4zaL5Tm80rc6RZj8LmWWv4WYT5v8raSz/L7A=
 github.com/aws/aws-sdk-go-v2/credentials v1.19.30 h1:TTCvvzFU6gXa4iJecNG/0F/B0oYTiazoRECr2XyLHrY=
 github.com/aws/aws-sdk-go-v2/credentials v1.19.30/go.mod h1:jKxAp2AEncnliinzpgOSZDFv6+VjvWhjw/AtbfsWT9U=
 github.com/aws/aws-sdk-go-v2/credentials v1.19.32 h1:eNE0JnIblBo1NCvd3tqEYuZz9XDefn69R74CHd3nT7U=
@@ -145,6 +147,8 @@ github.com/aws/aws-sdk-go-v2/credentials v1.19.38 h1:Xf8j1+vzwPRCta9pFXjj0677BzX
 github.com/aws/aws-sdk-go-v2/credentials v1.19.38/go.mod h1:PGYzFTznwRAJ2q0m+oX+P8SlfZQKpBAKQCokNuMl3Sg=
 github.com/aws/aws-sdk-go-v2/credentials v1.19.39 h1:XOg8LC3Kgnsa3WiPQjc7Bi8k5IBN92cPYfIV9XMFss0=
 github.com/aws/aws-sdk-go-v2/credentials v1.19.39/go.mod h1:GonTDBQ+mTpCVNwaHjj0PagspfrYYMEqOx7FehoEP/I=
+github.com/aws/aws-sdk-go-v2/credentials v1.20.1 h1:Z8GRNEx0u9sDkZOq4PUnN8mjGwbUQGRzMSXpvt3d8xQ=
+github.com/aws/aws-sdk-go-v2/credentials v1.20.1/go.mod h1:uBIK00kFo95dnemqfFMTWx0X8YRqsh6ecIoCjjOkZqM=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.31 h1:kfVL5wAunCJycL6MOQ6aNh6PlAYEymflcjuKmrWUA0o=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.31/go.mod h1:nWfRNDAppujCQgOUd43lKT4yeLv9z3nJ3bw1G3BgQKo=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.33 h1:MobhiR6KIerWxmO74Zit5I3379+mSc2DOdZ3DeRFB9w=
@@ -163,6 +167,8 @@ github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.39 h1:9GLrXl8PKQ3+bMniXFg3vl
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.39/go.mod h1:MmlE5TLgq7+QbXKKUSzqUz4h0Uu5kz2SEe6iPX+ZFHI=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.40 h1:r5aGipEVgI9aT/tAGjdrPbDQvIAKdTrS3rUPQtG4Rmo=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.40/go.mod h1:vOD3CnPxAdkL6MWZeROkZsTlskklMFfgVFkHzx/oZpY=
+github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.19.1 h1:YIEBqcqRnpi4Pfv0YHImtgi6czGCwKHANC7SwmUAVD0=
+github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.19.1/go.mod h1:imEf0oufgAo8KAkCHhrOdqGEC0YWx1PPBQH82shSxGw=
 github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.17.75 h1:S61/E3N01oral6B3y9hZ2E1iFDqCZPPOBoBQretCnBI=
 github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.17.75/go.mod h1:bDMQbkI1vJbNjnvJYpPTSNYBkI/VIv18ngWb/K84tkk=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.31 h1:Z8F3hfCY33IGpJjFAnv0wvtv1FIKj1GHmRDEYqy64tw=
@@ -183,6 +189,8 @@ github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.39 h1:YrEI22hVQcqMpq934
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.39/go.mod h1:N8qOX83LkaCeizvrfiNjwkBOXkxHt6a74CiZn8qz9F8=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.40 h1:UIXlbijuB2XK1Kr57fo8iIxCuaSHJzwZ1uo+2tbEYIk=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.40/go.mod h1:wcEsL6jscjZjVUinb0Q5qD/GXOG1yT3GNfmT9HuDwzU=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.5.1 h1:pc138gM1CW+XPc60rEwUlwwuwWFQK16CI1T7v1F9Oec=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.5.1/go.mod h1:1+koxpPIbfBdfzP6vojm5/zTpTQ/micYwlxIiNB3TxI=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.31 h1:hyOxUyXdh3AyjE93gBgsfziJag9ACwcs+ZpDBLzi8mw=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.31/go.mod h1:OERqI9k0draSLB8O8woxY3q25ZWTELRK4RRoLMuMZFo=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.33 h1:0YA0aCKgsJyno6xkFfaIgjE3/wK08+Qxo9nQfe1UrWM=
@@ -201,6 +209,8 @@ github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.39 h1:Vo7UZzBjB6zS6feEOu
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.39/go.mod h1:JgxtAO/77e95Rs9WMWUzz99hT182gqdAh7/DHuEMA/k=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.40 h1:xLQVRDs2NddDmK9BEyh5KSlJ1Gpy5/GIJXrV6WcVGAE=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.40/go.mod h1:XRXnpFVFGLaEVK+olDdFIM1vNa04ETW452oFGEPUxAo=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.8.1 h1:K0JsbZQj+1h208Ro1zHeA4l7bMp0NvRffHQ91q8Ol1s=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.8.1/go.mod h1:W3/vL6EtCIatICGy9ab29QhMuae+cOKPWcMxv02CO+Q=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.32 h1:0MrUL35H/Y4kdFfItoR5jCgtDQ4Z/8LudAoIHRfA4hE=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.32/go.mod h1:2tNZkuWz54arj8mHVf+8Y7cKkcD8Wr/fBpENgEXpjLc=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.34 h1:HQYnjFnXpX8EbPW5M1QT8mXzesRPwly0HEPTcFlS02Y=
@@ -219,6 +229,8 @@ github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.40 h1:oofDq8Y5M82fmDrxb8gsbP0LS73
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.40/go.mod h1:LSfLmbvx50+T+/DoUZRqB1qS38v7lvNUebqIpidAWYM=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.41 h1:nv/ILuCY0yXACzMQwvtt/HbqDDjemZiI0AeDbxGQlnU=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.41/go.mod h1:dzvOSpxaPqQ3j0xS6Lc1vyVuWW0RBj7s/QqYpzu3Q/0=
+github.com/aws/aws-sdk-go-v2/internal/v4a v1.5.1 h1:yhw5KD1phVyP9vijxOUzDfEtJx+bt+L63k+VfuiYFAA=
+github.com/aws/aws-sdk-go-v2/internal/v4a v1.5.1/go.mod h1:ZW2e0d7DYlRxlS9hEiMXE47gTdX5KRN4byUiNbUpG+Q=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.13 h1:mbRIur/BiHK6SKPjoBIXSE/hJ6g6JGRLuxQy1jGjlN4=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.13/go.mod h1:ITg9em2KbJx1s0y4aqRX5OYWG6HBZ5TVR//OdpEZ2CQ=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.14 h1:SA43nfaY7+1jjMNIc2ywu99JLJLButtIdLP6j+bT870=
@@ -267,6 +279,8 @@ github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.39 h1:inoUrqz4
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.39/go.mod h1:Yx+RrmAF+XGZTccwhQ3o4K5V8qkZBsTAcq148Y8g57k=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.40 h1:gr3Fw1cxZXNCdeo/lQ7isHEHzvHVM7z75qb2zW9aMjw=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.40/go.mod h1:8z/9CmfnQhiuXD7Ykbcg4a/whSWsniE0ODSx9uwVzfk=
+github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.14.1 h1:RmmWQPREQdk9U+PfqeHW3MqZaBaNK7TpV9W3RY+b+7g=
+github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.14.1/go.mod h1:0A3W4F+68ZnNk5XcNL/e9HFMwnP8RlEicFfy6eOEDyw=
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.32 h1:jWXtZdCnhXa9sGFixRaU2AxT4DIVse9HS4E2f+/KwV0=
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.32/go.mod h1:9JS1UpfVvyD/ZPX8GsKb/Pq8scEM+7GP5fqh9SwH7po=
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.34 h1:Lercr2QB2rOrCwyOusmnQ7IiopfkGcZAgMJbjcSdK/s=
@@ -321,6 +335,8 @@ github.com/aws/aws-sdk-go-v2/service/signin v1.5.8 h1:bghrxelVQpGurGI1X94BT68h6p
 github.com/aws/aws-sdk-go-v2/service/signin v1.5.8/go.mod h1:gkwdIl9w+6LFKlGRLz3+Dw+cudc9dD1ViMDhHGmzOgk=
 github.com/aws/aws-sdk-go-v2/service/signin v1.6.0 h1:agcr0j8YeFEzdXNo17Rg9MbbjLRjrimabwNtji4e+lU=
 github.com/aws/aws-sdk-go-v2/service/signin v1.6.0/go.mod h1:qU5PxgQ4JiUOOMotzfO3+5oUda5W+8JDVKyLQqlrJik=
+github.com/aws/aws-sdk-go-v2/service/signin v1.7.1 h1:mdMtSVKdQ3+mzBh+l0ogrFYZVQUCg6pJZOirA2ARsYE=
+github.com/aws/aws-sdk-go-v2/service/signin v1.7.1/go.mod h1:9IqUlsJDbUPcg6cgx3WEzXdjrbWzLDQrak0aaSqlTcI=
 github.com/aws/aws-sdk-go-v2/service/sso v1.33.0 h1:CaJyYhxBE0M/HJX/YvSaSmQlsI91VHB0lKU8LtLxL3A=
 github.com/aws/aws-sdk-go-v2/service/sso v1.33.0/go.mod h1:+e6BMRMPjBQoCw/WovYR9GLy2IU0z4Q77smOB1DraSg=
 github.com/aws/aws-sdk-go-v2/service/sso v1.33.2 h1:zMP1FDFE08L7sM5f1QqkH/ZgKKg8Uc0Dz7KhSSYqWkw=
@@ -339,6 +355,8 @@ github.com/aws/aws-sdk-go-v2/service/sso v1.33.8 h1:/DbiPZ8maO03uFnXa6yEhFdWOTA5
 github.com/aws/aws-sdk-go-v2/service/sso v1.33.8/go.mod h1:mUywXl2WlN+gZD0vNeg1Hn0EMOifDQ79StJcdqXHkXo=
 github.com/aws/aws-sdk-go-v2/service/sso v1.34.0 h1:FxaN8/sn61DTXNI6Gt678tFJUY8iUsCchm6Y/F/RjaA=
 github.com/aws/aws-sdk-go-v2/service/sso v1.34.0/go.mod h1:vu4OY6s8LJtT8BtYG2LD6BGSZMptkYn3o5hvCPB22jc=
+github.com/aws/aws-sdk-go-v2/service/sso v1.35.1 h1:B6WFn91tobD6gG4724ONHaqrpKsoETGnv98LHe/yIGM=
+github.com/aws/aws-sdk-go-v2/service/sso v1.35.1/go.mod h1:tWuiVBUtPBr8/rgRiYS8Uf85sHcAN+G7XS3D3CEoUh8=
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.38.0 h1:tC323YV77QdafeBr6LUhLDTsboyuyHLNRwAyCP44kGU=
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.38.0/go.mod h1:SfLK1sgviHmbI+MozR9iDwDjL4cdCVZtahsjoR+z7wg=
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.38.2 h1:9eTqUYl+SyVmaRPMyBXSO9wwqC6TRwZB82pKENK2hdQ=
@@ -357,6 +375,8 @@ github.com/aws/aws-sdk-go-v2/service/ssooidc v1.38.8 h1:wv4pCyq/LkBYc5R4m/g5S+uG
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.38.8/go.mod h1:9AKVT0vADSCPXRuoZjziHwsbdLDFMGRExwWBQourCa8=
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.39.0 h1:crWKPeGYTBTuBxQ3p73kjfJvt4brUIsr+Fuypko8FxY=
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.39.0/go.mod h1:HjjZVhaBz0JBR/kbWKThmNDhFKS7y6EURuk493tJk9Y=
+github.com/aws/aws-sdk-go-v2/service/ssooidc v1.40.1 h1:6yeYCWFvgbI2TI3K6jr9LtBNhXgJ7g4xqD+DEiaDDmM=
+github.com/aws/aws-sdk-go-v2/service/ssooidc v1.40.1/go.mod h1:naFe83jSMuYkH+QjQPX8n1MLhBkeCFM5Lsnh5m5wz3c=
 github.com/aws/aws-sdk-go-v2/service/sts v1.45.0 h1:Pd6PNlp4t8PTXxqzstICl52Wsy78vpjFZ7PRUj44mJc=
 github.com/aws/aws-sdk-go-v2/service/sts v1.45.0/go.mod h1:rmQ0TnHzuLPmabgjPcsywhsSOmaBDgzR4zvDxSPsGdg=
 github.com/aws/aws-sdk-go-v2/service/sts v1.45.2 h1:EJd8vZO3E8SE6nmPqxuxlQ1NeSb8as50sf6eGdV4Saw=
@@ -375,6 +395,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.45.8 h1:oQrmuqpBAExYPEPJp8dkj9KLmc0y
 github.com/aws/aws-sdk-go-v2/service/sts v1.45.8/go.mod h1:qNTXKrmzx2cC6VmM7PxHNasBMWKx3mfxgzcbVjcWVAU=
 github.com/aws/aws-sdk-go-v2/service/sts v1.46.0 h1:IZ63JdogSNNjex/jsODNv7jGDcO/xJYd9FsgyfCsp1g=
 github.com/aws/aws-sdk-go-v2/service/sts v1.46.0/go.mod h1:I+rwAf3spG5dITBaAo3xXRowk8kiOhtU1kYxfvCTC44=
+github.com/aws/aws-sdk-go-v2/service/sts v1.47.1 h1:Sv2xPnRHlThSUtVujYuUBPI/Il8si6UPHXL8DMiB/F0=
+github.com/aws/aws-sdk-go-v2/service/sts v1.47.1/go.mod h1:mKo/CzaCz8qytGW70NG4vIIGAx1HXTlb5lHNkC5k3lk=
 github.com/aws/smithy-go v1.27.4 h1:JQcphmBN4f0q/sPqXqROIItRNV/hy10cgu7CsFy616M=
 github.com/aws/smithy-go v1.27.4/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
 github.com/aws/smithy-go v1.27.5 h1:d1ro7KpYOYwP6m73YFa+Kc/A130VsAdX68SpsJwARMM=
@@ -1356,6 +1378,8 @@ go.lumeweb.com/ipfs-content v0.1.18 h1:Lq3/A+2kZcS4RK+bpdk+m4iJ95ZgpEa4DKhiH6bQW
 go.lumeweb.com/ipfs-content v0.1.18/go.mod h1:idWCsfndMDCsE5LtU0ZBNaFTBAaiuIe50dce0SDJLxw=
 go.lumeweb.com/ipfs-sdk/dnsname v0.1.64 h1:RTBD+zoXHOYYKreNRoQhyLLKKWp/VgYfr7qojCzKjww=
 go.lumeweb.com/ipfs-sdk/dnsname v0.1.64/go.mod h1:1++6EWMiG/BC5UQjlIobId2YcWDVHjHEhdsEzeISKpQ=
+go.lumeweb.com/oauth v0.1.6 h1:6c6LrXxMwx5klbq3OshzXjkGwvYVjAQhjX2FxCAgqqg=
+go.lumeweb.com/oauth v0.1.6/go.mod h1:Bfdxi1gkv+Ypj9yj9uOSmKnbZX8C7q7Pyn1OdPyuCbM=
 go.lumeweb.com/portal v0.5.2-0.20260724130026-d74f4f158e63 h1:vaHWpirPRR2dfzKFKDKi06sQVW2ECTtsvPMvZue4jhI=
 go.lumeweb.com/portal v0.5.2-0.20260724130026-d74f4f158e63/go.mod h1:dtgCsLBWhVS7Rsik+3LHzuNdLCbbDR5li6REsvpqDB8=
 go.lumeweb.com/portal v0.5.2-0.20260727130906-c632318fe632 h1:5Dp4xQr3vhb7o9/VvIm085tlXnw9FiUUdNal8ejTK7g=
@@ -1420,6 +1444,8 @@ go.lumeweb.com/portal v0.5.2-0.20260825214015-7e5ea80b95ce h1:Ew+MJyoSrCo6pOLR1V
 go.lumeweb.com/portal v0.5.2-0.20260825214015-7e5ea80b95ce/go.mod h1:0Q4fboX31D/7vn6uq4hI8mQv8n4j92FUvTKnQQXHiGk=
 go.lumeweb.com/portal v0.5.2-0.20260829094141-1f089e7c5ab4 h1:aQwEieP/OHTjf/A2wpxRvB/VuiRypFl+FfBy7j7lM3Q=
 go.lumeweb.com/portal v0.5.2-0.20260829094141-1f089e7c5ab4/go.mod h1:rtB9peWTa5gZmNq7KKiEc6qY9dDBu5jcdNPrvN72XDo=
+go.lumeweb.com/portal v0.5.2-0.20260901043913-d57a2e764d6b h1:+NL7fhAOQexkahMf/EzZOf3AjMpReBJVcZQ+bh0+h0Q=
+go.lumeweb.com/portal v0.5.2-0.20260901043913-d57a2e764d6b/go.mod h1:GuwmIAOiYwRIZoPXjLihG0WmazKF2L7gcUioqzbFrQk=
 go.lumeweb.com/portal-middleware v0.3.7 h1:kq4SZq4T/uhauqHehw2JaTbNJpPpE8/EQAC3R737H7c=
 go.lumeweb.com/portal-middleware v0.3.7/go.mod h1:Yn9ZsFy5n3x2jUJ085M9B/aoZ+ANQV5QD/MAE0BpJXo=
 go.lumeweb.com/portal-plugin-core v0.1.0 h1:bHHJ7oZrBKmBvdUFutr3Dx6FdwvSg/ZeF33QaRM0DKU=

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -14,8 +14,8 @@ import (
 	"github.com/ipld/go-car/v2"
 	"github.com/labstack/echo/v4"
 	"github.com/tus/tusd/v2/pkg/handler"
-	portalMw "go.lumeweb.com/portal-middleware/middleware"
 	"go.lumeweb.com/portal-middleware/auth/jwt"
+	portalMw "go.lumeweb.com/portal-middleware/middleware"
 	pluginCore "go.lumeweb.com/portal-plugin-ipfs/core"
 	"go.lumeweb.com/portal-plugin-ipfs/internal"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/api/dto"
@@ -40,22 +40,22 @@ const TUS_HTTP_ROUTE = "/api/upload/tus"
 
 type API struct {
 	*core.BaseComponent
-	coreUploadService     core.UploadService
-	uploadService         pluginCore.UploadService
-	pinService            pluginCore.IPFSPinService
-	blockService          pluginCore.BlockService
-	fileManagerService    pluginCore.FileManagerService
-	workflowService       core.WorkflowService
-	ipnsKeyService        pluginCore.IPNSKeyService
-	websiteService        pluginCore.WebsiteService
-	delegatedDomainSvc    *domain.DelegatedDomainService
-	dnsService            pluginCore.DNSService
-	dnsConfig            *pluginConfig.DnsConfig
-	tusService           core.TUSService
-	requestService       core.RequestService
-	tus                  core.TusHandler
-	ipfs                 protocol.ProtoNode
-	sse                  *sseState
+	coreUploadService  core.UploadService
+	uploadService      pluginCore.UploadService
+	pinService         pluginCore.IPFSPinService
+	blockService       pluginCore.BlockService
+	fileManagerService pluginCore.FileManagerService
+	workflowService    core.WorkflowService
+	ipnsKeyService     pluginCore.IPNSKeyService
+	websiteService     pluginCore.WebsiteService
+	delegatedDomainSvc *domain.DelegatedDomainService
+	dnsService         pluginCore.DNSService
+	dnsConfig          *pluginConfig.DnsConfig
+	tusService         core.TUSService
+	requestService     core.RequestService
+	tus                core.TusHandler
+	ipfs               protocol.ProtoNode
+	sse                *sseState
 }
 
 func NewAPI() (core.API, []core.ContextBuilderOption, error) {
@@ -244,7 +244,7 @@ See also: GET /pins (list pins), GET /pins/{id} (get pin details)`),
 				router.WithTags("Pinning"),
 				router.WithRequestBody(&dto.PinRequest{}, "Pin object", true),
 				router.WithSuccessResponse(http.StatusAccepted, "Successful response", router.WithJSONContent(dto.PinStatusResponse{})),
-			router.WithoutDefaultSuccessResponse(),
+				router.WithoutDefaultSuccessResponse(),
 			),
 		),
 		router.NewRoute(http.MethodGet, "/pins/:requestid", a.getPin,
@@ -274,7 +274,7 @@ See also:.*`),
 				router.WithPathParam("requestid", "Unique identifier for the pin operation. Example: bafkreiexample", ""),
 				router.WithRequestBody(&dto.PinRequest{}, "Pin object", true),
 				router.WithSuccessResponse(http.StatusAccepted, "Successful response", router.WithJSONContent(dto.PinStatusResponse{})),
-			router.WithoutDefaultSuccessResponse(),
+				router.WithoutDefaultSuccessResponse(),
 			),
 		),
 		router.NewRoute(http.MethodDelete, "/pins/:requestid", a.deletePin,
@@ -289,7 +289,7 @@ See also:.*`),
 				router.WithTags("Pinning"),
 				router.WithPathParam("requestid", "Unique identifier for the pin operation. Example: bafkreiexample", ""),
 				router.WithSuccessResponse(http.StatusAccepted, "Successful response"),
-			router.WithoutDefaultSuccessResponse(),
+				router.WithoutDefaultSuccessResponse(),
 			),
 		),
 		router.NewRoute(http.MethodOptions, "/pins", a.handlePinOptions,
@@ -554,7 +554,7 @@ See also:.*`),
 				router.WithTags("IPNS"),
 				router.WithRequestBody(&dto.IPNSKeyRequest{}, "IPNS key request", true),
 				router.WithSuccessResponse(http.StatusCreated, "IPNS key created", router.WithJSONContent(dto.IPNSKeyResponse{})),
-			router.WithoutDefaultSuccessResponse(),
+				router.WithoutDefaultSuccessResponse(),
 			),
 		),
 		router.NewRoute(http.MethodGet, "/ipns/keys", a.listIPNSKeys,
@@ -596,7 +596,7 @@ See also:.*`),
 				router.WithTags("IPNS"),
 				router.WithPathParam("id", "Numeric ID of the IPNS key. Example: 123", ""),
 				router.WithSuccessResponse(http.StatusNoContent, "IPNS key deleted"),
-			router.WithoutDefaultSuccessResponse(),
+				router.WithoutDefaultSuccessResponse(),
 			),
 		),
 	)
@@ -673,7 +673,7 @@ See also:.*`),
 				router.WithTags("Websites"),
 				router.WithRequestBody(&dto.WebsiteRequest{}, "Website request", true),
 				router.WithSuccessResponse(http.StatusCreated, "Website created", router.WithJSONContent(dto.WebsiteResponse{})),
-			router.WithoutDefaultSuccessResponse(),
+				router.WithoutDefaultSuccessResponse(),
 				router.WithErrorResponses(router.DefineSwaggerErrorResponses(
 					DefineErrorResponse(http.StatusBadRequest, "Invalid request body or validation error"),
 					DefineErrorResponse(http.StatusGone, "Website target content is broken"),
@@ -701,9 +701,9 @@ See also:.*`),
 					DefineErrorResponse(http.StatusUnauthorized, "Authentication required"),
 					DefineErrorResponse(http.StatusInternalServerError, "Internal server error occurred"),
 				)),
-				),
 			),
-				router.NewRoute(http.MethodGet, "/websites/:id", a.getWebsite,
+		),
+		router.NewRoute(http.MethodGet, "/websites/:id", a.getWebsite,
 			router.WithAccess(core.ACCESS_USER_ROLE),
 			router.WithSwagger(
 				router.WithSummary("Get website"),
@@ -756,7 +756,7 @@ See also:.*`),
 				router.WithTags("Websites"),
 				router.WithPathParam("id", "Website ID", ""),
 				router.WithSuccessResponse(http.StatusNoContent, "Website deleted"),
-			router.WithoutDefaultSuccessResponse(),
+				router.WithoutDefaultSuccessResponse(),
 			),
 		),
 		router.NewRoute(http.MethodPost, "/websites/:id/validate", a.validateWebsiteDNS,
@@ -824,7 +824,7 @@ See also:.*`),
 				router.WithPathParam("id", "Website ID", ""),
 				router.WithPathParam("domain_id", "Domain ID", ""),
 				router.WithSuccessResponse(http.StatusNoContent, "Domain deleted"),
-			router.WithoutDefaultSuccessResponse(),
+				router.WithoutDefaultSuccessResponse(),
 			),
 		),
 		router.NewRoute(http.MethodPost, "/websites/:id/domains/:domain_id/verify", a.verifyDomain,
@@ -866,6 +866,17 @@ See also:.*`),
 				router.WithPathParam("id", "Website ID", ""),
 				router.WithPathParam("domain_id", "Domain ID", ""),
 				router.WithSuccessResponse(http.StatusOK, "Domain DNS requirements", router.WithJSONContent(dto.DomainResponse{})),
+			),
+		),
+		router.NewRoute(http.MethodPost, "/websites/:id/domains/:domain_id/onchain", a.convertDomainToOnChain,
+			router.WithAccess(core.ACCESS_USER_ROLE),
+			router.WithSwagger(
+				router.WithSummary("Reclassify domain as on-chain managed"),
+				router.WithDescription(`Reclassifies a bound domain as on-chain managed (e.g. a Handshake HIP-5 name whose NS now points at an external contract). Deletes the portal-managed PowerDNS zone and DNSSEC for the binding and switches ownership verification to the TXT token; DANE/SSL state is retained. One-way.`),
+				router.WithTags("Websites", "Domains"),
+				router.WithPathParam("id", "Website ID", ""),
+				router.WithPathParam("domain_id", "Domain ID", ""),
+				router.WithSuccessResponse(http.StatusOK, "Converted domain", router.WithJSONContent(dto.DomainResponse{})),
 			),
 		),
 		router.NewRoute(http.MethodPost, "/websites/:id/domains/:domain_id/dane/republish", a.republishDomainDANE,
@@ -918,7 +929,7 @@ See also:.*`),
 				router.WithTags("DNS", "Zones"),
 				router.WithRequestBody(&dto.ZoneRequest{}, "Zone request", true),
 				router.WithSuccessResponse(http.StatusCreated, "Zone created", router.WithJSONContent(dto.ZoneResponse{})),
-			router.WithoutDefaultSuccessResponse(),
+				router.WithoutDefaultSuccessResponse(),
 			),
 		),
 		router.NewRoute(http.MethodGet, "/dns/zones", a.listZones,
@@ -975,7 +986,7 @@ See also:.*`),
 				router.WithTags("DNS", "Zones"),
 				router.WithPathParam("id", "Zone ID", ""),
 				router.WithSuccessResponse(http.StatusNoContent, "Zone deleted"),
-			router.WithoutDefaultSuccessResponse(),
+				router.WithoutDefaultSuccessResponse(),
 			),
 		),
 		router.NewRoute(http.MethodPost, "/dns/zones/:id/validate", a.validateZone,
@@ -1049,7 +1060,7 @@ See also:.*`),
 				router.WithPathParam("id", "Zone ID", ""),
 				router.WithRequestBody(&dto.RecordRequest{}, "Record request", true),
 				router.WithSuccessResponse(http.StatusCreated, "Record created", router.WithJSONContent(dto.RecordResponse{})),
-			router.WithoutDefaultSuccessResponse(),
+				router.WithoutDefaultSuccessResponse(),
 			),
 		),
 		router.NewRoute(http.MethodPut, "/dns/zones/:id/records/:name/:type", a.updateRecord,
@@ -1084,7 +1095,7 @@ See also:.*`),
 				router.WithPathParam("type", "Record type (A, AAAA, CNAME, TXT, etc.)", ""),
 				router.WithRequestBody(&dto.RecordDeleteRequest{}, "Optional content selector: when set, only the record with this content is deleted; when the body is absent the whole RRSet is deleted, and a present body with empty content is rejected", false),
 				router.WithSuccessResponse(http.StatusNoContent, "Record deleted"),
-			router.WithoutDefaultSuccessResponse(),
+				router.WithoutDefaultSuccessResponse(),
 			),
 		),
 		router.NewRoute(http.MethodPost, "/dns/zones/:id/records/bulk", a.bulkRecords,
@@ -1349,7 +1360,7 @@ See also:.*`),
 	)
 
 	if err := router.RegisterRoutes(r, accessSvc, a.Subdomain(), internalSSLStatusRoutes,
-		router.WithMiddlewares(gatewayAuthMw),  // Use gateway auth, not user auth
+		router.WithMiddlewares(gatewayAuthMw), // Use gateway auth, not user auth
 		router.WithCors()); err != nil {
 		return fmt.Errorf("failed to register internal SSL status routes: %w", err)
 	}

--- a/internal/api/api_domains.go
+++ b/internal/api/api_domains.go
@@ -603,6 +603,57 @@ func (a *API) republishDomainDANE(c echo.Context) error {
 	return httputil.EncodeResponse(ctx, &wd, &resp)
 }
 
+// convertDomainToOnChain converts a bound domain to on-chain managed (HIP-5),
+// the explicit one-way transition for an HNS name whose NS now points at an
+// external contract. It is destructive to the portal's PowerDNS state for that
+// binding (the managed zone is deleted) but deliberately keeps the domain's
+// DANE/SSL state (ProtocolData), which still applies on-chain.
+func (a *API) convertDomainToOnChain(c echo.Context) error {
+	ctx := httputil.Context(c)
+	reqCtx := ctx.Context.Request().Context()
+
+	userID, err := mcontext.GetUserID(c)
+	if err != nil {
+		return ctx.Error(err, http.StatusUnauthorized)
+	}
+
+	websiteID, err := strconv.ParseUint(c.Param("id"), 10, 64)
+	if err != nil {
+		apiErr := NewError(ErrKeyInvalidPathID, errors.New("invalid website ID"))
+		return ctx.Error(apiErr, apiErr.HttpStatus())
+	}
+
+	domainID, err := strconv.ParseUint(c.Param("domain_id"), 10, 64)
+	if err != nil {
+		apiErr := NewError(ErrKeyInvalidPathID, errors.New("invalid domain ID"))
+		return ctx.Error(apiErr, apiErr.HttpStatus())
+	}
+
+	if a.delegatedDomainSvc == nil {
+		apiErr := NewError(ErrKeyFileProcessingFailed, fmt.Errorf("domain service not available"))
+		return ctx.Error(apiErr, apiErr.HttpStatus())
+	}
+
+	wd, err := a.delegatedDomainSvc.ConvertToOnChain(reqCtx, uint(websiteID), userID, uint(domainID))
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			apiErr := NewError(ErrKeyDomainNotFound, errors.New("domain not found"))
+			return ctx.Error(apiErr, apiErr.HttpStatus())
+		}
+		// Refusals (already on-chain, not yet on-chain, shared zone) are
+		// user-correctable state conflicts, surfaced as 422 — never a 500.
+		apiErr := NewError(ErrKeyInvalidRequest, err)
+		return ctx.Error(apiErr, apiErr.HttpStatus())
+	}
+
+	resp := dto.DomainResponse{}
+	if err := resp.FromModel(wd); err != nil {
+		apiErr := NewError(ErrKeyFileProcessingFailed, err)
+		return ctx.Error(apiErr, apiErr.HttpStatus())
+	}
+	return ctx.JSON(http.StatusOK, &resp)
+}
+
 // checkPlatformDomainAvailability returns, for the given label, whether it is
 // claimable on each enabled platform root. Auth-only (per-user rate limiting is
 // enforced by the auth middleware); it only ever probes platform roots, never

--- a/internal/api/api_domains.go
+++ b/internal/api/api_domains.go
@@ -12,6 +12,7 @@ import (
 	mcontext "go.lumeweb.com/portal-middleware/context"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/api/dto"
 	pluginDb "go.lumeweb.com/portal-plugin-ipfs/internal/db"
+	"go.lumeweb.com/portal-plugin-ipfs/internal/service/domain"
 	"go.lumeweb.com/queryutil"
 	queryutilHttp "go.lumeweb.com/queryutil/http"
 	"go.uber.org/zap"
@@ -640,10 +641,20 @@ func (a *API) convertDomainToOnChain(c echo.Context) error {
 			apiErr := NewError(ErrKeyDomainNotFound, errors.New("domain not found"))
 			return ctx.Error(apiErr, apiErr.HttpStatus())
 		}
-		// Refusals (already on-chain, not yet on-chain, shared zone) are
-		// user-correctable state conflicts, surfaced as 422 — never a 500.
-		apiErr := NewError(ErrKeyInvalidRequest, err)
-		return ctx.Error(apiErr, apiErr.HttpStatus())
+		// User-correctable state conflicts (already on-chain, not yet on-chain,
+		// shared zone) are 422. Anything else is an infrastructure failure
+		// (DB/DNS service) and must be a 500, not a validation error.
+		switch {
+		case errors.Is(err, domain.ErrDomainAlreadyOnChain),
+			errors.Is(err, domain.ErrDomainNotOnChain),
+			errors.Is(err, domain.ErrDomainZoneShared):
+			apiErr := NewError(ErrKeyInvalidRequest, err)
+			return ctx.Error(apiErr, apiErr.HttpStatus())
+		default:
+			a.Logger().Error("Failed to convert domain on-chain", zap.Error(err))
+			apiErr := NewError(ErrKeyFileProcessingFailed, fmt.Errorf("failed to convert domain on-chain"))
+			return ctx.Error(apiErr, apiErr.HttpStatus())
+		}
 	}
 
 	resp := dto.DomainResponse{}

--- a/internal/api/api_domains.go
+++ b/internal/api/api_domains.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -366,42 +367,82 @@ func (a *API) verifyDomain(c echo.Context) error {
 	return httputil.EncodeResponse(ctx, &wd, &resp)
 }
 
-// domainDNSRequirements returns the DNS delegation requirements (DS/NS/GLUE/TLSA
-// parent + authoritative records) for a bound domain so a client can render
-// DNS/DNSSEC setup guidance after binding. It reuses the same typed
-// DomainResponse as create/verify so clients share one renderer.
-func (a *API) domainDNSRequirements(c echo.Context) error {
-	ctx := httputil.Context(c)
-	reqCtx := ctx.Context.Request().Context()
+// domainPathParams carries the request context and the authenticated user +
+// website/domain path IDs shared by every /websites/:id/domains/:domain_id
+// handler. When err is non-nil the handler must return it immediately: the
+// 401/400 response has already been written.
+type domainPathParams struct {
+	ctx       httputil.RequestContext
+	reqCtx    context.Context
+	userID    uint
+	websiteID uint
+	domainID  uint
+	err       error
+}
 
-	userID, err := mcontext.GetUserID(c)
-	if err != nil {
-		return ctx.Error(err, http.StatusUnauthorized)
+// parseDomainPath resolves the authenticated user and the :id/:domain_id path
+// parameters common to all per-domain handlers, writing the 401/400 response
+// on failure (returned as params.err for the handler to return).
+func (a *API) parseDomainPath(c echo.Context) domainPathParams {
+	p := domainPathParams{ctx: httputil.Context(c)}
+	p.reqCtx = p.ctx.Context.Request().Context()
+
+	p.userID, p.err = mcontext.GetUserID(c)
+	if p.err != nil {
+		p.err = p.ctx.Error(p.err, http.StatusUnauthorized)
+		return p
 	}
 
 	websiteID, err := strconv.ParseUint(c.Param("id"), 10, 64)
 	if err != nil {
 		apiErr := NewError(ErrKeyInvalidPathID, errors.New("invalid website ID"))
-		return ctx.Error(apiErr, apiErr.HttpStatus())
+		p.err = p.ctx.Error(apiErr, apiErr.HttpStatus())
+		return p
 	}
-
 	domainID, err := strconv.ParseUint(c.Param("domain_id"), 10, 64)
 	if err != nil {
 		apiErr := NewError(ErrKeyInvalidPathID, errors.New("invalid domain ID"))
-		return ctx.Error(apiErr, apiErr.HttpStatus())
+		p.err = p.ctx.Error(apiErr, apiErr.HttpStatus())
+		return p
 	}
+	p.websiteID = uint(websiteID)
+	p.domainID = uint(domainID)
+	return p
+}
 
+// loadDomainBinding loads the WebsiteDomain row for the authenticated user at
+// the parsed path, writing the 404/500 response on failure (returned as a
+// non-nil error the handler must return).
+func (a *API) loadDomainBinding(p *domainPathParams) (pluginDb.WebsiteDomain, error) {
 	var wd pluginDb.WebsiteDomain
-	if err := a.DB().WithContext(reqCtx).
-		Where("id = ? AND website_id = ? AND user_id = ?", domainID, websiteID, userID).
-		First(&wd).Error; err != nil {
+	err := a.DB().WithContext(p.reqCtx).
+		Where("id = ? AND website_id = ? AND user_id = ?", p.domainID, p.websiteID, p.userID).
+		First(&wd).Error
+	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			apiErr := NewError(ErrKeyDomainNotFound, errors.New("domain not found"))
-			return ctx.Error(apiErr, apiErr.HttpStatus())
+			return wd, p.ctx.Error(apiErr, apiErr.HttpStatus())
 		}
 		apiErr := NewError(ErrKeyFileProcessingFailed, err)
-		return ctx.Error(apiErr, apiErr.HttpStatus())
+		return wd, p.ctx.Error(apiErr, apiErr.HttpStatus())
 	}
+	return wd, nil
+}
+
+// domainDNSRequirements returns the DNS delegation requirements (DS/NS/GLUE/TLSA
+// parent + authoritative records) for a bound domain so a client can render
+// DNS/DNSSEC setup guidance after binding. It reuses the same typed
+// DomainResponse as create/verify so clients share one renderer.
+func (a *API) domainDNSRequirements(c echo.Context) error {
+	p := a.parseDomainPath(c)
+	if p.err != nil {
+		return p.err
+	}
+	wd, err := a.loadDomainBinding(&p)
+	if err != nil {
+		return err
+	}
+	ctx, reqCtx := p.ctx, p.reqCtx
 
 	resp := dto.DomainResponse{}
 	if err := resp.FromModel(&wd); err != nil {
@@ -510,37 +551,15 @@ func removeDSRecord(records []dto.DNSDelegationRecord) []dto.DNSDelegationRecord
 // RRset (PowerDNS REPLACE). This is the operator's escape hatch for a TLSA
 // that was deleted or went missing and won't be re-triggered by cert renewal.
 func (a *API) republishDomainDANE(c echo.Context) error {
-	ctx := httputil.Context(c)
-	reqCtx := ctx.Context.Request().Context()
-
-	userID, err := mcontext.GetUserID(c)
+	p := a.parseDomainPath(c)
+	if p.err != nil {
+		return p.err
+	}
+	wd, err := a.loadDomainBinding(&p)
 	if err != nil {
-		return ctx.Error(err, http.StatusUnauthorized)
+		return err
 	}
-
-	websiteID, err := strconv.ParseUint(c.Param("id"), 10, 64)
-	if err != nil {
-		apiErr := NewError(ErrKeyInvalidPathID, errors.New("invalid website ID"))
-		return ctx.Error(apiErr, apiErr.HttpStatus())
-	}
-
-	domainID, err := strconv.ParseUint(c.Param("domain_id"), 10, 64)
-	if err != nil {
-		apiErr := NewError(ErrKeyInvalidPathID, errors.New("invalid domain ID"))
-		return ctx.Error(apiErr, apiErr.HttpStatus())
-	}
-
-	var wd pluginDb.WebsiteDomain
-	if err := a.DB().WithContext(reqCtx).
-		Where("id = ? AND website_id = ? AND user_id = ?", domainID, websiteID, userID).
-		First(&wd).Error; err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			apiErr := NewError(ErrKeyDomainNotFound, errors.New("domain not found"))
-			return ctx.Error(apiErr, apiErr.HttpStatus())
-		}
-		apiErr := NewError(ErrKeyFileProcessingFailed, err)
-		return ctx.Error(apiErr, apiErr.HttpStatus())
-	}
+	ctx, reqCtx := p.ctx, p.reqCtx
 
 	if a.delegatedDomainSvc == nil {
 		apiErr := NewError(ErrKeyFileProcessingFailed, fmt.Errorf("domain service not available"))
@@ -610,32 +629,18 @@ func (a *API) republishDomainDANE(c echo.Context) error {
 // binding (the managed zone is deleted) but deliberately keeps the domain's
 // DANE/SSL state (ProtocolData), which still applies on-chain.
 func (a *API) convertDomainToOnChain(c echo.Context) error {
-	ctx := httputil.Context(c)
-	reqCtx := ctx.Context.Request().Context()
-
-	userID, err := mcontext.GetUserID(c)
-	if err != nil {
-		return ctx.Error(err, http.StatusUnauthorized)
+	p := a.parseDomainPath(c)
+	if p.err != nil {
+		return p.err
 	}
-
-	websiteID, err := strconv.ParseUint(c.Param("id"), 10, 64)
-	if err != nil {
-		apiErr := NewError(ErrKeyInvalidPathID, errors.New("invalid website ID"))
-		return ctx.Error(apiErr, apiErr.HttpStatus())
-	}
-
-	domainID, err := strconv.ParseUint(c.Param("domain_id"), 10, 64)
-	if err != nil {
-		apiErr := NewError(ErrKeyInvalidPathID, errors.New("invalid domain ID"))
-		return ctx.Error(apiErr, apiErr.HttpStatus())
-	}
+	ctx, reqCtx, userID := p.ctx, p.reqCtx, p.userID
 
 	if a.delegatedDomainSvc == nil {
 		apiErr := NewError(ErrKeyFileProcessingFailed, fmt.Errorf("domain service not available"))
 		return ctx.Error(apiErr, apiErr.HttpStatus())
 	}
 
-	wd, err := a.delegatedDomainSvc.ConvertToOnChain(reqCtx, uint(websiteID), userID, uint(domainID))
+	wd, err := a.delegatedDomainSvc.ConvertToOnChain(reqCtx, p.websiteID, userID, p.domainID)
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			apiErr := NewError(ErrKeyDomainNotFound, errors.New("domain not found"))

--- a/internal/api/api_domains_test.go
+++ b/internal/api/api_domains_test.go
@@ -639,3 +639,95 @@ func mustIssueTestCert(t testing.TB, _ string, domain string) string {
 	}
 	return certPEM
 }
+
+func TestAPI_DomainDNSRequirements_OnchainManaged(t *testing.T) {
+	// An on-chain managed (HIP-5) binding has no portal delegation: dns-
+	// requirements must report no delegation and no DNSSEC, and the hosting flag
+	// must be false, so clients render the on-chain explanation rather than
+	// NS/DS setup guidance.
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		helper := newMockHelper(t, ctx)
+		token, userID, testCID, _ := helper.SetupAuthenticatedTest()
+
+		website := createTestIPFSGatewayWebsite(1, userID, "example.com", testCID, pluginDb.WebsiteStatusActive)
+		require.NoError(t, ctx.DB().Create(website).Error)
+
+		wd := &pluginDb.WebsiteDomain{
+			WebsiteID:         1,
+			UserID:            userID,
+			Domain:            "onchain",
+			Namespace:         pluginDb.DomainNamespaceHNS,
+			Status:            pluginDb.DomainStatusOnchainManaged,
+			DNSHostingEnabled: false,
+		}
+		require.NoError(t, ctx.DB().Create(wd).Error)
+
+		rec := helper.makeAuthenticatedRequest(http.MethodGet, "/api/websites/1/domains/1/dns-requirements", token, nil)
+		require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+
+		var resp dto.DomainResponse
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+		assert.Equal(t, "onchain", resp.Domain)
+		assert.Equal(t, string(pluginDb.DomainStatusOnchainManaged), resp.Status)
+		assert.False(t, resp.DNSHostingEnabled)
+		assert.Nil(t, resp.Delegation, "on-chain managed domains have no portal delegation/NS-DS guidance")
+	}, TestOptions)
+}
+
+func TestAPI_ConvertDomainToOnChain(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		helper := newMockHelper(t, ctx)
+		token, userID, testCID, _ := helper.SetupAuthenticatedTest()
+
+		website := createTestIPFSGatewayWebsite(1, userID, "example.com", testCID, pluginDb.WebsiteStatusActive)
+		require.NoError(t, ctx.DB().Create(website).Error)
+
+		createBinding := func(domain string, status pluginDb.DomainStatus, zoneID uint) *pluginDb.WebsiteDomain {
+			wd := &pluginDb.WebsiteDomain{
+				WebsiteID: 1,
+				UserID:    userID,
+				Domain:    domain,
+				Namespace: pluginDb.DomainNamespaceHNS,
+				Status:    status,
+			}
+			if zoneID != 0 {
+				wd.ZoneID = zoneID
+				wd.GatewayHost = "1.2.3.4"
+				wd.DNSHostingEnabled = true
+				wd.DelegationData = datatypes.JSONMap{"mode": "delegated"}
+			}
+			require.NoError(t, ctx.DB().Create(wd).Error)
+			return wd
+		}
+
+		native := createBinding("native", pluginDb.DomainStatusRecordsGenerated, 5)
+		onchainBinding := createBinding("onchain", pluginDb.DomainStatusOnchainManaged, 0)
+
+		t.Run("refuses_when_not_onchain", func(t *testing.T) {
+			// A native binding whose NS still points at the portal must NOT be
+			// converted: the zone and delegation stay intact.
+			rec := helper.makeAuthenticatedRequest(http.MethodPost, "/api/websites/1/domains/1/onchain", token, nil)
+			require.Equal(t, http.StatusUnprocessableEntity, rec.Code, "body: %s", rec.Body.String())
+			assert.Contains(t, rec.Body.String(), "not yet on-chain managed")
+
+			var persisted pluginDb.WebsiteDomain
+			require.NoError(t, ctx.DB().First(&persisted, native.ID).Error)
+			assert.Equal(t, pluginDb.DomainStatusRecordsGenerated, persisted.Status)
+			assert.Equal(t, uint(5), persisted.ZoneID)
+			require.NotNil(t, persisted.DelegationData)
+		})
+
+		t.Run("refuses_when_already_onchain", func(t *testing.T) {
+			rec := helper.makeAuthenticatedRequest(http.MethodPost, "/api/websites/1/domains/2/onchain", token, nil)
+			require.Equal(t, http.StatusUnprocessableEntity, rec.Code, "body: %s", rec.Body.String())
+			assert.Contains(t, rec.Body.String(), "already on-chain managed")
+		})
+
+		t.Run("not_found", func(t *testing.T) {
+			rec := helper.makeAuthenticatedRequest(http.MethodPost, "/api/websites/1/domains/999/onchain", token, nil)
+			require.Equal(t, http.StatusNotFound, rec.Code, "body: %s", rec.Body.String())
+		})
+
+		_ = onchainBinding // already-on-chain guard exercised above
+	}, TestOptions)
+}

--- a/internal/config/dns.go
+++ b/internal/config/dns.go
@@ -52,6 +52,12 @@ type DnsConfig struct {
 	// Verification token key used as the subdomain label for validation TXT records
 	VerificationTokenKey string `config:"verification_token_key"`
 
+	// HIP5BlockedTLDs lists TLDs that are blocked on the HNS root and therefore
+	// mark an NS record as a HIP-5 TX record (e.g. "eth", "bit"), on top of
+	// underscore-prefixed labels which are always treated as HIP-5. Empty means
+	// only underscore-prefixed protocol tags count.
+	HIP5BlockedTLDs []string `config:"hip5_blocked_tlds"`
+
 	// DANEKeyEncryptionKey is the base64-encoded 32-byte AES-256 key used to
 	// encrypt per-domain DANE private keys at rest in the portal DB. Must be 32
 	// bytes when base64-decoded. If empty, DANE key persistence is skipped.
@@ -69,6 +75,7 @@ func (c DnsConfig) Defaults() map[string]any {
 		"Nameservers":                  []string{},
 		"HNSNameservers":               []string{},
 		"HNSResolver":                  "",
+		"HIP5BlockedTLDs":              []string{"eth", "bit"},
 		"GatewayDomain":                "",
 		"GatewayIP":                    "",
 		"VerificationTokenKey":         "lumeweb-verify",

--- a/internal/db/website_domain.go
+++ b/internal/db/website_domain.go
@@ -25,6 +25,13 @@ const (
 	DomainStatusActive            DomainStatus = "active"
 	DomainStatusSelfHosted        DomainStatus = "self_hosted"
 	DomainStatusError             DomainStatus = "error"
+	// DomainStatusOnchainManaged marks a name whose DNS is served on-chain
+	// (e.g. a Handshake HIP-5 name whose NS record points at an external
+	// contract). The portal provisions no zone, DNSSEC, or DANE for it; it owns
+	// ownership verification only (TXT token resolved through the namespace
+	// resolver). Distinct from self_hosted, which means the user runs their own
+	// authoritative servers under their own delegation.
+	DomainStatusOnchainManaged DomainStatus = "onchain_managed"
 )
 
 // WebsiteDomain binds a domain (by namespace) to a website.
@@ -79,7 +86,14 @@ func (WebsiteDomain) TableName() string {
 // shared DNSLink and apex records. HNS zones are DNSSEC-signed at the apex and
 // their records are provisioned by the delegation path even if delegation_data
 // or status is stale during a transition.
+//
+// On-chain managed (HIP-5) bindings are excluded: they own no portal-managed
+// zone, so there is no shared record set to preserve even though the namespace
+// is HNS.
 func (wd *WebsiteDomain) DelegationRecordsOwned() bool {
+	if wd.Status == DomainStatusOnchainManaged {
+		return false
+	}
 	return wd.Namespace == DomainNamespaceHNS || wd.DelegationOwned()
 }
 

--- a/internal/db/website_domain_test.go
+++ b/internal/db/website_domain_test.go
@@ -48,3 +48,61 @@ func TestWebsiteDomain_UniqueConstraint(t *testing.T) {
 		}).Error)
 	}, dbTestOptions)
 }
+
+func TestWebsiteDomain_DelegationRecordsOwned(t *testing.T) {
+	tests := []struct {
+		name string
+		wd   WebsiteDomain
+		want bool
+	}{
+		{
+			name: "native HNS delegation owns records",
+			wd: WebsiteDomain{
+				Namespace:      DomainNamespaceHNS,
+				Status:         DomainStatusWaitingDelegation,
+				DelegationData: map[string]any{"mode": "delegated"},
+			},
+			want: true,
+		},
+		{
+			name: "onchain managed HNS does not own records",
+			wd: WebsiteDomain{
+				Namespace: DomainNamespaceHNS,
+				Status:    DomainStatusOnchainManaged,
+			},
+			want: false,
+		},
+		{
+			name: "onchain managed with stray delegation data still does not own records",
+			wd: WebsiteDomain{
+				Namespace:      DomainNamespaceHNS,
+				Status:         DomainStatusOnchainManaged,
+				DelegationData: map[string]any{"mode": "hip5"},
+			},
+			want: false,
+		},
+		{
+			name: "ICANN with delegation data owns records",
+			wd: WebsiteDomain{
+				Namespace:      DomainNamespaceICANN,
+				Status:         DomainStatusRecordsGenerated,
+				DelegationData: map[string]any{"nameservers": []string{"ns1.com."}},
+			},
+			want: true,
+		},
+		{
+			name: "ICANN without delegation data does not own records",
+			wd: WebsiteDomain{
+				Namespace: DomainNamespaceICANN,
+				Status:    DomainStatusActive,
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.wd.DelegationRecordsOwned())
+		})
+	}
+}

--- a/internal/service/domain/delegated_domain_service.go
+++ b/internal/service/domain/delegated_domain_service.go
@@ -266,15 +266,17 @@ func (s *DelegatedDomainService) CreateDomain(ctx context.Context,
 	// Detect whether the name is managed on-chain (e.g. a Handshake HIP-5 name
 	// whose NS record points at an external contract). Best-effort: providers
 	// without an on-chain concept (ICANN) return false immediately; HNS defaults
-	// to native when the resolver cannot answer. A HIP-5 name serves its own
-	// DNS from the contract, so the portal cannot host it — binding with
-	// dnsHostingEnabled=true is rejected before any zone-dependent work.
+	// to native when the resolver cannot answer.
+	//
+	// A HIP-5 name serves its own DNS from the contract, so portal DNS hosting
+	// cannot apply to it. Binding is NOT rejected for dnsHostingEnabled=true
+	// (users default to managed DNS in the UX flow): the request is coerced to
+	// onchain_managed with dns_hosting_enabled=false — the only coherent state —
+	// and the response (status onchain_managed) lets the UI explain that DNS is
+	// served on-chain rather than failing the bind.
 	onchainManaged, err := provider.Inspect(ctx, domain)
 	if err != nil {
 		return nil, fmt.Errorf("domain inspection failed: %w", err)
-	}
-	if onchainManaged && dnsHostingEnabled {
-		return nil, fmt.Errorf("domain %q is managed on-chain (HIP-5) and cannot use portal DNS hosting; bind with dns_hosting_enabled=false", domain)
 	}
 
 	var website pluginDb.Website
@@ -319,13 +321,20 @@ func (s *DelegatedDomainService) CreateDomain(ctx context.Context,
 	// An on-chain managed name (HIP-5) serves its DNS from an external
 	// contract: the portal owns only ownership verification (a TXT token
 	// resolved through the HNS-aware resolver, which bridges to the contract)
-	// — no zone, no DNSLink/apex, no DNSSEC, no DANE. dnsHostingEnabled is
-	// false here (enforced above), and the binding is recorded with a distinct
-	// status so downstream code routes it to TXT-token verification instead of
-	// the delegation/DS flow used by native HNS.
+	// — no zone, no DNSLink/apex, no DNSSEC, no DANE. The binding is recorded
+	// with a distinct status so downstream code routes it to TXT-token
+	// verification instead of the delegation/DS flow used by native HNS.
+	// dnsHostingEnabled is always coerced to false here, even when the caller
+	// requested managed DNS (the default in the UX flow): portal hosting is
+	// impossible for a contract-served name, and the persisted flag must agree
+	// with the absence of a zone.
 	if onchainManaged {
 		wd.Status = pluginDb.DomainStatusOnchainManaged
-		if err := s.DB().WithContext(ctx).Model(wd).Update("status", pluginDb.DomainStatusOnchainManaged).Error; err != nil {
+		wd.DNSHostingEnabled = false
+		if err := s.DB().WithContext(ctx).Model(wd).Updates(map[string]any{
+			"status":              pluginDb.DomainStatusOnchainManaged,
+			"dns_hosting_enabled": false,
+		}).Error; err != nil {
 			return nil, fmt.Errorf("failed to finalize domain record: %w", err)
 		}
 		// This binding is the new website's first (primary) domain. Record it
@@ -1137,9 +1146,13 @@ func NewDelegatedDomainServiceFactory() (core.Service, []core.ContextBuilderOpti
 			}
 			reg.Register(NewICANNProvider(nsList))
 			hnsProv := NewHNSProvider(hnsResolver, hnsNSList, TLSASource{})
-			// Override the default HIP-5 blocked-TLD set when configured; an
-			// empty slice leaves only underscore-prefixed protocol tags counted.
-			if dnsCfg != nil && len(hip5BlockedTLDs) > 0 {
+			// Apply the configured HIP-5 blocked-TLD set. The override is applied
+			// whenever the config is present (even an empty slice): an empty set
+			// intentionally disables blocked-TLD detection, leaving only
+			// underscore-prefixed protocol tags counted. A nil/absent dnsCfg
+			// keeps the constructor's built-in defaults, matching the DnsConfig
+			// defaults of ["eth","bit"].
+			if dnsCfg != nil {
 				hnsProv.SetHIP5BlockedTLDs(hip5BlockedTLDs)
 			}
 			dns := core.GetService[pluginCore.DNSService](ctx, pluginCore.DNS_SERVICE)

--- a/internal/service/domain/delegated_domain_service.go
+++ b/internal/service/domain/delegated_domain_service.go
@@ -683,6 +683,115 @@ func (s *DelegatedDomainService) selfHealZone(ctx context.Context, provider Doma
 	return expectedDS, nil
 }
 
+// ConvertToOnChain converts a bound domain into an on-chain managed (HIP-5)
+// binding — the explicit, one-way path for the HNS-DNS → on-chain-DNS
+// transition, used when the name's NS record now points at an external
+// contract (a HIP-5 TX record the owner set on-chain).
+//
+// The portal stops owning the PowerDNS-served DNS for the name: the managed
+// zone (and the DNSSEC/DS carried by it) is deleted and the binding is
+// re-marked onchain_managed with dns_hosting_enabled=false, so ownership is
+// proven with the TXT token through the resolver instead of NS/DS delegation.
+// DANE/SSL state (ProtocolData: key, cert, TLSA, owner) is deliberately KEPT —
+// DANE still applies on-chain; only the PowerDNS-published records and DNSSEC
+// (not a concept on-chain) are dropped. The owning website is reset to
+// pending_validation so the TXT-token verification flow re-runs.
+//
+// Safety (never tear down on the caller's word alone):
+//   - Refused until Inspect confirms the name genuinely serves a HIP-5 record.
+//   - The PowerDNS zone is deleted only when no other live binding shares it:
+//     a shared zone is the parent of other native bindings, and deleting it
+//     would destroy their records/DNSSEC. Conversion is refused for shared
+//     zones with a clear instruction to detach those bindings first — a HIP-5
+//     apex resolves every subdomain via the contract anyway.
+//   - Refused for a binding already onchain_managed.
+func (s *DelegatedDomainService) ConvertToOnChain(ctx context.Context, websiteID, userID, domainID uint) (*pluginDb.WebsiteDomain, error) {
+	if s.DB() == nil {
+		return nil, fmt.Errorf("database not available")
+	}
+
+	var wd pluginDb.WebsiteDomain
+	if err := s.DB().WithContext(ctx).
+		Where("id = ? AND website_id = ? AND user_id = ?", domainID, websiteID, userID).
+		First(&wd).Error; err != nil {
+		return nil, err // includes gorm.ErrRecordNotFound
+	}
+
+	if wd.Status == pluginDb.DomainStatusOnchainManaged {
+		return nil, fmt.Errorf("domain %q is already on-chain managed (HIP-5)", wd.Domain)
+	}
+
+	provider := s.registry.Get(string(wd.Namespace))
+	if provider == nil {
+		return nil, fmt.Errorf("unsupported namespace: %s", wd.Namespace)
+	}
+
+	onchain, err := provider.Inspect(ctx, wd.Domain)
+	if err != nil {
+		return nil, fmt.Errorf("domain inspection failed: %w", err)
+	}
+	if !onchain {
+		return nil, fmt.Errorf("domain %q is not yet on-chain managed (HIP-5); its NS record does not point at an external contract", wd.Domain)
+	}
+
+	// Only delete the binding's PowerDNS zone when it is the sole owner. A zone
+	// shared with other live bindings (their parent/apex zone) must be kept —
+	// deleting it would destroy their records and DNSSEC.
+	if wd.ZoneID != 0 {
+		var sharers int64
+		if err := s.DB().WithContext(ctx).
+			Model(&pluginDb.WebsiteDomain{}).
+			Where("zone_id = ? AND id != ? AND deleted_at IS NULL", wd.ZoneID, wd.ID).
+			Count(&sharers).Error; err != nil {
+			return nil, fmt.Errorf("failed to count bindings sharing zone %d: %w", wd.ZoneID, err)
+		}
+		if sharers > 0 {
+			return nil, fmt.Errorf("domain %q cannot be converted (HIP-5): %d other binding(s) share its DNS zone; remove or convert them first", wd.Domain, sharers)
+		}
+		if s.dnsSvc != nil {
+			if err := s.dnsSvc.DeleteZone(ctx, wd.ZoneID); err != nil {
+				return nil, fmt.Errorf("failed to delete managed zone %d: %w", wd.ZoneID, err)
+			}
+		}
+	}
+
+	// Drop the PowerDNS-backed delegation state. ProtocolData (DANE key, cert,
+	// TLSA, owner) and per-domain SSL state are intentionally preserved: DANE/
+	// SSL still apply to the name — the records are simply served by the
+	// external contract now — and DNSSEC is not a concept on-chain.
+	updates := map[string]any{
+		"zone_id":             0,
+		"zone_name":           "",
+		"gateway_host":        "",
+		"delegation_data":     nil,
+		"dns_hosting_enabled": false,
+		"status":              pluginDb.DomainStatusOnchainManaged,
+	}
+	if err := s.DB().WithContext(ctx).Model(&wd).Updates(updates).Error; err != nil {
+		return nil, fmt.Errorf("failed to persist on-chain managed state: %w", err)
+	}
+	wd.ZoneID = 0
+	wd.ZoneName = ""
+	wd.GatewayHost = ""
+	wd.DelegationData = nil
+	wd.DNSHostingEnabled = false
+	wd.Status = pluginDb.DomainStatusOnchainManaged
+
+	// DNS moved on-chain: the site must prove ownership against the contract
+	// with the TXT token, so re-arm validation. A blocked website stays blocked
+	// (only an admin can lift an admin block); a pending one needs no change.
+	var website pluginDb.Website
+	if err := s.DB().WithContext(ctx).First(&website, wd.WebsiteID).Error; err == nil &&
+		website.Status != string(pluginDb.WebsiteStatusBlocked) &&
+		website.Status != string(pluginDb.WebsiteStatusPendingValidation) {
+		if err := s.DB().WithContext(ctx).Model(&website).Update("status", pluginDb.WebsiteStatusPendingValidation).Error; err != nil {
+			return nil, fmt.Errorf("failed to reset website to pending_validation: %w", err)
+		}
+	}
+
+	return &wd, nil
+}
+
 // DeleteDomain deletes a WebsiteDomain row scoped by id, website_id, and user_id.
 // Returns gorm.ErrRecordNotFound if no row was deleted.
 func (s *DelegatedDomainService) DeleteDomain(ctx context.Context, domainID, websiteID, userID uint) error {

--- a/internal/service/domain/delegated_domain_service.go
+++ b/internal/service/domain/delegated_domain_service.go
@@ -356,17 +356,11 @@ func (s *DelegatedDomainService) CreateDomain(ctx context.Context,
 		}
 		// This binding is the new website's first (primary) domain. Record it
 		// so the website service resolves the apex domain via PrimaryDomainID
-		// rather than the status=active fallback.
-		if website.PrimaryDomainID == nil {
-			primaryID := wd.ID
-			if err := s.DB().WithContext(ctx).Model(&website).Update("primary_domain_id", primaryID).Error; err != nil {
-				s.DB().WithContext(ctx).Unscoped().Delete(wd)
-				return nil, fmt.Errorf("failed to set primary domain: %w", err)
-			}
-			website.PrimaryDomainID = &primaryID
-		}
-		if notifyCreated {
-			s.notifyAdminWebsiteCreated(ctx, website.ID)
+		// rather than the status=active fallback. A failure rolls the just-
+		// inserted row back so the bind is cleanly retryable.
+		if err := s.assignPrimaryAndNotify(ctx, &website, wd, notifyCreated); err != nil {
+			s.DB().WithContext(ctx).Unscoped().Delete(wd)
+			return nil, err
 		}
 		return wd, nil
 	}
@@ -391,19 +385,11 @@ func (s *DelegatedDomainService) CreateDomain(ctx context.Context,
 		// This binding is the new website's first (primary) domain. Record it
 		// so the website service resolves the apex domain via PrimaryDomainID
 		// rather than the status=active fallback — a self-hosted binding is
-		// not active, so it would otherwise resolve to an empty domain.
-		if website.PrimaryDomainID == nil {
-			primaryID := wd.ID
-			if err := s.DB().WithContext(ctx).Model(&website).Update("primary_domain_id", primaryID).Error; err != nil {
-				return nil, fmt.Errorf("failed to set primary domain: %w", err)
-			}
-			website.PrimaryDomainID = &primaryID
-		}
-		// Self-hosted bindings skip the managed-DNS primary assignment below,
-		// so fire the created notification here for a genuine creation. The
-		// PrimaryDomainID set above lets the service resolve the domain.
-		if notifyCreated {
-			s.notifyAdminWebsiteCreated(ctx, website.ID)
+		// not active, so it would otherwise resolve to an empty domain. The
+		// created notification fires here because self-hosted bindings skip
+		// the managed-DNS assignment path below.
+		if err := s.assignPrimaryAndNotify(ctx, &website, wd, notifyCreated); err != nil {
+			return nil, err
 		}
 		return wd, nil
 	}
@@ -494,27 +480,35 @@ func (s *DelegatedDomainService) CreateDomain(ctx context.Context,
 	}
 
 	// If the owning website has no primary domain yet, make this binding the
-	// primary so Website.PrimaryDomainID never dangles after the first domain
-	// is added. This is how a website created with a transparent primary domain
-	// (and additional domains added later) keeps its FK consistent.
-	if website.PrimaryDomainID == nil {
-		if err := s.DB().WithContext(ctx).Model(&website).Update("primary_domain_id", wd.ID).Error; err != nil {
-			return nil, fmt.Errorf("failed to set primary domain: %w", err)
-		}
-		website.PrimaryDomainID = &wd.ID
-	}
-
-	// Only a genuine website creation (flagged by the create API caller) fires
-	// the admin "website created" notification. Domain-add operations on an
-	// existing website, which also flow through CreateDomain, must not emit a
-	// spurious created email. Firing here (service layer) lets the email's
-	// Domain field resolve against the binding just persisted. Non-fatal: a
-	// template/mail failure must not fail domain creation.
-	if notifyCreated {
-		s.notifyAdminWebsiteCreated(ctx, website.ID)
+	// Primary/notify handled by the shared helper: a fresh website gets its
+	// first binding recorded as primary, and only a genuine website creation
+	// (flag set by the create API caller) fires the admin created email —
+	// domain-add operations on an existing website must not emit one.
+	if err := s.assignPrimaryAndNotify(ctx, &website, wd, notifyCreated); err != nil {
+		return nil, err
 	}
 
 	return wd, nil
+}
+
+// assignPrimaryAndNotify records wd as the website's primary when the website
+// has none yet — so the website service resolves the apex domain via
+// PrimaryDomainID rather than the status=active fallback — and, when
+// notifyCreated, fires the admin "website created" notification. Shared by the
+// managed, self-hosted, and on-chain managed bind paths. Only the primary
+// write is fatal; the notification (via notifyAdminWebsiteCreated) is
+// best-effort.
+func (s *DelegatedDomainService) assignPrimaryAndNotify(ctx context.Context, website *pluginDb.Website, wd *pluginDb.WebsiteDomain, notifyCreated bool) error {
+	if website.PrimaryDomainID == nil {
+		if err := s.DB().WithContext(ctx).Model(website).Update("primary_domain_id", wd.ID).Error; err != nil {
+			return fmt.Errorf("failed to set primary domain: %w", err)
+		}
+		website.PrimaryDomainID = &wd.ID
+	}
+	if notifyCreated {
+		s.notifyAdminWebsiteCreated(ctx, website.ID)
+	}
+	return nil
 }
 
 // notifyAdminWebsiteCreated fires the admin "website created" notification for
@@ -699,150 +693,6 @@ func (s *DelegatedDomainService) selfHealZone(ctx context.Context, provider Doma
 	}
 
 	return expectedDS, nil
-}
-
-// Sentinel errors returned by ConvertToOnChain for user-correctable state
-// conflicts, so the API can map them to 4xx while genuine infrastructure
-// failures (DB, DNS service) surface as 5xx. Match with errors.Is.
-var (
-	ErrDomainAlreadyOnChain = errors.New("domain is already on-chain managed")
-	ErrDomainNotOnChain     = errors.New("domain is not yet on-chain managed")
-	ErrDomainZoneShared     = errors.New("domain's DNS zone is shared by other bindings")
-)
-
-// ConvertToOnChain converts a bound domain into an on-chain managed (HIP-5)
-// binding — the explicit, one-way path for the HNS-DNS → on-chain-DNS
-// transition, used when the name's NS record now points at an external
-// contract (a HIP-5 TX record the owner set on-chain).
-//
-// The portal stops owning the PowerDNS-served DNS for the name: the managed
-// zone (and the DNSSEC/DS carried by it) is deleted and the binding is
-// re-marked onchain_managed with dns_hosting_enabled=false, so ownership is
-// proven with the TXT token through the resolver instead of NS/DS delegation.
-// DANE/SSL state (ProtocolData: key, cert, TLSA, owner) is deliberately KEPT —
-// DANE still applies on-chain; only the PowerDNS-published records and DNSSEC
-// (not a concept on-chain) are dropped. The owning website is reset to
-// pending_validation so the TXT-token verification flow re-runs.
-//
-// Safety (never tear down on the caller's word alone):
-//   - Refused until Inspect confirms the name genuinely serves a HIP-5 record.
-//   - The PowerDNS zone is deleted only when no other live binding shares it:
-//     a shared zone is the parent of other native bindings, and deleting it
-//     would destroy their records/DNSSEC. Conversion is refused for shared
-//     zones with a clear instruction to detach those bindings first — a HIP-5
-//     apex resolves every subdomain via the contract anyway.
-//   - Refused for a binding already onchain_managed.
-func (s *DelegatedDomainService) ConvertToOnChain(ctx context.Context, websiteID, userID, domainID uint) (*pluginDb.WebsiteDomain, error) {
-	if s.DB() == nil {
-		return nil, fmt.Errorf("database not available")
-	}
-
-	var wd pluginDb.WebsiteDomain
-	if err := s.DB().WithContext(ctx).
-		Where("id = ? AND website_id = ? AND user_id = ?", domainID, websiteID, userID).
-		First(&wd).Error; err != nil {
-		return nil, err // includes gorm.ErrRecordNotFound
-	}
-
-	if wd.Status == pluginDb.DomainStatusOnchainManaged {
-		return nil, fmt.Errorf("%w: %q", ErrDomainAlreadyOnChain, wd.Domain)
-	}
-
-	provider := s.registry.Get(string(wd.Namespace))
-	if provider == nil {
-		return nil, fmt.Errorf("unsupported namespace: %s", wd.Namespace)
-	}
-
-	onchain, err := provider.Inspect(ctx, wd.Domain)
-	if err != nil {
-		return nil, fmt.Errorf("domain inspection failed: %w", err)
-	}
-	if !onchain {
-		return nil, fmt.Errorf("%w: %q; its NS record does not point at an external contract", ErrDomainNotOnChain, wd.Domain)
-	}
-
-	// Only the binding's sole-owner PowerDNS zone may be deleted. A zone shared
-	// with other live bindings (their parent/apex zone) must be kept — deleting
-	// it would destroy their records and DNSSEC.
-	zoneID := wd.ZoneID
-	if zoneID != 0 {
-		var sharers int64
-		if err := s.DB().WithContext(ctx).
-			Model(&pluginDb.WebsiteDomain{}).
-			Where("zone_id = ? AND id != ? AND deleted_at IS NULL", zoneID, wd.ID).
-			Count(&sharers).Error; err != nil {
-			return nil, fmt.Errorf("failed to count bindings sharing zone %d: %w", zoneID, err)
-		}
-		if sharers > 0 {
-			return nil, fmt.Errorf("%w: %q (%d other binding(s)); remove or convert them first", ErrDomainZoneShared, wd.Domain, sharers)
-		}
-	}
-
-	// Drop the PowerDNS-backed delegation state. ProtocolData (DANE key, cert,
-	// TLSA, owner) and per-domain SSL state are intentionally preserved: DANE/
-	// SSL still apply to the name — the records are simply served by the
-	// external contract now — and DNSSEC is not a concept on-chain.
-	updates := map[string]any{
-		"zone_id":             0,
-		"zone_name":           "",
-		"gateway_host":        "",
-		"delegation_data":     nil,
-		"dns_hosting_enabled": false,
-		"status":              pluginDb.DomainStatusOnchainManaged,
-	}
-	if err := s.DB().WithContext(ctx).Model(&wd).Updates(updates).Error; err != nil {
-		return nil, fmt.Errorf("failed to persist on-chain managed state: %w", err)
-	}
-	wd.ZoneID = 0
-	wd.ZoneName = ""
-	wd.GatewayHost = ""
-	wd.DelegationData = nil
-	wd.DNSHostingEnabled = false
-	wd.Status = pluginDb.DomainStatusOnchainManaged
-
-	// Delete the now-unreferenced PowerDNS zone LAST, best-effort. Order is
-	// deliberate: the DB runs first so a delete failure can never strand the
-	// binding pointing at a destroyed zone (the unrecoverable state). If a
-	// concurrent bind landed in this zone between the check above and here, the
-	// zone is re-counted and left alone so another binding's records/DNSSEC are
-	// not destroyed. A leftover/unreferenced zone is harmless (nothing serves
-	// it — the name resolves via the contract) and is logged for ops cleanup.
-	if zoneID != 0 && s.dnsSvc != nil {
-		var sharers int64
-		if err := s.DB().WithContext(ctx).
-			Model(&pluginDb.WebsiteDomain{}).
-			Where("zone_id = ? AND id != ? AND deleted_at IS NULL", zoneID, wd.ID).
-			Count(&sharers).Error; err != nil {
-			s.Logger().Warn("failed to re-count zone sharers before on-chain conversion zone delete",
-				zap.Uint("zone_id", zoneID), zap.String("domain", wd.Domain), zap.Error(err))
-		} else if sharers > 0 {
-			s.Logger().Info("on-chain conversion: zone now shared by other bindings; leaving it intact",
-				zap.Uint("zone_id", zoneID), zap.String("domain", wd.Domain))
-		} else if err := s.dnsSvc.DeleteZone(ctx, zoneID); err != nil {
-			// Non-fatal: the binding is already cleanly on-chain; the orphaned
-			// zone is unreachable garbage an operator can clear.
-			s.Logger().Warn("on-chain conversion: failed to delete orphaned managed zone (non-fatal)",
-				zap.Uint("zone_id", zoneID), zap.String("domain", wd.Domain), zap.Error(err))
-		}
-	}
-
-	// DNS moved on-chain: the site must prove ownership against the contract
-	// with the TXT token, so re-arm validation. A blocked website stays blocked
-	// (only an admin can lift an admin block); a pending one needs no change.
-	// A website-load failure is surfaced rather than silently skipped so the
-	// caller knows validation was not re-armed.
-	var website pluginDb.Website
-	if err := s.DB().WithContext(ctx).First(&website, wd.WebsiteID).Error; err != nil {
-		return nil, fmt.Errorf("failed to load website %d for on-chain conversion: %w", wd.WebsiteID, err)
-	}
-	if website.Status != string(pluginDb.WebsiteStatusBlocked) &&
-		website.Status != string(pluginDb.WebsiteStatusPendingValidation) {
-		if err := s.DB().WithContext(ctx).Model(&website).Update("status", pluginDb.WebsiteStatusPendingValidation).Error; err != nil {
-			return nil, fmt.Errorf("failed to reset website to pending_validation: %w", err)
-		}
-	}
-
-	return &wd, nil
 }
 
 // DeleteDomain deletes a WebsiteDomain row scoped by id, website_id, and user_id.

--- a/internal/service/domain/delegated_domain_service.go
+++ b/internal/service/domain/delegated_domain_service.go
@@ -274,9 +274,19 @@ func (s *DelegatedDomainService) CreateDomain(ctx context.Context,
 	// onchain_managed with dns_hosting_enabled=false — the only coherent state —
 	// and the response (status onchain_managed) lets the UI explain that DNS is
 	// served on-chain rather than failing the bind.
-	onchainManaged, err := provider.Inspect(ctx, domain)
-	if err != nil {
-		return nil, fmt.Errorf("domain inspection failed: %w", err)
+	//
+	// Platform subdomain claims (platformRootID != nil) never inspect: the
+	// platform root is operator-owned and its subdomains resolve via the
+	// operator's own portal-managed zone, so they can never be HIP-5 — and
+	// skipping the resolver query keeps the operator hot path (every platform
+	// claim) free of a per-bind DNS round-trip.
+	var onchainManaged bool
+	if platformRootID == nil {
+		var inspectErr error
+		onchainManaged, inspectErr = provider.Inspect(ctx, domain)
+		if inspectErr != nil {
+			return nil, fmt.Errorf("domain inspection failed: %w", inspectErr)
+		}
 	}
 
 	var website pluginDb.Website
@@ -335,6 +345,13 @@ func (s *DelegatedDomainService) CreateDomain(ctx context.Context,
 			"status":              pluginDb.DomainStatusOnchainManaged,
 			"dns_hosting_enabled": false,
 		}).Error; err != nil {
+			// The row was already inserted with dns_hosting_enabled from the
+			// request (true by default). A half-finalized onchain binding is the
+			// worst failure shape: it would look like an "enable-orphan" to
+			// SetDomainDNSEnabled and a retry could provision a PowerDNS zone
+			// for a genuinely HIP-5 name. Remove the row so the bind is cleanly
+			// rolled back and the name can be retried.
+			s.DB().WithContext(ctx).Unscoped().Delete(wd)
 			return nil, fmt.Errorf("failed to finalize domain record: %w", err)
 		}
 		// This binding is the new website's first (primary) domain. Record it
@@ -343,6 +360,7 @@ func (s *DelegatedDomainService) CreateDomain(ctx context.Context,
 		if website.PrimaryDomainID == nil {
 			primaryID := wd.ID
 			if err := s.DB().WithContext(ctx).Model(&website).Update("primary_domain_id", primaryID).Error; err != nil {
+				s.DB().WithContext(ctx).Unscoped().Delete(wd)
 				return nil, fmt.Errorf("failed to set primary domain: %w", err)
 			}
 			website.PrimaryDomainID = &primaryID
@@ -683,6 +701,15 @@ func (s *DelegatedDomainService) selfHealZone(ctx context.Context, provider Doma
 	return expectedDS, nil
 }
 
+// Sentinel errors returned by ConvertToOnChain for user-correctable state
+// conflicts, so the API can map them to 4xx while genuine infrastructure
+// failures (DB, DNS service) surface as 5xx. Match with errors.Is.
+var (
+	ErrDomainAlreadyOnChain = errors.New("domain is already on-chain managed")
+	ErrDomainNotOnChain     = errors.New("domain is not yet on-chain managed")
+	ErrDomainZoneShared     = errors.New("domain's DNS zone is shared by other bindings")
+)
+
 // ConvertToOnChain converts a bound domain into an on-chain managed (HIP-5)
 // binding — the explicit, one-way path for the HNS-DNS → on-chain-DNS
 // transition, used when the name's NS record now points at an external
@@ -718,7 +745,7 @@ func (s *DelegatedDomainService) ConvertToOnChain(ctx context.Context, websiteID
 	}
 
 	if wd.Status == pluginDb.DomainStatusOnchainManaged {
-		return nil, fmt.Errorf("domain %q is already on-chain managed (HIP-5)", wd.Domain)
+		return nil, fmt.Errorf("%w: %q", ErrDomainAlreadyOnChain, wd.Domain)
 	}
 
 	provider := s.registry.Get(string(wd.Namespace))
@@ -731,27 +758,23 @@ func (s *DelegatedDomainService) ConvertToOnChain(ctx context.Context, websiteID
 		return nil, fmt.Errorf("domain inspection failed: %w", err)
 	}
 	if !onchain {
-		return nil, fmt.Errorf("domain %q is not yet on-chain managed (HIP-5); its NS record does not point at an external contract", wd.Domain)
+		return nil, fmt.Errorf("%w: %q; its NS record does not point at an external contract", ErrDomainNotOnChain, wd.Domain)
 	}
 
-	// Only delete the binding's PowerDNS zone when it is the sole owner. A zone
-	// shared with other live bindings (their parent/apex zone) must be kept —
-	// deleting it would destroy their records and DNSSEC.
-	if wd.ZoneID != 0 {
+	// Only the binding's sole-owner PowerDNS zone may be deleted. A zone shared
+	// with other live bindings (their parent/apex zone) must be kept — deleting
+	// it would destroy their records and DNSSEC.
+	zoneID := wd.ZoneID
+	if zoneID != 0 {
 		var sharers int64
 		if err := s.DB().WithContext(ctx).
 			Model(&pluginDb.WebsiteDomain{}).
-			Where("zone_id = ? AND id != ? AND deleted_at IS NULL", wd.ZoneID, wd.ID).
+			Where("zone_id = ? AND id != ? AND deleted_at IS NULL", zoneID, wd.ID).
 			Count(&sharers).Error; err != nil {
-			return nil, fmt.Errorf("failed to count bindings sharing zone %d: %w", wd.ZoneID, err)
+			return nil, fmt.Errorf("failed to count bindings sharing zone %d: %w", zoneID, err)
 		}
 		if sharers > 0 {
-			return nil, fmt.Errorf("domain %q cannot be converted (HIP-5): %d other binding(s) share its DNS zone; remove or convert them first", wd.Domain, sharers)
-		}
-		if s.dnsSvc != nil {
-			if err := s.dnsSvc.DeleteZone(ctx, wd.ZoneID); err != nil {
-				return nil, fmt.Errorf("failed to delete managed zone %d: %w", wd.ZoneID, err)
-			}
+			return nil, fmt.Errorf("%w: %q (%d other binding(s)); remove or convert them first", ErrDomainZoneShared, wd.Domain, sharers)
 		}
 	}
 
@@ -777,12 +800,42 @@ func (s *DelegatedDomainService) ConvertToOnChain(ctx context.Context, websiteID
 	wd.DNSHostingEnabled = false
 	wd.Status = pluginDb.DomainStatusOnchainManaged
 
+	// Delete the now-unreferenced PowerDNS zone LAST, best-effort. Order is
+	// deliberate: the DB runs first so a delete failure can never strand the
+	// binding pointing at a destroyed zone (the unrecoverable state). If a
+	// concurrent bind landed in this zone between the check above and here, the
+	// zone is re-counted and left alone so another binding's records/DNSSEC are
+	// not destroyed. A leftover/unreferenced zone is harmless (nothing serves
+	// it — the name resolves via the contract) and is logged for ops cleanup.
+	if zoneID != 0 && s.dnsSvc != nil {
+		var sharers int64
+		if err := s.DB().WithContext(ctx).
+			Model(&pluginDb.WebsiteDomain{}).
+			Where("zone_id = ? AND id != ? AND deleted_at IS NULL", zoneID, wd.ID).
+			Count(&sharers).Error; err != nil {
+			s.Logger().Warn("failed to re-count zone sharers before on-chain conversion zone delete",
+				zap.Uint("zone_id", zoneID), zap.String("domain", wd.Domain), zap.Error(err))
+		} else if sharers > 0 {
+			s.Logger().Info("on-chain conversion: zone now shared by other bindings; leaving it intact",
+				zap.Uint("zone_id", zoneID), zap.String("domain", wd.Domain))
+		} else if err := s.dnsSvc.DeleteZone(ctx, zoneID); err != nil {
+			// Non-fatal: the binding is already cleanly on-chain; the orphaned
+			// zone is unreachable garbage an operator can clear.
+			s.Logger().Warn("on-chain conversion: failed to delete orphaned managed zone (non-fatal)",
+				zap.Uint("zone_id", zoneID), zap.String("domain", wd.Domain), zap.Error(err))
+		}
+	}
+
 	// DNS moved on-chain: the site must prove ownership against the contract
 	// with the TXT token, so re-arm validation. A blocked website stays blocked
 	// (only an admin can lift an admin block); a pending one needs no change.
+	// A website-load failure is surfaced rather than silently skipped so the
+	// caller knows validation was not re-armed.
 	var website pluginDb.Website
-	if err := s.DB().WithContext(ctx).First(&website, wd.WebsiteID).Error; err == nil &&
-		website.Status != string(pluginDb.WebsiteStatusBlocked) &&
+	if err := s.DB().WithContext(ctx).First(&website, wd.WebsiteID).Error; err != nil {
+		return nil, fmt.Errorf("failed to load website %d for on-chain conversion: %w", wd.WebsiteID, err)
+	}
+	if website.Status != string(pluginDb.WebsiteStatusBlocked) &&
 		website.Status != string(pluginDb.WebsiteStatusPendingValidation) {
 		if err := s.DB().WithContext(ctx).Model(&website).Update("status", pluginDb.WebsiteStatusPendingValidation).Error; err != nil {
 			return nil, fmt.Errorf("failed to reset website to pending_validation: %w", err)

--- a/internal/service/domain/delegated_domain_service.go
+++ b/internal/service/domain/delegated_domain_service.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	dane "go.lumeweb.com/dane"
@@ -25,6 +26,12 @@ type DelegatedDomainService struct {
 	*core.BaseComponent
 	registry *Registry
 	dnsSvc   DNSZoneService
+	// zoneLifecycleLocks serializes zone lifecycle transitions (a bind that
+	// provisions/reuses a zone in CreateDomain vs a conversion that deletes a
+	// zone in ConvertToOnChain), keyed by the zone's canonical apex name, so a
+	// concurrent bind can never have its zone destroyed by a conversion's
+	// delete. sync.Map so the service can be copied/value-constructed safely.
+	zoneLifecycleLocks sync.Map // string(zone apex) -> *sync.Mutex
 	// websiteSvc is resolved once at startup for cross-service calls (e.g.
 	// activating a website after a platform subdomain is claimed). It is always
 	// present: the portal registers all service instances before running
@@ -229,6 +236,35 @@ func (s *DelegatedDomainService) resolveManagedZone(ctx context.Context, domain 
 	return z, true, nil
 }
 
+// zoneLifecycleKey returns the canonical apex name of the PowerDNS zone a
+// bind/convert of `domain` lives in, mirroring the one-zone rule in
+// resolveManagedZone (apex owns its zone; a subdomain reuses the parent's
+// zone). Both CreateDomain and ConvertToOnChain derive the same key so their
+// per-zone lifecycle locks collide.
+func zoneLifecycleKey(domain string) string {
+	if p := parentDomain(domain); p != "" {
+		return canonicalZoneName(p)
+	}
+	return canonicalZoneName(domain)
+}
+
+// zoneLifecycleLock returns the per-zone mutex serializing zone lifecycle
+// transitions for the given zone apex.
+func (s *DelegatedDomainService) zoneLifecycleLock(zoneApex string) *sync.Mutex {
+	v, _ := s.zoneLifecycleLocks.LoadOrStore(zoneApex, &sync.Mutex{})
+	return v.(*sync.Mutex)
+}
+
+// withZoneLifecycleLock runs fn while holding the per-zone lifecycle lock for
+// the given zone apex, serializing zone provisioning (CreateDomain) against
+// zone deletion (ConvertToOnChain) for the same zone.
+func (s *DelegatedDomainService) withZoneLifecycleLock(zoneApex string, fn func() error) error {
+	lock := s.zoneLifecycleLock(zoneApex)
+	lock.Lock()
+	defer lock.Unlock()
+	return fn()
+}
+
 // parentDomain returns the domain's parent (everything after the first label),
 // or "" when the domain is an apex (single-label HNS, or a bare TLD-less ICANN
 // name). Mirrors the website service's extractParentDomain.
@@ -396,90 +432,98 @@ func (s *DelegatedDomainService) CreateDomain(ctx context.Context,
 
 	// Managed DNS: create DNS resources only after the DB row is committed.
 	// The authoritative zone follows the one-zone rule — apex owns, subdomain
-	// reuses the parent's zone.
-	zone, zoneCreated, err := s.resolveManagedZone(ctx, domain, userID, platformRootID)
-	if err != nil {
-		s.DB().WithContext(ctx).Unscoped().Delete(wd)
-		return nil, fmt.Errorf("zone resolution failed: %w", err)
-	}
-
-	target := pluginDb.WebsiteTargetType(website.TargetType).ToDNSLinkPath(website.TargetHash())
-	// Name the record after the binding's domain (not the zone apex) so a
-	// subdomain reusing a parent zone writes its own _dnslink.<subdomain>,
-	// not the parent's.
-	if err := s.dnsSvc.CreateDNSLinkRecord(ctx, zone.ID, domain, target); err != nil {
-		s.DB().WithContext(ctx).Unscoped().Delete(wd)
-		if zoneCreated {
-			_ = s.dnsSvc.DeleteZone(ctx, zone.ID)
+	// reuses the parent's zone. The per-zone lifecycle lock is held across zone
+	// resolution through the row's zone-id commit so a concurrent
+	// ConvertToOnChain cannot delete the zone (and its records/DNSSEC) between
+	// the bind deciding to use it and the binding committing its reference.
+	if err := s.withZoneLifecycleLock(zoneLifecycleKey(domain), func() error {
+		zone, zoneCreated, err := s.resolveManagedZone(ctx, domain, userID, platformRootID)
+		if err != nil {
+			s.DB().WithContext(ctx).Unscoped().Delete(wd)
+			return fmt.Errorf("zone resolution failed: %w", err)
 		}
-		return nil, fmt.Errorf("dnslink creation failed: %w", err)
-	}
 
-	// Create apex record pointing to the gateway. DNSSEC-signed alt-root
-	// providers (e.g. HNS) need a real A record (gateway IP) so the apex
-	// carries an RRSIG; otherwise use an ALIAS to the gateway hostname.
-	apexType := provider.ApexRecordType()
-	var apexContent string
-	if apexType == pluginCore.RecordTypeA {
-		apexContent = s.gatewayIP()
-		if apexContent == "" {
+		target := pluginDb.WebsiteTargetType(website.TargetType).ToDNSLinkPath(website.TargetHash())
+		// Name the record after the binding's domain (not the zone apex) so a
+		// subdomain reusing a parent zone writes its own _dnslink.<subdomain>,
+		// not the parent's.
+		if err := s.dnsSvc.CreateDNSLinkRecord(ctx, zone.ID, domain, target); err != nil {
 			s.DB().WithContext(ctx).Unscoped().Delete(wd)
 			if zoneCreated {
 				_ = s.dnsSvc.DeleteZone(ctx, zone.ID)
 			}
-			return nil, fmt.Errorf("gateway_ip not configured: alt-root apex requires a real A record and cannot fall back to ALIAS (set dns.gateway_ip, e.g. to the gateway IP)")
+			return fmt.Errorf("dnslink creation failed: %w", err)
 		}
-	} else if gatewayHost := s.gatewayHost(); gatewayHost != "" {
-		apexContent = gatewayHost
-	}
 
-	if apexContent != "" {
-		if err := s.dnsSvc.CreateApexRecord(ctx, zone.ID, domain, apexType, apexContent); err != nil {
+		// Create apex record pointing to the gateway. DNSSEC-signed alt-root
+		// providers (e.g. HNS) need a real A record (gateway IP) so the apex
+		// carries an RRSIG; otherwise use an ALIAS to the gateway hostname.
+		apexType := provider.ApexRecordType()
+		var apexContent string
+		if apexType == pluginCore.RecordTypeA {
+			apexContent = s.gatewayIP()
+			if apexContent == "" {
+				s.DB().WithContext(ctx).Unscoped().Delete(wd)
+				if zoneCreated {
+					_ = s.dnsSvc.DeleteZone(ctx, zone.ID)
+				}
+				return fmt.Errorf("gateway_ip not configured: alt-root apex requires a real A record and cannot fall back to ALIAS (set dns.gateway_ip, e.g. to the gateway IP)")
+			}
+		} else if gatewayHost := s.gatewayHost(); gatewayHost != "" {
+			apexContent = gatewayHost
+		}
+
+		if apexContent != "" {
+			if err := s.dnsSvc.CreateApexRecord(ctx, zone.ID, domain, apexType, apexContent); err != nil {
+				s.DB().WithContext(ctx).Unscoped().Delete(wd)
+				if zoneCreated {
+					_ = s.dnsSvc.DeleteZone(ctx, zone.ID)
+				}
+				return fmt.Errorf("apex record creation failed: %w", err)
+			}
+			wd.GatewayHost = apexContent
+		}
+
+		// Build delegation after zone is created (needs zone ID).
+		delegationAny, err := provider.BuildDelegation(ctx, zone.ID, domain, &website, config)
+		if err != nil {
+			s.DB().WithContext(ctx).Unscoped().Delete(wd)
+			// Only tear down a zone this call created. For a platform claim the
+			// zone is the operator's shared platform-root zone (zoneCreated is
+			// false), which must never be deleted on a per-claim failure —
+			// doing so would take down every subdomain on that root.
+			if zoneCreated {
+				_ = s.dnsSvc.DeleteZone(ctx, zone.ID)
+			}
+			return fmt.Errorf("delegation build failed: %w", err)
+		}
+		delegationBytes, err := json.Marshal(delegationAny)
+		if err != nil {
 			s.DB().WithContext(ctx).Unscoped().Delete(wd)
 			if zoneCreated {
 				_ = s.dnsSvc.DeleteZone(ctx, zone.ID)
 			}
-			return nil, fmt.Errorf("apex record creation failed: %w", err)
+			return fmt.Errorf("marshal delegation data: %w", err)
 		}
-		wd.GatewayHost = apexContent
+
+		// Update the row with zone info, delegation data, and final status.
+		wd.ZoneID = zone.ID
+		wd.Status = pluginDb.DomainStatusRecordsGenerated
+		wd.DelegationData = jsonToMap(delegationBytes)
+		if err := s.DB().WithContext(ctx).Model(wd).Updates(map[string]any{
+			"zone_id":             zone.ID,
+			"status":              pluginDb.DomainStatusRecordsGenerated,
+			"delegation_data":     wd.DelegationData,
+			"dns_hosting_enabled": wd.DNSHostingEnabled,
+		}).Error; err != nil {
+			return fmt.Errorf("failed to finalize domain record: %w", err)
+		}
+
+		return nil
+	}); err != nil {
+		return nil, err
 	}
 
-	// Build delegation after zone is created (needs zone ID).
-	delegationAny, err := provider.BuildDelegation(ctx, zone.ID, domain, &website, config)
-	if err != nil {
-		s.DB().WithContext(ctx).Unscoped().Delete(wd)
-		// Only tear down a zone this call created. For a platform claim the
-		// zone is the operator's shared platform-root zone (zoneCreated is
-		// false), which must never be deleted on a per-claim failure —
-		// doing so would take down every subdomain on that root.
-		if zoneCreated {
-			_ = s.dnsSvc.DeleteZone(ctx, zone.ID)
-		}
-		return nil, fmt.Errorf("delegation build failed: %w", err)
-	}
-	delegationBytes, err := json.Marshal(delegationAny)
-	if err != nil {
-		s.DB().WithContext(ctx).Unscoped().Delete(wd)
-		if zoneCreated {
-			_ = s.dnsSvc.DeleteZone(ctx, zone.ID)
-		}
-		return nil, fmt.Errorf("marshal delegation data: %w", err)
-	}
-
-	// Update the row with zone info, delegation data, and final status.
-	wd.ZoneID = zone.ID
-	wd.Status = pluginDb.DomainStatusRecordsGenerated
-	wd.DelegationData = jsonToMap(delegationBytes)
-	if err := s.DB().WithContext(ctx).Model(wd).Updates(map[string]any{
-		"zone_id":             zone.ID,
-		"status":              pluginDb.DomainStatusRecordsGenerated,
-		"delegation_data":     wd.DelegationData,
-		"dns_hosting_enabled": wd.DNSHostingEnabled,
-	}).Error; err != nil {
-		return nil, fmt.Errorf("failed to finalize domain record: %w", err)
-	}
-
-	// If the owning website has no primary domain yet, make this binding the
 	// Primary/notify handled by the shared helper: a fresh website gets its
 	// first binding recorded as primary, and only a genuine website creation
 	// (flag set by the create API caller) fires the admin created email —

--- a/internal/service/domain/delegated_domain_service.go
+++ b/internal/service/domain/delegated_domain_service.go
@@ -263,6 +263,20 @@ func (s *DelegatedDomainService) CreateDomain(ctx context.Context,
 		return nil, fmt.Errorf("validation failed: %w", err)
 	}
 
+	// Detect whether the name is managed on-chain (e.g. a Handshake HIP-5 name
+	// whose NS record points at an external contract). Best-effort: providers
+	// without an on-chain concept (ICANN) return false immediately; HNS defaults
+	// to native when the resolver cannot answer. A HIP-5 name serves its own
+	// DNS from the contract, so the portal cannot host it — binding with
+	// dnsHostingEnabled=true is rejected before any zone-dependent work.
+	onchainManaged, err := provider.Inspect(ctx, domain)
+	if err != nil {
+		return nil, fmt.Errorf("domain inspection failed: %w", err)
+	}
+	if onchainManaged && dnsHostingEnabled {
+		return nil, fmt.Errorf("domain %q is managed on-chain (HIP-5) and cannot use portal DNS hosting; bind with dns_hosting_enabled=false", domain)
+	}
+
 	var website pluginDb.Website
 	if err := s.DB().WithContext(ctx).
 		Where("user_id = ? AND id = ?", userID, websiteID).
@@ -300,6 +314,34 @@ func (s *DelegatedDomainService) CreateDomain(ctx context.Context,
 
 	if err := s.DB().WithContext(ctx).Create(wd).Error; err != nil {
 		return nil, fmt.Errorf("persist failed: %w", err)
+	}
+
+	// An on-chain managed name (HIP-5) serves its DNS from an external
+	// contract: the portal owns only ownership verification (a TXT token
+	// resolved through the HNS-aware resolver, which bridges to the contract)
+	// — no zone, no DNSLink/apex, no DNSSEC, no DANE. dnsHostingEnabled is
+	// false here (enforced above), and the binding is recorded with a distinct
+	// status so downstream code routes it to TXT-token verification instead of
+	// the delegation/DS flow used by native HNS.
+	if onchainManaged {
+		wd.Status = pluginDb.DomainStatusOnchainManaged
+		if err := s.DB().WithContext(ctx).Model(wd).Update("status", pluginDb.DomainStatusOnchainManaged).Error; err != nil {
+			return nil, fmt.Errorf("failed to finalize domain record: %w", err)
+		}
+		// This binding is the new website's first (primary) domain. Record it
+		// so the website service resolves the apex domain via PrimaryDomainID
+		// rather than the status=active fallback.
+		if website.PrimaryDomainID == nil {
+			primaryID := wd.ID
+			if err := s.DB().WithContext(ctx).Model(&website).Update("primary_domain_id", primaryID).Error; err != nil {
+				return nil, fmt.Errorf("failed to set primary domain: %w", err)
+			}
+			website.PrimaryDomainID = &primaryID
+		}
+		if notifyCreated {
+			s.notifyAdminWebsiteCreated(ctx, website.ID)
+		}
+		return wd, nil
 	}
 
 	// A self-hosted DNS binding owns no PowerDNS zone: the user runs the
@@ -1081,6 +1123,7 @@ func NewDelegatedDomainServiceFactory() (core.Service, []core.ContextBuilderOpti
 			var nsList []string
 			var hnsNSList []string
 			hnsResolver := ""
+			var hip5BlockedTLDs []string
 			if dnsCfg != nil {
 				nsList = dnsCfg.Nameservers
 				hnsNSList = dnsCfg.HNSNameservers
@@ -1090,9 +1133,15 @@ func NewDelegatedDomainServiceFactory() (core.Service, []core.ContextBuilderOpti
 					hnsNSList = nsList
 				}
 				hnsResolver = dnsCfg.HNSResolver
+				hip5BlockedTLDs = dnsCfg.HIP5BlockedTLDs
 			}
 			reg.Register(NewICANNProvider(nsList))
 			hnsProv := NewHNSProvider(hnsResolver, hnsNSList, TLSASource{})
+			// Override the default HIP-5 blocked-TLD set when configured; an
+			// empty slice leaves only underscore-prefixed protocol tags counted.
+			if dnsCfg != nil && len(hip5BlockedTLDs) > 0 {
+				hnsProv.SetHIP5BlockedTLDs(hip5BlockedTLDs)
+			}
 			dns := core.GetService[pluginCore.DNSService](ctx, pluginCore.DNS_SERVICE)
 			if dns != nil {
 				hnsProv.SetDNSService(dns)

--- a/internal/service/domain/delegated_domain_service_test.go
+++ b/internal/service/domain/delegated_domain_service_test.go
@@ -737,8 +737,10 @@ func testOptionsWithHNSResolver(addr string) coreTesting.TestContextBuilderOptio
 
 func TestDelegatedDomainService_CreateDomain_Hip5OnchainManaged(t *testing.T) {
 	// A Handshake name whose NS record is a HIP-5 TX record must bind as on-chain
-	// managed: no zone, no DANE, TXT-verification status, and binding with portal
-	// DNS hosting (dnsHostingEnabled=true) must be rejected.
+	// managed: no zone, no DANE, TXT-verification status. A managed-DNS request
+	// (dnsHostingEnabled=true, the UX default) is coerced to onchain_managed with
+	// dns_hosting_enabled=false — portal hosting is impossible for a
+	// contract-served name — rather than failing the bind.
 	const domain = "myname"
 
 	addr, _ := startCustomPortDNSServer(t, domain+".",
@@ -746,7 +748,10 @@ func TestDelegatedDomainService_CreateDomain_Hip5OnchainManaged(t *testing.T) {
 
 	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 		db := ctx.DB()
-		website := createTestWebsite(tb, db, 1, domain)
+		// The test DNS server answers NS queries with the HIP-5 record for any
+		// name, so each subtest uses a distinct bound domain to avoid colliding
+		// on the (domain, namespace) unique key.
+		domains := []string{"myname", "myname2"}
 
 		svc := core.GetService[*DelegatedDomainService](ctx, pluginCore.DELEGATED_DOMAIN_SERVICE)
 		require.NotNil(tb, svc)
@@ -758,30 +763,40 @@ func TestDelegatedDomainService_CreateDomain_Hip5OnchainManaged(t *testing.T) {
 		require.NotNil(tb, hnsProv)
 		hnsProv.resolverAddr = addr
 
-		// Portal DNS hosting must be rejected for an on-chain managed name; no
-		// row is persisted by the failed attempt.
-		_, err := svc.CreateDomain(context.Background(), "hns", domain, website.ID, 1, true, false, nil, nil)
-		require.Error(tb, err)
-		assert.Contains(tb, err.Error(), "HIP-5")
-
-		// Self-hosted (dnsHostingEnabled=false) binds as onchain_managed with no
-		// zone, no delegation data, and fires the created notification (the
-		// binding is the new website's primary).
 		mockWebsite := core.GetService[*mocks.MockWebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
-		mockWebsite.EXPECT().NotifyAdminWebsiteCreated(mock.Anything, website.ID).Return(nil).Once()
 
-		wd, err := svc.CreateDomain(context.Background(), "hns", domain, website.ID, 1, false, true, nil, nil)
-		require.NoError(tb, err)
-		assert.Equal(tb, pluginDb.DomainStatusOnchainManaged, wd.Status)
-		assert.Equal(tb, uint(0), wd.ZoneID)
-		assert.False(tb, wd.DNSHostingEnabled)
-		assert.Nil(tb, wd.DelegationData)
+		for i, hostingRequest := range []bool{true, false} {
+			name := "hosting request coerced"
+			if !hostingRequest {
+				name = "explicit self-hosted request"
+			}
+			t.Run(name, func(t *testing.T) {
+				d := domains[i]
+				website := createTestWebsite(tb, db, 1, d)
 
-		// The binding is recorded as the website's primary so the website
-		// service resolves the apex domain via PrimaryDomainID.
-		var reloaded pluginDb.Website
-		require.NoError(tb, db.First(&reloaded, website.ID).Error)
-		require.NotNil(tb, reloaded.PrimaryDomainID)
-		assert.Equal(tb, wd.ID, *reloaded.PrimaryDomainID)
+				mockWebsite.EXPECT().NotifyAdminWebsiteCreated(mock.Anything, website.ID).Return(nil).Once()
+
+				wd, err := svc.CreateDomain(context.Background(), "hns", d, website.ID, 1, hostingRequest, true, nil, nil)
+				require.NoError(tb, err)
+				assert.Equal(tb, pluginDb.DomainStatusOnchainManaged, wd.Status)
+				assert.Equal(tb, uint(0), wd.ZoneID)
+				// Portal DNS hosting is coerced off for on-chain managed names,
+				// even when the caller requested managed DNS.
+				assert.False(tb, wd.DNSHostingEnabled)
+				assert.Nil(tb, wd.DelegationData)
+
+				// The binding is recorded as the website's primary so the website
+				// service resolves the apex domain via PrimaryDomainID.
+				var reloaded pluginDb.Website
+				require.NoError(tb, db.First(&reloaded, website.ID).Error)
+				require.NotNil(tb, reloaded.PrimaryDomainID)
+				assert.Equal(tb, wd.ID, *reloaded.PrimaryDomainID)
+
+				// The persisted flag agrees with the absence of a zone.
+				var persisted pluginDb.WebsiteDomain
+				require.NoError(tb, db.First(&persisted, wd.ID).Error)
+				assert.False(tb, persisted.DNSHostingEnabled)
+			})
+		}
 	}, testOptionsWithHNSResolver(addr))
 }

--- a/internal/service/domain/delegated_domain_service_test.go
+++ b/internal/service/domain/delegated_domain_service_test.go
@@ -20,6 +20,7 @@ import (
 	"go.lumeweb.com/portal-plugin-ipfs/internal/testing/testopts"
 	"go.lumeweb.com/portal/core"
 	coreTesting "go.lumeweb.com/portal/core/testing"
+	"gorm.io/datatypes"
 	"gorm.io/gorm"
 )
 
@@ -799,4 +800,188 @@ func TestDelegatedDomainService_CreateDomain_Hip5OnchainManaged(t *testing.T) {
 			})
 		}
 	}, testOptionsWithHNSResolver(addr))
+}
+
+func TestDelegatedDomainService_ConvertToOnChain_HappyPath(t *testing.T) {
+	// A native HNS binding (portal-hosted zone + DNSSEC/delegation) whose name
+	// has since been pointed at an external contract converts to on-chain
+	// managed: the managed zone is deleted, delegation/DNSSEC state is dropped,
+	// but DANE/SSL state (ProtocolData) is retained and the website re-arms
+	// validation.
+	const domain = "convertme"
+	const zoneID = uint(77)
+
+	hip5Addr, _ := startCustomPortDNSServer(t, domain+".",
+		[]string{"0x36fc69f0983e536d1787cc83f481581f22cca2a1._eth."})
+
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		db := ctx.DB()
+		website := createTestWebsite(tb, db, 1, domain)
+		// Simulate a website already serving the site so the conversion
+		// re-arms validation back to pending.
+		require.NoError(tb, db.Model(&website).Update("status", pluginDb.WebsiteStatusActive).Error)
+
+		wd := &pluginDb.WebsiteDomain{
+			WebsiteID:         website.ID,
+			UserID:            1,
+			Domain:            domain,
+			Namespace:         pluginDb.DomainNamespaceHNS,
+			ZoneName:          domain + ".",
+			GatewayHost:       "1.2.3.4",
+			ZoneID:            zoneID,
+			Status:            pluginDb.DomainStatusActive,
+			DNSHostingEnabled: true,
+			DelegationData: datatypes.JSONMap{
+				"mode": "delegated",
+				"authoritative_records": []map[string]any{
+					{"type": "NS", "value": "ns1.lumeweb\nns2.lumeweb"},
+				},
+			},
+			// Simulated DANE state that must survive the conversion (DANE/SSL
+			// still applies on-chain; only PowerDNS-served records go away).
+			ProtocolData: datatypes.JSONMap{
+				"dane_cert_pem":    "CERT",
+				"tlsa":             "3 1 1 abc",
+				"owner_name":       "_443._tcp." + domain + ".",
+				"dane_private_key": "encrypted-key",
+			},
+		}
+		require.NoError(tb, db.Create(wd).Error)
+
+		svc := core.GetService[*DelegatedDomainService](ctx, pluginCore.DELEGATED_DOMAIN_SERVICE)
+		require.NotNil(tb, svc)
+		hnsProv := svc.registry.Get("hns").(*HNSProvider)
+		hnsProv.resolverAddr = hip5Addr
+
+		mockDNS := core.GetService[*mocks.MockDNSService](ctx, pluginCore.DNS_SERVICE)
+		mockDNS.EXPECT().DeleteZone(mock.Anything, zoneID).Return(nil).Once()
+
+		converted, err := svc.ConvertToOnChain(context.Background(), website.ID, 1, wd.ID)
+		require.NoError(tb, err)
+		assert.Equal(tb, pluginDb.DomainStatusOnchainManaged, converted.Status)
+		assert.Equal(tb, uint(0), converted.ZoneID)
+		assert.False(tb, converted.DNSHostingEnabled)
+		assert.Nil(tb, converted.DelegationData)
+		// DANE/SSL ProtocolData is retained.
+		require.NotNil(tb, converted.ProtocolData)
+		assert.Equal(tb, "CERT", converted.ProtocolData["dane_cert_pem"])
+		assert.Equal(tb, "3 1 1 abc", converted.ProtocolData["tlsa"])
+
+		// Persisted state mirrors the in-memory binding.
+		var persisted pluginDb.WebsiteDomain
+		require.NoError(tb, db.First(&persisted, wd.ID).Error)
+		assert.Equal(tb, pluginDb.DomainStatusOnchainManaged, persisted.Status)
+		assert.Equal(tb, uint(0), persisted.ZoneID)
+		assert.Nil(tb, persisted.DelegationData)
+		assert.False(tb, persisted.DNSHostingEnabled)
+		assert.Equal(tb, "CERT", persisted.ProtocolData["dane_cert_pem"])
+
+		// The website re-armed validation (active -> pending_validation).
+		var reloaded pluginDb.Website
+		require.NoError(tb, db.First(&reloaded, website.ID).Error)
+		assert.Equal(tb, string(pluginDb.WebsiteStatusPendingValidation), reloaded.Status)
+	}, TestOptions)
+}
+
+func TestDelegatedDomainService_ConvertToOnChain_NotHIP5Refused(t *testing.T) {
+	// Conversion is refused until the name genuinely serves a HIP-5 record; it
+	// never tears down DNS on the caller's word alone.
+	const domain = "staysnative"
+	nativeAddr, _ := startCustomPortDNSServer(t, domain+".", []string{"ns1.lumeweb."})
+
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		db := ctx.DB()
+		website := createTestWebsite(tb, db, 1, domain)
+		wd := &pluginDb.WebsiteDomain{
+			WebsiteID: website.ID, UserID: 1, Domain: domain,
+			Namespace: pluginDb.DomainNamespaceHNS, ZoneID: 9,
+			Status: pluginDb.DomainStatusActive, DNSHostingEnabled: true,
+			GatewayHost:    "1.2.3.4",
+			DelegationData: datatypes.JSONMap{"mode": "delegated"},
+		}
+		require.NoError(tb, db.Create(wd).Error)
+
+		svc := core.GetService[*DelegatedDomainService](ctx, pluginCore.DELEGATED_DOMAIN_SERVICE)
+		hnsProv := svc.registry.Get("hns").(*HNSProvider)
+		hnsProv.resolverAddr = nativeAddr
+
+		mockDNS := core.GetService[*mocks.MockDNSService](ctx, pluginCore.DNS_SERVICE)
+
+		_, err := svc.ConvertToOnChain(context.Background(), website.ID, 1, wd.ID)
+		require.Error(tb, err)
+		assert.Contains(tb, err.Error(), "not yet on-chain managed")
+		mockDNS.AssertNotCalled(tb, "DeleteZone", mock.Anything, mock.Anything)
+	}, TestOptions)
+}
+
+func TestDelegatedDomainService_ConvertToOnChain_AlreadyOnchainRefused(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		db := ctx.DB()
+		website := createTestWebsite(tb, db, 1, "onchain")
+		wd := &pluginDb.WebsiteDomain{
+			WebsiteID: website.ID, UserID: 1, Domain: "onchain",
+			Namespace: pluginDb.DomainNamespaceHNS,
+			Status:    pluginDb.DomainStatusOnchainManaged,
+		}
+		require.NoError(tb, db.Create(wd).Error)
+
+		svc := core.GetService[*DelegatedDomainService](ctx, pluginCore.DELEGATED_DOMAIN_SERVICE)
+
+		_, err := svc.ConvertToOnChain(context.Background(), website.ID, 1, wd.ID)
+		require.Error(tb, err)
+		assert.Contains(tb, err.Error(), "already on-chain managed")
+	}, TestOptions)
+}
+
+func TestDelegatedDomainService_ConvertToOnChain_SharedZoneRefused(t *testing.T) {
+	// A zone shared with other live bindings (their parent/apex zone) must not
+	// be deleted; conversion is refused so the owner detaches them first.
+	const domain = "sharedzone"
+	hip5Addr, _ := startCustomPortDNSServer(t, domain+".",
+		[]string{"0xdeadbeef._eth."})
+
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		db := ctx.DB()
+		website := createTestWebsite(tb, db, 1, domain)
+
+		apex := &pluginDb.WebsiteDomain{
+			WebsiteID: website.ID, UserID: 1, Domain: domain,
+			Namespace: pluginDb.DomainNamespaceHNS, ZoneID: 55,
+			Status: pluginDb.DomainStatusActive, DNSHostingEnabled: true,
+			GatewayHost:    "1.2.3.4",
+			DelegationData: datatypes.JSONMap{"mode": "delegated"},
+		}
+		require.NoError(tb, db.Create(apex).Error)
+		// A second binding under the same apex zone.
+		sub := &pluginDb.WebsiteDomain{
+			WebsiteID: website.ID, UserID: 1, Domain: "sub." + domain,
+			Namespace: pluginDb.DomainNamespaceHNS, ZoneID: 55,
+			Status: pluginDb.DomainStatusActive, DNSHostingEnabled: true,
+			GatewayHost:    "1.2.3.4",
+			DelegationData: datatypes.JSONMap{"mode": "delegated"},
+		}
+		require.NoError(tb, db.Create(sub).Error)
+
+		svc := core.GetService[*DelegatedDomainService](ctx, pluginCore.DELEGATED_DOMAIN_SERVICE)
+		hnsProv := svc.registry.Get("hns").(*HNSProvider)
+		hnsProv.resolverAddr = hip5Addr
+
+		mockDNS := core.GetService[*mocks.MockDNSService](ctx, pluginCore.DNS_SERVICE)
+
+		_, err := svc.ConvertToOnChain(context.Background(), website.ID, 1, apex.ID)
+		require.Error(tb, err)
+		assert.Contains(tb, err.Error(), "share its DNS zone")
+		mockDNS.AssertNotCalled(tb, "DeleteZone", mock.Anything, mock.Anything)
+	}, TestOptions)
+}
+
+func TestDelegatedDomainService_ConvertToOnChain_NotFound(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		svc := core.GetService[*DelegatedDomainService](ctx, pluginCore.DELEGATED_DOMAIN_SERVICE)
+		require.NotNil(tb, svc)
+
+		_, err := svc.ConvertToOnChain(context.Background(), 1, 1, 999999)
+		require.Error(tb, err)
+		assert.True(tb, errors.Is(err, gorm.ErrRecordNotFound))
+	}, TestOptions)
 }

--- a/internal/service/domain/delegated_domain_service_test.go
+++ b/internal/service/domain/delegated_domain_service_test.go
@@ -718,3 +718,70 @@ func TestDelegatedDomainService_UpdateTLSA_PublishesToManagedZone(t *testing.T) 
 		}, keyTestOptions)
 	})
 }
+
+// testOptionsWithHNSResolver is TestOptions with the DNS service config's
+// HNSResolver pointed at the given address, so the factory's HNSProvider
+// performs HIP-5 inspection against a live test server. It intentionally does
+// NOT combine with the package-level TestOptions: building a second mock
+// plugin would re-register the ipfs plugin and panic.
+func testOptionsWithHNSResolver(addr string) coreTesting.TestContextBuilderOption {
+	// Combine with the package-level TestOptions (which registers the ipfs
+	// plugin once) and push the resolver into the config manager via the
+	// core-testing service-config option — GetServiceConfig reads the config
+	// manager, not the mock service's GetConfig().
+	return coreTesting.CombineOptions(
+		TestOptions,
+		coreTesting.WithServiceConfig(internal.ProtocolName, pluginCore.DNS_SERVICE, &pluginConfig.DnsConfig{HNSResolver: addr}),
+	)
+}
+
+func TestDelegatedDomainService_CreateDomain_Hip5OnchainManaged(t *testing.T) {
+	// A Handshake name whose NS record is a HIP-5 TX record must bind as on-chain
+	// managed: no zone, no DANE, TXT-verification status, and binding with portal
+	// DNS hosting (dnsHostingEnabled=true) must be rejected.
+	const domain = "myname"
+
+	addr, _ := startCustomPortDNSServer(t, domain+".",
+		[]string{"0x36fc69f0983e536d1787cc83f481581f22cca2a1._eth."})
+
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		db := ctx.DB()
+		website := createTestWebsite(tb, db, 1, domain)
+
+		svc := core.GetService[*DelegatedDomainService](ctx, pluginCore.DELEGATED_DOMAIN_SERVICE)
+		require.NotNil(tb, svc)
+
+		// Point the registered HNS provider at the live test resolver. The
+		// factory only reads DnsConfig.HNSResolver at startup; assigning the
+		// provider's resolver here keeps the test deterministic.
+		hnsProv := svc.registry.Get("hns").(*HNSProvider)
+		require.NotNil(tb, hnsProv)
+		hnsProv.resolverAddr = addr
+
+		// Portal DNS hosting must be rejected for an on-chain managed name; no
+		// row is persisted by the failed attempt.
+		_, err := svc.CreateDomain(context.Background(), "hns", domain, website.ID, 1, true, false, nil, nil)
+		require.Error(tb, err)
+		assert.Contains(tb, err.Error(), "HIP-5")
+
+		// Self-hosted (dnsHostingEnabled=false) binds as onchain_managed with no
+		// zone, no delegation data, and fires the created notification (the
+		// binding is the new website's primary).
+		mockWebsite := core.GetService[*mocks.MockWebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
+		mockWebsite.EXPECT().NotifyAdminWebsiteCreated(mock.Anything, website.ID).Return(nil).Once()
+
+		wd, err := svc.CreateDomain(context.Background(), "hns", domain, website.ID, 1, false, true, nil, nil)
+		require.NoError(tb, err)
+		assert.Equal(tb, pluginDb.DomainStatusOnchainManaged, wd.Status)
+		assert.Equal(tb, uint(0), wd.ZoneID)
+		assert.False(tb, wd.DNSHostingEnabled)
+		assert.Nil(tb, wd.DelegationData)
+
+		// The binding is recorded as the website's primary so the website
+		// service resolves the apex domain via PrimaryDomainID.
+		var reloaded pluginDb.Website
+		require.NoError(tb, db.First(&reloaded, website.ID).Error)
+		require.NotNil(tb, reloaded.PrimaryDomainID)
+		assert.Equal(tb, wd.ID, *reloaded.PrimaryDomainID)
+	}, testOptionsWithHNSResolver(addr))
+}

--- a/internal/service/domain/delegated_domain_service_test.go
+++ b/internal/service/domain/delegated_domain_service_test.go
@@ -854,7 +854,18 @@ func TestDelegatedDomainService_ConvertToOnChain_HappyPath(t *testing.T) {
 		hnsProv.resolverAddr = hip5Addr
 
 		mockDNS := core.GetService[*mocks.MockDNSService](ctx, pluginCore.DNS_SERVICE)
-		mockDNS.EXPECT().DeleteZone(mock.Anything, zoneID).Return(nil).Once()
+		mockDNS.EXPECT().DeleteZone(mock.Anything, zoneID).
+			// The conversion persists the on-chain state BEFORE deleting the
+			// zone: at delete time the DB row must already be onchain with the
+			// zone cleared, so a delete failure can never strand a binding
+			// pointing at a destroyed zone.
+			Run(func(_ context.Context, z uint) {
+				var now pluginDb.WebsiteDomain
+				require.NoError(tb, ctx.DB().First(&now, wd.ID).Error)
+				assert.Equal(tb, pluginDb.DomainStatusOnchainManaged, now.Status)
+				assert.Equal(tb, uint(0), now.ZoneID)
+			}).
+			Return(nil).Once()
 
 		converted, err := svc.ConvertToOnChain(context.Background(), website.ID, 1, wd.ID)
 		require.NoError(tb, err)
@@ -970,7 +981,8 @@ func TestDelegatedDomainService_ConvertToOnChain_SharedZoneRefused(t *testing.T)
 
 		_, err := svc.ConvertToOnChain(context.Background(), website.ID, 1, apex.ID)
 		require.Error(tb, err)
-		assert.Contains(tb, err.Error(), "share its DNS zone")
+		assert.ErrorIs(tb, err, ErrDomainZoneShared)
+		assert.Contains(tb, err.Error(), "shared by other bindings")
 		mockDNS.AssertNotCalled(tb, "DeleteZone", mock.Anything, mock.Anything)
 	}, TestOptions)
 }

--- a/internal/service/domain/hns_provider.go
+++ b/internal/service/domain/hns_provider.go
@@ -228,11 +228,18 @@ func (p *HNSProvider) Validate(domain string) error {
 // false so the name binds as native HNS and can be converted to on-chain
 // managed later by an explicit admin action — never silently guessed by the
 // janitor.
+//
+// The query runs under a short deadline of its own: Inspect is on the bind
+// hot path (every user HNS bind), so a slow/unreachable resolver must not
+// stall a bind for the DNS client's 5s timeout. A deadline expiration is
+// treated like any resolver failure: bind as native, to be reconciled later.
 func (p *HNSProvider) Inspect(ctx context.Context, domain string) (bool, error) {
 	if p.resolverAddr == "" {
 		return false, nil
 	}
-	nss, err := queryNS(ctx, p.resolverAddr, dnsname.EnsureFQDN(domain))
+	inspectCtx, cancel := context.WithTimeout(ctx, hip5InspectTimeout)
+	defer cancel()
+	nss, err := queryNS(inspectCtx, p.resolverAddr, dnsname.EnsureFQDN(domain))
 	if err != nil {
 		return false, nil
 	}
@@ -243,6 +250,11 @@ func (p *HNSProvider) Inspect(ctx context.Context, domain string) (bool, error) 
 	}
 	return false, nil
 }
+
+// hip5InspectTimeout bounds how long the HIP5 inspection DNS query may run.
+// It is deliberately shorter than the DNS client timeout (5s) so the bind
+// path never blocks on a slow resolver.
+const hip5InspectTimeout = 1500 * time.Millisecond
 
 // isHIP5TX detects a HIP-5 TX record by its final label, per HIP-0005 the
 // protocol tag: it is either structurally invalid on the HNS root

--- a/internal/service/domain/hns_provider.go
+++ b/internal/service/domain/hns_provider.go
@@ -123,6 +123,10 @@ type HNSProvider struct {
 	tlsaSource   TLSASource
 	tlsaMu       sync.RWMutex
 	dnsSvc       DNSZoneService
+	// hip5BlockedTLDs are TLDs that are blocked on the HNS root and therefore
+	// mark an NS record's final label as a HIP-5 protocol tag (e.g. "eth",
+	// "bit"), in addition to underscore-prefixed labels which are always HIP-5.
+	hip5BlockedTLDs map[string]bool
 }
 
 // TLSASource holds certificates keyed by domain for TLSA computation.
@@ -133,10 +137,33 @@ type TLSASource struct {
 
 func NewHNSProvider(resolver string, nsRecords []string, tlsa TLSASource) *HNSProvider {
 	return &HNSProvider{
-		resolverAddr: resolver,
-		nsRecords:    nsRecords,
-		tlsaSource:   tlsa,
+		resolverAddr:    resolver,
+		nsRecords:       nsRecords,
+		tlsaSource:      tlsa,
+		hip5BlockedTLDs: defaultHIP5BlockedTLDs(),
 	}
+}
+
+// defaultHIP5BlockedTLDs returns the TLDs that are blocked on the HNS root and
+// thus treated as HIP-5 protocol tags, alongside underscore-prefixed labels.
+// Operators may extend the set via SetHIP5BlockedTLDs.
+func defaultHIP5BlockedTLDs() map[string]bool {
+	return map[string]bool{
+		"eth": true,
+		"bit": true,
+	}
+}
+
+// SetHIP5BlockedTLDs replaces the set of TLDs marking an NS record's final
+// label as a HIP-5 protocol tag (see hip5BlockedTLDs). An empty list leaves
+// only underscore-prefixed labels counted as HIP-5. Must be called before the
+// provider serves requests (it is not synchronized with Inspect).
+func (p *HNSProvider) SetHIP5BlockedTLDs(tlds []string) {
+	m := make(map[string]bool, len(tlds))
+	for _, t := range tlds {
+		m[strings.ToLower(t)] = true
+	}
+	p.hip5BlockedTLDs = m
 }
 
 // SetDNSService injects the DNS zone service for DNSSEC enablement.
@@ -187,6 +214,53 @@ func (p *HNSProvider) Validate(domain string) error {
 		return fmt.Errorf("%q ends in an ICANN TLD; use the ICANN namespace", domain)
 	}
 	return nil
+}
+
+// Inspect reports whether the HNS name is managed on-chain via HIP-5: it
+// queries the HNS resolver for the name's NS records and checks whether any of
+// them is a HIP-5 TX record (whose final label is a HIP-5 protocol tag, e.g.
+// "_eth" or a blocked TLD like "eth"). Such a name serves its DNS from an
+// external contract, so the portal must not provision a PowerDNS zone for it
+// and proves ownership with a TXT token resolved through the resolver.
+//
+// Detection is best-effort: when the resolver is not configured or cannot
+// answer (name not yet registered on-chain, resolver unreachable), it returns
+// false so the name binds as native HNS and can be converted to on-chain
+// managed later by an explicit admin action — never silently guessed by the
+// janitor.
+func (p *HNSProvider) Inspect(ctx context.Context, domain string) (bool, error) {
+	if p.resolverAddr == "" {
+		return false, nil
+	}
+	nss, err := queryNS(ctx, p.resolverAddr, dnsname.EnsureFQDN(domain))
+	if err != nil {
+		return false, nil
+	}
+	for _, ns := range nss {
+		if p.isHIP5TX(ns) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// isHIP5TX detects a HIP-5 TX record by its final label, per HIP-0005 the
+// protocol tag: it is either structurally invalid on the HNS root
+// (underscore-prefixed, e.g. "_eth") or a TLD blocked by the HNS root
+// (e.g. "eth", "bit"). The labels before it are the chain-specific input (an
+// ETH hex address, a SOL base58 address, ...) and are deliberately not parsed
+// here — the HNS resolver already validated the record when it served it, and
+// the address format is not our concern.
+func (p *HNSProvider) isHIP5TX(ns string) bool {
+	labels := strings.Split(strings.TrimSuffix(ns, "."), ".")
+	if len(labels) < 2 {
+		return false
+	}
+	last := strings.ToLower(labels[len(labels)-1])
+	if strings.HasPrefix(last, "_") {
+		return true
+	}
+	return p.hip5BlockedTLDs[last]
 }
 
 func (p *HNSProvider) BuildDelegation(ctx context.Context, zoneID uint,

--- a/internal/service/domain/hns_provider_test.go
+++ b/internal/service/domain/hns_provider_test.go
@@ -236,3 +236,131 @@ func TestHNSProvider_BuildDelegation_NoDSRecord(t *testing.T) {
 		assert.NotEqual(t, "DS", rec.Type, "delegation bundle must not persist a DS record")
 	}
 }
+
+func TestHNSProvider_isHIP5TX(t *testing.T) {
+	p := NewHNSProvider("", nil, TLSASource{})
+
+	tests := []struct {
+		name string
+		ns   string
+		want bool
+	}{
+		{
+			name: "eth contract address with underscore tag",
+			ns:   "0x667ab1d9f98817ffb28cd61b911f921181c669b3._eth.",
+			want: true,
+		},
+		{
+			name: "sol address with underscore tag",
+			ns:   "somebase58encodedaddress._sol.",
+			want: true,
+		},
+		{
+			name: "blocked TLD without underscore (eth)",
+			ns:   "0x36fc69f0983e536d1787cc83f481581f22cca2a1.eth.",
+			want: true,
+		},
+		{
+			name: "blocked TLD (bit)",
+			ns:   "0x00deadbeef.bit.",
+			want: true,
+		},
+		{
+			name: "blocked TLD is case-insensitive",
+			ns:   "0x36fc69f0983e536d1787cc83f481581f22cca2a1.ETH.",
+			want: true,
+		},
+		{
+			name: "subdomain under address",
+			ns:   "sub.0x36fc69f0983e536d1787cc83f481581f22cca2a1._eth.",
+			want: true,
+		},
+		{
+			name: "native HNS nameserver",
+			ns:   "ns1.lumeweb.",
+			want: false,
+		},
+		{
+			name: "single label",
+			ns:   "ns1.",
+			want: false,
+		},
+		{
+			name: "relative ns without trailing dot",
+			ns:   "ns1.lumeweb",
+			want: false,
+		},
+		{
+			name: "empty",
+			ns:   "",
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, p.isHIP5TX(tt.ns))
+		})
+	}
+}
+
+func TestHNSProvider_SetHIP5BlockedTLDs(t *testing.T) {
+	// Defaults treat "eth" and "bit" as HIP-5 protocol tags.
+	p := NewHNSProvider("", nil, TLSASource{})
+	assert.True(t, p.isHIP5TX("0xabc.eth."))
+
+	// Replacing the set with a custom TLD drops "eth" from detection.
+	p.SetHIP5BlockedTLDs([]string{"sol"})
+	assert.False(t, p.isHIP5TX("0xabc.eth."))
+	assert.True(t, p.isHIP5TX("0xabc.sol."))
+
+	// Clearing the list leaves only underscore-prefixed tags counted.
+	p.SetHIP5BlockedTLDs(nil)
+	assert.False(t, p.isHIP5TX("0xabc.sol."))
+	assert.True(t, p.isHIP5TX("0xabc._sol."))
+}
+
+func TestHNSProvider_Inspect_HIP5Detection(t *testing.T) {
+	const domain = "myname."
+
+	// The HNS resolver serves a HIP-5 TX record for the name.
+	addr, served := startCustomPortDNSServer(t, domain,
+		[]string{"0x36fc69f0983e536d1787cc83f481581f22cca2a1._eth."})
+
+	p := NewHNSProvider(addr, nil, TLSASource{})
+	before := served.value()
+	onchain, err := p.Inspect(context.Background(), "myname")
+	require.NoError(t, err)
+	assert.True(t, onchain, "HIP-5 TX record must be detected as on-chain managed")
+	assert.Greater(t, served.value(), before, "Inspect must query the configured resolver")
+}
+
+func TestHNSProvider_Inspect_NativeHNS(t *testing.T) {
+	const domain = "myname."
+
+	// The HNS resolver serves ordinary nameservers (native delegation).
+	addr, _ := startCustomPortDNSServer(t, domain, []string{"ns1.lumeweb.", "ns2.lumeweb."})
+
+	p := NewHNSProvider(addr, nil, TLSASource{})
+	onchain, err := p.Inspect(context.Background(), "myname")
+	require.NoError(t, err)
+	assert.False(t, onchain, "ordinary nameservers must not be treated as on-chain managed")
+}
+
+func TestHNSProvider_Inspect_NoResolverConfigured(t *testing.T) {
+	// Without a configured resolver, Inspect must default to native (false)
+	// rather than erroring, so binding can proceed.
+	p := NewHNSProvider("", nil, TLSASource{})
+	onchain, err := p.Inspect(context.Background(), "myname")
+	require.NoError(t, err)
+	assert.False(t, onchain)
+}
+
+func TestHNSProvider_Inspect_ResolverUnreachable(t *testing.T) {
+	// A resolver that cannot answer (nothing listening on the port) must be
+	// treated as native (false), not a hard error.
+	p := NewHNSProvider("127.0.0.1:1", nil, TLSASource{})
+	onchain, err := p.Inspect(context.Background(), "myname")
+	require.NoError(t, err)
+	assert.False(t, onchain)
+}

--- a/internal/service/domain/icann_provider.go
+++ b/internal/service/domain/icann_provider.go
@@ -53,6 +53,13 @@ func (p *ICANNProvider) Validate(domain string) error {
 	return nil
 }
 
+// Inspect reports that ICANN names are never on-chain managed: the
+// registry/registrar model lives out-of-band, so the portal always provisions
+// a managed zone for them as normal.
+func (p *ICANNProvider) Inspect(ctx context.Context, domain string) (bool, error) {
+	return false, nil
+}
+
 func (p *ICANNProvider) BuildDelegation(ctx context.Context, zoneID uint,
 	domain string, website *pluginDb.Website, config json.RawMessage) (any, error) {
 

--- a/internal/service/domain/icann_provider_test.go
+++ b/internal/service/domain/icann_provider_test.go
@@ -36,6 +36,14 @@ func TestICANNProvider_BuildDelegation(t *testing.T) {
 	assert.Contains(t, bundle.Nameservers, "ns1.example.com.")
 }
 
+func TestICANNProvider_Inspect(t *testing.T) {
+	// ICANN names are never on-chain managed: Inspect is a static false.
+	p := NewICANNProvider(nil)
+	onchain, err := p.Inspect(context.Background(), "example.com")
+	assert.NoError(t, err)
+	assert.False(t, onchain)
+}
+
 func TestICANNProvider_VerifyDelegation(t *testing.T) {
 	p := NewICANNProvider(nil)
 	// ICANN ignores expectedDS entirely.

--- a/internal/service/domain/onchain.go
+++ b/internal/service/domain/onchain.go
@@ -1,0 +1,154 @@
+package domain
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	pluginDb "go.lumeweb.com/portal-plugin-ipfs/internal/db"
+	"go.uber.org/zap"
+)
+
+// Sentinel errors returned by ConvertToOnChain for user-correctable state
+// conflicts, so the API can map them to 4xx while genuine infrastructure
+// failures (DB, DNS service) surface as 5xx. Match with errors.Is.
+var (
+	ErrDomainAlreadyOnChain = errors.New("domain is already on-chain managed")
+	ErrDomainNotOnChain     = errors.New("domain is not yet on-chain managed")
+	ErrDomainZoneShared     = errors.New("domain's DNS zone is shared by other bindings")
+)
+
+// ConvertToOnChain converts a bound domain into an on-chain managed (HIP-5)
+// binding — the explicit, one-way path for the HNS-DNS → on-chain-DNS
+// transition, used when the name's NS record now points at an external
+// contract (a HIP-5 TX record the owner set on-chain).
+//
+// The portal stops owning the PowerDNS-served DNS for the name: the managed
+// zone (and the DNSSEC/DS carried by it) is deleted and the binding is
+// re-marked onchain_managed with dns_hosting_enabled=false, so ownership is
+// proven with the TXT token through the resolver instead of NS/DS delegation.
+// DANE/SSL state (ProtocolData: key, cert, TLSA, owner) is deliberately KEPT —
+// DANE still applies on-chain; only the PowerDNS-published records and DNSSEC
+// (not a concept on-chain) are dropped. The owning website is reset to
+// pending_validation so the TXT-token verification flow re-runs.
+//
+// Safety (never tear down on the caller's word alone):
+//   - Refused until Inspect confirms the name genuinely serves a HIP-5 record.
+//   - The PowerDNS zone is deleted only when no other live binding shares it:
+//     a shared zone is the parent of other native bindings, and deleting it
+//     would destroy their records/DNSSEC. Conversion is refused for shared
+//     zones with a clear instruction to detach those bindings first — a HIP-5
+//     apex resolves every subdomain via the contract anyway.
+//   - Refused for a binding already onchain_managed.
+func (s *DelegatedDomainService) ConvertToOnChain(ctx context.Context, websiteID, userID, domainID uint) (*pluginDb.WebsiteDomain, error) {
+	if s.DB() == nil {
+		return nil, fmt.Errorf("database not available")
+	}
+
+	var wd pluginDb.WebsiteDomain
+	if err := s.DB().WithContext(ctx).
+		Where("id = ? AND website_id = ? AND user_id = ?", domainID, websiteID, userID).
+		First(&wd).Error; err != nil {
+		return nil, err // includes gorm.ErrRecordNotFound
+	}
+
+	if wd.Status == pluginDb.DomainStatusOnchainManaged {
+		return nil, fmt.Errorf("%w: %q", ErrDomainAlreadyOnChain, wd.Domain)
+	}
+
+	provider := s.registry.Get(string(wd.Namespace))
+	if provider == nil {
+		return nil, fmt.Errorf("unsupported namespace: %s", wd.Namespace)
+	}
+
+	onchain, err := provider.Inspect(ctx, wd.Domain)
+	if err != nil {
+		return nil, fmt.Errorf("domain inspection failed: %w", err)
+	}
+	if !onchain {
+		return nil, fmt.Errorf("%w: %q; its NS record does not point at an external contract", ErrDomainNotOnChain, wd.Domain)
+	}
+
+	// Only the binding's sole-owner PowerDNS zone may be deleted. A zone shared
+	// with other live bindings (their parent/apex zone) must be kept — deleting
+	// it would destroy their records and DNSSEC.
+	zoneID := wd.ZoneID
+	if zoneID != 0 {
+		var sharers int64
+		if err := s.DB().WithContext(ctx).
+			Model(&pluginDb.WebsiteDomain{}).
+			Where("zone_id = ? AND id != ? AND deleted_at IS NULL", zoneID, wd.ID).
+			Count(&sharers).Error; err != nil {
+			return nil, fmt.Errorf("failed to count bindings sharing zone %d: %w", zoneID, err)
+		}
+		if sharers > 0 {
+			return nil, fmt.Errorf("%w: %q (%d other binding(s)); remove or convert them first", ErrDomainZoneShared, wd.Domain, sharers)
+		}
+	}
+
+	// Drop the PowerDNS-backed delegation state. ProtocolData (DANE key, cert,
+	// TLSA, owner) and per-domain SSL state are intentionally preserved: DANE/
+	// SSL still apply to the name — the records are simply served by the
+	// external contract now — and DNSSEC is not a concept on-chain.
+	updates := map[string]any{
+		"zone_id":             0,
+		"zone_name":           "",
+		"gateway_host":        "",
+		"delegation_data":     nil,
+		"dns_hosting_enabled": false,
+		"status":              pluginDb.DomainStatusOnchainManaged,
+	}
+	if err := s.DB().WithContext(ctx).Model(&wd).Updates(updates).Error; err != nil {
+		return nil, fmt.Errorf("failed to persist on-chain managed state: %w", err)
+	}
+	wd.ZoneID = 0
+	wd.ZoneName = ""
+	wd.GatewayHost = ""
+	wd.DelegationData = nil
+	wd.DNSHostingEnabled = false
+	wd.Status = pluginDb.DomainStatusOnchainManaged
+
+	// Delete the now-unreferenced PowerDNS zone LAST, best-effort. Order is
+	// deliberate: the DB runs first so a delete failure can never strand the
+	// binding pointing at a destroyed zone (the unrecoverable state). If a
+	// concurrent bind landed in this zone between the check above and here, the
+	// zone is re-counted and left alone so another binding's records/DNSSEC are
+	// not destroyed. A leftover/unreferenced zone is harmless (nothing serves
+	// it — the name resolves via the contract) and is logged for ops cleanup.
+	if zoneID != 0 && s.dnsSvc != nil {
+		var sharers int64
+		if err := s.DB().WithContext(ctx).
+			Model(&pluginDb.WebsiteDomain{}).
+			Where("zone_id = ? AND id != ? AND deleted_at IS NULL", zoneID, wd.ID).
+			Count(&sharers).Error; err != nil {
+			s.Logger().Warn("failed to re-count zone sharers before on-chain conversion zone delete",
+				zap.Uint("zone_id", zoneID), zap.String("domain", wd.Domain), zap.Error(err))
+		} else if sharers > 0 {
+			s.Logger().Info("on-chain conversion: zone now shared by other bindings; leaving it intact",
+				zap.Uint("zone_id", zoneID), zap.String("domain", wd.Domain))
+		} else if err := s.dnsSvc.DeleteZone(ctx, zoneID); err != nil {
+			// Non-fatal: the binding is already cleanly on-chain; the orphaned
+			// zone is unreachable garbage an operator can clear.
+			s.Logger().Warn("on-chain conversion: failed to delete orphaned managed zone (non-fatal)",
+				zap.Uint("zone_id", zoneID), zap.String("domain", wd.Domain), zap.Error(err))
+		}
+	}
+
+	// DNS moved on-chain: the site must prove ownership against the contract
+	// with the TXT token, so re-arm validation. A blocked website stays blocked
+	// (only an admin can lift an admin block); a pending one needs no change.
+	// A website-load failure is surfaced rather than silently skipped so the
+	// caller knows validation was not re-armed.
+	var website pluginDb.Website
+	if err := s.DB().WithContext(ctx).First(&website, wd.WebsiteID).Error; err != nil {
+		return nil, fmt.Errorf("failed to load website %d for on-chain conversion: %w", wd.WebsiteID, err)
+	}
+	if website.Status != string(pluginDb.WebsiteStatusBlocked) &&
+		website.Status != string(pluginDb.WebsiteStatusPendingValidation) {
+		if err := s.DB().WithContext(ctx).Model(&website).Update("status", pluginDb.WebsiteStatusPendingValidation).Error; err != nil {
+			return nil, fmt.Errorf("failed to reset website to pending_validation: %w", err)
+		}
+	}
+
+	return &wd, nil
+}

--- a/internal/service/domain/onchain.go
+++ b/internal/service/domain/onchain.go
@@ -69,85 +69,85 @@ func (s *DelegatedDomainService) ConvertToOnChain(ctx context.Context, websiteID
 		return nil, fmt.Errorf("%w: %q; its NS record does not point at an external contract", ErrDomainNotOnChain, wd.Domain)
 	}
 
-	// Only the binding's sole-owner PowerDNS zone may be deleted. A zone shared
-	// with other live bindings (their parent/apex zone) must be kept — deleting
-	// it would destroy their records and DNSSEC.
+	// Serialize this conversion against CreateDomain's zone provisioning so a
+	// concurrent bind into the same zone can never have its zone (and records/
+	// DNSSEC) destroyed between our sharer check and the delete. Both paths key
+	// the same per-zone lock on the zone's canonical apex name.
 	zoneID := wd.ZoneID
-	if zoneID != 0 {
-		var sharers int64
-		if err := s.DB().WithContext(ctx).
-			Model(&pluginDb.WebsiteDomain{}).
-			Where("zone_id = ? AND id != ? AND deleted_at IS NULL", zoneID, wd.ID).
-			Count(&sharers).Error; err != nil {
-			return nil, fmt.Errorf("failed to count bindings sharing zone %d: %w", zoneID, err)
+	if err := s.withZoneLifecycleLock(zoneLifecycleKey(wd.Domain), func() error {
+		// Only the binding's sole-owner PowerDNS zone may be deleted. A zone
+		// shared with other live bindings (their parent/apex zone) must be kept
+		// — deleting it would destroy their records and DNSSEC.
+		if zoneID != 0 {
+			var sharers int64
+			if err := s.DB().WithContext(ctx).
+				Model(&pluginDb.WebsiteDomain{}).
+				Where("zone_id = ? AND id != ? AND deleted_at IS NULL", zoneID, wd.ID).
+				Count(&sharers).Error; err != nil {
+				return fmt.Errorf("failed to count bindings sharing zone %d: %w", zoneID, err)
+			}
+			if sharers > 0 {
+				return fmt.Errorf("%w: %q (%d other binding(s)); remove or convert them first", ErrDomainZoneShared, wd.Domain, sharers)
+			}
 		}
-		if sharers > 0 {
-			return nil, fmt.Errorf("%w: %q (%d other binding(s)); remove or convert them first", ErrDomainZoneShared, wd.Domain, sharers)
-		}
-	}
 
-	// Drop the PowerDNS-backed delegation state. ProtocolData (DANE key, cert,
-	// TLSA, owner) and per-domain SSL state are intentionally preserved: DANE/
-	// SSL still apply to the name — the records are simply served by the
-	// external contract now — and DNSSEC is not a concept on-chain.
-	updates := map[string]any{
-		"zone_id":             0,
-		"zone_name":           "",
-		"gateway_host":        "",
-		"delegation_data":     nil,
-		"dns_hosting_enabled": false,
-		"status":              pluginDb.DomainStatusOnchainManaged,
-	}
-	if err := s.DB().WithContext(ctx).Model(&wd).Updates(updates).Error; err != nil {
-		return nil, fmt.Errorf("failed to persist on-chain managed state: %w", err)
-	}
-	wd.ZoneID = 0
-	wd.ZoneName = ""
-	wd.GatewayHost = ""
-	wd.DelegationData = nil
-	wd.DNSHostingEnabled = false
-	wd.Status = pluginDb.DomainStatusOnchainManaged
-
-	// Delete the now-unreferenced PowerDNS zone LAST, best-effort. Order is
-	// deliberate: the DB runs first so a delete failure can never strand the
-	// binding pointing at a destroyed zone (the unrecoverable state). If a
-	// concurrent bind landed in this zone between the check above and here, the
-	// zone is re-counted and left alone so another binding's records/DNSSEC are
-	// not destroyed. A leftover/unreferenced zone is harmless (nothing serves
-	// it — the name resolves via the contract) and is logged for ops cleanup.
-	if zoneID != 0 && s.dnsSvc != nil {
-		var sharers int64
-		if err := s.DB().WithContext(ctx).
-			Model(&pluginDb.WebsiteDomain{}).
-			Where("zone_id = ? AND id != ? AND deleted_at IS NULL", zoneID, wd.ID).
-			Count(&sharers).Error; err != nil {
-			s.Logger().Warn("failed to re-count zone sharers before on-chain conversion zone delete",
-				zap.Uint("zone_id", zoneID), zap.String("domain", wd.Domain), zap.Error(err))
-		} else if sharers > 0 {
-			s.Logger().Info("on-chain conversion: zone now shared by other bindings; leaving it intact",
-				zap.Uint("zone_id", zoneID), zap.String("domain", wd.Domain))
-		} else if err := s.dnsSvc.DeleteZone(ctx, zoneID); err != nil {
-			// Non-fatal: the binding is already cleanly on-chain; the orphaned
-			// zone is unreachable garbage an operator can clear.
-			s.Logger().Warn("on-chain conversion: failed to delete orphaned managed zone (non-fatal)",
-				zap.Uint("zone_id", zoneID), zap.String("domain", wd.Domain), zap.Error(err))
+		// Re-arm the website to pending_validation BEFORE committing the
+		// conversion. A failure here is clean (nothing has been converted yet
+		// and the caller can retry), whereas failing after the on-chain commit
+		// would leave an already-converted domain reported as a 500 and make
+		// retry hit "already on-chain managed". A blocked website stays blocked
+		// (only an admin can lift an admin block); a pending one needs no
+		// change.
+		var website pluginDb.Website
+		if err := s.DB().WithContext(ctx).First(&website, wd.WebsiteID).Error; err != nil {
+			return fmt.Errorf("failed to load website %d for on-chain conversion: %w", wd.WebsiteID, err)
 		}
-	}
-
-	// DNS moved on-chain: the site must prove ownership against the contract
-	// with the TXT token, so re-arm validation. A blocked website stays blocked
-	// (only an admin can lift an admin block); a pending one needs no change.
-	// A website-load failure is surfaced rather than silently skipped so the
-	// caller knows validation was not re-armed.
-	var website pluginDb.Website
-	if err := s.DB().WithContext(ctx).First(&website, wd.WebsiteID).Error; err != nil {
-		return nil, fmt.Errorf("failed to load website %d for on-chain conversion: %w", wd.WebsiteID, err)
-	}
-	if website.Status != string(pluginDb.WebsiteStatusBlocked) &&
-		website.Status != string(pluginDb.WebsiteStatusPendingValidation) {
-		if err := s.DB().WithContext(ctx).Model(&website).Update("status", pluginDb.WebsiteStatusPendingValidation).Error; err != nil {
-			return nil, fmt.Errorf("failed to reset website to pending_validation: %w", err)
+		if website.Status != string(pluginDb.WebsiteStatusBlocked) &&
+			website.Status != string(pluginDb.WebsiteStatusPendingValidation) {
+			if err := s.DB().WithContext(ctx).Model(&website).Update("status", pluginDb.WebsiteStatusPendingValidation).Error; err != nil {
+				return fmt.Errorf("failed to reset website to pending_validation: %w", err)
+			}
 		}
+
+		// Drop the PowerDNS-backed delegation state. ProtocolData (DANE key,
+		// cert, TLSA, owner) and per-domain SSL state are intentionally
+		// preserved: DANE/SSL still apply to the name — the records are simply
+		// served by the external contract now — and DNSSEC is not a concept
+		// on-chain.
+		updates := map[string]any{
+			"zone_id":             0,
+			"zone_name":           "",
+			"gateway_host":        "",
+			"delegation_data":     nil,
+			"dns_hosting_enabled": false,
+			"status":              pluginDb.DomainStatusOnchainManaged,
+		}
+		if err := s.DB().WithContext(ctx).Model(&wd).Updates(updates).Error; err != nil {
+			return fmt.Errorf("failed to persist on-chain managed state: %w", err)
+		}
+		wd.ZoneID = 0
+		wd.ZoneName = ""
+		wd.GatewayHost = ""
+		wd.DelegationData = nil
+		wd.DNSHostingEnabled = false
+		wd.Status = pluginDb.DomainStatusOnchainManaged
+
+		// Delete the now-unreferenced PowerDNS zone LAST, best-effort. Order is
+		// deliberate: the DB runs first so a delete failure can never strand
+		// the binding pointing at a destroyed zone (the unrecoverable state). A
+		// leftover/unreferenced zone is harmless (nothing serves it — the name
+		// resolves via the contract) and is logged for ops cleanup. The zone
+		// lock guarantees no other binding is attached between the check above
+		// and here.
+		if zoneID != 0 && s.dnsSvc != nil {
+			if err := s.dnsSvc.DeleteZone(ctx, zoneID); err != nil {
+				s.Logger().Warn("on-chain conversion: failed to delete orphaned managed zone (non-fatal)",
+					zap.Uint("zone_id", zoneID), zap.String("domain", wd.Domain), zap.Error(err))
+			}
+		}
+		return nil
+	}); err != nil {
+		return nil, err
 	}
 
 	return &wd, nil

--- a/internal/service/domain/onchain.go
+++ b/internal/service/domain/onchain.go
@@ -136,11 +136,29 @@ func (s *DelegatedDomainService) ConvertToOnChain(ctx context.Context, websiteID
 		// deliberate: the DB runs first so a delete failure can never strand
 		// the binding pointing at a destroyed zone (the unrecoverable state). A
 		// leftover/unreferenced zone is harmless (nothing serves it — the name
-		// resolves via the contract) and is logged for ops cleanup. The zone
-		// lock guarantees no other binding is attached between the check above
-		// and here.
+		// resolves via the contract) and is logged for ops cleanup.
+		//
+		// Re-count sharers immediately before the delete as defense-in-depth.
+		// The per-zone lock above serializes against CreateDomain for the
+		// common apex case, but the lock key can diverge from the real zone
+		// apex when a "subdomain" owns its zone (parent has none) and it does
+		// NOT serialize other zone_id writers (e.g. the website-enable path).
+		// Re-checking committed state right before DeleteZone catches any
+		// binding attached by those writers: if any live binding shares the
+		// zone, the delete is skipped and the (now-referenced) zone is left
+		// intact.
 		if zoneID != 0 && s.dnsSvc != nil {
-			if err := s.dnsSvc.DeleteZone(ctx, zoneID); err != nil {
+			var sharers int64
+			if err := s.DB().WithContext(ctx).
+				Model(&pluginDb.WebsiteDomain{}).
+				Where("zone_id = ? AND deleted_at IS NULL", zoneID).
+				Count(&sharers).Error; err != nil {
+				s.Logger().Warn("failed to re-count zone sharers before on-chain conversion zone delete",
+					zap.Uint("zone_id", zoneID), zap.String("domain", wd.Domain), zap.Error(err))
+			} else if sharers > 0 {
+				s.Logger().Info("on-chain conversion: zone picked up by another binding; leaving it intact",
+					zap.Uint("zone_id", zoneID), zap.String("domain", wd.Domain))
+			} else if err := s.dnsSvc.DeleteZone(ctx, zoneID); err != nil {
 				s.Logger().Warn("on-chain conversion: failed to delete orphaned managed zone (non-fatal)",
 					zap.Uint("zone_id", zoneID), zap.String("domain", wd.Domain), zap.Error(err))
 			}

--- a/internal/service/domain/provider.go
+++ b/internal/service/domain/provider.go
@@ -13,6 +13,16 @@ import (
 type DomainProvider interface {
 	Protocol() string
 	Validate(domain string) error
+	// Inspect queries the domain's on-chain/registry state at bind time and
+	// reports whether the name is managed on-chain (e.g. a Handshake HIP-5 name
+	// whose NS record is a HIP-5 TX record pointing at an external contract).
+	// An on-chain managed name serves its own DNS, so the portal must NOT
+	// provision a PowerDNS zone for it and proves ownership via TXT token.
+	// Providers without an on-chain concept (ICANN) always return false.
+	// Detection is best-effort: HNS returns false when the resolver cannot
+	// answer (name not yet registered, resolver unreachable), defaulting to
+	// native so binding can proceed.
+	Inspect(ctx context.Context, domain string) (onchainManaged bool, err error)
 	BuildDelegation(ctx context.Context, zoneID uint, domain string, website *pluginDb.Website, config json.RawMessage) (any, error)
 	VerifyDelegation(ctx context.Context, domain string, expectedDS string) (bool, error)
 	// OnCertAvailable is called when a cert is pushed via /internal/dns/cert.

--- a/internal/service/website/hip5_test.go
+++ b/internal/service/website/hip5_test.go
@@ -1,0 +1,75 @@
+package website
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	pluginCore "go.lumeweb.com/portal-plugin-ipfs/core"
+	pluginDb "go.lumeweb.com/portal-plugin-ipfs/internal/db"
+	"go.lumeweb.com/portal/core"
+	coreTesting "go.lumeweb.com/portal/core/testing"
+)
+
+func TestShouldPerformTokenCheck(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		ws := core.GetService[pluginCore.WebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
+		require.NotNil(tb, ws)
+		svc, ok := ws.(*WebsiteServiceDefault)
+		require.True(tb, ok, "expected WebsiteServiceDefault")
+
+		pending := &pluginDb.Website{Status: string(pluginDb.WebsiteStatusPendingValidation)}
+
+		// A delegated-domain service that considers .hns-suffixed names
+		// delegation-owned (mimicking the real HNS provider), so only the
+		// on-chain-managed guard should make the token check run for HNS.
+		setMockDelegatedDomainSvc(ws, &testDelegatedDomainService{
+			uses: func(domain string) bool {
+				return strings.HasSuffix(domain, ".hns")
+			},
+		})
+
+		t.Run("onchain managed HNS performs TXT token check", func(t *testing.T) {
+			wd := &pluginDb.WebsiteDomain{
+				Domain:    "my.hns",
+				Namespace: pluginDb.DomainNamespaceHNS,
+				Status:    pluginDb.DomainStatusOnchainManaged,
+			}
+			assert.True(tb, svc.shouldPerformTokenCheck(pending, wd),
+				"on-chain managed (HIP-5) must prove ownership via TXT token")
+		})
+
+		t.Run("native HNS skips TXT token check (delegation)", func(t *testing.T) {
+			wd := &pluginDb.WebsiteDomain{
+				Domain:    "example.hns",
+				Namespace: pluginDb.DomainNamespaceHNS,
+				Status:    pluginDb.DomainStatusWaitingDelegation,
+			}
+			assert.False(tb, svc.shouldPerformTokenCheck(pending, wd),
+				"native HNS proves ownership via delegation, no TXT token")
+		})
+
+		t.Run("platform subdomain skips TXT token check", func(t *testing.T) {
+			platformID := uint(1)
+			wd := &pluginDb.WebsiteDomain{
+				Domain:           "sub.hns",
+				Namespace:        pluginDb.DomainNamespaceHNS,
+				Status:           pluginDb.DomainStatusActive,
+				PlatformDomainID: &platformID,
+			}
+			assert.False(tb, svc.shouldPerformTokenCheck(pending, wd),
+				"platform subdomain is operator-controlled, no TXT token")
+		})
+
+		t.Run("ICANN performs TXT token check", func(t *testing.T) {
+			wd := &pluginDb.WebsiteDomain{
+				Domain:    "example.com",
+				Namespace: pluginDb.DomainNamespaceICANN,
+				Status:    pluginDb.DomainStatusRecordsGenerated,
+			}
+			assert.True(tb, svc.shouldPerformTokenCheck(pending, wd),
+				"ICANN proves ownership via TXT token")
+		})
+	}, TestOptions)
+}

--- a/internal/service/website/hip5_test.go
+++ b/internal/service/website/hip5_test.go
@@ -1,6 +1,7 @@
 package website
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -8,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 	pluginCore "go.lumeweb.com/portal-plugin-ipfs/core"
 	pluginDb "go.lumeweb.com/portal-plugin-ipfs/internal/db"
+	"go.lumeweb.com/portal-plugin-ipfs/internal/testing/util"
 	"go.lumeweb.com/portal/core"
 	coreTesting "go.lumeweb.com/portal/core/testing"
 )
@@ -71,5 +73,48 @@ func TestShouldPerformTokenCheck(t *testing.T) {
 			assert.True(tb, svc.shouldPerformTokenCheck(pending, wd),
 				"ICANN proves ownership via TXT token")
 		})
+	}, TestOptions)
+}
+
+func TestSetDomainDNSEnabled_OnchainManagedRefusesEnable(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		websiteService := core.GetService[pluginCore.WebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
+		require.NotNil(tb, websiteService)
+
+		testCID := util.GenerateTestCID(t, "onchain-test")
+		domain := "onchain.hns"
+		website := createTestIPFSWebsite(testUserID1, domain, testCID.String())
+		website.Status = string(pluginDb.WebsiteStatusPendingValidation)
+		require.NoError(tb, ctx.DB().Create(website).Error)
+
+		wd := prebindPrimaryDomain(tb, ctx, website, domain, false)
+		// Mark the binding on-chain managed (HIP-5): no portal zone, hosting off.
+		wd.Namespace = pluginDb.DomainNamespaceHNS
+		wd.Status = pluginDb.DomainStatusOnchainManaged
+		require.NoError(tb, ctx.DB().Model(wd).Updates(map[string]interface{}{
+			"namespace": string(pluginDb.DomainNamespaceHNS),
+			"status":    string(pluginDb.DomainStatusOnchainManaged),
+		}).Error)
+
+		// Enabling portal DNS hosting is refused with a clear error — the
+		// external contract serves the name's DNS, so a portal zone would be
+		// unreachable.
+		_, err := websiteService.SetDomainDNSEnabled(context.Background(), testUserID1, website.ID, wd.ID, true)
+		require.Error(tb, err)
+		assert.Contains(tb, err.Error(), "on-chain managed")
+
+		// Disabling is a reconciled no-op (flag=false and zone=0 already agree);
+		// the binding comes back unchanged without DNS churn.
+		updated, err := websiteService.SetDomainDNSEnabled(context.Background(), testUserID1, website.ID, wd.ID, false)
+		require.NoError(tb, err)
+		require.NotNil(tb, updated)
+		assert.Equal(tb, pluginDb.DomainStatusOnchainManaged, updated.Status)
+		assert.False(tb, updated.DNSHostingEnabled)
+
+		// The flag was never flipped on and no zone appeared.
+		var persisted pluginDb.WebsiteDomain
+		require.NoError(tb, ctx.DB().First(&persisted, wd.ID).Error)
+		assert.False(tb, persisted.DNSHostingEnabled)
+		assert.Equal(tb, uint(0), persisted.ZoneID)
 	}, TestOptions)
 }

--- a/internal/service/website/janitor_test.go
+++ b/internal/service/website/janitor_test.go
@@ -18,6 +18,7 @@ import (
 	"go.lumeweb.com/portal-plugin-ipfs/internal/testing/util"
 	"go.lumeweb.com/portal/core"
 	coreTesting "go.lumeweb.com/portal/core/testing"
+	"gorm.io/gorm"
 )
 
 var JanitorTestOptions = coreTesting.CombineOptions(
@@ -276,4 +277,47 @@ func TestWebsiteJanitorJob_DisplayName(t *testing.T) {
 func TestWebsiteJanitorJob_Origin(t *testing.T) {
 	job := NewWebsiteJanitorJob()
 	assert.Equal(t, core.JobOriginPlugin, job.Origin())
+}
+
+// recordingDelegatedDomainSvc records the statuses the janitor polls for
+// pending delegations, so tests can assert exactly which lifecycle states are
+// ever inspected (and that on-chain managed bindings are not).
+type recordingDelegatedDomainSvc struct {
+	statuses []pluginDb.DomainStatus
+}
+
+func (r *recordingDelegatedDomainSvc) UsesDelegationForOwnership(string) bool { return false }
+func (r *recordingDelegatedDomainSvc) VerifyDomain(context.Context, *pluginDb.WebsiteDomain) (bool, error) {
+	return true, nil
+}
+func (r *recordingDelegatedDomainSvc) GetNamespaceForDomain(string) (string, bool) { return "", false }
+func (r *recordingDelegatedDomainSvc) GetWebsiteDomainByName(context.Context, string) (*pluginDb.WebsiteDomain, error) {
+	return nil, gorm.ErrRecordNotFound
+}
+func (r *recordingDelegatedDomainSvc) GetPendingWebsiteDomainsPaginated(_ context.Context, status pluginDb.DomainStatus, _, _ int) ([]pluginDb.WebsiteDomain, error) {
+	r.statuses = append(r.statuses, status)
+	return nil, nil
+}
+
+func TestWebsiteJanitorJob_verifyPendingDelegations_IgnoresOnchainManaged(t *testing.T) {
+	// The janitor's delegation verification must only ever poll the delegation
+	// lifecycle statuses (records_generated, waiting_delegation). On-chain
+	// managed (HIP-5) bindings prove ownership via the TXT token flow and must
+	// never be picked up for NS/DS delegation verification.
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		job := NewWebsiteJanitorJob()
+		janitorJob := job.(*WebsiteJanitorJob)
+		janitorJob.db = ctx.DB()
+		janitorJob.logger = ctx.Logger()
+		fake := &recordingDelegatedDomainSvc{}
+		janitorJob.delegatedDomainSvc = fake
+
+		require.NoError(tb, janitorJob.verifyPendingDelegations(context.Background()))
+
+		assert.ElementsMatch(tb, []pluginDb.DomainStatus{
+			pluginDb.DomainStatusWaitingDelegation,
+			pluginDb.DomainStatusRecordsGenerated,
+		}, fake.statuses)
+		assert.NotContains(tb, fake.statuses, pluginDb.DomainStatusOnchainManaged)
+	}, JanitorTestOptions)
 }

--- a/internal/service/website/validate_dns_test.go
+++ b/internal/service/website/validate_dns_test.go
@@ -3,14 +3,18 @@ package website
 import (
 	"context"
 	"fmt"
+	"net"
+	"strings"
 	"testing"
 	"time"
 
 	dnslink "github.com/dnslink-std/go"
+	"github.com/miekg/dns"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	pluginCore "go.lumeweb.com/portal-plugin-ipfs/core"
+	pluginConfig "go.lumeweb.com/portal-plugin-ipfs/internal/config"
 	pluginDb "go.lumeweb.com/portal-plugin-ipfs/internal/db"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/testing/mocks"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/testing/util"
@@ -1009,5 +1013,97 @@ func TestValidateDNS_OnchainManaged_MissingTokenTokenMissing(t *testing.T) {
 		require.NoError(tb, err)
 		assert.False(tb, result.Valid)
 		assert.Equal(tb, pluginCore.ValidationReasonTokenMissing, result.Reason)
+	}, TestOptions)
+}
+
+// startTXTTestServer runs a real UDP DNS server answering TXT queries from a
+// name -> records map. It stands in for the HNS resolver -> on-chain contract
+// bridge so ValidateDNS exercises the LIVE lookup path (resolverForDomain ->
+// NewLiveResolver(HNSResolver)), not the injected mock resolver.
+func startTXTTestServer(tb testing.TB, answers map[string][]string) string {
+	tb.Helper()
+	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
+	require.NoError(tb, err)
+	addr := pc.LocalAddr().String()
+
+	handler := dns.HandlerFunc(func(w dns.ResponseWriter, req *dns.Msg) {
+		m := new(dns.Msg)
+		m.SetReply(req)
+		m.Authoritative = true
+		if len(req.Question) > 0 {
+			q := req.Question[0]
+			if q.Qtype == dns.TypeTXT {
+				if txts, ok := answers[strings.ToLower(strings.TrimSuffix(q.Name, "."))]; ok {
+					for _, val := range txts {
+						m.Answer = append(m.Answer, &dns.TXT{
+							Hdr: dns.RR_Header{Name: q.Name, Rrtype: dns.TypeTXT, Class: dns.ClassINET, Ttl: 300},
+							Txt: []string{val},
+						})
+					}
+				}
+			}
+		}
+		_ = w.WriteMsg(m)
+	})
+	srv := &dns.Server{PacketConn: pc, Handler: handler}
+	go func() { _ = srv.ActivateAndServe() }()
+	tb.Cleanup(func() { _ = srv.Shutdown() })
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		c := &dns.Client{Net: "udp", Timeout: 200 * time.Millisecond}
+		m := new(dns.Msg)
+		m.SetQuestion("ready.", dns.TypeA)
+		if _, _, err := c.Exchange(m, addr); err == nil {
+			return addr
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	tb.Fatalf("txt test server not ready at %s", addr)
+	return ""
+}
+
+func TestValidateDNS_OnchainManaged_LiveResolverBridge(t *testing.T) {
+	// End-to-end through the real resolver path: resolverForDomain builds
+	// NewLiveResolver(dnsConfig.HNSResolver), which queries the (simulated) HNS
+	// resolver -> on-chain contract for `_dnslink` and the pinner-verify TXT.
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		ws := core.GetService[pluginCore.WebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
+		require.NotNil(tb, ws)
+		svc, ok := ws.(*WebsiteServiceDefault)
+		require.True(tb, ok)
+
+		testCID := util.GenerateTestCID(t, "onchain-live-bridge")
+		domain := "onchain.hns"
+		website := createTestIPFSWebsite(testUserID1, domain, testCID.String())
+		stubPinnedCID(t, ctx, testUserID1, testCID.String())
+		created, err := ws.CreateWebsite(context.Background(), website)
+		require.NoError(tb, err)
+		onchainPrimaryDomain(tb, ctx, created, domain)
+
+		addr := startTXTTestServer(t, map[string][]string{
+			"_dnslink." + domain:       {"dnslink=/ipfs/" + created.TargetHash()},
+			"lumeweb-verify." + domain: {"lumeweb-verify=" + created.ValidationToken},
+		})
+
+		// Point the website service at the live resolver via the real field,
+		// and have the delegated-domain lookup classify the domain as HNS so
+		// resolverForDomain routes to NewLiveResolver(HNSResolver).
+		svc.dnsConfig = &pluginConfig.DnsConfig{HNSResolver: addr}
+		svc.resolver = nil
+		setMockDelegatedDomainSvc(ws, &testDelegatedDomainService{
+			getNs: func(string) (string, bool) {
+				return string(pluginDb.DomainNamespaceHNS), true
+			},
+		})
+
+		result, err := ws.ValidateDNS(context.Background(), testUserID1, created.ID)
+		require.NoError(tb, err)
+		assert.True(tb, result.Valid)
+		assert.Equal(tb, pluginCore.ValidationReasonValidated, result.Reason)
+
+		final, err := ws.GetWebsite(context.Background(), testUserID1, created.ID)
+		require.NoError(tb, err)
+		assert.Equal(tb, string(pluginDb.WebsiteStatusActive), final.Status)
 	}, TestOptions)
 }

--- a/internal/service/website/validate_dns_test.go
+++ b/internal/service/website/validate_dns_test.go
@@ -918,3 +918,96 @@ func TestValidateDNS_DelegatedAttached_VerifyError_Fails(t *testing.T) {
 		assert.Contains(tb, result.Message, "Domain delegation not yet published")
 	}, TestOptions)
 }
+
+// onchainPrimaryDomain binds `domain` to `website` as an on-chain managed
+// (HIP-5) primary binding: HNS namespace, onchain_managed status, no zone.
+func onchainPrimaryDomain(tb testing.TB, ctx coreTesting.TestContext, website *pluginDb.Website, domain string) *pluginDb.WebsiteDomain {
+	tb.Helper()
+	wd := prebindPrimaryDomain(tb, ctx, website, domain, false)
+	wd.Namespace = pluginDb.DomainNamespaceHNS
+	wd.Status = pluginDb.DomainStatusOnchainManaged
+	require.NoError(tb, ctx.DB().Model(wd).Updates(map[string]interface{}{
+		"namespace": string(pluginDb.DomainNamespaceHNS),
+		"status":    string(pluginDb.DomainStatusOnchainManaged),
+	}).Error)
+	// prebindPrimaryDomain only mutates the in-memory PrimaryDomainID; persist
+	// it so ValidateDNS (which reloads the website from the DB) resolves the
+	// primary binding.
+	require.NoError(tb, ctx.DB().Model(website).Update("primary_domain_id", wd.ID).Error)
+	return wd
+}
+
+func TestValidateDNS_OnchainManaged_ValidTokenValidates(t *testing.T) {
+	// An on-chain managed (HIP-5) binding must run the full TXT-token
+	// verification flow through the resolver: it is neither delegation-owned
+	// (no zone to verify) nor blocked from the token check, so a matching
+	// DNSLink + pinner-verify TXT activates the site.
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		ws := core.GetService[pluginCore.WebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
+		require.NotNil(tb, ws)
+
+		testCID := util.GenerateTestCID(t, "onchain-validate")
+		domain := "onchain.hns"
+		website := createTestIPFSWebsite(testUserID1, domain, testCID.String())
+		stubPinnedCID(t, ctx, testUserID1, testCID.String())
+		created, err := ws.CreateWebsite(context.Background(), website)
+		require.NoError(tb, err)
+		onchainPrimaryDomain(tb, ctx, created, domain)
+
+		mockResolver := mocks.NewMockDNSResolver(t)
+		mockResolver.EXPECT().ResolveDNSLink(domain).Return(dnslink.Result{
+			Links: map[string]dnslink.NamespaceEntries{
+				"ipfs": {{Identifier: created.TargetHash()}},
+			},
+		}, nil)
+		mockResolver.EXPECT().LookupTXT(mock.Anything, "lumeweb-verify."+domain).Return([]string{
+			fmt.Sprintf("lumeweb-verify=%s", created.ValidationToken),
+		}, nil)
+		setMockResolver(ws, mockResolver)
+
+		result, err := ws.ValidateDNS(context.Background(), testUserID1, created.ID)
+		require.NoError(tb, err)
+		assert.True(tb, result.Valid)
+		assert.Equal(tb, pluginCore.ValidationReasonValidated, result.Reason)
+
+		final, err := ws.GetWebsite(context.Background(), testUserID1, created.ID)
+		require.NoError(tb, err)
+		assert.Equal(tb, string(pluginDb.WebsiteStatusActive), final.Status)
+	}, TestOptions)
+}
+
+func TestValidateDNS_OnchainManaged_MissingTokenTokenMissing(t *testing.T) {
+	// The TXT token check MUST run for an on-chain managed binding: a
+	// missing/stale pinner-verify TXT record must block activation
+	// (TokenMissing), proving the flow is not skipped as it is for native-HNS
+	// delegation.
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		ws := core.GetService[pluginCore.WebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
+		require.NotNil(tb, ws)
+
+		testCID := util.GenerateTestCID(t, "onchain-missing-token")
+		domain := "onchain-token.hns"
+		website := createTestIPFSWebsite(testUserID1, domain, testCID.String())
+		stubPinnedCID(t, ctx, testUserID1, testCID.String())
+		created, err := ws.CreateWebsite(context.Background(), website)
+		require.NoError(tb, err)
+		onchainPrimaryDomain(tb, ctx, created, domain)
+
+		mockResolver := mocks.NewMockDNSResolver(t)
+		mockResolver.EXPECT().ResolveDNSLink(domain).Return(dnslink.Result{
+			Links: map[string]dnslink.NamespaceEntries{
+				"ipfs": {{Identifier: created.TargetHash()}},
+			},
+		}, nil)
+		// The contract serves the token record but with a STALE token.
+		mockResolver.EXPECT().LookupTXT(mock.Anything, "lumeweb-verify."+domain).Return([]string{
+			"lumeweb-verify=wrong-token",
+		}, nil)
+		setMockResolver(ws, mockResolver)
+
+		result, err := ws.ValidateDNS(context.Background(), testUserID1, created.ID)
+		require.NoError(tb, err)
+		assert.False(tb, result.Valid)
+		assert.Equal(tb, pluginCore.ValidationReasonTokenMissing, result.Reason)
+	}, TestOptions)
+}

--- a/internal/service/website/website.go
+++ b/internal/service/website/website.go
@@ -867,7 +867,7 @@ func (s *WebsiteServiceDefault) UpdateWebsite(ctx context.Context, userID uint, 
 			// under portal DNS hosting; refuse the flip rather than persisting a
 			// flag that would disagree with the absence of a zone.
 			if enableDNS && wd.Status == pluginDb.DomainStatusOnchainManaged {
-				return nil, fmt.Errorf("DNS hosting is not available for on-chain managed domain %q (HIP-5); its DNS is served by the external contract", wd.Domain)
+				return nil, onchainDNSHostingUnavailableError(wd.Domain)
 			}
 			wd.DNSHostingEnabled = enableDNS
 			if uerr := s.DB().WithContext(ctx).Model(wd).Update("dns_hosting_enabled", enableDNS).Error; uerr != nil {
@@ -1490,6 +1490,15 @@ func (s *WebsiteServiceDefault) shouldPerformTokenCheck(website *pluginDb.Websit
 		return false
 	}
 	return true
+}
+
+// onchainDNSHostingUnavailableError returns the error shared by every path
+// that refuses to put an on-chain managed (HIP-5) binding under portal DNS
+// hosting: the external contract serves the name's DNS, so a portal zone would
+// be unreachable and the dns_hosting_enabled flag would disagree with the
+// absence of a zone.
+func onchainDNSHostingUnavailableError(domain string) error {
+	return fmt.Errorf("DNS hosting is not available for on-chain managed domain %q (HIP-5); its DNS is served by the external contract", domain)
 }
 
 func (s *WebsiteServiceDefault) ValidateDNS(ctx context.Context, userID uint, websiteID uint) (pluginCore.ValidateDNSResult, error) {
@@ -2392,7 +2401,7 @@ func (s *WebsiteServiceDefault) SetDomainDNSEnabled(ctx context.Context, userID,
 	// no resolver would ever query. Disabling is already a no-op (the binding
 	// is flag=false, zone=0, so it is reconciled below).
 	if enabled && wd.Status == pluginDb.DomainStatusOnchainManaged {
-		return nil, fmt.Errorf("DNS hosting is not available for on-chain managed domain %q (HIP-5); its DNS is served by the external contract", wd.Domain)
+		return nil, onchainDNSHostingUnavailableError(wd.Domain)
 	}
 
 	// Already in the desired state with nothing left to reconcile. The binding

--- a/internal/service/website/website.go
+++ b/internal/service/website/website.go
@@ -863,6 +863,12 @@ func (s *WebsiteServiceDefault) UpdateWebsite(ctx context.Context, userID uint, 
 				zap.Error(err),
 				zap.Uint("website_id", websiteID))
 		} else if wd != nil {
+			// A primary binding that is on-chain managed (HIP-5) cannot be put
+			// under portal DNS hosting; refuse the flip rather than persisting a
+			// flag that would disagree with the absence of a zone.
+			if enableDNS && wd.Status == pluginDb.DomainStatusOnchainManaged {
+				return nil, fmt.Errorf("DNS hosting is not available for on-chain managed domain %q (HIP-5); its DNS is served by the external contract", wd.Domain)
+			}
 			wd.DNSHostingEnabled = enableDNS
 			if uerr := s.DB().WithContext(ctx).Model(wd).Update("dns_hosting_enabled", enableDNS).Error; uerr != nil {
 				s.Logger().Warn("Failed to persist dns_hosting_enabled on primary domain",
@@ -2378,6 +2384,15 @@ func (s *WebsiteServiceDefault) SetDomainDNSEnabled(ctx context.Context, userID,
 		Where("id = ? AND website_id = ? AND user_id = ?", domainID, websiteID, userID).
 		First(&wd).Error; err != nil {
 		return nil, fmt.Errorf("domain lookup failed: %w", err)
+	}
+
+	// An on-chain managed (HIP-5) binding serves its DNS from the external
+	// contract; the portal cannot host it. Enabling portal DNS hosting is
+	// refused with a clear error rather than silently creating a PowerDNS zone
+	// no resolver would ever query. Disabling is already a no-op (the binding
+	// is flag=false, zone=0, so it is reconciled below).
+	if enabled && wd.Status == pluginDb.DomainStatusOnchainManaged {
+		return nil, fmt.Errorf("DNS hosting is not available for on-chain managed domain %q (HIP-5); its DNS is served by the external contract", wd.Domain)
 	}
 
 	// Already in the desired state with nothing left to reconcile. The binding

--- a/internal/service/website/website.go
+++ b/internal/service/website/website.go
@@ -1470,6 +1470,15 @@ func (s *WebsiteServiceDefault) shouldPerformTokenCheck(website *pluginDb.Websit
 		s.Logger().Debug("skipping TXT token (platform subdomain, operator-controlled DNS)", zap.String("domain", primaryWD.Domain))
 		return false
 	}
+	// An on-chain managed name (HIP-5) proves ownership with the TXT
+	// verification token, resolved through the namespace-appropriate resolver
+	// (HNS resolver → on-chain contract serves the PINNER-VERIFY TXT), exactly
+	// like ICANN. This must be checked before UsesDelegationForOwnership, which
+	// would otherwise treat the HNS name as delegation-owned and skip the token.
+	if primaryWD.Status == pluginDb.DomainStatusOnchainManaged {
+		s.Logger().Debug("performing TXT token (on-chain managed HIP-5 domain)", zap.String("domain", primaryWD.Domain))
+		return true
+	}
 	if s.delegatedDomainSvc != nil && s.delegatedDomainSvc.UsesDelegationForOwnership(primaryWD.Domain) {
 		s.Logger().Debug("skipping TXT token (ownership proven via delegation verification)", zap.String("domain", primaryWD.Domain))
 		return false

--- a/internal/testing/mocks/MockDNSService.go
+++ b/internal/testing/mocks/MockDNSService.go
@@ -83,7 +83,7 @@ type MockDNSService_BulkDeleteRecords_Call struct {
 //   - userID uint
 //   - records []dto.RecordIdentifier
 //   - dryRun bool
-func (_e *MockDNSService_Expecter) BulkDeleteRecords(ctx interface{}, zoneID interface{}, userID interface{}, records interface{}, dryRun interface{}) *MockDNSService_BulkDeleteRecords_Call {
+func (_e *MockDNSService_Expecter) BulkDeleteRecords(ctx any, zoneID any, userID any, records any, dryRun any) *MockDNSService_BulkDeleteRecords_Call {
 	return &MockDNSService_BulkDeleteRecords_Call{Call: _e.mock.On("BulkDeleteRecords", ctx, zoneID, userID, records, dryRun)}
 }
 
@@ -250,7 +250,7 @@ type MockDNSService_CreateApexRecord_Call struct {
 //   - domain string
 //   - recordType core0.RecordType
 //   - content string
-func (_e *MockDNSService_Expecter) CreateApexRecord(ctx interface{}, zoneID interface{}, domain interface{}, recordType interface{}, content interface{}) *MockDNSService_CreateApexRecord_Call {
+func (_e *MockDNSService_Expecter) CreateApexRecord(ctx any, zoneID any, domain any, recordType any, content any) *MockDNSService_CreateApexRecord_Call {
 	return &MockDNSService_CreateApexRecord_Call{Call: _e.mock.On("CreateApexRecord", ctx, zoneID, domain, recordType, content)}
 }
 
@@ -324,7 +324,7 @@ type MockDNSService_CreateDNSLinkRecord_Call struct {
 //   - zoneID uint
 //   - domain string
 //   - target string
-func (_e *MockDNSService_Expecter) CreateDNSLinkRecord(ctx interface{}, zoneID interface{}, domain interface{}, target interface{}) *MockDNSService_CreateDNSLinkRecord_Call {
+func (_e *MockDNSService_Expecter) CreateDNSLinkRecord(ctx any, zoneID any, domain any, target any) *MockDNSService_CreateDNSLinkRecord_Call {
 	return &MockDNSService_CreateDNSLinkRecord_Call{Call: _e.mock.On("CreateDNSLinkRecord", ctx, zoneID, domain, target)}
 }
 
@@ -406,7 +406,7 @@ type MockDNSService_CreateRecord_Call struct {
 //   - recordType string
 //   - content string
 //   - ttl uint
-func (_e *MockDNSService_Expecter) CreateRecord(ctx interface{}, zoneID interface{}, name interface{}, recordType interface{}, content interface{}, ttl interface{}) *MockDNSService_CreateRecord_Call {
+func (_e *MockDNSService_Expecter) CreateRecord(ctx any, zoneID any, name any, recordType any, content any, ttl any) *MockDNSService_CreateRecord_Call {
 	return &MockDNSService_CreateRecord_Call{Call: _e.mock.On("CreateRecord", ctx, zoneID, name, recordType, content, ttl)}
 }
 
@@ -487,7 +487,7 @@ type MockDNSService_CreateWebsiteDNSRecords_Call struct {
 //   - targetHash string
 //   - targetType db.WebsiteTargetType
 //   - validationToken string
-func (_e *MockDNSService_Expecter) CreateWebsiteDNSRecords(ctx interface{}, zoneID interface{}, websiteDomain interface{}, targetHash interface{}, targetType interface{}, validationToken interface{}) *MockDNSService_CreateWebsiteDNSRecords_Call {
+func (_e *MockDNSService_Expecter) CreateWebsiteDNSRecords(ctx any, zoneID any, websiteDomain any, targetHash any, targetType any, validationToken any) *MockDNSService_CreateWebsiteDNSRecords_Call {
 	return &MockDNSService_CreateWebsiteDNSRecords_Call{Call: _e.mock.On("CreateWebsiteDNSRecords", ctx, zoneID, websiteDomain, targetHash, targetType, validationToken)}
 }
 
@@ -566,7 +566,7 @@ type MockDNSService_CreateWebsiteValidationRecord_Call struct {
 //   - zoneID uint
 //   - websiteDomain string
 //   - validationToken string
-func (_e *MockDNSService_Expecter) CreateWebsiteValidationRecord(ctx interface{}, zoneID interface{}, websiteDomain interface{}, validationToken interface{}) *MockDNSService_CreateWebsiteValidationRecord_Call {
+func (_e *MockDNSService_Expecter) CreateWebsiteValidationRecord(ctx any, zoneID any, websiteDomain any, validationToken any) *MockDNSService_CreateWebsiteValidationRecord_Call {
 	return &MockDNSService_CreateWebsiteValidationRecord_Call{Call: _e.mock.On("CreateWebsiteValidationRecord", ctx, zoneID, websiteDomain, validationToken)}
 }
 
@@ -645,7 +645,7 @@ type MockDNSService_CreateZone_Call struct {
 //   - ctx context.Context
 //   - domain string
 //   - userID uint
-func (_e *MockDNSService_Expecter) CreateZone(ctx interface{}, domain interface{}, userID interface{}) *MockDNSService_CreateZone_Call {
+func (_e *MockDNSService_Expecter) CreateZone(ctx any, domain any, userID any) *MockDNSService_CreateZone_Call {
 	return &MockDNSService_CreateZone_Call{Call: _e.mock.On("CreateZone", ctx, domain, userID)}
 }
 
@@ -762,9 +762,9 @@ type MockDNSService_DeleteRecord_Call struct {
 //   - name string
 //   - recordType string
 //   - contents ...string
-func (_e *MockDNSService_Expecter) DeleteRecord(ctx interface{}, zoneID interface{}, name interface{}, recordType interface{}, contents ...interface{}) *MockDNSService_DeleteRecord_Call {
+func (_e *MockDNSService_Expecter) DeleteRecord(ctx any, zoneID any, name any, recordType any, contents ...any) *MockDNSService_DeleteRecord_Call {
 	return &MockDNSService_DeleteRecord_Call{Call: _e.mock.On("DeleteRecord",
-		append([]interface{}{ctx, zoneID, name, recordType}, contents...)...)}
+		append([]any{ctx, zoneID, name, recordType}, contents...)...)}
 }
 
 func (_c *MockDNSService_DeleteRecord_Call) Run(run func(ctx context.Context, zoneID uint, name string, recordType string, contents ...string)) *MockDNSService_DeleteRecord_Call {
@@ -838,7 +838,7 @@ type MockDNSService_DeleteWebsiteDNSRecords_Call struct {
 //   - ctx context.Context
 //   - zoneID uint
 //   - websiteDomain string
-func (_e *MockDNSService_Expecter) DeleteWebsiteDNSRecords(ctx interface{}, zoneID interface{}, websiteDomain interface{}) *MockDNSService_DeleteWebsiteDNSRecords_Call {
+func (_e *MockDNSService_Expecter) DeleteWebsiteDNSRecords(ctx any, zoneID any, websiteDomain any) *MockDNSService_DeleteWebsiteDNSRecords_Call {
 	return &MockDNSService_DeleteWebsiteDNSRecords_Call{Call: _e.mock.On("DeleteWebsiteDNSRecords", ctx, zoneID, websiteDomain)}
 }
 
@@ -901,7 +901,7 @@ type MockDNSService_DeleteWebsiteValidationRecord_Call struct {
 //   - ctx context.Context
 //   - zoneID uint
 //   - websiteDomain string
-func (_e *MockDNSService_Expecter) DeleteWebsiteValidationRecord(ctx interface{}, zoneID interface{}, websiteDomain interface{}) *MockDNSService_DeleteWebsiteValidationRecord_Call {
+func (_e *MockDNSService_Expecter) DeleteWebsiteValidationRecord(ctx any, zoneID any, websiteDomain any) *MockDNSService_DeleteWebsiteValidationRecord_Call {
 	return &MockDNSService_DeleteWebsiteValidationRecord_Call{Call: _e.mock.On("DeleteWebsiteValidationRecord", ctx, zoneID, websiteDomain)}
 }
 
@@ -963,7 +963,7 @@ type MockDNSService_DeleteZone_Call struct {
 // DeleteZone is a helper method to define mock.On call
 //   - ctx context.Context
 //   - zoneID uint
-func (_e *MockDNSService_Expecter) DeleteZone(ctx interface{}, zoneID interface{}) *MockDNSService_DeleteZone_Call {
+func (_e *MockDNSService_Expecter) DeleteZone(ctx any, zoneID any) *MockDNSService_DeleteZone_Call {
 	return &MockDNSService_DeleteZone_Call{Call: _e.mock.On("DeleteZone", ctx, zoneID)}
 }
 
@@ -1029,7 +1029,7 @@ type MockDNSService_EnableDNSSEC_Call struct {
 // EnableDNSSEC is a helper method to define mock.On call
 //   - ctx context.Context
 //   - zoneID uint
-func (_e *MockDNSService_Expecter) EnableDNSSEC(ctx interface{}, zoneID interface{}) *MockDNSService_EnableDNSSEC_Call {
+func (_e *MockDNSService_Expecter) EnableDNSSEC(ctx any, zoneID any) *MockDNSService_EnableDNSSEC_Call {
 	return &MockDNSService_EnableDNSSEC_Call{Call: _e.mock.On("EnableDNSSEC", ctx, zoneID)}
 }
 
@@ -1088,7 +1088,7 @@ type MockDNSService_EnsureSOAMNAME_Call struct {
 //   - zoneID uint
 //   - domain string
 //   - nameservers []string
-func (_e *MockDNSService_Expecter) EnsureSOAMNAME(ctx interface{}, zoneID interface{}, domain interface{}, nameservers interface{}) *MockDNSService_EnsureSOAMNAME_Call {
+func (_e *MockDNSService_Expecter) EnsureSOAMNAME(ctx any, zoneID any, domain any, nameservers any) *MockDNSService_EnsureSOAMNAME_Call {
 	return &MockDNSService_EnsureSOAMNAME_Call{Call: _e.mock.On("EnsureSOAMNAME", ctx, zoneID, domain, nameservers)}
 }
 
@@ -1164,7 +1164,7 @@ type MockDNSService_GetActiveDNSSECDS_Call struct {
 // GetActiveDNSSECDS is a helper method to define mock.On call
 //   - ctx context.Context
 //   - zoneID uint
-func (_e *MockDNSService_Expecter) GetActiveDNSSECDS(ctx interface{}, zoneID interface{}) *MockDNSService_GetActiveDNSSECDS_Call {
+func (_e *MockDNSService_Expecter) GetActiveDNSSECDS(ctx any, zoneID any) *MockDNSService_GetActiveDNSSECDS_Call {
 	return &MockDNSService_GetActiveDNSSECDS_Call{Call: _e.mock.On("GetActiveDNSSECDS", ctx, zoneID)}
 }
 
@@ -1289,7 +1289,7 @@ type MockDNSService_GetRRSet_Call struct {
 //   - zoneID uint
 //   - name string
 //   - recordType string
-func (_e *MockDNSService_Expecter) GetRRSet(ctx interface{}, zoneID interface{}, name interface{}, recordType interface{}) *MockDNSService_GetRRSet_Call {
+func (_e *MockDNSService_Expecter) GetRRSet(ctx any, zoneID any, name any, recordType any) *MockDNSService_GetRRSet_Call {
 	return &MockDNSService_GetRRSet_Call{Call: _e.mock.On("GetRRSet", ctx, zoneID, name, recordType)}
 }
 
@@ -1367,7 +1367,7 @@ type MockDNSService_GetZone_Call struct {
 // GetZone is a helper method to define mock.On call
 //   - ctx context.Context
 //   - zoneID uint
-func (_e *MockDNSService_Expecter) GetZone(ctx interface{}, zoneID interface{}) *MockDNSService_GetZone_Call {
+func (_e *MockDNSService_Expecter) GetZone(ctx any, zoneID any) *MockDNSService_GetZone_Call {
 	return &MockDNSService_GetZone_Call{Call: _e.mock.On("GetZone", ctx, zoneID)}
 }
 
@@ -1435,7 +1435,7 @@ type MockDNSService_GetZoneByDomain_Call struct {
 // GetZoneByDomain is a helper method to define mock.On call
 //   - ctx context.Context
 //   - domain string
-func (_e *MockDNSService_Expecter) GetZoneByDomain(ctx interface{}, domain interface{}) *MockDNSService_GetZoneByDomain_Call {
+func (_e *MockDNSService_Expecter) GetZoneByDomain(ctx any, domain any) *MockDNSService_GetZoneByDomain_Call {
 	return &MockDNSService_GetZoneByDomain_Call{Call: _e.mock.On("GetZoneByDomain", ctx, domain)}
 }
 
@@ -1512,7 +1512,7 @@ type MockDNSService_GetZoneRecords_Call struct {
 //   - filters []queryutil.CrudFilter
 //   - sorts []queryutil.Sort
 //   - pagination queryutil.Pagination
-func (_e *MockDNSService_Expecter) GetZoneRecords(ctx interface{}, zoneID interface{}, filters interface{}, sorts interface{}, pagination interface{}) *MockDNSService_GetZoneRecords_Call {
+func (_e *MockDNSService_Expecter) GetZoneRecords(ctx any, zoneID any, filters any, sorts any, pagination any) *MockDNSService_GetZoneRecords_Call {
 	return &MockDNSService_GetZoneRecords_Call{Call: _e.mock.On("GetZoneRecords", ctx, zoneID, filters, sorts, pagination)}
 }
 
@@ -1647,7 +1647,7 @@ type MockDNSService_ListZones_Call struct {
 //   - filters []queryutil.CrudFilter
 //   - sorts []queryutil.Sort
 //   - pagination queryutil.Pagination
-func (_e *MockDNSService_Expecter) ListZones(ctx interface{}, filters interface{}, sorts interface{}, pagination interface{}) *MockDNSService_ListZones_Call {
+func (_e *MockDNSService_Expecter) ListZones(ctx any, filters any, sorts any, pagination any) *MockDNSService_ListZones_Call {
 	return &MockDNSService_ListZones_Call{Call: _e.mock.On("ListZones", ctx, filters, sorts, pagination)}
 }
 
@@ -1748,7 +1748,7 @@ type MockDNSService_SetConfig_Call struct {
 
 // SetConfig is a helper method to define mock.On call
 //   - cfg config.Manager
-func (_e *MockDNSService_Expecter) SetConfig(cfg interface{}) *MockDNSService_SetConfig_Call {
+func (_e *MockDNSService_Expecter) SetConfig(cfg any) *MockDNSService_SetConfig_Call {
 	return &MockDNSService_SetConfig_Call{Call: _e.mock.On("SetConfig", cfg)}
 }
 
@@ -1788,7 +1788,7 @@ type MockDNSService_SetContext_Call struct {
 
 // SetContext is a helper method to define mock.On call
 //   - ctx core.Context
-func (_e *MockDNSService_Expecter) SetContext(ctx interface{}) *MockDNSService_SetContext_Call {
+func (_e *MockDNSService_Expecter) SetContext(ctx any) *MockDNSService_SetContext_Call {
 	return &MockDNSService_SetContext_Call{Call: _e.mock.On("SetContext", ctx)}
 }
 
@@ -1828,7 +1828,7 @@ type MockDNSService_SetDB_Call struct {
 
 // SetDB is a helper method to define mock.On call
 //   - db1 *gorm.DB
-func (_e *MockDNSService_Expecter) SetDB(db1 interface{}) *MockDNSService_SetDB_Call {
+func (_e *MockDNSService_Expecter) SetDB(db1 any) *MockDNSService_SetDB_Call {
 	return &MockDNSService_SetDB_Call{Call: _e.mock.On("SetDB", db1)}
 }
 
@@ -1868,7 +1868,7 @@ type MockDNSService_SetLogger_Call struct {
 
 // SetLogger is a helper method to define mock.On call
 //   - logger *core.Logger
-func (_e *MockDNSService_Expecter) SetLogger(logger interface{}) *MockDNSService_SetLogger_Call {
+func (_e *MockDNSService_Expecter) SetLogger(logger any) *MockDNSService_SetLogger_Call {
 	return &MockDNSService_SetLogger_Call{Call: _e.mock.On("SetLogger", logger)}
 }
 
@@ -1922,7 +1922,7 @@ type MockDNSService_SetTLSARecord_Call struct {
 //   - zoneID uint
 //   - domain string
 //   - content string
-func (_e *MockDNSService_Expecter) SetTLSARecord(ctx interface{}, zoneID interface{}, domain interface{}, content interface{}) *MockDNSService_SetTLSARecord_Call {
+func (_e *MockDNSService_Expecter) SetTLSARecord(ctx any, zoneID any, domain any, content any) *MockDNSService_SetTLSARecord_Call {
 	return &MockDNSService_SetTLSARecord_Call{Call: _e.mock.On("SetTLSARecord", ctx, zoneID, domain, content)}
 }
 
@@ -2004,7 +2004,7 @@ type MockDNSService_UpdateRecord_Call struct {
 //   - recordType string
 //   - records []string
 //   - ttl uint
-func (_e *MockDNSService_Expecter) UpdateRecord(ctx interface{}, zoneID interface{}, name interface{}, recordType interface{}, records interface{}, ttl interface{}) *MockDNSService_UpdateRecord_Call {
+func (_e *MockDNSService_Expecter) UpdateRecord(ctx any, zoneID any, name any, recordType any, records any, ttl any) *MockDNSService_UpdateRecord_Call {
 	return &MockDNSService_UpdateRecord_Call{Call: _e.mock.On("UpdateRecord", ctx, zoneID, name, recordType, records, ttl)}
 }
 
@@ -2084,7 +2084,7 @@ type MockDNSService_UpdateWebsiteDNSRecords_Call struct {
 //   - websiteDomain string
 //   - targetHash string
 //   - targetType db.WebsiteTargetType
-func (_e *MockDNSService_Expecter) UpdateWebsiteDNSRecords(ctx interface{}, zoneID interface{}, websiteDomain interface{}, targetHash interface{}, targetType interface{}) *MockDNSService_UpdateWebsiteDNSRecords_Call {
+func (_e *MockDNSService_Expecter) UpdateWebsiteDNSRecords(ctx any, zoneID any, websiteDomain any, targetHash any, targetType any) *MockDNSService_UpdateWebsiteDNSRecords_Call {
 	return &MockDNSService_UpdateWebsiteDNSRecords_Call{Call: _e.mock.On("UpdateWebsiteDNSRecords", ctx, zoneID, websiteDomain, targetHash, targetType)}
 }
 
@@ -2157,7 +2157,7 @@ type MockDNSService_UpdateZone_Call struct {
 //   - ctx context.Context
 //   - zoneID uint
 //   - status db.DNSZoneStatus
-func (_e *MockDNSService_Expecter) UpdateZone(ctx interface{}, zoneID interface{}, status interface{}) *MockDNSService_UpdateZone_Call {
+func (_e *MockDNSService_Expecter) UpdateZone(ctx any, zoneID any, status any) *MockDNSService_UpdateZone_Call {
 	return &MockDNSService_UpdateZone_Call{Call: _e.mock.On("UpdateZone", ctx, zoneID, status)}
 }
 
@@ -2228,7 +2228,7 @@ type MockDNSService_ValidateNameservers_Call struct {
 // ValidateNameservers is a helper method to define mock.On call
 //   - ctx context.Context
 //   - zoneID uint
-func (_e *MockDNSService_Expecter) ValidateNameservers(ctx interface{}, zoneID interface{}) *MockDNSService_ValidateNameservers_Call {
+func (_e *MockDNSService_Expecter) ValidateNameservers(ctx any, zoneID any) *MockDNSService_ValidateNameservers_Call {
 	return &MockDNSService_ValidateNameservers_Call{Call: _e.mock.On("ValidateNameservers", ctx, zoneID)}
 }
 

--- a/internal/testing/mocks/MockDomainProvider.go
+++ b/internal/testing/mocks/MockDomainProvider.go
@@ -170,6 +170,72 @@ func (_c *MockDomainProvider_BuildDelegation_Call) RunAndReturn(run func(ctx con
 	return _c
 }
 
+// Inspect provides a mock function for the type MockDomainProvider
+func (_mock *MockDomainProvider) Inspect(ctx context.Context, domain string) (bool, error) {
+	ret := _mock.Called(ctx, domain)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Inspect")
+	}
+
+	var r0 bool
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (bool, error)); ok {
+		return returnFunc(ctx, domain)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) bool); ok {
+		r0 = returnFunc(ctx, domain)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, domain)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockDomainProvider_Inspect_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Inspect'
+type MockDomainProvider_Inspect_Call struct {
+	*mock.Call
+}
+
+// Inspect is a helper method to define mock.On call
+//   - ctx context.Context
+//   - domain string
+func (_e *MockDomainProvider_Expecter) Inspect(ctx any, domain any) *MockDomainProvider_Inspect_Call {
+	return &MockDomainProvider_Inspect_Call{Call: _e.mock.On("Inspect", ctx, domain)}
+}
+
+func (_c *MockDomainProvider_Inspect_Call) Run(run func(ctx context.Context, domain string)) *MockDomainProvider_Inspect_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockDomainProvider_Inspect_Call) Return(onchainManaged bool, err error) *MockDomainProvider_Inspect_Call {
+	_c.Call.Return(onchainManaged, err)
+	return _c
+}
+
+func (_c *MockDomainProvider_Inspect_Call) RunAndReturn(run func(ctx context.Context, domain string) (bool, error)) *MockDomainProvider_Inspect_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // LiveNameservers provides a mock function for the type MockDomainProvider
 func (_mock *MockDomainProvider) LiveNameservers(ctx context.Context, domain string) ([]string, error) {
 	ret := _mock.Called(ctx, domain)
@@ -391,50 +457,6 @@ func (_c *MockDomainProvider_Protocol_Call) RunAndReturn(run func() string) *Moc
 	return _c
 }
 
-// UsesManagedZoneTLSA provides a mock function for the type MockDomainProvider
-func (_mock *MockDomainProvider) UsesManagedZoneTLSA() bool {
-	ret := _mock.Called()
-
-	if len(ret) == 0 {
-		panic("no return value specified for UsesManagedZoneTLSA")
-	}
-
-	var r0 bool
-	if returnFunc, ok := ret.Get(0).(func() bool); ok {
-		r0 = returnFunc()
-	} else {
-		r0 = ret.Get(0).(bool)
-	}
-	return r0
-}
-
-// MockDomainProvider_UsesManagedZoneTLSA_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UsesManagedZoneTLSA'
-type MockDomainProvider_UsesManagedZoneTLSA_Call struct {
-	*mock.Call
-}
-
-// UsesManagedZoneTLSA is a helper method to define mock.On call
-func (_e *MockDomainProvider_Expecter) UsesManagedZoneTLSA() *MockDomainProvider_UsesManagedZoneTLSA_Call {
-	return &MockDomainProvider_UsesManagedZoneTLSA_Call{Call: _e.mock.On("UsesManagedZoneTLSA")}
-}
-
-func (_c *MockDomainProvider_UsesManagedZoneTLSA_Call) Run(run func()) *MockDomainProvider_UsesManagedZoneTLSA_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run()
-	})
-	return _c
-}
-
-func (_c *MockDomainProvider_UsesManagedZoneTLSA_Call) Return(b bool) *MockDomainProvider_UsesManagedZoneTLSA_Call {
-	_c.Call.Return(b)
-	return _c
-}
-
-func (_c *MockDomainProvider_UsesManagedZoneTLSA_Call) RunAndReturn(run func() bool) *MockDomainProvider_UsesManagedZoneTLSA_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // RequiresDNSSEC provides a mock function for the type MockDomainProvider
 func (_mock *MockDomainProvider) RequiresDNSSEC() bool {
 	ret := _mock.Called()
@@ -475,6 +497,50 @@ func (_c *MockDomainProvider_RequiresDNSSEC_Call) Return(b bool) *MockDomainProv
 }
 
 func (_c *MockDomainProvider_RequiresDNSSEC_Call) RunAndReturn(run func() bool) *MockDomainProvider_RequiresDNSSEC_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// UsesManagedZoneTLSA provides a mock function for the type MockDomainProvider
+func (_mock *MockDomainProvider) UsesManagedZoneTLSA() bool {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for UsesManagedZoneTLSA")
+	}
+
+	var r0 bool
+	if returnFunc, ok := ret.Get(0).(func() bool); ok {
+		r0 = returnFunc()
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+	return r0
+}
+
+// MockDomainProvider_UsesManagedZoneTLSA_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UsesManagedZoneTLSA'
+type MockDomainProvider_UsesManagedZoneTLSA_Call struct {
+	*mock.Call
+}
+
+// UsesManagedZoneTLSA is a helper method to define mock.On call
+func (_e *MockDomainProvider_Expecter) UsesManagedZoneTLSA() *MockDomainProvider_UsesManagedZoneTLSA_Call {
+	return &MockDomainProvider_UsesManagedZoneTLSA_Call{Call: _e.mock.On("UsesManagedZoneTLSA")}
+}
+
+func (_c *MockDomainProvider_UsesManagedZoneTLSA_Call) Run(run func()) *MockDomainProvider_UsesManagedZoneTLSA_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockDomainProvider_UsesManagedZoneTLSA_Call) Return(b bool) *MockDomainProvider_UsesManagedZoneTLSA_Call {
+	_c.Call.Return(b)
+	return _c
+}
+
+func (_c *MockDomainProvider_UsesManagedZoneTLSA_Call) RunAndReturn(run func() bool) *MockDomainProvider_UsesManagedZoneTLSA_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/testing/mocks/MockWebsiteService.go
+++ b/internal/testing/mocks/MockWebsiteService.go
@@ -45,6 +45,63 @@ func (_m *MockWebsiteService) EXPECT() *MockWebsiteService_Expecter {
 	return &MockWebsiteService_Expecter{mock: &_m.Mock}
 }
 
+// ActivatePlatformSubdomainWebsite provides a mock function for the type MockWebsiteService
+func (_mock *MockWebsiteService) ActivatePlatformSubdomainWebsite(ctx context.Context, websiteID uint) error {
+	ret := _mock.Called(ctx, websiteID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ActivatePlatformSubdomainWebsite")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uint) error); ok {
+		r0 = returnFunc(ctx, websiteID)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockWebsiteService_ActivatePlatformSubdomainWebsite_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ActivatePlatformSubdomainWebsite'
+type MockWebsiteService_ActivatePlatformSubdomainWebsite_Call struct {
+	*mock.Call
+}
+
+// ActivatePlatformSubdomainWebsite is a helper method to define mock.On call
+//   - ctx context.Context
+//   - websiteID uint
+func (_e *MockWebsiteService_Expecter) ActivatePlatformSubdomainWebsite(ctx any, websiteID any) *MockWebsiteService_ActivatePlatformSubdomainWebsite_Call {
+	return &MockWebsiteService_ActivatePlatformSubdomainWebsite_Call{Call: _e.mock.On("ActivatePlatformSubdomainWebsite", ctx, websiteID)}
+}
+
+func (_c *MockWebsiteService_ActivatePlatformSubdomainWebsite_Call) Run(run func(ctx context.Context, websiteID uint)) *MockWebsiteService_ActivatePlatformSubdomainWebsite_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 uint
+		if args[1] != nil {
+			arg1 = args[1].(uint)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockWebsiteService_ActivatePlatformSubdomainWebsite_Call) Return(err error) *MockWebsiteService_ActivatePlatformSubdomainWebsite_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockWebsiteService_ActivatePlatformSubdomainWebsite_Call) RunAndReturn(run func(ctx context.Context, websiteID uint) error) *MockWebsiteService_ActivatePlatformSubdomainWebsite_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // BlockWebsite provides a mock function for the type MockWebsiteService
 func (_mock *MockWebsiteService) BlockWebsite(ctx context.Context, websiteID uint) error {
 	ret := _mock.Called(ctx, websiteID)
@@ -890,6 +947,63 @@ func (_c *MockWebsiteService_Logger_Call) RunAndReturn(run func() *core.Logger) 
 	return _c
 }
 
+// NotifyAdminWebsiteCreated provides a mock function for the type MockWebsiteService
+func (_mock *MockWebsiteService) NotifyAdminWebsiteCreated(ctx context.Context, websiteID uint) error {
+	ret := _mock.Called(ctx, websiteID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for NotifyAdminWebsiteCreated")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uint) error); ok {
+		r0 = returnFunc(ctx, websiteID)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockWebsiteService_NotifyAdminWebsiteCreated_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'NotifyAdminWebsiteCreated'
+type MockWebsiteService_NotifyAdminWebsiteCreated_Call struct {
+	*mock.Call
+}
+
+// NotifyAdminWebsiteCreated is a helper method to define mock.On call
+//   - ctx context.Context
+//   - websiteID uint
+func (_e *MockWebsiteService_Expecter) NotifyAdminWebsiteCreated(ctx any, websiteID any) *MockWebsiteService_NotifyAdminWebsiteCreated_Call {
+	return &MockWebsiteService_NotifyAdminWebsiteCreated_Call{Call: _e.mock.On("NotifyAdminWebsiteCreated", ctx, websiteID)}
+}
+
+func (_c *MockWebsiteService_NotifyAdminWebsiteCreated_Call) Run(run func(ctx context.Context, websiteID uint)) *MockWebsiteService_NotifyAdminWebsiteCreated_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 uint
+		if args[1] != nil {
+			arg1 = args[1].(uint)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockWebsiteService_NotifyAdminWebsiteCreated_Call) Return(err error) *MockWebsiteService_NotifyAdminWebsiteCreated_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockWebsiteService_NotifyAdminWebsiteCreated_Call) RunAndReturn(run func(ctx context.Context, websiteID uint) error) *MockWebsiteService_NotifyAdminWebsiteCreated_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // SetConfig provides a mock function for the type MockWebsiteService
 func (_mock *MockWebsiteService) SetConfig(cfg config.Manager) {
 	_mock.Called(cfg)
@@ -1507,120 +1621,6 @@ func (_c *MockWebsiteService_ValidateDNS_Call) Return(validateDNSResult core0.Va
 }
 
 func (_c *MockWebsiteService_ValidateDNS_Call) RunAndReturn(run func(ctx context.Context, userID uint, websiteID uint) (core0.ValidateDNSResult, error)) *MockWebsiteService_ValidateDNS_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// NotifyAdminWebsiteCreated provides a mock function for the type MockWebsiteService
-func (_mock *MockWebsiteService) NotifyAdminWebsiteCreated(ctx context.Context, websiteID uint) error {
-	ret := _mock.Called(ctx, websiteID)
-
-	if len(ret) == 0 {
-		panic("no return value specified for NotifyAdminWebsiteCreated")
-	}
-
-	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, uint) error); ok {
-		r0 = returnFunc(ctx, websiteID)
-	} else {
-		r0 = ret.Error(0)
-	}
-	return r0
-}
-
-// MockWebsiteService_NotifyAdminWebsiteCreated_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'NotifyAdminWebsiteCreated'
-type MockWebsiteService_NotifyAdminWebsiteCreated_Call struct {
-	*mock.Call
-}
-
-// NotifyAdminWebsiteCreated is a helper method to define mock.On call
-//   - ctx context.Context
-//   - websiteID uint
-func (_e *MockWebsiteService_Expecter) NotifyAdminWebsiteCreated(ctx any, websiteID any) *MockWebsiteService_NotifyAdminWebsiteCreated_Call {
-	return &MockWebsiteService_NotifyAdminWebsiteCreated_Call{Call: _e.mock.On("NotifyAdminWebsiteCreated", ctx, websiteID)}
-}
-
-func (_c *MockWebsiteService_NotifyAdminWebsiteCreated_Call) Run(run func(ctx context.Context, websiteID uint)) *MockWebsiteService_NotifyAdminWebsiteCreated_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		var arg1 uint
-		if args[1] != nil {
-			arg1 = args[1].(uint)
-		}
-		run(
-			arg0,
-			arg1,
-		)
-	})
-	return _c
-}
-
-func (_c *MockWebsiteService_NotifyAdminWebsiteCreated_Call) Return(err error) *MockWebsiteService_NotifyAdminWebsiteCreated_Call {
-	_c.Call.Return(err)
-	return _c
-}
-
-func (_c *MockWebsiteService_NotifyAdminWebsiteCreated_Call) RunAndReturn(run func(ctx context.Context, websiteID uint) error) *MockWebsiteService_NotifyAdminWebsiteCreated_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// ActivatePlatformSubdomainWebsite provides a mock function for the type MockWebsiteService
-func (_mock *MockWebsiteService) ActivatePlatformSubdomainWebsite(ctx context.Context, websiteID uint) error {
-	ret := _mock.Called(ctx, websiteID)
-
-	if len(ret) == 0 {
-		panic("no return value specified for ActivatePlatformSubdomainWebsite")
-	}
-
-	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, uint) error); ok {
-		r0 = returnFunc(ctx, websiteID)
-	} else {
-		r0 = ret.Error(0)
-	}
-	return r0
-}
-
-// MockWebsiteService_ActivatePlatformSubdomainWebsite_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ActivatePlatformSubdomainWebsite'
-type MockWebsiteService_ActivatePlatformSubdomainWebsite_Call struct {
-	*mock.Call
-}
-
-// ActivatePlatformSubdomainWebsite is a helper method to define mock.On call
-//   - ctx context.Context
-//   - websiteID uint
-func (_e *MockWebsiteService_Expecter) ActivatePlatformSubdomainWebsite(ctx any, websiteID any) *MockWebsiteService_ActivatePlatformSubdomainWebsite_Call {
-	return &MockWebsiteService_ActivatePlatformSubdomainWebsite_Call{Call: _e.mock.On("ActivatePlatformSubdomainWebsite", ctx, websiteID)}
-}
-
-func (_c *MockWebsiteService_ActivatePlatformSubdomainWebsite_Call) Run(run func(ctx context.Context, websiteID uint)) *MockWebsiteService_ActivatePlatformSubdomainWebsite_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		var arg1 uint
-		if args[1] != nil {
-			arg1 = args[1].(uint)
-		}
-		run(
-			arg0,
-			arg1,
-		)
-	})
-	return _c
-}
-
-func (_c *MockWebsiteService_ActivatePlatformSubdomainWebsite_Call) Return(err error) *MockWebsiteService_ActivatePlatformSubdomainWebsite_Call {
-	_c.Call.Return(err)
-	return _c
-}
-
-func (_c *MockWebsiteService_ActivatePlatformSubdomainWebsite_Call) RunAndReturn(run func(ctx context.Context, websiteID uint) error) *MockWebsiteService_ActivatePlatformSubdomainWebsite_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
Adds Handshake HIP-5 (cross-chain) name support: names whose NS record points at an external contract bind as `onchain_managed` when dns\_hosting\_enabled is false, with no portal zone, DNSSEC, or DANE. Ownership is proven with the TXT verification token resolved through the HNS resolver.

Adds `DomainProvider.Inspect` for on-chain detection, HIP-5 detection in `HNSProvider` via final-label parsing (underscore-prefixed or blocked TLDs, configurable via `dns.hip5_blocked_tlds`), and routes onchain\_managed bindings through TXT-token verification. Portal DNS hosting is rejected for HIP-5 names.

Bumps `go.lumeweb.com/portal` to the current develop digest so the core/testing harness builds; mocks regenerated against it.

- `develop` <!-- branch-stack -->
  - **feat(domain): add HIP5 cross-chain on-chain managed domains** :point\_left:

***

Adds the explicit HNS-DNS → on-chain transition via `POST /websites/:id/domains/:domain_id/onchain` (`ConvertToOnChain`): deletes the managed zone/DNSSEC when the name is genuinely on-chain, keeps DANE/SSL state, and owns TXT-token verification for on-chain bindings.
