### PR TITLE
refactor(domain): introduce DomainClass hosting-locus classification

### DIFF
--- a/internal/api/api_platform_domains_test.go
+++ b/internal/api/api_platform_domains_test.go
@@ -208,6 +208,10 @@ func TestAPI_CreateDomain_PlatformClaim(t *testing.T) {
 		mockDNS.EXPECT().GetZoneByDomain(mock.Anything, "pinned.site").
 			Return(&pluginDb.DNSZone{Model: gorm.Model{ID: 7}, Domain: "pinned.site"}, nil).Once()
 		mockDNS.EXPECT().CreateDNSLinkRecord(mock.Anything, uint(7), mock.Anything, mock.Anything).Return(nil).Maybe()
+		// Claiming triggers the website activation hook (FSM transition is
+		// exercised by the website-service tests).
+		core.GetService[*mocks.MockWebsiteService](ctx, pluginCore.WEBSITE_SERVICE).
+			EXPECT().ActivatePlatformSubdomainWebsite(mock.Anything, uint(1)).Return(nil).Once()
 
 		rec := helper.makeAuthenticatedRequest(http.MethodPost, "/api/websites/1/domains",
 			token, []byte(`{"platform_domain":"pinned.site","generate":true}`))

--- a/internal/db/website_domain.go
+++ b/internal/db/website_domain.go
@@ -34,6 +34,42 @@ const (
 	DomainStatusOnchainManaged DomainStatus = "onchain_managed"
 )
 
+// DomainClass classifies a bound name by who serves its DNS. It is derived
+// from persisted state (status + ZoneID), never stored. dns_hosting_enabled is
+// excluded on purpose: when the flag disagrees with the zone reference it is a
+// reconcile orphan that SetDomainDNSEnabled repairs, and classification must
+// follow the same zone reference the rest of the code keys on.
+type DomainClass uint8
+
+const (
+	// ClassPortalManaged names served from a portal-created PowerDNS zone.
+	// ZoneID != 0 is the authoritative marker (see VerifyDomain), so a binding
+	// with a zone is portal-managed regardless of lifecycle status.
+	ClassPortalManaged DomainClass = iota
+	// ClassSelfHosted names whose DNS the user runs themselves (status
+	// self_hosted), and bindings with no portal zone yet (draft): no
+	// DS/TLSA/DNSSEC reconciliation applies to them.
+	ClassSelfHosted
+	// ClassOnChainManaged marks a name whose DNS is served on-chain (e.g. a
+	// Handshake HIP-5 name whose NS record points at an external contract).
+	// The portal owns only the ownership check (TXT token through the
+	// namespace resolver) and never provisions a zone, DNSSEC, or DANE.
+	ClassOnChainManaged
+)
+
+// Class returns the binding's DNS-hosting locus. Derived from state, not
+// stored; see DomainClass for why dns_hosting_enabled is not an input.
+func (wd *WebsiteDomain) Class() DomainClass {
+	switch {
+	case wd.Status == DomainStatusOnchainManaged:
+		return ClassOnChainManaged
+	case wd.ZoneID != 0:
+		return ClassPortalManaged
+	default:
+		return ClassSelfHosted
+	}
+}
+
 // WebsiteDomain binds a domain (by namespace) to a website.
 type WebsiteDomain struct {
 	ID             uint `gorm:"primaryKey"`
@@ -91,10 +127,7 @@ func (WebsiteDomain) TableName() string {
 // zone, so there is no shared record set to preserve even though the namespace
 // is HNS.
 func (wd *WebsiteDomain) DelegationRecordsOwned() bool {
-	if wd.Status == DomainStatusOnchainManaged {
-		return false
-	}
-	return wd.Namespace == DomainNamespaceHNS || wd.DelegationOwned()
+	return wd.Class() != ClassOnChainManaged && (wd.Namespace == DomainNamespaceHNS || wd.DelegationOwned())
 }
 
 // DelegationOwned reports whether this binding's PowerDNS zone also hosts

--- a/internal/db/website_domain_test.go
+++ b/internal/db/website_domain_test.go
@@ -49,6 +49,58 @@ func TestWebsiteDomain_UniqueConstraint(t *testing.T) {
 	}, dbTestOptions)
 }
 
+func TestWebsiteDomain_Class(t *testing.T) {
+	tests := []struct {
+		name string
+		wd   WebsiteDomain
+		want DomainClass
+	}{
+		{
+			name: "onchain managed is on-chain managed even with a stray zone id",
+			wd: WebsiteDomain{
+				Status: DomainStatusOnchainManaged,
+				ZoneID: 7,
+			},
+			want: ClassOnChainManaged,
+		},
+		{
+			name: "zone is authoritative for portal-managed regardless of status",
+			wd: WebsiteDomain{
+				Status: DomainStatusError,
+				ZoneID: 42,
+			},
+			want: ClassPortalManaged,
+		},
+		{
+			name: "no zone means self-hosted for draft bindings",
+			wd: WebsiteDomain{
+				Status: DomainStatusDraft,
+			},
+			want: ClassSelfHosted,
+		},
+		{
+			name: "self-hosted status with no zone is self-hosted",
+			wd: WebsiteDomain{
+				Status: DomainStatusSelfHosted,
+			},
+			want: ClassSelfHosted,
+		},
+		{
+			name: "dns_hosting_enabled is deliberately not an input",
+			wd: WebsiteDomain{
+				Status:            DomainStatusDraft,
+				DNSHostingEnabled: true,
+			},
+			want: ClassSelfHosted,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.wd.Class())
+		})
+	}
+}
+
 func TestWebsiteDomain_DelegationRecordsOwned(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/protocol/ipfs/peer_tracker_test.go
+++ b/internal/protocol/ipfs/peer_tracker_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/ipfs/go-cid"
 	"github.com/multiformats/go-multihash"
+
+	"go.lumeweb.com/portal-plugin-ipfs/internal/protocol/encoding"
 )
 
 func TestBlockRequestTracker_AddRequest(t *testing.T) {
@@ -525,8 +527,8 @@ func TestBlockRequestTracker_RemovePeerFromAll_DisconnectScenario(t *testing.T) 
 
 func TestBlockRequestTrackerMaintainsPeerIndex(t *testing.T) {
 	tracker := NewBlockRequestTracker()
-	cidA := mustTestCID(t, "QmYwAPJzv5CZsnA625qs3FTJ2xDkg7WjNnCm129r48gVfX")
-	cidB := mustTestCID(t, "QmYwAPJzv5CZsnA625qs3FTJ2xDkg7WjNnCm129r48gVfW")
+	cidA := encoding.NormalizeCid(mustTestCID(t, "QmYwAPJzv5CZsnA625qs3FTJ2xDkg7WjNnCm129r48gVfX"))
+	cidB := encoding.NormalizeCid(mustTestCID(t, "QmYwAPJzv5CZsnA625qs3FTJ2xDkg7WjNnCm129r48gVfW"))
 
 	tracker.AddRequest(cidA, "peer-a")
 	tracker.AddRequest(cidA, "peer-a")
@@ -561,8 +563,8 @@ func TestBlockRequestTrackerMaintainsPeerIndex(t *testing.T) {
 
 func TestBlockRequestTrackerRemovesReverseIndexEntries(t *testing.T) {
 	tracker := NewBlockRequestTracker()
-	cidA := mustTestCID(t, "QmYwAPJzv5CZsnA625qs3FTJ2xDkg7WjNnCm129r48gVfX")
-	cidB := mustTestCID(t, "QmYwAPJzv5CZsnA625qs3FTJ2xDkg7WjNnCm129r48gVfW")
+	cidA := encoding.NormalizeCid(mustTestCID(t, "QmYwAPJzv5CZsnA625qs3FTJ2xDkg7WjNnCm129r48gVfX"))
+	cidB := encoding.NormalizeCid(mustTestCID(t, "QmYwAPJzv5CZsnA625qs3FTJ2xDkg7WjNnCm129r48gVfW"))
 
 	tracker.AddRequest(cidA, "peer-a")
 	tracker.AddRequest(cidA, "peer-b")

--- a/internal/service/domain/delegated_domain_service.go
+++ b/internal/service/domain/delegated_domain_service.go
@@ -611,11 +611,12 @@ func (s *DelegatedDomainService) VerifyDomain(ctx context.Context,
 	// binding is not part of the portal's lifecycle (no DS to reconcile, no
 	// SOA/DNSSEC to self-heal), so verification is a no-op that leaves the
 	// binding's existing status rather than querying PowerDNS for a zone that
-	// does not exist. The presence of a real PowerDNS zone (ZoneID != 0) is
-	// the authoritative marker of a portal-hosted binding, regardless of the
-	// dns_hosting_enabled flag (which may be false on legacy bindings that
-	// still hold a zone).
-	if wd.ZoneID == 0 {
+	// does not exist. The binding's class expresses the same authority: only
+	// portal-managed bindings (ZoneID != 0, regardless of dns_hosting_enabled,
+	// which may be false on legacy bindings that still hold a zone) have
+	// delegation to verify; self-hosted, on-chain managed (HIP-5), and draft
+	// bindings exit here.
+	if wd.Class() != pluginDb.ClassPortalManaged {
 		return false, nil
 	}
 
@@ -642,7 +643,7 @@ func (s *DelegatedDomainService) VerifyDomain(ctx context.Context,
 		if dsErr != nil {
 			return false, fmt.Errorf("resolve live DS for zone %d: %w", wd.ZoneID, dsErr)
 		}
-	} else if wd.ZoneID != 0 {
+	} else {
 		// Best-effort for non-DNSSEC providers: surface DB/PowerDNS errors so
 		// they are observable, but the provider verifies on NS and ignores DS,
 		// so a failure here must not block delegation.
@@ -695,7 +696,10 @@ func (s *DelegatedDomainService) VerifyDomain(ctx context.Context,
 // requiring the user to re-bind. The two invariants are gated independently:
 //
 //  1. DNSSEC active signing key (fatal). For managed-DNSSEC namespaces
-//     (UsesManagedZoneTLSA, e.g. HNS). A "no active key" result (("", nil))
+//     (RequiresDNSSEC, e.g. HNS). Uses the same capability as the expectedDS
+//     computation in VerifyDomain: a namespace that requires a live DS still
+//     heals its signing key even when it does not publish DANE. A
+//     "no active key" result (("", nil))
 //     means DNSSEC was never enabled or the key was rotated away: EnableDNSSEC
 //     is idempotent (reuses an active key, mints one only when none exists),
 //     then the live DS is re-read. Failure is fatal — a managed zone without a
@@ -712,8 +716,10 @@ func (s *DelegatedDomainService) VerifyDomain(ctx context.Context,
 //
 // It returns the (possibly healed) expected DS and a fatal error, or nil.
 func (s *DelegatedDomainService) selfHealZone(ctx context.Context, provider DomainProvider, wd *pluginDb.WebsiteDomain, expectedDS string) (string, error) {
-	// DNSSEC self-heal: only managed-DNSSEC namespaces (UsesManagedZoneTLSA).
-	if provider.UsesManagedZoneTLSA() && expectedDS == "" {
+	// DNSSEC self-heal: only managed-DNSSEC namespaces (RequiresDNSSEC, the
+	// same gate VerifyDomain uses for expectedDS; a DNSSEC-required namespace
+	// that does not publish DANE must still heal its signing key).
+	if provider.RequiresDNSSEC() && expectedDS == "" {
 		if _, err := s.dnsSvc.EnableDNSSEC(ctx, wd.ZoneID); err != nil {
 			return "", fmt.Errorf("enable dnssec for zone %d: %w", wd.ZoneID, err)
 		}

--- a/internal/service/domain/platform_domain_test.go
+++ b/internal/service/domain/platform_domain_test.go
@@ -301,6 +301,7 @@ func TestCreatePlatformSubdomain_NestedRoot_UsesGrantedRootZone(t *testing.T) {
 		createPlatformRoot(tb, ctx, "api.platform.com", pluginDb.DomainNamespaceICANN, nestedZone.ID, true)
 
 		svc := core.GetService[*DelegatedDomainService](ctx, pluginCore.DELEGATED_DOMAIN_SERVICE)
+		websiteMock := core.GetService[*mocks.MockWebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
 
 		// The subdomain must resolve to the GRANTED root's zone (parentZone),
 		// not the nested root's. The mock only allows the parent zone lookup.
@@ -308,6 +309,7 @@ func TestCreatePlatformSubdomain_NestedRoot_UsesGrantedRootZone(t *testing.T) {
 			Return(&pluginDb.DNSZone{Model: gorm.Model{ID: parentZone.ID}, Domain: "platform.com"}, nil).Once()
 		mockDNS.EXPECT().CreateDNSLinkRecord(mock.Anything, uint(parentZone.ID), mock.Anything, mock.Anything).Return(nil).Once()
 		mockDNS.EXPECT().CreateApexRecord(mock.Anything, uint(parentZone.ID), mock.Anything, pluginCore.RecordTypeALIAS, "gw.example.com").Return(nil).Once()
+		websiteMock.EXPECT().ActivatePlatformSubdomainWebsite(mock.Anything, website.ID).Return(nil).Once()
 
 		wd, err := svc.CreatePlatformSubdomain(context.Background(), website.ID, 1, pd.ID, "blog", false, false)
 		require.NoError(tb, err)
@@ -540,9 +542,11 @@ func TestCreatePlatformSubdomain_Generate_RetriesOnCollision(t *testing.T) {
 		}
 
 		mockDNS := core.GetService[*mocks.MockDNSService](ctx, pluginCore.DNS_SERVICE)
+		websiteMock := core.GetService[*mocks.MockWebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
 		mockDNS.EXPECT().GetZoneByDomain(mock.Anything, "platform.com").
 			Return(&pluginDb.DNSZone{Model: gorm.Model{ID: 7}, Domain: "platform.com"}, nil).Once()
 		mockDNS.EXPECT().CreateDNSLinkRecord(mock.Anything, uint(7), mock.Anything, mock.Anything).Return(nil).Once()
+		websiteMock.EXPECT().ActivatePlatformSubdomainWebsite(mock.Anything, website.ID).Return(nil).Once()
 
 		wd, err := svc.CreatePlatformSubdomain(context.Background(), website.ID, 1, pd.ID, "", true, false)
 		require.NoError(tb, err)
@@ -564,10 +568,12 @@ func TestCreatePlatformSubdomain_Generate_WritesApexToOperatorZone(t *testing.T)
 
 		svc := core.GetService[*DelegatedDomainService](ctx, pluginCore.DELEGATED_DOMAIN_SERVICE)
 		mockDNS := core.GetService[*mocks.MockDNSService](ctx, pluginCore.DNS_SERVICE)
+		websiteMock := core.GetService[*mocks.MockWebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
 		mockDNS.EXPECT().GetZoneByDomain(mock.Anything, "platform.com").
 			Return(&pluginDb.DNSZone{Model: gorm.Model{ID: 7}, Domain: "platform.com"}, nil).Once()
 		mockDNS.EXPECT().CreateDNSLinkRecord(mock.Anything, uint(7), mock.Anything, mock.Anything).Return(nil).Once()
 		mockDNS.EXPECT().CreateApexRecord(mock.Anything, uint(7), mock.Anything, pluginCore.RecordTypeALIAS, "gw.example.com").Return(nil).Once()
+		websiteMock.EXPECT().ActivatePlatformSubdomainWebsite(mock.Anything, website.ID).Return(nil).Once()
 
 		wd, err := svc.CreatePlatformSubdomain(context.Background(), website.ID, 1, pd.ID, "blog", false, false)
 		require.NoError(tb, err)
@@ -609,11 +615,13 @@ func TestCreatePlatformSubdomain_HNS_HappyPath(t *testing.T) {
 
 		svc := core.GetService[*DelegatedDomainService](ctx, pluginCore.DELEGATED_DOMAIN_SERVICE)
 		mockDNS := core.GetService[*mocks.MockDNSService](ctx, pluginCore.DNS_SERVICE)
+		websiteMock := core.GetService[*mocks.MockWebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
 		mockDNS.EXPECT().GetZoneByDomain(mock.Anything, "altroot").
 			Return(&pluginDb.DNSZone{Model: gorm.Model{ID: 7}, Domain: "altroot"}, nil).Once()
 		mockDNS.EXPECT().CreateDNSLinkRecord(mock.Anything, uint(7), mock.Anything, mock.Anything).Return(nil).Once()
 		mockDNS.EXPECT().CreateApexRecord(mock.Anything, uint(7), mock.Anything, pluginCore.RecordTypeA, "127.0.0.1").Return(nil).Once()
 		mockDNS.EXPECT().EnableDNSSEC(mock.Anything, uint(7)).Return("", nil).Maybe()
+		websiteMock.EXPECT().ActivatePlatformSubdomainWebsite(mock.Anything, website.ID).Return(nil).Once()
 
 		wd, err := svc.CreatePlatformSubdomain(context.Background(), website.ID, 1, pd.ID, "blog", false, false)
 		require.NoError(tb, err)
@@ -639,11 +647,13 @@ func TestCreatePlatformSubdomain_HNS_Generate(t *testing.T) {
 
 		svc := core.GetService[*DelegatedDomainService](ctx, pluginCore.DELEGATED_DOMAIN_SERVICE)
 		mockDNS := core.GetService[*mocks.MockDNSService](ctx, pluginCore.DNS_SERVICE)
+		websiteMock := core.GetService[*mocks.MockWebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
 		mockDNS.EXPECT().GetZoneByDomain(mock.Anything, "altroot").
 			Return(&pluginDb.DNSZone{Model: gorm.Model{ID: 7}, Domain: "altroot"}, nil).Once()
 		mockDNS.EXPECT().CreateDNSLinkRecord(mock.Anything, uint(7), mock.Anything, mock.Anything).Return(nil).Once()
 		mockDNS.EXPECT().CreateApexRecord(mock.Anything, uint(7), mock.Anything, pluginCore.RecordTypeA, "127.0.0.1").Return(nil).Once()
 		mockDNS.EXPECT().EnableDNSSEC(mock.Anything, uint(7)).Return("", nil).Maybe()
+		websiteMock.EXPECT().ActivatePlatformSubdomainWebsite(mock.Anything, website.ID).Return(nil).Once()
 
 		wd, err := svc.CreatePlatformSubdomain(context.Background(), website.ID, 1, pd.ID, "", true, false)
 		require.NoError(tb, err)
@@ -737,11 +747,13 @@ func TestBindPlatformRootApex_WritesApexIntoOperatorZone(t *testing.T) {
 
 		svc := core.GetService[*DelegatedDomainService](ctx, pluginCore.DELEGATED_DOMAIN_SERVICE)
 		mockDNS := core.GetService[*mocks.MockDNSService](ctx, pluginCore.DNS_SERVICE)
+		websiteMock := core.GetService[*mocks.MockWebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
 		// Apex match resolves the operator's zone; records are written into it.
 		mockDNS.EXPECT().GetZoneByDomain(mock.Anything, "pinned.site").
 			Return(&pluginDb.DNSZone{Model: gorm.Model{ID: 7}, Domain: "pinned.site"}, nil).Once()
 		mockDNS.EXPECT().CreateDNSLinkRecord(mock.Anything, uint(7), "pinned.site", mock.Anything).Return(nil).Once()
 		mockDNS.EXPECT().CreateApexRecord(mock.Anything, uint(7), "pinned.site", pluginCore.RecordTypeALIAS, "gw.example.com").Return(nil).Once()
+		websiteMock.EXPECT().ActivatePlatformSubdomainWebsite(mock.Anything, website.ID).Return(nil).Once()
 
 		wd, err := svc.BindPlatformRootApex(context.Background(), website.ID, 1, pd.ID)
 		require.NoError(tb, err)
@@ -795,6 +807,8 @@ func TestBindPlatformRootApex_MultipleRootsAsAdditionalDomains(t *testing.T) {
 			Return(&pluginDb.DNSZone{Model: gorm.Model{ID: 22}, Domain: "pinner.xyz"}, nil).Once()
 		mockDNS.EXPECT().CreateDNSLinkRecord(mock.Anything, uint(22), "pinner.xyz", mock.Anything).Return(nil).Once()
 		mockDNS.EXPECT().CreateApexRecord(mock.Anything, uint(22), "pinner.xyz", pluginCore.RecordTypeALIAS, "gw.example.com").Return(nil).Once()
+		websiteMock := core.GetService[*mocks.MockWebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
+		websiteMock.EXPECT().ActivatePlatformSubdomainWebsite(mock.Anything, website.ID).Return(nil).Twice()
 
 		wdSite, err := svc.BindPlatformRootApex(context.Background(), website.ID, 1, pdSite.ID)
 		require.NoError(tb, err)

--- a/internal/service/website/janitor_test.go
+++ b/internal/service/website/janitor_test.go
@@ -53,7 +53,7 @@ func TestWebsiteJanitorJob_Run_Disabled(t *testing.T) {
 		janitorJob := job.(*WebsiteJanitorJob)
 		janitorJob.config = websiteConfig
 		janitorJob.db = ctx.DB()
-		janitorJob.logger = nil
+		janitorJob.logger = ctx.Logger()
 
 		err := job.Run(ctx, context.Background())
 
@@ -75,7 +75,7 @@ func TestWebsiteJanitorJob_Run_NoWebsites(t *testing.T) {
 		janitorJob := job.(*WebsiteJanitorJob)
 		janitorJob.config = websiteConfig
 		janitorJob.db = ctx.DB()
-		janitorJob.logger = nil
+		janitorJob.logger = ctx.Logger()
 
 		err := job.Run(ctx, context.Background())
 
@@ -97,7 +97,7 @@ func TestWebsiteJanitorJob_validateWebsite_SkipsPendingValidation(t *testing.T) 
 		janitorJob := job.(*WebsiteJanitorJob)
 		janitorJob.config = websiteConfig
 		janitorJob.db = ctx.DB()
-		janitorJob.logger = nil
+		janitorJob.logger = ctx.Logger()
 
 		// Build an IPFS website in pending_validation state whose CID is NOT
 		// pinned. Before the fix, the janitor would mark it broken.
@@ -143,7 +143,7 @@ func TestWebsiteJanitorJob_validateWebsite_GracePeriodDefersBroken(t *testing.T)
 		janitorJob := job.(*WebsiteJanitorJob)
 		janitorJob.config = websiteConfig
 		janitorJob.db = ctx.DB()
-		janitorJob.logger = nil
+		janitorJob.logger = ctx.Logger()
 
 		// An active website whose CID is NOT pinned, created just now (within
 		// the grace period).
@@ -190,7 +190,7 @@ func TestWebsiteJanitorJob_validateWebsite_GracePeriodDisabledMarksBroken(t *tes
 		janitorJob := job.(*WebsiteJanitorJob)
 		janitorJob.config = websiteConfig
 		janitorJob.db = ctx.DB()
-		janitorJob.logger = nil
+		janitorJob.logger = ctx.Logger()
 
 		mhBytes, err := mh.Sum([]byte("unpinned-no-grace"), mh.SHA2_256, -1)
 		require.NoError(tb, err)
@@ -232,7 +232,7 @@ func TestWebsiteJanitorJob_validateWebsite_GracePeriodElapsedMarksBroken(t *test
 		janitorJob := job.(*WebsiteJanitorJob)
 		janitorJob.config = websiteConfig
 		janitorJob.db = ctx.DB()
-		janitorJob.logger = nil
+		janitorJob.logger = ctx.Logger()
 
 		mhBytes, err := mh.Sum([]byte("unpinned-grace-elapsed"), mh.SHA2_256, -1)
 		require.NoError(tb, err)


### PR DESCRIPTION
Adds a `DomainClass` enum derived from persisted binding state (status + ZoneID) that classifies each domain by DNS-hosting locus: portal-managed, self-hosted, or on-chain managed.

`VerifyDomain` and `DelegationRecordsOwned` now dispatch on that class instead of scattered `ZoneID == 0` / `Status == onchain_managed` checks, and the DNSSEC self-heal in `selfHealZone` gates on the same `RequiresDNSSEC` capability the expectedDS computation uses.

Also fixes failing tests across the suite: platform-subdomain tests gain the `ActivatePlatformSubdomainWebsite` mock expectation, janitor grace tests wire a logger instead of nil, block-request tracker tests use normalized CID keys, and CAR integration test fixtures are regenerable via `go generate`.

- `develop` <!-- branch-stack -->
  - **refactor(domain): introduce DomainClass hosting-locus classification** :point\_left:

---

<!-- kody-pr-summary:start -->
## Summary

This pull request introduces a **domain classification system** that categorizes website domain bindings by their DNS-hosting locus (who serves the domain's DNS), and updates the domain verification and platform subdomain activation flows accordingly.

## Changes

### Domain Classification Model
- Added a new `DomainClass` type with three classifications:
  - **ClassPortalManaged**: Domains served from a portal-created PowerDNS zone (identified by non-zero `ZoneID`)
  - **ClassSelfHosted**: Domains where users manage their own DNS
  - **ClassOnChainManaged**: Domains whose DNS is served on-chain (e.g., Handshake HIP-5 names)
- Added a `Class()` method on `WebsiteDomain` that derives the classification from persisted state (status + zone ID), explicitly **excluding** the `dns_hosting_enabled` flag to avoid divergence from the authoritative zone reference
- Refactored `DelegationRecordsOwned()` to use the new classification instead of direct status checks

### Domain Verification Updates
- `VerifyDomain` now uses the domain classification to determine whether delegation verification applies, replacing the previous direct `ZoneID == 0` check
- The classification check exits early for self-hosted, on-chain managed, and draft bindings—no longer attempting DNS/DNSSEC reconciliation for those types
- Clarified that portal-managed binding verification applies based on zone presence, regardless of lifecycle status

### DNSSEC Self-Heal Logic
- Updated `selfHealZone` to use the `RequiresDNSSEC()` capability instead of `UsesManagedZoneTLSA()`, aligning it with the same gate used for expected DS computation in `VerifyDomain`
- This ensures DNSSEC-required namespaces still heal their signing key even if they also publish DANE records

### Platform Subdomain Activation
- Added test coverage for the new `ActivatePlatformSubdomainWebsite` hook called when platform domains are claimed, generated, or apex-bound
- Tests now verify that activation occurs during:
  - Platform claim
  - Platform subdomain creation (generate and non-generate paths)
  - Platform root apex binding

### Test Infrastructure
- Fixed janitor tests by replacing `nil` loggers with actual context loggers to prevent null pointer dereferences
- Updated peer tracker tests to normalize CIDs before tracker operations, ensuring consistent identity handling
<!-- kody-pr-summary:end -->