### PR TITLE
refactor(domain): harden domain hosting and provider consistency

### DIFF
--- a/core/provider_policy.go
+++ b/core/provider_policy.go
@@ -1,0 +1,39 @@
+package core
+
+// DNSSECPolicy captures whether a namespace provider's delegation is confirmed
+// against a live DS record served by the parent zone (managed-DNSSEC namespaces,
+// e.g. HNS) or on NS visibility alone (e.g. ICANN).
+type DNSSECPolicy uint8
+
+const (
+	DNSSECNotRequired DNSSECPolicy = iota
+	DNSSECRequired
+)
+
+// TLSAPolicy captures whether a provider publishes a DANE TLSA record into the
+// portal-managed authoritative zone (DANE-capable alt-root namespaces, e.g.
+// HNS). DNSSEC and TLSA are independent capabilities: a provider may DNSSEC-sign
+// without DANE (and vice versa), so one must never be used as a proxy for the
+// other.
+type TLSAPolicy uint8
+
+const (
+	TLSANotManaged TLSAPolicy = iota
+	TLSAManaged
+)
+
+// ProviderPolicy is the immutable hosting-capability set of a namespace
+// provider. Every capability decision (DNSSEC gating, managed-zone TLSA
+// publication, apex record type) derives from it. The per-method boolean and
+// record-type adapters (RequiresDNSSEC, UsesManagedZoneTLSA, ApexRecordType)
+// are transient compatibility shims over this single source of truth and must
+// not become additional sources of truth.
+//
+// It lives in this (leaf) core package — alongside RecordType — so any
+// consumer, including generated mocks, can reference it without importing the
+// service package that owns the providers.
+type ProviderPolicy struct {
+	DNSSEC         DNSSECPolicy
+	TLSA           TLSAPolicy
+	ApexRecordType RecordType
+}

--- a/internal/api/api_domains.go
+++ b/internal/api/api_domains.go
@@ -452,13 +452,16 @@ func (a *API) domainDNSRequirements(c echo.Context) error {
 
 	// The DS to publish is computed live from PowerDNS's current active signing
 	// key rather than read from stored delegation data (which would go stale on
-	// key rotation). Only portal-managed, DNSSEC-signed namespaces (e.g. HNS)
+	// key rotation). Only portal-managed, DNSSEC-required namespaces (e.g. HNS)
 	// yield a DS and report DNSSEC state; ICANN domains have no parent DS and
 	// no portal DNSSEC, so this is a no-op that omits the DNSSEC fields
 	// entirely (per the DTO contract) and only defends against a stale DS.
+	// Gating on the DNSSEC policy (not the TLSA/DANE capability) ensures a
+	// provider that requires DNSSEC but does not publish DANE still receives
+	// the live DS in the response.
 	// A self-hosted binding owns no delegation bundle, so resp.Delegation is
 	// nil and this block is naturally skipped.
-	managed := a.delegatedDomainSvc != nil && a.delegatedDomainSvc.NamespaceUsesManagedZoneTLSA(string(wd.Namespace))
+	managed := a.delegatedDomainSvc != nil && a.delegatedDomainSvc.NamespaceRequiresDNSSEC(string(wd.Namespace))
 	if resp.Delegation != nil && a.dnsService != nil {
 		if managed {
 			ds, dsErr := a.dnsService.GetActiveDNSSECDS(reqCtx, wd.ZoneID)
@@ -579,6 +582,15 @@ func (a *API) republishDomainDANE(c echo.Context) error {
 	// to publish into -- short-circuit rather than return a false success.
 	if wd.ZoneID == 0 {
 		apiErr := NewError(ErrKeyNoStoredCertificate, fmt.Errorf("domain %q has no assigned managed zone; cannot republish", wd.Domain))
+		return ctx.Error(apiErr, apiErr.HttpStatus())
+	}
+
+	// Only portal-managed bindings may be force-republished: on-chain,
+	// self-hosted, and unresolved bindings never authorize managed-zone TLSA
+	// writes, and an inconsistent on-chain binding with a stray zone must not
+	// be routed through the DANE republish path at all.
+	if !wd.CanPublishManagedZoneRecords() {
+		apiErr := NewError(ErrKeyNoStoredCertificate, fmt.Errorf("domain %q is not portal-managed; cannot republish DANE", wd.Domain))
 		return ctx.Error(apiErr, apiErr.HttpStatus())
 	}
 

--- a/internal/api/api_domains_test.go
+++ b/internal/api/api_domains_test.go
@@ -731,3 +731,73 @@ func TestAPI_ConvertDomainToOnChain(t *testing.T) {
 		_ = onchainBinding // already-on-chain guard exercised above
 	}, TestOptions)
 }
+
+// TestAPI_DNSRequirements_ExposesLiveDSForDNSSECRequiredNoTLSAProvider proves
+// dns-requirements gates the live DS on the provider's DNSSEC policy, not the
+// TLSA/DANE capability: a synthetic provider whose policy is DNSSEC-required but
+// TLSA-disabled still gets the live DS injected into parent_records.
+func TestAPI_DNSRequirements_ExposesLiveDSForDNSSECRequiredNoTLSAProvider(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		helper := newMockHelper(t, ctx)
+		token, userID, testCID, _ := helper.SetupAuthenticatedTest()
+
+		// Register a synthetic provider: DNSSEC required, but no managed-zone
+		// DANE. This combination must still expose the live DS.
+		dds := core.GetService[*domain.DelegatedDomainService](ctx, pluginCore.DELEGATED_DOMAIN_SERVICE)
+		require.NotNil(tb, dds)
+		dds.RegisterProvider(&util.SyntheticDomainProvider{
+			ProtocolName: "synth",
+			PolicyValue: pluginCore.ProviderPolicy{
+				DNSSEC:         pluginCore.DNSSECRequired,
+				TLSA:           pluginCore.TLSANotManaged,
+				ApexRecordType: pluginCore.RecordTypeA,
+			},
+		})
+
+		website := createTestIPFSGatewayWebsite(1, userID, "example.com", testCID, pluginDb.WebsiteStatusActive)
+		require.NoError(t, ctx.DB().Create(website).Error)
+
+		wd := &pluginDb.WebsiteDomain{
+			WebsiteID: 1, UserID: userID, Domain: "synth.example",
+			Namespace:   pluginDb.DomainNamespace("synth"),
+			Status:      pluginDb.DomainStatusRecordsGenerated,
+			ZoneID:      42,
+			ZoneName:    "synth.example.",
+			GatewayHost: "gateway.lumeweb.com",
+			DelegationData: datatypes.JSONMap{
+				"mode": "delegated",
+				"parent_records": []map[string]any{
+					{"type": "NS", "value": "ns1.synth.example"},
+				},
+				// No authoritative TLSA — this provider does not publish DANE.
+				"authoritative_records": []map[string]any{
+					{"type": "NS", "value": "ns1.synth.example"},
+				},
+			},
+		}
+		require.NoError(t, ctx.DB().Create(wd).Error)
+
+		mockDNS := helper.SetupDNSServiceMocks()
+		mockDNS.EXPECT().GetActiveDNSSECDS(mock.Anything, uint(42)).Return("60776 13 2 abc", nil).Once()
+
+		rec := helper.makeAuthenticatedRequest(http.MethodGet, "/api/websites/1/domains/1/dns-requirements", token, nil)
+		require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+
+		var resp dto.DomainResponse
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+		require.NotNil(t, resp.Delegation)
+
+		// The live DS is exposed even though the provider has TLSA disabled:
+		// DS exposure is driven by the DNSSEC policy, never the TLSA capability.
+		assert.Equal(t, "enabled", resp.Delegation.DNSSEC)
+		found := false
+		for _, r := range resp.Delegation.ParentRecords {
+			if r.Type == "DS" {
+				found = true
+				assert.Equal(t, "60776 13 2 abc", r.Value)
+			}
+		}
+		assert.True(t, found, "live DS must be present in parent records for a DNSSEC-required provider")
+		mockDNS.AssertExpectations(t)
+	}, TestOptions)
+}

--- a/internal/db/website_domain.go
+++ b/internal/db/website_domain.go
@@ -39,35 +39,90 @@ const (
 // excluded on purpose: when the flag disagrees with the zone reference it is a
 // reconcile orphan that SetDomainDNSEnabled repairs, and classification must
 // follow the same zone reference the rest of the code keys on.
+//
+// Lifecycle and hosting locus are separate concepts and must not be conflated.
+// The lifecycle (DomainStatus) tracks draft/provisioning/waiting/active/error
+// progress; the hosting locus (this class) answers who is authoritative for the
+// name's DNS. A draft or error lifecycle status says nothing about hosting
+// until provisioning either establishes a portal zone or records the user's
+// explicit self-hosted decision, so a zone-less non-self-hosted binding is
+// unresolved rather than self-hosted.
 type DomainClass uint8
 
 const (
 	// ClassPortalManaged names served from a portal-created PowerDNS zone.
-	// ZoneID != 0 is the authoritative marker (see VerifyDomain), so a binding
-	// with a zone is portal-managed regardless of lifecycle status.
+	// ZoneID != 0 is the authoritative marker: a non-on-chain binding with a
+	// zone is portal-managed regardless of lifecycle status, including
+	// delegation-owned HNS bindings whose DNSHostingEnabled flag is false.
 	ClassPortalManaged DomainClass = iota
-	// ClassSelfHosted names whose DNS the user runs themselves (status
-	// self_hosted), and bindings with no portal zone yet (draft): no
-	// DS/TLSA/DNSSEC reconciliation applies to them.
+	// ClassSelfHosted names whose DNS the user runs themselves: status
+	// self_hosted and no portal zone. The portal provisions no zone, so no
+	// DS/TLSA/DNSSEC reconciliation applies. A stray non-zero ZoneID on a
+	// self_hosted binding is classified portal-managed — the persisted zone
+	// reference is authoritative and the status/flag disagreement is a
+	// reconcile orphan, never a reason to treat the binding as unmanaged.
 	ClassSelfHosted
 	// ClassOnChainManaged marks a name whose DNS is served on-chain (e.g. a
 	// Handshake HIP-5 name whose NS record points at an external contract).
 	// The portal owns only the ownership check (TXT token through the
 	// namespace resolver) and never provisions a zone, DNSSEC, or DANE.
+	// This class takes precedence over a stray ZoneID: an on-chain binding
+	// must never be treated as portal-managed no matter what zone reference
+	// it carries.
 	ClassOnChainManaged
+	// ClassUnresolved names whose hosting locus is not yet determinable from
+	// persisted state: draft, error, empty, or unknown lifecycle status with
+	// no portal zone. This is deliberately NOT self-hosted — provisioning has
+	// neither confirmed a portal zone nor recorded the user's explicit
+	// self-hosted decision. No portal DNS side effects may be authorized for
+	// an unresolved binding; it reconciles only through the explicit
+	// enable/disable transition path.
+	ClassUnresolved
 )
 
-// Class returns the binding's DNS-hosting locus. Derived from state, not
-// stored; see DomainClass for why dns_hosting_enabled is not an input.
+// Class returns the binding's DNS-hosting locus. Precedence is fixed:
+// on-chain managed status wins over any zone reference (a stray zone on an
+// on-chain binding is data incoherence, never a portal authorization); a
+// non-zero ZoneID marks a portal-managed binding; an explicit self_hosted
+// status with no zone is self-hosted; everything else is unresolved.
+// dns_hosting_enabled is deliberately not an input (see DomainClass).
 func (wd *WebsiteDomain) Class() DomainClass {
 	switch {
 	case wd.Status == DomainStatusOnchainManaged:
 		return ClassOnChainManaged
 	case wd.ZoneID != 0:
 		return ClassPortalManaged
-	default:
+	case wd.Status == DomainStatusSelfHosted:
 		return ClassSelfHosted
+	default:
+		return ClassUnresolved
 	}
+}
+
+// HasPortalAuthority reports whether the portal is authoritative for this
+// binding's DNS: the binding references a managed PowerDNS zone (ZoneID != 0)
+// and is not on-chain managed. All portal DNS reads/writes (managed records,
+// delegation verification, DNSSEC, managed-zone TLSA) are gated on this.
+func (wd *WebsiteDomain) HasPortalAuthority() bool {
+	return wd.Class() == ClassPortalManaged
+}
+
+// NeedsDelegationVerification reports whether the portal should verify this
+// binding's external delegation (NS/DS visibility) before treating it as
+// active. Only portal-managed bindings have delegation for the portal to
+// verify; self-hosted, on-chain, and unresolved bindings prove ownership by
+// other means (hosting DNS / namespace TXT) or are not yet classifiable.
+func (wd *WebsiteDomain) NeedsDelegationVerification() bool {
+	return wd.Class() == ClassPortalManaged
+}
+
+// CanPublishManagedZoneRecords reports whether website/managed-DNS operations
+// may create, update, or delete records in this binding's portal-managed zone.
+// On-chain, self-hosted, and unresolved bindings can never authorize portal
+// DNS writes — an inconsistent state (e.g. an on-chain binding carrying a
+// stray zone ID) must not permit them merely because a zone reference exists.
+func (wd *WebsiteDomain) CanPublishManagedZoneRecords() bool {
+	return wd.Class() == ClassPortalManaged
 }
 
 // WebsiteDomain binds a domain (by namespace) to a website.

--- a/internal/db/website_domain_test.go
+++ b/internal/db/website_domain_test.go
@@ -56,10 +56,25 @@ func TestWebsiteDomain_Class(t *testing.T) {
 		want DomainClass
 	}{
 		{
-			name: "onchain managed is on-chain managed even with a stray zone id",
+			name: "onchain managed with zero zone is on-chain managed",
+			wd: WebsiteDomain{
+				Status: DomainStatusOnchainManaged,
+			},
+			want: ClassOnChainManaged,
+		},
+		{
+			name: "onchain managed takes precedence over a stray zone id",
 			wd: WebsiteDomain{
 				Status: DomainStatusOnchainManaged,
 				ZoneID: 7,
+			},
+			want: ClassOnChainManaged,
+		},
+		{
+			name: "onchain managed with hosting enabled is still on-chain managed",
+			wd: WebsiteDomain{
+				Status:            DomainStatusOnchainManaged,
+				DNSHostingEnabled: true,
 			},
 			want: ClassOnChainManaged,
 		},
@@ -72,11 +87,46 @@ func TestWebsiteDomain_Class(t *testing.T) {
 			want: ClassPortalManaged,
 		},
 		{
-			name: "no zone means self-hosted for draft bindings",
+			name: "records-generated with a zone is portal-managed",
 			wd: WebsiteDomain{
-				Status: DomainStatusDraft,
+				Status: DomainStatusRecordsGenerated,
+				ZoneID: 42,
 			},
-			want: ClassSelfHosted,
+			want: ClassPortalManaged,
+		},
+		{
+			name: "waiting-delegation with a zone is portal-managed",
+			wd: WebsiteDomain{
+				Status: DomainStatusWaitingDelegation,
+				ZoneID: 42,
+			},
+			want: ClassPortalManaged,
+		},
+		{
+			name: "active with a zone is portal-managed",
+			wd: WebsiteDomain{
+				Status: DomainStatusActive,
+				ZoneID: 42,
+			},
+			want: ClassPortalManaged,
+		},
+		{
+			name: "self-hosted status with a stray zone is portal-managed",
+			wd: WebsiteDomain{
+				Status: DomainStatusSelfHosted,
+				ZoneID: 42,
+			},
+			want: ClassPortalManaged,
+		},
+		{
+			name: "delegation-owned HNS with hosting disabled and retained zone is portal-managed",
+			wd: WebsiteDomain{
+				Namespace:         DomainNamespaceHNS,
+				Status:            DomainStatusWaitingDelegation,
+				ZoneID:            42,
+				DNSHostingEnabled: false,
+			},
+			want: ClassPortalManaged,
 		},
 		{
 			name: "self-hosted status with no zone is self-hosted",
@@ -86,12 +136,48 @@ func TestWebsiteDomain_Class(t *testing.T) {
 			want: ClassSelfHosted,
 		},
 		{
+			name: "draft with no zone is unresolved, not self-hosted",
+			wd: WebsiteDomain{
+				Status: DomainStatusDraft,
+			},
+			want: ClassUnresolved,
+		},
+		{
+			name: "empty status with no zone is unresolved",
+			wd: WebsiteDomain{
+				Status: "",
+			},
+			want: ClassUnresolved,
+		},
+		{
+			name: "error status with no zone is unresolved",
+			wd: WebsiteDomain{
+				Status: DomainStatusError,
+			},
+			want: ClassUnresolved,
+		},
+		{
+			name: "unknown status with no zone is unresolved",
+			wd: WebsiteDomain{
+				Status: DomainStatus("unexpected"),
+			},
+			want: ClassUnresolved,
+		},
+		{
 			name: "dns_hosting_enabled is deliberately not an input",
 			wd: WebsiteDomain{
 				Status:            DomainStatusDraft,
 				DNSHostingEnabled: true,
 			},
-			want: ClassSelfHosted,
+			want: ClassUnresolved,
+		},
+		{
+			name: "dns_hosting_enabled false is not an input for a zone-less draft",
+			wd: WebsiteDomain{
+				Status:            DomainStatusDraft,
+				DNSHostingEnabled: false,
+			},
+			want: ClassUnresolved,
 		},
 	}
 	for _, tt := range tests {
@@ -99,6 +185,43 @@ func TestWebsiteDomain_Class(t *testing.T) {
 			assert.Equal(t, tt.want, tt.wd.Class())
 		})
 	}
+}
+
+func TestWebsiteDomain_ClassSemanticHelpers(t *testing.T) {
+	// The semantic helpers must express the same business decision as Class()
+	// and never diverge from it, so routing code can rely on them without
+	// re-deriving hosting rules from raw fields.
+	portal := WebsiteDomain{Status: DomainStatusActive, ZoneID: 42}
+	onchainStray := WebsiteDomain{Status: DomainStatusOnchainManaged, ZoneID: 42}
+	selfHosted := WebsiteDomain{Status: DomainStatusSelfHosted}
+	unresolved := WebsiteDomain{Status: DomainStatusDraft}
+	onchain := WebsiteDomain{Status: DomainStatusOnchainManaged}
+
+	t.Run("portal managed grants authority", func(t *testing.T) {
+		assert.True(t, portal.HasPortalAuthority())
+		assert.True(t, portal.NeedsDelegationVerification())
+		assert.True(t, portal.CanPublishManagedZoneRecords())
+	})
+
+	t.Run("on-chain never grants portal authority even with a stray zone", func(t *testing.T) {
+		assert.False(t, onchain.HasPortalAuthority())
+		assert.False(t, onchainStray.HasPortalAuthority())
+		assert.False(t, onchainStray.NeedsDelegationVerification())
+		assert.False(t, onchainStray.CanPublishManagedZoneRecords())
+		assert.False(t, onchain.CanPublishManagedZoneRecords())
+	})
+
+	t.Run("self-hosted never grants portal authority", func(t *testing.T) {
+		assert.False(t, selfHosted.HasPortalAuthority())
+		assert.False(t, selfHosted.NeedsDelegationVerification())
+		assert.False(t, selfHosted.CanPublishManagedZoneRecords())
+	})
+
+	t.Run("unresolved never grants portal authority", func(t *testing.T) {
+		assert.False(t, unresolved.HasPortalAuthority())
+		assert.False(t, unresolved.NeedsDelegationVerification())
+		assert.False(t, unresolved.CanPublishManagedZoneRecords())
+	})
 }
 
 func TestWebsiteDomain_DelegationRecordsOwned(t *testing.T) {

--- a/internal/service/domain/delegated_domain_service.go
+++ b/internal/service/domain/delegated_domain_service.go
@@ -96,6 +96,32 @@ type DSRecord struct {
 	Digest     string `json:"digest"`
 }
 
+// DelegationVerificationState distinguishes the delegation outcomes a caller
+// must be able to act on without re-deriving hosting rules.
+type DelegationVerificationState uint8
+
+const (
+	// DelegationNotApplicable means the binding's hosting class does not use
+	// portal delegation verification (self-hosted, on-chain managed, or
+	// unresolved). This is neither success nor failure of delegation — it
+	// simply does not apply, and it is not ownership proof by itself.
+	DelegationNotApplicable DelegationVerificationState = iota
+	// DelegationPending means the portal-managed delegation is not yet live
+	// (NS/DS not yet visible at the parent).
+	DelegationPending
+	// DelegationVerified means the portal-managed delegation is live, or the
+	// binding is an operator-trusted platform binding.
+	DelegationVerified
+)
+
+// DelegationVerificationResult is the typed outcome of VerifyDomain. Callers
+// must switch on State rather than interpreting a bare boolean, which cannot
+// distinguish "not applicable" from "pending" and would deadlock valid
+// on-chain/self-hosted bindings.
+type DelegationVerificationResult struct {
+	State DelegationVerificationState
+}
+
 // NewDelegatedDomainService creates a DelegatedDomainService with the given
 // registry and DNS service. BaseComponent is injected by the framework.
 func NewDelegatedDomainService(reg *Registry, dns DNSZoneService) *DelegatedDomainService {
@@ -104,6 +130,18 @@ func NewDelegatedDomainService(reg *Registry, dns DNSZoneService) *DelegatedDoma
 		dnsSvc:   dns,
 		slugGen:  pluginConfig.GenerateDNSSlug,
 	}
+}
+
+// RegisterProvider registers a namespace provider with the service's registry,
+// delegating to Registry.Register (including its policy validation and
+// duplicate-protocol panic). The service factory registers the built-in ICANN
+// and HNS providers at startup; this is the entry point for operators wiring
+// additional namespaces (and for tests injecting synthetic providers).
+func (s *DelegatedDomainService) RegisterProvider(p DomainProvider) {
+	if s.registry == nil {
+		s.registry = NewRegistry()
+	}
+	s.registry.Register(p)
 }
 
 // gatewayHost returns the configured gateway domain for ALIAS records,
@@ -187,8 +225,11 @@ func (s *DelegatedDomainService) resolveManagedZone(ctx context.Context, domain 
 		// zone. The subdomain path is also guarded upstream (CreatePlatformSubdomain
 		// rejects compositions that collapse to the apex), so this is the
 		// enforcement point of record for the one-zone platform relaxation.
-		if domain != pd.Domain && !strings.HasSuffix(domain, "."+pd.Domain) {
-			return nil, false, fmt.Errorf("domain %q is not a subdomain of platform root %q", domain, pd.Domain)
+		// Apex match (domain == pd.Domain) for a root-apex binding
+		// (BindPlatformRootApex), or a name that label-boundary-descends from
+		// the granted root for a subdomain claim.
+		if !isPlatformRootApexOrDescendant(domain, pd.Domain) {
+			return nil, false, fmt.Errorf("domain %q is not the apex or a subdomain of platform root %q", domain, pd.Domain)
 		}
 		z, err := s.dnsSvc.GetZoneByDomain(ctx, pd.Domain)
 		if err != nil {
@@ -484,8 +525,10 @@ func (s *DelegatedDomainService) CreateDomain(ctx context.Context,
 			wd.GatewayHost = apexContent
 		}
 
-		// Build delegation after zone is created (needs zone ID).
-		delegationAny, err := provider.BuildDelegation(ctx, zone.ID, domain, &website, config)
+		// Build delegation after zone is created (needs zone ID). The provider
+		// returns its typed delegation already serialized as json.RawMessage, so
+		// no untyped any crosses the provider boundary here.
+		delegationBytes, err := provider.BuildDelegation(ctx, zone.ID, domain, &website, config)
 		if err != nil {
 			s.DB().WithContext(ctx).Unscoped().Delete(wd)
 			// Only tear down a zone this call created. For a platform claim the
@@ -496,14 +539,6 @@ func (s *DelegatedDomainService) CreateDomain(ctx context.Context,
 				_ = s.dnsSvc.DeleteZone(ctx, zone.ID)
 			}
 			return fmt.Errorf("delegation build failed: %w", err)
-		}
-		delegationBytes, err := json.Marshal(delegationAny)
-		if err != nil {
-			s.DB().WithContext(ctx).Unscoped().Delete(wd)
-			if zoneCreated {
-				_ = s.dnsSvc.DeleteZone(ctx, zone.ID)
-			}
-			return fmt.Errorf("marshal delegation data: %w", err)
 		}
 
 		// Update the row with zone info, delegation data, and final status.
@@ -567,57 +602,61 @@ func (s *DelegatedDomainService) notifyAdminWebsiteCreated(ctx context.Context, 
 	}
 }
 
-// VerifyDomain checks delegation and persists the result.
+// VerifyDomain checks delegation and persists the result. It returns a typed
+// DelegationVerificationResult so callers can distinguish "not applicable"
+// (self-hosted / on-chain / unresolved bindings) from "pending" (portal
+// delegation not yet live) from "verified" without re-deriving hosting rules.
 func (s *DelegatedDomainService) VerifyDomain(ctx context.Context,
-	wd *pluginDb.WebsiteDomain) (bool, error) {
+	wd *pluginDb.WebsiteDomain) (DelegationVerificationResult, error) {
 
 	provider := s.registry.Get(string(wd.Namespace))
 	if provider == nil {
-		return false, fmt.Errorf("unsupported namespace: %s", wd.Namespace)
+		return DelegationVerificationResult{}, fmt.Errorf("unsupported namespace: %s", wd.Namespace)
 	}
 
 	// A platform subdomain is minted under an operator-owned root: the platform
 	// controls both sides of the DNS check, so there is no user-side TXT
 	// verification to perform and no external delegation to wait on. It is
-	// considered active as soon as it exists. This is the single content
-	// special-case for platform subdomains and is deliberately a guard clause.
-	//
-	// The auto-activation is only sound when the binding's namespace actually
-	// matches the platform root's namespace — the platform-root zone where the
-	// records were created is namespace-specific. If a PlatformDomainID is set
-	// but the namespace does not match (data-integrity corruption or a stale
-	// pointer), falling through to the normal path lets the real DNS state
-	// decide rather than blindly marking an unknown-authoritative binding
-	// Active.
+	// considered active as soon as it exists. The auto-activation is only sound
+	// when the full operator-trust relationship holds (shared validator): the
+	// root resolves live, the namespaces match, the domain is the apex or a
+	// label-boundary descendant, and the binding's zone equals the root's zone.
+	// A mismatch is data-integrity corruption and must NOT auto-activate the
+	// binding or mutate any status.
 	if wd.PlatformDomainID != nil {
-		var pd pluginDb.PlatformDomain
-		if err := s.DB().WithContext(ctx).First(&pd, *wd.PlatformDomainID).Error; err != nil {
-			return false, fmt.Errorf("load platform root %d for auto-activation: %w", *wd.PlatformDomainID, err)
-		}
-		if pd.Namespace != wd.Namespace {
-			return false, fmt.Errorf("platform root %d namespace mismatch: binding is %q, root is %q", *wd.PlatformDomainID, wd.Namespace, pd.Namespace)
+		if err := s.ValidatePlatformBinding(ctx, wd); err != nil {
+			return DelegationVerificationResult{}, err
 		}
 		wd.Status = pluginDb.DomainStatusActive
 		if s.DB() != nil {
 			if err := s.DB().WithContext(ctx).Model(wd).Update("status", wd.Status).Error; err != nil {
-				return false, fmt.Errorf("failed to persist domain status: %w", err)
+				return DelegationVerificationResult{}, fmt.Errorf("failed to persist domain status: %w", err)
 			}
 		}
-		return true, nil
+		return DelegationVerificationResult{State: DelegationVerified}, nil
 	}
 
-	// A self-hosted DNS binding owns no portal-managed zone to verify: the user
-	// runs the authoritative server and DNSSEC/DANE delegation is theirs. The
-	// binding is not part of the portal's lifecycle (no DS to reconcile, no
-	// SOA/DNSSEC to self-heal), so verification is a no-op that leaves the
-	// binding's existing status rather than querying PowerDNS for a zone that
-	// does not exist. The binding's class expresses the same authority: only
-	// portal-managed bindings (ZoneID != 0, regardless of dns_hosting_enabled,
-	// which may be false on legacy bindings that still hold a zone) have
-	// delegation to verify; self-hosted, on-chain managed (HIP-5), and draft
-	// bindings exit here.
-	if wd.Class() != pluginDb.ClassPortalManaged {
-		return false, nil
+	// Only portal-managed bindings have portal delegation to verify
+	// (NeedsDelegationVerification, the authoritative derived hosting locus):
+	//   - self-hosted: the user runs the authoritative server; DNSSEC/DANE
+	//     delegation is theirs.
+	//   - on-chain managed (HIP-5): ownership is proven via the namespace-aware
+	//     TXT token flow, never via delegation.
+	//   - unresolved (draft/error/empty): not classifiable until provisioning
+	//     resolves it.
+	// All return NotApplicable without touching PowerDNS. In particular an
+	// on-chain binding carrying a stray zone ID is data incoherence and must
+	// not authorize any portal DNS work: log the inconsistency and still return
+	// NotApplicable.
+	if !wd.NeedsDelegationVerification() {
+		if wd.Status == pluginDb.DomainStatusOnchainManaged && wd.ZoneID != 0 {
+			s.Logger().Warn("on-chain managed binding carries a stray zone; refusing portal DNS operations",
+				zap.Uint("id", wd.ID),
+				zap.String("domain", wd.Domain),
+				zap.String("status", string(wd.Status)),
+				zap.Uint("zone_id", wd.ZoneID))
+		}
+		return DelegationVerificationResult{State: DelegationNotApplicable}, nil
 	}
 
 	// Expected DS is computed live from PowerDNS's current active signing key
@@ -641,7 +680,7 @@ func (s *DelegatedDomainService) VerifyDomain(ctx context.Context,
 		var dsErr error
 		expectedDS, dsErr = s.dnsSvc.GetActiveDNSSECDS(ctx, wd.ZoneID)
 		if dsErr != nil {
-			return false, fmt.Errorf("resolve live DS for zone %d: %w", wd.ZoneID, dsErr)
+			return DelegationVerificationResult{}, fmt.Errorf("resolve live DS for zone %d: %w", wd.ZoneID, dsErr)
 		}
 	} else {
 		// Best-effort for non-DNSSEC providers: surface DB/PowerDNS errors so
@@ -663,7 +702,7 @@ func (s *DelegatedDomainService) VerifyDomain(ctx context.Context,
 	// covers any portal-managed PowerDNS zone, ICANN included.
 	expectedDS, err := s.selfHealZone(ctx, provider, wd, expectedDS)
 	if err != nil {
-		return false, err
+		return DelegationVerificationResult{}, err
 	}
 
 	verified, err := provider.VerifyDelegation(ctx, wd.Domain, expectedDS)
@@ -672,22 +711,24 @@ func (s *DelegatedDomainService) VerifyDomain(ctx context.Context,
 		if s.DB() != nil {
 			_ = s.DB().WithContext(ctx).Model(wd).Update("status", wd.Status)
 		}
-		return false, err
+		return DelegationVerificationResult{}, err
 	}
 
+	state := DelegationPending
 	if verified {
 		wd.Status = pluginDb.DomainStatusActive
+		state = DelegationVerified
 	} else {
 		wd.Status = pluginDb.DomainStatusWaitingDelegation
 	}
 
 	if s.DB() != nil {
 		if err := s.DB().WithContext(ctx).Model(wd).Update("status", wd.Status).Error; err != nil {
-			return false, fmt.Errorf("failed to persist domain status: %w", err)
+			return DelegationVerificationResult{}, fmt.Errorf("failed to persist domain status: %w", err)
 		}
 	}
 
-	return verified, nil
+	return DelegationVerificationResult{State: state}, nil
 }
 
 // selfHealZone re-ensures the portal-managed-zone invariants that are
@@ -715,10 +756,18 @@ func (s *DelegatedDomainService) VerifyDomain(ctx context.Context,
 //     by the NS record), so a failed correction is logged, not raised.
 //
 // It returns the (possibly healed) expected DS and a fatal error, or nil.
+//
+// Fail-closed contract for the DNSSEC gate: if EnableDNSSEC successfully
+// returns but the post-heal live DS read is non-empty we proceed; if the read
+// succeeds but is empty we return a wrapped error (the invariant could not be
+// established) so VerifyDomain does not fall through to VerifyDelegation and
+// must not mark the binding Active. An erroring read is indeterminate and also
+// returns an error. Only a non-DNSSEC policy treats a missing/erroring DS as
+// non-fatal (handled by VerifyDomain before selfHealZone is consulted).
 func (s *DelegatedDomainService) selfHealZone(ctx context.Context, provider DomainProvider, wd *pluginDb.WebsiteDomain, expectedDS string) (string, error) {
-	// DNSSEC self-heal: only managed-DNSSEC namespaces (RequiresDNSSEC, the
-	// same gate VerifyDomain uses for expectedDS; a DNSSEC-required namespace
-	// that does not publish DANE must still heal its signing key).
+	// DNSSEC self-heal: only managed-DNSSEC namespaces (policy DNSSEC required,
+	// the same gate VerifyDomain uses for expectedDS; a DNSSEC-required
+	// namespace that does not publish DANE must still heal its signing key).
 	if provider.RequiresDNSSEC() && expectedDS == "" {
 		if _, err := s.dnsSvc.EnableDNSSEC(ctx, wd.ZoneID); err != nil {
 			return "", fmt.Errorf("enable dnssec for zone %d: %w", wd.ZoneID, err)
@@ -727,6 +776,9 @@ func (s *DelegatedDomainService) selfHealZone(ctx context.Context, provider Doma
 		healedDS, dsErr := s.dnsSvc.GetActiveDNSSECDS(ctx, wd.ZoneID)
 		if dsErr != nil {
 			return "", fmt.Errorf("resolve live DS for zone %d after enable: %w", wd.ZoneID, dsErr)
+		}
+		if healedDS == "" {
+			return "", fmt.Errorf("dnssec self-heal failed for zone %d (domain %s): no active signing key after EnableDNSSEC; cannot verify delegation", wd.ZoneID, wd.Domain)
 		}
 		expectedDS = healedDS
 	}
@@ -838,9 +890,14 @@ func (s *DelegatedDomainService) UpdateTLSAFromCert(ctx context.Context, namespa
 	tlsa = TLSAHashPrefix() + hash
 	ownerName = dane.TLSAOwnerName(domain, DaneTLSAPort, DaneTLSATransport)
 
-	// Notify the provider that a cert is available
-	if err := provider.OnCertAvailable(ctx, domain, certPEM); err != nil {
-		return "", "", fmt.Errorf("provider OnCertAvailable: %w", err)
+	// Notify DANE-capable providers that a cert is available. Certificate/DANE
+	// handling is an optional sub-interface: a provider without DANE (e.g.
+	// ICANN) simply does not implement CertificateProvider, so there is no
+	// mandatory no-op to call.
+	if certProvider, ok := provider.(CertificateProvider); ok {
+		if err := certProvider.OnCertAvailable(ctx, domain, certPEM); err != nil {
+			return "", "", fmt.Errorf("provider OnCertAvailable: %w", err)
+		}
 	}
 
 	if s.DB() == nil {
@@ -858,6 +915,7 @@ func (s *DelegatedDomainService) UpdateTLSAFromCert(ctx context.Context, namespa
 	// owner name, by contrast, are refreshed on every push (a cert may be freely
 	// re-issued from the same key with an identical SPKI).
 	var zoneID uint
+	portalManaged := false
 	txErr := s.DB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		// Lock the target row so concurrent cert pushes serialize per-domain.
 		locked := tx.Clauses(clause.Locking{Strength: "UPDATE"})
@@ -866,6 +924,7 @@ func (s *DelegatedDomainService) UpdateTLSAFromCert(ctx context.Context, namespa
 			return err // includes gorm.ErrRecordNotFound
 		}
 		zoneID = wd.ZoneID
+		portalManaged = wd.Class() == pluginDb.ClassPortalManaged
 		if wd.ProtocolData == nil {
 			wd.ProtocolData = make(datatypes.JSONMap)
 		}
@@ -944,7 +1003,11 @@ func (s *DelegatedDomainService) UpdateTLSAFromCert(ctx context.Context, namespa
 	// named after the binding's domain (not the zone apex) so a subdomain
 	// reusing a parent zone publishes _443._tcp.<subdomain> rather than
 	// overwriting the parent's TLSA.
-	if s.dnsSvc != nil && zoneID != 0 && provider.UsesManagedZoneTLSA() {
+	// Only portal-managed bindings authorize a managed-zone TLSA write. An
+	// on-chain (HIP-5) or self-hosted/unresolved binding carrying a stray
+	// zone reference must never publish TLSA into it — the zone may be shared
+	// and is not this binding's portal authority.
+	if s.dnsSvc != nil && portalManaged && zoneID != 0 && provider.UsesManagedZoneTLSA() {
 		if err := s.dnsSvc.SetTLSARecord(ctx, zoneID, domain, tlsa); err != nil {
 			// DNS publish failure is surfaced but the persisted cert/TLSA state
 			// is retained so a later cert push retries the publish.
@@ -970,6 +1033,20 @@ func (s *DelegatedDomainService) NamespaceUsesManagedZoneTLSA(namespace string) 
 	}
 	prov := s.registry.Get(namespace)
 	return prov != nil && prov.UsesManagedZoneTLSA()
+}
+
+// NamespaceRequiresDNSSEC reports whether the given namespace's provider
+// confirms delegation against a live DS served by the parent zone
+// (managed-DNSSEC policy). DNS-requirements exposes live DS state based on
+// this: a provider that requires DNSSEC but does not publish DANE still needs
+// the live DS in the response, so the DNSSEC policy — never the TLSA policy —
+// gates DS exposure.
+func (s *DelegatedDomainService) NamespaceRequiresDNSSEC(namespace string) bool {
+	if s.registry == nil {
+		return false
+	}
+	prov := s.registry.Get(namespace)
+	return prov != nil && prov.Policy().DNSSEC == pluginCore.DNSSECRequired
 }
 
 // GetNamespaceForDomain returns the namespace for the given domain if it

--- a/internal/service/domain/delegated_domain_service_test.go
+++ b/internal/service/domain/delegated_domain_service_test.go
@@ -458,8 +458,7 @@ func TestDelegatedDomainService_VerifyDomain_SelfHealsDNSSEC(t *testing.T) {
 			// this test guards — EnableDNSSEC MUST have been invoked, the DS
 			// re-read, and the SOA MNAME self-heal fired, before delegation
 			// verification.
-			verified, err := svc.VerifyDomain(context.Background(), wd)
-			_ = verified
+			_, err := svc.VerifyDomain(context.Background(), wd)
 			if err != nil {
 				// Allowed: resolver-not-configured after the self-heal mocks
 				// fired. The point of this test is the self-heal sequence.
@@ -501,8 +500,7 @@ func TestDelegatedDomainService_VerifyDomain_SelfHealsDNSSEC(t *testing.T) {
 				WebsiteID: 1, UserID: 1, Domain: "example.com", Namespace: pluginDb.DomainNamespaceICANN, ZoneID: 42,
 			}
 
-			verified, err := svc.VerifyDomain(context.Background(), wd)
-			_ = verified
+			_, err := svc.VerifyDomain(context.Background(), wd)
 			if err != nil {
 				// Allowed: post-heal delegation error (system resolver).
 				tb.Logf("expected post-heal delegation error: %v", err)
@@ -546,8 +544,7 @@ func TestDelegatedDomainService_VerifyDomain_SelfHealsDNSSEC(t *testing.T) {
 				WebsiteID: 1, UserID: 1, Domain: "lumeweb.com", Namespace: pluginDb.DomainNamespaceICANN, ZoneID: 8,
 			}
 
-			verified, err := svc.VerifyDomain(context.Background(), wd)
-			_ = verified
+			_, err := svc.VerifyDomain(context.Background(), wd)
 			if err != nil {
 				// Allowed: post-heal ICANN delegation error (system resolver).
 				// The key assertion is that the DS error itself was swallowed —
@@ -590,7 +587,8 @@ func TestDelegatedDomainService_VerifyDomain_PlatformNamespaceMismatch_Rejects(t
 		verified, err := svc.VerifyDomain(context.Background(), wd)
 		require.Error(tb, err, "namespace mismatch must not auto-activate")
 		assert.Contains(tb, err.Error(), "namespace mismatch")
-		assert.False(tb, verified)
+		assert.NotEqual(tb, DelegationVerified, verified.State,
+			"a failed platform trust check must never report delegation verified")
 
 		// Must not have been promoted to Active.
 		var reloaded pluginDb.WebsiteDomain
@@ -621,7 +619,7 @@ func TestDelegatedDomainService_VerifyDomain_PlatformMatching_Activates(t *testi
 		svc := core.GetService[*DelegatedDomainService](ctx, pluginCore.DELEGATED_DOMAIN_SERVICE)
 		verified, err := svc.VerifyDomain(context.Background(), wd)
 		require.NoError(tb, err)
-		assert.True(tb, verified)
+		assert.Equal(tb, DelegationVerified, verified.State)
 
 		var reloaded pluginDb.WebsiteDomain
 		require.NoError(tb, db.First(&reloaded, wd.ID).Error)

--- a/internal/service/domain/hns_provider.go
+++ b/internal/service/domain/hns_provider.go
@@ -175,11 +175,29 @@ func (p *HNSProvider) Protocol() string {
 	return "hns"
 }
 
-// ApexRecordType returns RecordTypeA: HNS zones are DNSSEC-signed at the apex,
-// so the apex must be a real A record that carries an RRSIG. PowerDNS cannot
-// sign a synthetic ALIAS at the apex.
+// Policy returns the HNS hosting-capability policy: managed-DNSSEC (delegation
+// confirmed against a live DS), managed-zone DANE (TLSA published into the
+// portal zone), and a real apex A record so the signed apex carries an RRSIG.
+func (p *HNSProvider) Policy() pluginCore.ProviderPolicy {
+	return pluginCore.ProviderPolicy{
+		DNSSEC:         pluginCore.DNSSECRequired,
+		TLSA:           pluginCore.TLSAManaged,
+		ApexRecordType: pluginCore.RecordTypeA,
+	}
+}
+
+// RequiresDNSSEC derives from the policy: HNS confirms delegation against a
+// live DS served by the alt-root parent before marking the domain Active
+// (managed-DNSSEC).
+func (p *HNSProvider) RequiresDNSSEC() bool {
+	return p.Policy().DNSSEC == pluginCore.DNSSECRequired
+}
+
+// ApexRecordType derives from the policy: HNS zones are DNSSEC-signed at the
+// apex, so the apex must be a real A record that carries an RRSIG. PowerDNS
+// cannot sign a synthetic ALIAS at the apex.
 func (p *HNSProvider) ApexRecordType() pluginCore.RecordType {
-	return pluginCore.RecordTypeA
+	return p.Policy().ApexRecordType
 }
 
 var hnsDomainRe = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$`)
@@ -276,7 +294,7 @@ func (p *HNSProvider) isHIP5TX(ns string) bool {
 }
 
 func (p *HNSProvider) BuildDelegation(ctx context.Context, zoneID uint,
-	domain string, website *pluginDb.Website, config json.RawMessage) (any, error) {
+	domain string, website *pluginDb.Website, config json.RawMessage) (json.RawMessage, error) {
 
 	zoneName := dnsname.EnsureFQDN(domain)
 
@@ -332,7 +350,13 @@ func (p *HNSProvider) BuildDelegation(ctx context.Context, zoneID uint,
 		bundle = p.buildDelegated(zoneName, nsRecords, tlsa, &cfg)
 	}
 
-	return bundle, nil
+	// Serialize at the provider boundary: the delegation never crosses it as an
+	// unconstrained any. The persisted JSON shape is the typed DelegationBundle.
+	raw, err := json.Marshal(bundle)
+	if err != nil {
+		return nil, fmt.Errorf("marshal hns delegation: %w", err)
+	}
+	return raw, nil
 }
 
 // enableDNSSEC ensures DNSSEC is enabled on the zone via PowerDNS. It is
@@ -670,14 +694,8 @@ func (p *HNSProvider) OnCertAvailable(ctx context.Context, domain string, certPE
 	return nil
 }
 
-// UsesManagedZoneTLSA reports that HNS uses DANE and that its TLSA must be
-// published into the portal-managed authoritative PowerDNS zone.
+// UsesManagedZoneTLSA derives from the policy: HNS uses DANE and its TLSA must
+// be published into the portal-managed authoritative PowerDNS zone.
 func (p *HNSProvider) UsesManagedZoneTLSA() bool {
-	return true
-}
-
-// RequiresDNSSEC reports that HNS confirms delegation against a live DS served
-// by the alt-root parent before marking the domain Active (managed-DNSSEC).
-func (p *HNSProvider) RequiresDNSSEC() bool {
-	return true
+	return p.Policy().TLSA == pluginCore.TLSAManaged
 }

--- a/internal/service/domain/hns_provider_test.go
+++ b/internal/service/domain/hns_provider_test.go
@@ -61,10 +61,7 @@ func TestHNSProvider_BuildDelegation_DefaultDelegated(t *testing.T) {
 	})
 	result, err := p.BuildDelegation(context.Background(), 1, "example", &pluginDb.Website{}, nil)
 	assert.NoError(t, err)
-	bundle, ok := result.(DelegationBundle)
-	assert.True(t, ok)
-	b, _ := json.Marshal(bundle)
-	s := string(b)
+	s := string(result)
 	assert.Contains(t, s, "ns1.example.com.")
 	assert.Contains(t, s, "TLSA")
 	assert.Contains(t, s, `"mode":"`+string(HNSModeDelegated)+`"`)
@@ -76,12 +73,9 @@ func TestHNSProvider_BuildDelegation_NoTLSASource(t *testing.T) {
 	p := NewHNSProvider("", []string{"ns1.example.com."}, TLSASource{})
 	result, err := p.BuildDelegation(context.Background(), 1, "example", &pluginDb.Website{}, nil)
 	assert.NoError(t, err)
-	bundle, ok := result.(DelegationBundle)
-	assert.True(t, ok)
 
 	// Delegation should be created but without TLSA records.
-	b, _ := json.Marshal(bundle)
-	s := string(b)
+	s := string(result)
 	assert.NotContains(t, s, "TLSA")
 }
 
@@ -92,10 +86,7 @@ func TestHNSProvider_BuildDelegation_InlineMode_UsesDaneLib(t *testing.T) {
 	})
 	result, err := p.BuildDelegation(context.Background(), 1, "example", &pluginDb.Website{}, cfg)
 	assert.NoError(t, err)
-	bundle, ok := result.(DelegationBundle)
-	assert.True(t, ok)
-	b, _ := json.Marshal(bundle)
-	s := string(b)
+	s := string(result)
 
 	assert.Contains(t, s, `"mode":"`+string(HNSModeInline)+`"`)
 	assert.Contains(t, s, "SYNTH4")
@@ -125,10 +116,7 @@ func TestHNSProvider_BuildDelegation_DelegatedWithGlue_UsesDane(t *testing.T) {
 	})
 	result, err := p.BuildDelegation(context.Background(), 1, "example", &pluginDb.Website{}, cfg)
 	assert.NoError(t, err)
-	bundle, ok := result.(DelegationBundle)
-	assert.True(t, ok)
-	b, _ := json.Marshal(bundle)
-	s := string(b)
+	s := string(result)
 
 	assert.Contains(t, s, `"mode":"`+string(HNSModeDelegated)+`"`)
 	assert.Contains(t, s, "GLUE4")
@@ -142,10 +130,7 @@ func TestHNSProvider_BuildDelegation_TLSAFromCertPEM_UsesDaneLibrary(t *testing.
 	})
 	result, err := p.BuildDelegation(context.Background(), 1, "example", &pluginDb.Website{}, nil)
 	assert.NoError(t, err)
-	bundle, ok := result.(DelegationBundle)
-	assert.True(t, ok)
-	b, _ := json.Marshal(bundle)
-	s := string(b)
+	s := string(result)
 	assert.Contains(t, s, "3 1 1")
 	assert.Contains(t, s, "TLSA")
 
@@ -160,10 +145,7 @@ func TestHNSProvider_OnCertAvailable_UpdatesTLSASource(t *testing.T) {
 	// Before: no cert, BuildDelegation succeeds in bootstrap mode (no TLSA).
 	result, err := p.BuildDelegation(context.Background(), 1, "example", &pluginDb.Website{}, nil)
 	assert.NoError(t, err)
-	bundle, ok := result.(DelegationBundle)
-	assert.True(t, ok)
-	b, _ := json.Marshal(bundle)
-	assert.NotContains(t, string(b), "TLSA", "bootstrap delegation should not contain TLSA")
+	assert.NotContains(t, string(result), "TLSA", "bootstrap delegation should not contain TLSA")
 
 	// Push cert via OnCertAvailable
 	certPEM := testCertPEM(t)
@@ -173,10 +155,7 @@ func TestHNSProvider_OnCertAvailable_UpdatesTLSASource(t *testing.T) {
 	// After: TLSA should now be present
 	result, err = p.BuildDelegation(context.Background(), 1, "example", &pluginDb.Website{}, nil)
 	assert.NoError(t, err)
-	bundle, ok = result.(DelegationBundle)
-	assert.True(t, ok)
-	b, _ = json.Marshal(bundle)
-	assert.Contains(t, string(b), "TLSA")
+	assert.Contains(t, string(result), "TLSA")
 }
 
 func TestHNSProvider_SynthName_FromDaneLib(t *testing.T) {
@@ -229,8 +208,8 @@ func TestHNSProvider_BuildDelegation_NoDSRecord(t *testing.T) {
 	result, err := p.BuildDelegation(context.Background(), 1, "example", &pluginDb.Website{}, nil)
 	require.NoError(t, err)
 
-	bundle, ok := result.(DelegationBundle)
-	require.True(t, ok, "expected DelegationBundle, got %T", result)
+	var bundle DelegationBundle
+	require.NoError(t, json.Unmarshal(result, &bundle), "expected serialized DelegationBundle")
 
 	for _, rec := range bundle.ParentRecords {
 		assert.NotEqual(t, "DS", rec.Type, "delegation bundle must not persist a DS record")

--- a/internal/service/domain/icann_provider.go
+++ b/internal/service/domain/icann_provider.go
@@ -29,11 +29,33 @@ func (p *ICANNProvider) Protocol() string {
 	return "icann"
 }
 
-// ApexRecordType returns RecordTypeALIAS: ICANN apex is served through the
+// Policy returns the ICANN hosting-capability policy: no managed-DNSSEC, no
+// managed-zone DANE, and a synthetic ALIAS apex (not separately signed).
+func (p *ICANNProvider) Policy() pluginCore.ProviderPolicy {
+	return pluginCore.ProviderPolicy{
+		DNSSEC:         pluginCore.DNSSECNotRequired,
+		TLSA:           pluginCore.TLSANotManaged,
+		ApexRecordType: pluginCore.RecordTypeALIAS,
+	}
+}
+
+// RequiresDNSSEC derives from the policy: ICANN verifies delegation on NS
+// visibility alone and does not require a live DS from the parent zone.
+func (p *ICANNProvider) RequiresDNSSEC() bool {
+	return p.Policy().DNSSEC == pluginCore.DNSSECRequired
+}
+
+// UsesManagedZoneTLSA derives from the policy: ICANN does not use DANE, so no
+// TLSA record is published for ICANN domains.
+func (p *ICANNProvider) UsesManagedZoneTLSA() bool {
+	return p.Policy().TLSA == pluginCore.TLSAManaged
+}
+
+// ApexRecordType derives from the policy: ICANN apex is served through the
 // gateway and is not separately DNSSEC-signed at the apex in our setup, so a
 // synthetic ALIAS is acceptable.
 func (p *ICANNProvider) ApexRecordType() pluginCore.RecordType {
-	return pluginCore.RecordTypeALIAS
+	return p.Policy().ApexRecordType
 }
 
 func (p *ICANNProvider) Validate(domain string) error {
@@ -61,34 +83,23 @@ func (p *ICANNProvider) Inspect(ctx context.Context, domain string) (bool, error
 }
 
 func (p *ICANNProvider) BuildDelegation(ctx context.Context, zoneID uint,
-	domain string, website *pluginDb.Website, config json.RawMessage) (any, error) {
+	domain string, website *pluginDb.Website, config json.RawMessage) (json.RawMessage, error) {
 
-	return ICANNDelegation{
+	// Serialize at the provider boundary; the persisted JSON shape is the typed
+	// ICANNDelegation.
+	raw, err := json.Marshal(ICANNDelegation{
 		Nameservers: p.nameservers,
-	}, nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal icann delegation: %w", err)
+	}
+	return raw, nil
 }
 
 func (p *ICANNProvider) VerifyDelegation(ctx context.Context, domain string,
 	expectedDS string) (bool, error) {
 	// ICANN domains do not use an alt-root delegation step.
 	return true, nil
-}
-
-// OnCertAvailable is a no-op for ICANN domains (no DANE/TLSA needed).
-func (p *ICANNProvider) OnCertAvailable(ctx context.Context, domain string, certPEM string) error {
-	return nil
-}
-
-// UsesManagedZoneTLSA reports that ICANN does not use DANE, so no TLSA record
-// is published for ICANN domains.
-func (p *ICANNProvider) UsesManagedZoneTLSA() bool {
-	return false
-}
-
-// RequiresDNSSEC reports that ICANN verifies delegation on NS visibility alone
-// and does not require a live DS from the parent zone.
-func (p *ICANNProvider) RequiresDNSSEC() bool {
-	return false
 }
 
 // Nameservers returns the ICANN nameservers configured for the namespace.

--- a/internal/service/domain/icann_provider_test.go
+++ b/internal/service/domain/icann_provider_test.go
@@ -2,9 +2,11 @@ package domain
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	pluginDb "go.lumeweb.com/portal-plugin-ipfs/internal/db"
 )
 
@@ -31,8 +33,8 @@ func TestICANNProvider_BuildDelegation(t *testing.T) {
 	result, err := p.BuildDelegation(context.Background(), 1, "example.com", &pluginDb.Website{}, nil)
 	assert.NoError(t, err)
 
-	bundle, ok := result.(ICANNDelegation)
-	assert.True(t, ok)
+	var bundle ICANNDelegation
+	require.NoError(t, json.Unmarshal(result, &bundle))
 	assert.Contains(t, bundle.Nameservers, "ns1.example.com.")
 }
 

--- a/internal/service/domain/integration_test.go
+++ b/internal/service/domain/integration_test.go
@@ -63,7 +63,9 @@ func TestIntegration_CreateAndVerifyHNSDomain(t *testing.T) {
 		// UpdateTLSAFromCert requires a persisted WebsiteDomain row.
 		nsProvider := svc.registry.Get("hns")
 		require.NotNil(tb, nsProvider, "HNS provider should be registered")
-		require.NoError(tb, nsProvider.OnCertAvailable(context.Background(), "example", certPEM))
+		certProvider, ok := nsProvider.(CertificateProvider)
+		require.True(tb, ok, "HNS provider must implement CertificateProvider")
+		require.NoError(tb, certProvider.OnCertAvailable(context.Background(), "example", certPEM))
 
 		mockDNS.EXPECT().CreateZone(mock.Anything, "example", uint(1)).
 			Return(&pluginDb.DNSZone{Model: gorm.Model{ID: 1}, Domain: "example"}, nil).Once()

--- a/internal/service/domain/platform_domain.go
+++ b/internal/service/domain/platform_domain.go
@@ -500,11 +500,15 @@ func (s *DelegatedDomainService) createPlatformBinding(ctx context.Context, webs
 	if err != nil {
 		return nil, err
 	}
-	// Re-validate the trust relationship on the persisted binding before
-	// promoting it: the created binding must sit on the exact operator zone
+	// Hydrate the platform reference in memory first (CreateDomain never
+	// persists it) so the shared validator actually checks the trust
+	// relationship: the created binding must sit on the exact operator zone
 	// (zone identity), under the same namespace, as the granted root. A
-	// mismatch aborts the claim without activating it or touching the website.
+	// mismatch aborts the claim, rolls back the just-created binding (the
+	// operator zone is shared and left intact), and never touches the website.
+	wd.PlatformDomainID = &pd.ID
 	if err := s.ValidatePlatformBinding(ctx, wd); err != nil {
+		s.DB().WithContext(ctx).Unscoped().Delete(wd)
 		return nil, fmt.Errorf("platform binding trust check failed: %w", err)
 	}
 	// The platform controls both sides of the DNS check (see VerifyDomain's
@@ -513,7 +517,6 @@ func (s *DelegatedDomainService) createPlatformBinding(ctx context.Context, webs
 	if err := s.DB().WithContext(ctx).Model(wd).Updates(updates).Error; err != nil {
 		return nil, fmt.Errorf("failed to mark platform subdomain: %w", err)
 	}
-	wd.PlatformDomainID = &pd.ID
 	wd.Status = pluginDb.DomainStatusActive
 
 	// The website itself must follow the binding to active. Platform subdomains

--- a/internal/service/domain/platform_domain.go
+++ b/internal/service/domain/platform_domain.go
@@ -141,6 +141,57 @@ func labelFor(label, root string) string {
 	return strings.ToLower(label) + "." + root
 }
 
+// isPlatformRootApexOrDescendant reports whether name equals the platform root
+// apex or is a proper label-boundary descendant of it (e.g. "docs.platform.test"
+// for root "platform.test"). The comparison is label-boundary aware: a lookalike
+// like "evilplatform.test" is NOT a descendant of "platform.test" because the
+// root must begin at a label boundary (immediately after a dot).
+func isPlatformRootApexOrDescendant(name, root string) bool {
+	if name == root {
+		return true
+	}
+	return len(name) > len(root)+1 && strings.HasSuffix(name, "."+root)
+}
+
+// ValidatePlatformBinding verifies the operator-trust relationship a platform
+// binding depends on. Before a platform binding bypasses user ownership /
+// delegation verification (auto-activation) — or while resolving/creating the
+// binding's managed zone — all of the following must hold:
+//
+//  1. PlatformDomainID resolves to a live platform-domain row (a soft-deleted
+//     row fails lookup here under GORM's default scope).
+//  2. The binding namespace equals the platform root's namespace.
+//  3. The binding domain equals the root apex (apex-binding flow) or is a
+//     proper label-boundary descendant of the root (subdomain claims).
+//  4. The binding ZoneID is non-zero and equals the PlatformDomain.ZoneID
+//     (the operator-owned zone the records live in).
+//
+// Any mismatch returns a descriptive integrity error and must not change
+// either the domain or the website status (the caller propagates it). This is
+// the single shared validator for platform trust, used both when resolving/
+// creating platform bindings and when verifying or auto-activating them. An
+// existing binding does not require the root to remain Enabled — Enabled only
+// gates new claims; an otherwise-valid existing website stays valid.
+func (s *DelegatedDomainService) ValidatePlatformBinding(ctx context.Context, wd *pluginDb.WebsiteDomain) error {
+	if wd.PlatformDomainID == nil || s.DB() == nil {
+		return nil // not a platform binding; nothing to validate
+	}
+	var pd pluginDb.PlatformDomain
+	if err := s.DB().WithContext(ctx).First(&pd, *wd.PlatformDomainID).Error; err != nil {
+		return fmt.Errorf("platform root %d unavailable: %w", *wd.PlatformDomainID, err)
+	}
+	if pd.Namespace != wd.Namespace {
+		return fmt.Errorf("platform root %d namespace mismatch: binding is %q, root is %q", *wd.PlatformDomainID, wd.Namespace, pd.Namespace)
+	}
+	if !isPlatformRootApexOrDescendant(wd.Domain, pd.Domain) {
+		return fmt.Errorf("binding domain %q is not the apex or a label-boundary descendant of platform root %q", wd.Domain, pd.Domain)
+	}
+	if wd.ZoneID == 0 || wd.ZoneID != pd.ZoneID {
+		return fmt.Errorf("binding domain %q zone %d does not match platform root %q zone %d", wd.Domain, wd.ZoneID, pd.Domain, pd.ZoneID)
+	}
+	return nil
+}
+
 // GetPlatformDomainByName returns a PlatformDomain by (domain, namespace), or
 // nil when none match.
 func (s *DelegatedDomainService) GetPlatformDomainByName(ctx context.Context, domain string, namespace pluginDb.DomainNamespace) (*pluginDb.PlatformDomain, error) {
@@ -448,6 +499,13 @@ func (s *DelegatedDomainService) createPlatformBinding(ctx context.Context, webs
 	wd, err := s.CreateDomain(ctx, string(pd.Namespace), fqdn, websiteID, userID, true, notifyCreated, nil, &pd.ID)
 	if err != nil {
 		return nil, err
+	}
+	// Re-validate the trust relationship on the persisted binding before
+	// promoting it: the created binding must sit on the exact operator zone
+	// (zone identity), under the same namespace, as the granted root. A
+	// mismatch aborts the claim without activating it or touching the website.
+	if err := s.ValidatePlatformBinding(ctx, wd); err != nil {
+		return nil, fmt.Errorf("platform binding trust check failed: %w", err)
 	}
 	// The platform controls both sides of the DNS check (see VerifyDomain's
 	// platform guard), so the binding is active as soon as it is created.

--- a/internal/service/domain/platform_domain_test.go
+++ b/internal/service/domain/platform_domain_test.go
@@ -988,3 +988,40 @@ func TestValidatePlatformBinding(t *testing.T) {
 		}, TestOptions)
 	})
 }
+
+// TestCreatePlatformSubdomain_ZoneMismatch_RejectedAndRolledBack proves the
+// createPlatformBinding trust guard actually executes (regression for the
+// no-op validator where PlatformDomainID had not yet been hydrated): when the
+// operator-zone lookup returns a different zone than the one recorded on the
+// platform root, the claim is rejected — not silently promoted to Active — and
+// the just-created binding is rolled back.
+func TestCreatePlatformSubdomain_ZoneMismatch_RejectedAndRolledBack(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		db := ctx.DB()
+		website := createTestWebsite(tb, db, 1, "example.com")
+		// Platform root whose recorded operator zone is ID 7.
+		pd := createPlatformRoot(tb, ctx, "platform.com", pluginDb.DomainNamespaceICANN, 7, true)
+
+		svc := core.GetService[*DelegatedDomainService](ctx, pluginCore.DELEGATED_DOMAIN_SERVICE)
+		require.NotNil(tb, svc)
+		mockDNS := core.GetService[*mocks.MockDNSService](ctx, pluginCore.DNS_SERVICE)
+		require.NotNil(tb, mockDNS)
+
+		// The operator-zone lookup returns a DIFFERENT zone (123) than the one
+		// recorded on the platform root (7) — inconsistent state. The claim must
+		// be rejected by the shared trust validator, never promoted Active.
+		mockDNS.EXPECT().GetZoneByDomain(mock.Anything, "platform.com").
+			Return(&pluginDb.DNSZone{Model: gorm.Model{ID: 123}, Domain: "platform.com", UserID: 1}, nil).Once()
+		mockDNS.EXPECT().CreateDNSLinkRecord(mock.Anything, uint(123), mock.Anything, mock.Anything).Return(nil).Maybe()
+
+		_, err := svc.CreatePlatformSubdomain(context.Background(), website.ID, 1, pd.ID, "starter", false, false)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "trust check failed")
+
+		// The mismatched binding was rolled back.
+		var count int64
+		require.NoError(t, db.Unscoped().Model(&pluginDb.WebsiteDomain{}).
+			Where("domain = ?", "starter.platform.com").Count(&count).Error)
+		assert.Zero(t, count, "a mismatched platform claim must not leave a persisted binding")
+	}, TestOptions)
+}

--- a/internal/service/domain/platform_domain_test.go
+++ b/internal/service/domain/platform_domain_test.go
@@ -717,10 +717,10 @@ func TestResolveManagedZone_PlatformGuard_HNSSingleLabel(t *testing.T) {
 		assert.Equal(t, uint(7), z.ID)
 		assert.False(t, created, "a platform apex must never create a new zone")
 
-		// An unrelated name is not a subdomain of the granted root.
+		// An unrelated name is not the apex nor a subdomain of the granted root.
 		_, _, err = svc.resolveManagedZone(context.Background(), "other.xyz", 1, &pd.ID)
 		require.Error(tb, err)
-		assert.Contains(tb, err.Error(), "not a subdomain")
+		assert.Contains(tb, err.Error(), "not the apex or a subdomain")
 
 		// A proper subdomain resolves to the granted root's zone.
 		mockDNS.EXPECT().GetZoneByDomain(mock.Anything, "altroot").
@@ -840,4 +840,151 @@ func TestBindPlatformRootApex_MultipleRootsAsAdditionalDomains(t *testing.T) {
 
 		mockDNS.AssertNotCalled(tb, "CreateZone", mock.Anything, mock.Anything, mock.Anything)
 	}, platformApexTestOptions)
+}
+
+// TestValidatePlatformBinding exercises the shared platform-trust validator.
+// Before a platform binding bypasses user ownership/delegation verification, the
+// root must resolve live, the namespaces must match, the domain must be the apex
+// or a label-boundary descendant, and the binding's zone must equal the root's
+// zone. Mismatches return descriptive integrity errors and must not mutate the
+// binding's status.
+func TestValidatePlatformBinding(t *testing.T) {
+	newBinding := func(pd *pluginDb.PlatformDomain, domain string, namespace pluginDb.DomainNamespace, zoneID uint) *pluginDb.WebsiteDomain {
+		return &pluginDb.WebsiteDomain{
+			WebsiteID:        1,
+			UserID:           1,
+			Domain:           domain,
+			Namespace:        namespace,
+			ZoneID:           zoneID,
+			Status:           pluginDb.DomainStatusRecordsGenerated,
+			PlatformDomainID: &pd.ID,
+		}
+	}
+
+	t.Run("matching_root_apex_verifies", func(t *testing.T) {
+		coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+			svc := core.GetService[*DelegatedDomainService](ctx, pluginCore.DELEGATED_DOMAIN_SERVICE)
+			pd := createPlatformRoot(tb, ctx, "platform.test", pluginDb.DomainNamespaceICANN, 7, true)
+			wd := newBinding(pd, "platform.test", pluginDb.DomainNamespaceICANN, 7)
+			require.NoError(t, ctx.DB().Create(wd).Error)
+			assert.NoError(t, svc.ValidatePlatformBinding(context.Background(), wd))
+		}, TestOptions)
+	})
+
+	t.Run("matching_descendant_verifies", func(t *testing.T) {
+		coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+			svc := core.GetService[*DelegatedDomainService](ctx, pluginCore.DELEGATED_DOMAIN_SERVICE)
+			pd := createPlatformRoot(tb, ctx, "platform.test", pluginDb.DomainNamespaceICANN, 7, true)
+			wd := newBinding(pd, "starter.platform.test", pluginDb.DomainNamespaceICANN, 7)
+			require.NoError(t, ctx.DB().Create(wd).Error)
+			assert.NoError(t, svc.ValidatePlatformBinding(context.Background(), wd))
+		}, TestOptions)
+	})
+
+	t.Run("namespace_mismatch_fails_without_status_mutation", func(t *testing.T) {
+		coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+			svc := core.GetService[*DelegatedDomainService](ctx, pluginCore.DELEGATED_DOMAIN_SERVICE)
+			pd := createPlatformRoot(tb, ctx, "altroot", pluginDb.DomainNamespaceHNS, 7, true)
+			wd := newBinding(pd, "starter.altroot", pluginDb.DomainNamespaceICANN, 7)
+			require.NoError(t, ctx.DB().Create(wd).Error)
+			err := svc.ValidatePlatformBinding(context.Background(), wd)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "namespace mismatch")
+			var persisted pluginDb.WebsiteDomain
+			require.NoError(t, ctx.DB().First(&persisted, wd.ID).Error)
+			assert.Equal(t, pluginDb.DomainStatusRecordsGenerated, persisted.Status)
+		}, TestOptions)
+	})
+
+	t.Run("unrelated_domain_with_matching_namespace_fails", func(t *testing.T) {
+		coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+			svc := core.GetService[*DelegatedDomainService](ctx, pluginCore.DELEGATED_DOMAIN_SERVICE)
+			pd := createPlatformRoot(tb, ctx, "platform.test", pluginDb.DomainNamespaceICANN, 7, true)
+			wd := newBinding(pd, "other.example", pluginDb.DomainNamespaceICANN, 7)
+			require.NoError(t, ctx.DB().Create(wd).Error)
+			err := svc.ValidatePlatformBinding(context.Background(), wd)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "not the apex or a label-boundary descendant")
+		}, TestOptions)
+	})
+
+	t.Run("label_boundary_lookalike_fails", func(t *testing.T) {
+		// "evilplatform.test" must NOT be treated as a descendant of the root
+		// "platform.test": the root must begin at a label boundary.
+		coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+			svc := core.GetService[*DelegatedDomainService](ctx, pluginCore.DELEGATED_DOMAIN_SERVICE)
+			pd := createPlatformRoot(tb, ctx, "platform.test", pluginDb.DomainNamespaceICANN, 7, true)
+			wd := newBinding(pd, "evilplatform.test", pluginDb.DomainNamespaceICANN, 7)
+			require.NoError(t, ctx.DB().Create(wd).Error)
+			err := svc.ValidatePlatformBinding(context.Background(), wd)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "not the apex or a label-boundary descendant")
+		}, TestOptions)
+	})
+
+	t.Run("zone_mismatch_fails", func(t *testing.T) {
+		coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+			svc := core.GetService[*DelegatedDomainService](ctx, pluginCore.DELEGATED_DOMAIN_SERVICE)
+			pd := createPlatformRoot(tb, ctx, "platform.test", pluginDb.DomainNamespaceICANN, 7, true)
+			wd := newBinding(pd, "starter.platform.test", pluginDb.DomainNamespaceICANN, 99)
+			require.NoError(t, ctx.DB().Create(wd).Error)
+			err := svc.ValidatePlatformBinding(context.Background(), wd)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "zone")
+		}, TestOptions)
+	})
+
+	t.Run("zero_zone_fails", func(t *testing.T) {
+		coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+			svc := core.GetService[*DelegatedDomainService](ctx, pluginCore.DELEGATED_DOMAIN_SERVICE)
+			pd := createPlatformRoot(tb, ctx, "platform.test", pluginDb.DomainNamespaceICANN, 7, true)
+			wd := newBinding(pd, "starter.platform.test", pluginDb.DomainNamespaceICANN, 0)
+			require.NoError(t, ctx.DB().Create(wd).Error)
+			err := svc.ValidatePlatformBinding(context.Background(), wd)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "zone")
+		}, TestOptions)
+	})
+
+	t.Run("missing_platform_root_fails", func(t *testing.T) {
+		coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+			svc := core.GetService[*DelegatedDomainService](ctx, pluginCore.DELEGATED_DOMAIN_SERVICE)
+			missingID := uint(999999)
+			wd := &pluginDb.WebsiteDomain{
+				WebsiteID: 1, UserID: 1, Domain: "starter.platform.test",
+				Namespace: pluginDb.DomainNamespaceICANN, ZoneID: 7,
+				Status:           pluginDb.DomainStatusRecordsGenerated,
+				PlatformDomainID: &missingID,
+			}
+			require.NoError(t, ctx.DB().Create(wd).Error)
+			err := svc.ValidatePlatformBinding(context.Background(), wd)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "unavailable")
+		}, TestOptions)
+	})
+
+	t.Run("soft_deleted_platform_root_fails", func(t *testing.T) {
+		coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+			svc := core.GetService[*DelegatedDomainService](ctx, pluginCore.DELEGATED_DOMAIN_SERVICE)
+			pd := createPlatformRoot(tb, ctx, "platform.test", pluginDb.DomainNamespaceICANN, 7, true)
+			require.NoError(t, ctx.DB().Delete(&pluginDb.PlatformDomain{}, pd.ID).Error)
+			wd := newBinding(pd, "starter.platform.test", pluginDb.DomainNamespaceICANN, 7)
+			require.NoError(t, ctx.DB().Create(wd).Error)
+			err := svc.ValidatePlatformBinding(context.Background(), wd)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "unavailable")
+		}, TestOptions)
+	})
+
+	t.Run("enabled_not_required_for_existing_binding", func(t *testing.T) {
+		// An existing, otherwise-valid platform binding stays valid even when
+		// its root is later disabled — Enabled gates new claims only.
+		coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+			svc := core.GetService[*DelegatedDomainService](ctx, pluginCore.DELEGATED_DOMAIN_SERVICE)
+			pd := createPlatformRoot(tb, ctx, "platform.test", pluginDb.DomainNamespaceICANN, 7, false)
+			wd := newBinding(pd, "starter.platform.test", pluginDb.DomainNamespaceICANN, 7)
+			require.NoError(t, ctx.DB().Create(wd).Error)
+			assert.NoError(t, svc.ValidatePlatformBinding(context.Background(), wd))
+		}, TestOptions)
+	})
 }

--- a/internal/service/domain/provider.go
+++ b/internal/service/domain/provider.go
@@ -3,12 +3,29 @@ package domain
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"sort"
 
 	"github.com/samber/lo"
 	pluginCore "go.lumeweb.com/portal-plugin-ipfs/core"
 	pluginDb "go.lumeweb.com/portal-plugin-ipfs/internal/db"
 )
+
+// DNSSECPolicy, TLSAPolicy, and ProviderPolicy live in the plugin core package
+// (pluginCore) so they can be referenced without import cycles by consumers
+// such as generated mocks; see core/provider_policy.go.
+
+// CertificateProvider is the optional capability for providers whose namespaces
+// translate TLS certificates into DANE/TLSA state (managed-zone DANE).
+// Providers without DANE (e.g. ICANN) do not implement it, so certificate/DANE
+// behavior is an explicit optional sub-interface rather than a mandatory no-op
+// on every provider.
+type CertificateProvider interface {
+	// OnCertAvailable is called when a cert is pushed via /internal/dns/cert.
+	// Providers can use it to update TLSA in delegation data or trigger
+	// namespace-specific protocol updates. Returning nil is safe.
+	OnCertAvailable(ctx context.Context, domain string, certPEM string) error
+}
 
 type DomainProvider interface {
 	Protocol() string
@@ -23,26 +40,15 @@ type DomainProvider interface {
 	// answer (name not yet registered, resolver unreachable), defaulting to
 	// native so binding can proceed.
 	Inspect(ctx context.Context, domain string) (onchainManaged bool, err error)
-	BuildDelegation(ctx context.Context, zoneID uint, domain string, website *pluginDb.Website, config json.RawMessage) (any, error)
+	// BuildDelegation returns the provider's typed delegation payload as a
+	// json.RawMessage, so delegation never crosses the provider boundary as an
+	// unconstrained any. Each provider marshals its own typed delegation
+	// structure (e.g. HNS DelegationBundle, ICANN ICANNDelegation); the
+	// persisted JSON shape is unchanged.
+	BuildDelegation(ctx context.Context, zoneID uint, domain string, website *pluginDb.Website, config json.RawMessage) (json.RawMessage, error)
 	VerifyDelegation(ctx context.Context, domain string, expectedDS string) (bool, error)
-	// OnCertAvailable is called when a cert is pushed via /internal/dns/cert.
-	// Providers can use it to update TLSA in delegation data or trigger
-	// namespace-specific protocol updates. Can be nil-safe by returning nil.
-	OnCertAvailable(ctx context.Context, domain string, certPEM string) error
-	// UsesManagedZoneTLSA reports whether this provider's TLS certs translate
-	// into a DANE TLSA record that the portal must publish into its
-	// portal-managed authoritative PowerDNS zone (e.g. an alt-root namespace
-	// whose zone the portal DNSSEC-signs). Providers that do not use DANE
-	// (e.g. ICANN) return false so no spurious _443._tcp TLSA is published.
-	UsesManagedZoneTLSA() bool
-	// RequiresDNSSEC reports whether this provider's delegation is confirmed
-	// against a live DS record served by the parent zone (managed-DNSSEC
-	// namespaces, e.g. HNS). Providers that verify on NS visibility alone
-	// (e.g. ICANN) and ignore DS return false, so a DS-resolution failure never
-	// blocks their verification. Distinct from UsesManagedZoneTLSA: a provider
-	// could DNSSEC-sign without DANE (and vice versa), so DNSSEC-requirement is
-	// its own capability.
-	RequiresDNSSEC() bool
+	// Policy returns the provider's immutable hosting-capability policy.
+	Policy() pluginCore.ProviderPolicy
 	// Nameservers returns the nameservers this provider publishes and
 	// validates delegation against for its namespace. Alt-root providers
 	// (e.g. HNS) return their own namespace-specific nameservers, which
@@ -55,11 +61,21 @@ type DomainProvider interface {
 	// system default resolver). Used to validate that a zone's namespace
 	// delegation is live.
 	LiveNameservers(ctx context.Context, domain string) ([]string, error)
+	// Deprecated compatibility adapters — their values MUST derive from
+	// Policy() and are never independent sources of truth:
+
+	// UsesManagedZoneTLSA reports whether this provider's TLS certs translate
+	// into a DANE TLSA record that the portal must publish into its
+	// portal-managed authoritative PowerDNS zone. Derived from Policy().TLSA.
+	UsesManagedZoneTLSA() bool
+	// RequiresDNSSEC reports whether this provider's delegation is confirmed
+	// against a live DS record served by the parent zone (managed-DNSSEC
+	// namespaces, e.g. HNS). Derived from Policy().DNSSEC. A provider could
+	// DNSSEC-sign without DANE (and vice versa), so providers must never use
+	// the TLSA capability as a proxy for DNSSEC.
+	RequiresDNSSEC() bool
 	// ApexRecordType returns the DNS record type used for the zone apex.
-	// DNSSEC-signed alt-root providers (e.g. HNS) must return RecordTypeA so
-	// the apex is a real, signable RRset, which PowerDNS cannot provide for a
-	// synthetic ALIAS/CNAME record at the apex. Providers whose apex is not
-	// separately signed return RecordTypeALIAS.
+	// Derived from Policy().ApexRecordType.
 	ApexRecordType() pluginCore.RecordType
 }
 
@@ -71,11 +87,33 @@ func NewRegistry() *Registry {
 	return &Registry{providers: make(map[string]DomainProvider)}
 }
 
+// validatePolicy rejects unknown enum values and invalid record types at
+// registration time (mirroring the duplicate-registration panic), so a broken
+// capability can never silently reach a hosting-sensitive decision.
+func validatePolicy(key string, pol pluginCore.ProviderPolicy) {
+	switch pol.DNSSEC {
+	case pluginCore.DNSSECNotRequired, pluginCore.DNSSECRequired:
+	default:
+		panic(fmt.Sprintf("domain provider %q registered with invalid DNSSEC policy value %d", key, pol.DNSSEC))
+	}
+	switch pol.TLSA {
+	case pluginCore.TLSANotManaged, pluginCore.TLSAManaged:
+	default:
+		panic(fmt.Sprintf("domain provider %q registered with invalid TLSA policy value %d", key, pol.TLSA))
+	}
+	switch pol.ApexRecordType {
+	case pluginCore.RecordTypeA, pluginCore.RecordTypeALIAS:
+	default:
+		panic(fmt.Sprintf("domain provider %q registered with invalid apex record type %q", key, pol.ApexRecordType))
+	}
+}
+
 func (r *Registry) Register(p DomainProvider) {
 	key := p.Protocol()
 	if _, exists := r.providers[key]; exists {
 		panic("domain provider already registered for protocol: " + key)
 	}
+	validatePolicy(key, p.Policy())
 	r.providers[key] = p
 }
 

--- a/internal/service/domain/provider_test.go
+++ b/internal/service/domain/provider_test.go
@@ -1,18 +1,20 @@
 package domain
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	pluginCore "go.lumeweb.com/portal-plugin-ipfs/core"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/testing/mocks"
 )
-
 
 func TestRegistry_RegisterAndGet(t *testing.T) {
 	r := NewRegistry()
 	mockProv := mocks.NewMockDomainProvider(t)
 	mockProv.EXPECT().Protocol().Return("test").Maybe()
+	mockProv.EXPECT().Policy().Return(mockProviderPolicy()).Maybe()
 
 	r.Register(mockProv)
 	assert.Equal(t, mockProv, r.Get("test"))
@@ -20,17 +22,103 @@ func TestRegistry_RegisterAndGet(t *testing.T) {
 	assert.Equal(t, []string{"test"}, r.Names())
 }
 
+// mockProviderPolicy returns a structurally valid ProviderPolicy so a mock
+// provider passes the registration-time policy validation.
+func mockProviderPolicy() pluginCore.ProviderPolicy {
+	return pluginCore.ProviderPolicy{
+		DNSSEC:         pluginCore.DNSSECNotRequired,
+		TLSA:           pluginCore.TLSANotManaged,
+		ApexRecordType: pluginCore.RecordTypeALIAS,
+	}
+}
+
 func TestRegistry_DuplicatePanics(t *testing.T) {
 	r := NewRegistry()
 	mockProv := mocks.NewMockDomainProvider(t)
 	mockProv.EXPECT().Protocol().Return("test").Maybe()
+	mockProv.EXPECT().Policy().Return(mockProviderPolicy()).Maybe()
 
 	r.Register(mockProv)
 	assert.Panics(t, func() {
 		mockProv2 := mocks.NewMockDomainProvider(t)
 		mockProv2.EXPECT().Protocol().Return("test").Maybe()
+		mockProv2.EXPECT().Policy().Return(mockProviderPolicy()).Maybe()
 		r.Register(mockProv2)
 	})
+}
+
+// TestRegistry_RegisterValidatesProviderPolicy verifies that provider
+// registration rejects unknown policy enum values and invalid record types up
+// front, so a broken capability can never silently reach a hosting-sensitive
+// decision — while every relevant valid DNSSEC/TLSA combination (including
+// DNSSEC-required with TLSA-disabled) registers cleanly.
+func TestRegistry_RegisterValidatesProviderPolicy(t *testing.T) {
+	newProv := func(ds pluginCore.DNSSECPolicy, tlsa pluginCore.TLSAPolicy, apex pluginCore.RecordType) *syntheticTestProvider {
+		return &syntheticTestProvider{
+			protocol: "synthetic",
+			policy: pluginCore.ProviderPolicy{
+				DNSSEC:         ds,
+				TLSA:           tlsa,
+				ApexRecordType: apex,
+			},
+		}
+	}
+
+	t.Run("invalid_dnssec_policy_rejected", func(t *testing.T) {
+		r := NewRegistry()
+		assert.Panics(t, func() {
+			r.Register(newProv(99, pluginCore.TLSANotManaged, pluginCore.RecordTypeALIAS))
+		})
+	})
+
+	t.Run("invalid_tlsa_policy_rejected", func(t *testing.T) {
+		r := NewRegistry()
+		assert.Panics(t, func() {
+			r.Register(newProv(pluginCore.DNSSECNotRequired, 99, pluginCore.RecordTypeALIAS))
+		})
+	})
+
+	t.Run("invalid_apex_record_type_rejected", func(t *testing.T) {
+		r := NewRegistry()
+		assert.Panics(t, func() {
+			r.Register(newProv(pluginCore.DNSSECNotRequired, pluginCore.TLSANotManaged, pluginCore.RecordTypeTXT))
+		})
+	})
+
+	t.Run("all_valid_policy_combinations_register", func(t *testing.T) {
+		combos := []pluginCore.ProviderPolicy{
+			{DNSSEC: pluginCore.DNSSECNotRequired, TLSA: pluginCore.TLSANotManaged, ApexRecordType: pluginCore.RecordTypeALIAS},
+			{DNSSEC: pluginCore.DNSSECNotRequired, TLSA: pluginCore.TLSAManaged, ApexRecordType: pluginCore.RecordTypeA},
+			{DNSSEC: pluginCore.DNSSECRequired, TLSA: pluginCore.TLSANotManaged, ApexRecordType: pluginCore.RecordTypeA},
+			{DNSSEC: pluginCore.DNSSECRequired, TLSA: pluginCore.TLSAManaged, ApexRecordType: pluginCore.RecordTypeA},
+		}
+		for i, pol := range combos {
+			i, pol := i, pol
+			t.Run(fmt.Sprintf("combo_%d", i), func(t *testing.T) {
+				r := NewRegistry()
+				prov := newProv(pol.DNSSEC, pol.TLSA, pol.ApexRecordType)
+				prov.protocol = fmt.Sprintf("synthetic-%d", i)
+				require.NotPanics(t, func() { r.Register(prov) })
+				assert.Equal(t, pol, r.Get(prov.Protocol()).Policy())
+			})
+		}
+	})
+}
+
+func TestHNSProvider_RequiresDNSSEC_UsesManagedZoneTLSA_DeriveFromPolicy(t *testing.T) {
+	// The legacy boolean adapters must derive from Policy() (single source of
+	// truth), so they can never disagree with the policy.
+	hns := NewHNSProvider("", nil, TLSASource{})
+	assert.True(t, hns.RequiresDNSSEC())
+	assert.True(t, hns.UsesManagedZoneTLSA())
+	assert.Equal(t, pluginCore.DNSSECRequired, hns.Policy().DNSSEC)
+	assert.Equal(t, pluginCore.TLSAManaged, hns.Policy().TLSA)
+
+	icann := NewICANNProvider(nil)
+	assert.False(t, icann.RequiresDNSSEC())
+	assert.False(t, icann.UsesManagedZoneTLSA())
+	assert.Equal(t, pluginCore.DNSSECNotRequired, icann.Policy().DNSSEC)
+	assert.Equal(t, pluginCore.TLSANotManaged, icann.Policy().TLSA)
 }
 
 func TestNormalizeDomain(t *testing.T) {

--- a/internal/service/domain/verify_domain_policy_test.go
+++ b/internal/service/domain/verify_domain_policy_test.go
@@ -1,0 +1,258 @@
+package domain
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	pluginCore "go.lumeweb.com/portal-plugin-ipfs/core"
+	pluginDb "go.lumeweb.com/portal-plugin-ipfs/internal/db"
+	"go.lumeweb.com/portal-plugin-ipfs/internal/testing/mocks"
+	"go.lumeweb.com/portal/core"
+	coreTesting "go.lumeweb.com/portal/core/testing"
+)
+
+// syntheticTestProvider is a configurable DomainProvider test double for the
+// capability matrix, kept local to this package so the domain test binary does
+// not pull in the heavier test-support dependency graph (which would conflict
+// on protobuf registration). See internal/testing/util.SyntheticDomainProvider
+// for the equivalent shared double used by the API tests.
+type syntheticTestProvider struct {
+	protocol  string
+	policy    pluginCore.ProviderPolicy
+	called    bool   // set when VerifyDelegation runs
+	verifyDS  string // expectedDS delivered to VerifyDelegation
+	verifyOK  bool
+	verifyErr error
+}
+
+func (p *syntheticTestProvider) Protocol() string { return p.protocol }
+func (p *syntheticTestProvider) Validate(string) error {
+	return nil
+}
+func (p *syntheticTestProvider) Inspect(context.Context, string) (bool, error) {
+	return false, nil
+}
+func (p *syntheticTestProvider) BuildDelegation(context.Context, uint, string, *pluginDb.Website, json.RawMessage) (json.RawMessage, error) {
+	return json.Marshal(map[string]any{"protocol": p.protocol})
+}
+func (p *syntheticTestProvider) VerifyDelegation(_ context.Context, _ string, expectedDS string) (bool, error) {
+	p.called = true
+	p.verifyDS = expectedDS
+	return p.verifyOK, p.verifyErr
+}
+func (p *syntheticTestProvider) Policy() pluginCore.ProviderPolicy { return p.policy }
+func (p *syntheticTestProvider) Nameservers() []string             { return nil }
+func (p *syntheticTestProvider) LiveNameservers(context.Context, string) ([]string, error) {
+	return nil, nil
+}
+func (p *syntheticTestProvider) UsesManagedZoneTLSA() bool {
+	return p.policy.TLSA == pluginCore.TLSAManaged
+}
+func (p *syntheticTestProvider) RequiresDNSSEC() bool {
+	return p.policy.DNSSEC == pluginCore.DNSSECRequired
+}
+func (p *syntheticTestProvider) ApexRecordType() pluginCore.RecordType {
+	return p.policy.ApexRecordType
+}
+
+// TestVerifyDomain_DNSSECCapabilityMatrix exercises VerifyDomain across every
+// relevant DNSSEC/TLSA policy combination using a synthetic provider, rather
+// than relying only on the concrete ICANN/HNS implementations. It verifies:
+//
+//   - DNSSEC-required providers resolve the live DS (gated on the DNSSEC
+//     policy, not the TLSA policy) and hand it to delegation verification.
+//   - A DNSSEC-required zone with no live DS self-heals via EnableDNSSEC and
+//     re-reads the DS; failing to heal fails closed (error, no provider
+//     verification, no Active) instead of silently degrading to NS-only.
+//   - DS read errors are fatal for DNSSEC-required providers and best-effort
+//     non-fatal for providers that do not require DNSSEC.
+func TestVerifyDomain_DNSSECCapabilityMatrix(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		db := ctx.DB()
+		svc := core.GetService[*DelegatedDomainService](ctx, pluginCore.DELEGATED_DOMAIN_SERVICE)
+		require.NotNil(tb, svc)
+		mockDNS := core.GetService[*mocks.MockDNSService](ctx, pluginCore.DNS_SERVICE)
+		require.NotNil(tb, mockDNS)
+
+		cases := []struct {
+			name             string
+			protocol         string
+			policy           pluginCore.ProviderPolicy
+			initialDS        string
+			initialDSErr     error
+			enableHeal       bool
+			healedDS         string
+			wantState        DelegationVerificationState
+			wantErr          bool
+			expectDSNonEmpty bool // the DS handed to the provider must be live
+		}{
+			{
+				name:             "dnssec_required_tlsa_enabled_existing_ds",
+				protocol:         "synth-a",
+				policy:           pluginCore.ProviderPolicy{DNSSEC: pluginCore.DNSSECRequired, TLSA: pluginCore.TLSAManaged, ApexRecordType: pluginCore.RecordTypeA},
+				initialDS:        "live-ds-a",
+				wantState:        DelegationVerified,
+				expectDSNonEmpty: true,
+			},
+			{
+				// The key capability-matrix case: DNSSEC required but DANE/TLSA
+				// disabled — the live DS must still be resolved and passed to
+				// the provider; the TLSA capability is NOT a proxy for DNSSEC.
+				name:             "dnssec_required_tlsa_disabled_existing_ds",
+				protocol:         "synth-b",
+				policy:           pluginCore.ProviderPolicy{DNSSEC: pluginCore.DNSSECRequired, TLSA: pluginCore.TLSANotManaged, ApexRecordType: pluginCore.RecordTypeA},
+				initialDS:        "live-ds-b",
+				wantState:        DelegationVerified,
+				expectDSNonEmpty: true,
+			},
+			{
+				name:      "dnssec_not_required_tlsa_disabled_no_ds",
+				protocol:  "synth-c",
+				policy:    pluginCore.ProviderPolicy{DNSSEC: pluginCore.DNSSECNotRequired, TLSA: pluginCore.TLSANotManaged, ApexRecordType: pluginCore.RecordTypeALIAS},
+				initialDS: "",
+				wantState: DelegationVerified,
+			},
+			{
+				name:             "dnssec_not_required_ds_read_error_nonfatal",
+				protocol:         "synth-d",
+				policy:           pluginCore.ProviderPolicy{DNSSEC: pluginCore.DNSSECNotRequired, TLSA: pluginCore.TLSANotManaged, ApexRecordType: pluginCore.RecordTypeALIAS},
+				initialDSErr:     errors.New("powerdns down"),
+				wantState:        DelegationVerified,
+				expectDSNonEmpty: false,
+			},
+			{
+				name:         "dnssec_required_ds_read_error_fatal",
+				protocol:     "synth-e",
+				policy:       pluginCore.ProviderPolicy{DNSSEC: pluginCore.DNSSECRequired, TLSA: pluginCore.TLSANotManaged, ApexRecordType: pluginCore.RecordTypeA},
+				initialDSErr: errors.New("powerdns down"),
+				wantErr:      true,
+			},
+			{
+				name:             "dnssec_required_empty_then_enable_then_live_ds",
+				protocol:         "synth-f",
+				policy:           pluginCore.ProviderPolicy{DNSSEC: pluginCore.DNSSECRequired, TLSA: pluginCore.TLSANotManaged, ApexRecordType: pluginCore.RecordTypeA},
+				initialDS:        "",
+				enableHeal:       true,
+				healedDS:         "minted-ds",
+				wantState:        DelegationVerified,
+				expectDSNonEmpty: true,
+			},
+			{
+				// Fail-closed: EnableDNSSEC succeeded but the post-heal DS read
+				// is still empty. VerifyDomain must error, never call the
+				// provider's VerifyDelegation, and never mark the binding Active.
+				name:       "dnssec_required_empty_after_heal_fails_closed",
+				protocol:   "synth-g",
+				policy:     pluginCore.ProviderPolicy{DNSSEC: pluginCore.DNSSECRequired, TLSA: pluginCore.TLSAManaged, ApexRecordType: pluginCore.RecordTypeA},
+				initialDS:  "",
+				enableHeal: true,
+				healedDS:   "",
+				wantErr:    true,
+			},
+		}
+
+		zoneSeq := 0
+		for _, tc := range cases {
+			zoneSeq++
+			zone := uint(2000 + zoneSeq)
+			domain := tc.protocol + ".example"
+
+			prov := &syntheticTestProvider{protocol: tc.protocol, policy: tc.policy, verifyOK: true}
+			svc.registry.Register(prov)
+
+			t.Run(tc.name, func(t *testing.T) {
+				wd := &pluginDb.WebsiteDomain{
+					WebsiteID: 1, UserID: 1, Domain: domain, Namespace: pluginDb.DomainNamespace(tc.protocol),
+					ZoneID: zone, Status: pluginDb.DomainStatusRecordsGenerated,
+				}
+				require.NoError(t, db.Create(wd).Error)
+
+				if tc.initialDSErr != nil {
+					mockDNS.EXPECT().GetActiveDNSSECDS(mock.Anything, zone).Return("", tc.initialDSErr).Once()
+				} else {
+					mockDNS.EXPECT().GetActiveDNSSECDS(mock.Anything, zone).Return(tc.initialDS, nil).Once()
+				}
+				if tc.enableHeal {
+					mockDNS.EXPECT().EnableDNSSEC(mock.Anything, zone).Return("dnskey", nil).Once()
+					// Post-heal re-read; registered after the initial read so
+					// testimony matches the first call to the second expectation.
+					mockDNS.EXPECT().GetActiveDNSSECDS(mock.Anything, zone).Return(tc.healedDS, nil).Once()
+				}
+				mockDNS.EXPECT().EnsureSOAMNAME(mock.Anything, zone, domain, mock.Anything).Return(nil).Maybe()
+
+				res, err := svc.VerifyDomain(context.Background(), wd)
+				if tc.wantErr {
+					require.Error(t, err)
+					assert.False(t, prov.called, "provider VerifyDelegation must not run when the DNSSEC invariant failed")
+					var persisted pluginDb.WebsiteDomain
+					require.NoError(t, db.Unscoped().First(&persisted, wd.ID).Error)
+					assert.NotEqual(t, pluginDb.DomainStatusActive, persisted.Status,
+						"a binding whose DNSSEC invariant could not be established must not become Active")
+					return
+				}
+
+				require.NoError(t, err)
+				assert.Equal(t, tc.wantState, res.State)
+				assert.True(t, prov.called, "delegation verification must run for a healthy portal-managed binding")
+				if tc.expectDSNonEmpty {
+					assert.NotEmpty(t, prov.verifyDS, "a DNSSEC-required provider must receive the live DS")
+				}
+				var persisted pluginDb.WebsiteDomain
+				require.NoError(t, db.Unscoped().First(&persisted, wd.ID).Error)
+				if tc.wantState == DelegationVerified {
+					assert.Equal(t, pluginDb.DomainStatusActive, persisted.Status)
+				}
+			})
+		}
+	}, TestOptions)
+}
+
+// TestVerifyDomain_OnchainStrayZone_NotApplicableNoPortalDNS proves the
+// cross-service safety rule: an on-chain managed binding carrying a stray
+// (incoherent) zone ID is classified OnChainManaged — VerifyDomain returns
+// NotApplicable and performs no portal DNS reads (GetActiveDNSSECDS is never
+// consulted), no EnableDNSSEC, and no provider delegation verification.
+func TestVerifyDomain_OnchainStrayZone_NotApplicableNoPortalDNS(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		db := ctx.DB()
+		svc := core.GetService[*DelegatedDomainService](ctx, pluginCore.DELEGATED_DOMAIN_SERVICE)
+		require.NotNil(tb, svc)
+		mockDNS := core.GetService[*mocks.MockDNSService](ctx, pluginCore.DNS_SERVICE)
+
+		// Any namespace provider here; the on-chain status short-circuits
+		// before any provider capability is consulted.
+		prov := &syntheticTestProvider{
+			protocol: "onchain-synth",
+			policy:   pluginCore.ProviderPolicy{DNSSEC: pluginCore.DNSSECRequired, TLSA: pluginCore.TLSAManaged, ApexRecordType: pluginCore.RecordTypeA},
+			verifyOK: true,
+		}
+		svc.registry.Register(prov)
+
+		wd := &pluginDb.WebsiteDomain{
+			WebsiteID: 1, UserID: 1, Domain: "onchain.example",
+			Namespace: pluginDb.DomainNamespace("onchain-synth"),
+			ZoneID:    77, // stray, incoherent zone reference
+			Status:    pluginDb.DomainStatusOnchainManaged,
+		}
+		require.NoError(t, db.Create(wd).Error)
+
+		res, err := svc.VerifyDomain(context.Background(), wd)
+		require.NoError(t, err)
+		assert.Equal(t, DelegationNotApplicable, res.State)
+		assert.False(t, prov.called, "no provider verification for a non-portal binding")
+
+		mockDNS.AssertNotCalled(t, "GetActiveDNSSECDS")
+		mockDNS.AssertNotCalled(t, "EnableDNSSEC")
+		mockDNS.AssertNotCalled(t, "EnsureSOAMNAME")
+
+		// Status must be left untouched (not promoted to Active).
+		var persisted pluginDb.WebsiteDomain
+		require.NoError(t, db.First(&persisted, wd.ID).Error)
+		assert.Equal(t, pluginDb.DomainStatusOnchainManaged, persisted.Status)
+	}, TestOptions)
+}

--- a/internal/service/website/hip5_test.go
+++ b/internal/service/website/hip5_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 	pluginCore "go.lumeweb.com/portal-plugin-ipfs/core"
 	pluginDb "go.lumeweb.com/portal-plugin-ipfs/internal/db"
+	"go.lumeweb.com/portal-plugin-ipfs/internal/testing/mocks"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/testing/util"
 	"go.lumeweb.com/portal/core"
 	coreTesting "go.lumeweb.com/portal/core/testing"
@@ -116,5 +117,56 @@ func TestSetDomainDNSEnabled_OnchainManagedRefusesEnable(t *testing.T) {
 		require.NoError(tb, ctx.DB().First(&persisted, wd.ID).Error)
 		assert.False(tb, persisted.DNSHostingEnabled)
 		assert.Equal(tb, uint(0), persisted.ZoneID)
+	}, TestOptions)
+}
+
+// TestSetDomainDNSEnabled_OnchainManagedStrayZone_RefusesEnableNoZoneDelete is
+// the stray-zone variant of the on-chain enable refusal: even when an on-chain
+// binding incoherently carries a zone reference, enabling portal DNS must be
+// refused and the website/DNS flows must never create, delete, or write to any
+// portal zone.
+func TestSetDomainDNSEnabled_OnchainManagedStrayZone_RefusesEnableNoZoneDelete(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		websiteService := core.GetService[pluginCore.WebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
+		require.NotNil(tb, websiteService)
+		mockDNS := core.GetService[*mocks.MockDNSService](ctx, pluginCore.DNS_SERVICE)
+		require.NotNil(tb, mockDNS)
+
+		testCID := util.GenerateTestCID(t, "onchain-stray-enable")
+		domain := "onchain-stray-enable.hns"
+		website := createTestIPFSWebsite(testUserID1, domain, testCID.String())
+		website.Status = string(pluginDb.WebsiteStatusPendingValidation)
+		require.NoError(tb, ctx.DB().Create(website).Error)
+
+		wd := prebindPrimaryDomain(tb, ctx, website, domain, false)
+		wd.Namespace = pluginDb.DomainNamespaceHNS
+		wd.Status = pluginDb.DomainStatusOnchainManaged
+		require.NoError(tb, ctx.DB().Model(wd).Updates(map[string]interface{}{
+			"namespace": string(pluginDb.DomainNamespaceHNS),
+			"status":    string(pluginDb.DomainStatusOnchainManaged),
+			"zone_id":   uint(77), // stray, incoherent zone reference
+		}).Error)
+
+		_, err := websiteService.SetDomainDNSEnabled(context.Background(), testUserID1, website.ID, wd.ID, true)
+		require.Error(tb, err)
+		assert.Contains(tb, err.Error(), "on-chain managed")
+
+		// No portal DNS operation may fire from the enable refusal.
+		mockDNS.AssertNotCalled(tb, "CreateZone")
+		mockDNS.AssertNotCalled(tb, "GetZone")
+		mockDNS.AssertNotCalled(tb, "GetZoneByDomain")
+		mockDNS.AssertNotCalled(tb, "DeleteZone")
+		mockDNS.AssertNotCalled(tb, "CreateWebsiteDNSRecords")
+		mockDNS.AssertNotCalled(tb, "CreateWebsiteValidationRecord")
+
+		// Disabling stays a no-op (flag already false); the stray zone reference
+		// is left untouched — cleanup is out of scope for website flows.
+		updated, err := websiteService.SetDomainDNSEnabled(context.Background(), testUserID1, website.ID, wd.ID, false)
+		require.NoError(tb, err)
+		require.NotNil(tb, updated)
+		assert.Equal(tb, pluginDb.DomainStatusOnchainManaged, updated.Status)
+		assert.False(tb, updated.DNSHostingEnabled)
+		mockDNS.AssertNotCalled(tb, "DeleteZone")
+		mockDNS.AssertNotCalled(tb, "DeleteWebsiteDNSRecords")
 	}, TestOptions)
 }

--- a/internal/service/website/janitor.go
+++ b/internal/service/website/janitor.go
@@ -541,13 +541,18 @@ func (j *WebsiteJanitorJob) verifyPendingDelegations(ctx context.Context) error 
 			for i := range wds {
 				wd := &wds[i]
 				verifyCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-				_, err := j.delegatedDomainSvc.VerifyDomain(verifyCtx, wd)
+				res, err := j.delegatedDomainSvc.VerifyDomain(verifyCtx, wd)
 				cancel()
 				if err != nil {
 					j.logger.Warn("delegation verification failed",
 						zap.String("domain", wd.Domain),
 						zap.String("namespace", string(wd.Namespace)),
 						zap.Error(err))
+					continue
+				}
+				if res.State != domsvc.DelegationVerified {
+					// Still pending (or not applicable): leave it for a later
+					// run — the status was left as-is by VerifyDomain.
 					continue
 				}
 

--- a/internal/service/website/janitor_test.go
+++ b/internal/service/website/janitor_test.go
@@ -14,6 +14,7 @@ import (
 	pluginConfig "go.lumeweb.com/portal-plugin-ipfs/internal/config"
 	pluginDb "go.lumeweb.com/portal-plugin-ipfs/internal/db"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/db/migrations"
+	domsvc "go.lumeweb.com/portal-plugin-ipfs/internal/service/domain"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/testing/testopts"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/testing/util"
 	"go.lumeweb.com/portal/core"
@@ -287,8 +288,8 @@ type recordingDelegatedDomainSvc struct {
 }
 
 func (r *recordingDelegatedDomainSvc) UsesDelegationForOwnership(string) bool { return false }
-func (r *recordingDelegatedDomainSvc) VerifyDomain(context.Context, *pluginDb.WebsiteDomain) (bool, error) {
-	return true, nil
+func (r *recordingDelegatedDomainSvc) VerifyDomain(context.Context, *pluginDb.WebsiteDomain) (domsvc.DelegationVerificationResult, error) {
+	return domsvc.DelegationVerificationResult{State: domsvc.DelegationVerified}, nil
 }
 func (r *recordingDelegatedDomainSvc) GetNamespaceForDomain(string) (string, bool) { return "", false }
 func (r *recordingDelegatedDomainSvc) GetWebsiteDomainByName(context.Context, string) (*pluginDb.WebsiteDomain, error) {

--- a/internal/service/website/validate_dns_test.go
+++ b/internal/service/website/validate_dns_test.go
@@ -16,6 +16,7 @@ import (
 	pluginCore "go.lumeweb.com/portal-plugin-ipfs/core"
 	pluginConfig "go.lumeweb.com/portal-plugin-ipfs/internal/config"
 	pluginDb "go.lumeweb.com/portal-plugin-ipfs/internal/db"
+	domsvc "go.lumeweb.com/portal-plugin-ipfs/internal/service/domain"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/testing/mocks"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/testing/util"
 	"go.lumeweb.com/portal/core"
@@ -34,7 +35,7 @@ func setMockResolver(ws pluginCore.WebsiteService, r DNSResolver) {
 
 type testDelegatedDomainService struct {
 	uses      func(string) bool
-	verify    func(context.Context, *pluginDb.WebsiteDomain) (bool, error)
+	verify    func(context.Context, *pluginDb.WebsiteDomain) (domsvc.DelegationVerificationResult, error)
 	getNs     func(string) (string, bool)
 	getByName func(context.Context, string) (*pluginDb.WebsiteDomain, error)
 }
@@ -46,11 +47,11 @@ func (t *testDelegatedDomainService) UsesDelegationForOwnership(d string) bool {
 	return false
 }
 
-func (t *testDelegatedDomainService) VerifyDomain(ctx context.Context, wd *pluginDb.WebsiteDomain) (bool, error) {
+func (t *testDelegatedDomainService) VerifyDomain(ctx context.Context, wd *pluginDb.WebsiteDomain) (domsvc.DelegationVerificationResult, error) {
 	if t.verify != nil {
 		return t.verify(ctx, wd)
 	}
-	return true, nil
+	return domsvc.DelegationVerificationResult{State: domsvc.DelegationVerified}, nil
 }
 
 func (t *testDelegatedDomainService) GetNamespaceForDomain(d string) (string, bool) {
@@ -559,11 +560,11 @@ func TestValidateDNS_SelfHostedPrimary_DoesNotRequireDelegation(t *testing.T) {
 			uses: func(d string) bool { return false },
 			// Mirror the real VerifyDomain: a self-hosted (zone-less) binding
 			// returns (false, nil). checkDelegation must not fail on this.
-			verify: func(ctx context.Context, wd *pluginDb.WebsiteDomain) (bool, error) {
+			verify: func(ctx context.Context, wd *pluginDb.WebsiteDomain) (domsvc.DelegationVerificationResult, error) {
 				if wd.ZoneID == 0 {
-					return false, nil
+					return domsvc.DelegationVerificationResult{State: domsvc.DelegationNotApplicable}, nil
 				}
-				return true, nil
+				return domsvc.DelegationVerificationResult{State: domsvc.DelegationVerified}, nil
 			},
 		}
 		setMockDelegatedDomainSvc(ws, mockDelegated)
@@ -689,8 +690,8 @@ func TestValidateDNS_DelegatedAttached_Success(t *testing.T) {
 
 		mockDelegated := &testDelegatedDomainService{
 			uses: func(d string) bool { return true },
-			verify: func(ctx context.Context, wd *pluginDb.WebsiteDomain) (bool, error) {
-				return true, nil
+			verify: func(ctx context.Context, wd *pluginDb.WebsiteDomain) (domsvc.DelegationVerificationResult, error) {
+				return domsvc.DelegationVerificationResult{State: domsvc.DelegationVerified}, nil
 			},
 		}
 		setMockDelegatedDomainSvc(ws, mockDelegated)
@@ -743,11 +744,11 @@ func TestValidateDNS_SecondaryPending_DoesNotBlockPrimary(t *testing.T) {
 			// lookup is skipped and only the delegation gate is exercised.
 			uses: func(d string) bool { return true },
 			// The primary verifies; the secondary would fail if ever checked.
-			verify: func(ctx context.Context, wd *pluginDb.WebsiteDomain) (bool, error) {
+			verify: func(ctx context.Context, wd *pluginDb.WebsiteDomain) (domsvc.DelegationVerificationResult, error) {
 				if wd.Domain == "secondary.hns" {
-					return false, nil
+					return domsvc.DelegationVerificationResult{State: domsvc.DelegationPending}, nil
 				}
-				return true, nil
+				return domsvc.DelegationVerificationResult{State: domsvc.DelegationVerified}, nil
 			},
 		}
 		setMockDelegatedDomainSvc(ws, mockDelegated)
@@ -798,8 +799,8 @@ func TestValidateDNS_DelegatedAttached_FailsVerification(t *testing.T) {
 
 		mockDelegated := &testDelegatedDomainService{
 			uses: func(d string) bool { return true },
-			verify: func(ctx context.Context, wd *pluginDb.WebsiteDomain) (bool, error) {
-				return false, nil
+			verify: func(ctx context.Context, wd *pluginDb.WebsiteDomain) (domsvc.DelegationVerificationResult, error) {
+				return domsvc.DelegationVerificationResult{State: domsvc.DelegationPending}, nil
 			},
 		}
 		setMockDelegatedDomainSvc(ws, mockDelegated)
@@ -854,11 +855,11 @@ func TestValidateDNS_SelfHostedHNSPrimary_DoesNotDeadEnd(t *testing.T) {
 			// Mirror the real VerifyDomain on a zone-less binding: it returns
 			// (false, nil). checkDelegation must NOT route zone-less bindings
 			// through it (that is an unreachable dead-end), so it must pass.
-			verify: func(ctx context.Context, wd *pluginDb.WebsiteDomain) (bool, error) {
+			verify: func(ctx context.Context, wd *pluginDb.WebsiteDomain) (domsvc.DelegationVerificationResult, error) {
 				if wd.ZoneID == 0 {
-					return false, nil
+					return domsvc.DelegationVerificationResult{State: domsvc.DelegationNotApplicable}, nil
 				}
-				return true, nil
+				return domsvc.DelegationVerificationResult{State: domsvc.DelegationVerified}, nil
 			},
 		}
 		setMockDelegatedDomainSvc(ws, mockDelegated)
@@ -909,8 +910,8 @@ func TestValidateDNS_DelegatedAttached_VerifyError_Fails(t *testing.T) {
 
 		mockDelegated := &testDelegatedDomainService{
 			uses: func(d string) bool { return true },
-			verify: func(ctx context.Context, wd *pluginDb.WebsiteDomain) (bool, error) {
-				return false, fmt.Errorf("delegation verify internal error")
+			verify: func(ctx context.Context, wd *pluginDb.WebsiteDomain) (domsvc.DelegationVerificationResult, error) {
+				return domsvc.DelegationVerificationResult{}, fmt.Errorf("delegation verify internal error")
 			},
 		}
 		setMockDelegatedDomainSvc(ws, mockDelegated)
@@ -1101,6 +1102,62 @@ func TestValidateDNS_OnchainManaged_LiveResolverBridge(t *testing.T) {
 		require.NoError(tb, err)
 		assert.True(tb, result.Valid)
 		assert.Equal(tb, pluginCore.ValidationReasonValidated, result.Reason)
+
+		final, err := ws.GetWebsite(context.Background(), testUserID1, created.ID)
+		require.NoError(tb, err)
+		assert.Equal(tb, string(pluginDb.WebsiteStatusActive), final.Status)
+	}, TestOptions)
+}
+
+// TestValidateDNS_OnchainStrayZone_ValidTokenValidatesNoPortalDNS guards the
+// cross-service safety rule for an on-chain managed (HIP-5) binding that
+// incoherently carries a stray zone ID: website validation treats delegation as
+// NotApplicable (passing after the DNSLink/TXT ownership checks) and performs no
+// portal DNS operations at all — no delegation verification, no zone read/write,
+// no DNSSEC, no TLSA.
+func TestValidateDNS_OnchainStrayZone_ValidTokenValidatesNoPortalDNS(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		ws := core.GetService[pluginCore.WebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
+		require.NotNil(tb, ws)
+		mockDNS := core.GetService[*mocks.MockDNSService](ctx, pluginCore.DNS_SERVICE)
+		require.NotNil(tb, mockDNS)
+
+		testCID := util.GenerateTestCID(t, "onchain-stray")
+		domain := "onchain-stray.hns"
+		website := createTestIPFSWebsite(testUserID1, domain, testCID.String())
+		stubPinnedCID(t, ctx, testUserID1, testCID.String())
+		created, err := ws.CreateWebsite(context.Background(), website)
+		require.NoError(tb, err)
+		wd := onchainPrimaryDomain(tb, ctx, created, domain)
+		// Incoherent stray zone: the HIP-5 contract serves DNS, the portal owns
+		// no zone — this reference must never authorize portal DNS work.
+		require.NoError(tb, ctx.DB().Model(wd).Update("zone_id", uint(77)).Error)
+
+		mockResolver := mocks.NewMockDNSResolver(t)
+		mockResolver.EXPECT().ResolveDNSLink(domain).Return(dnslink.Result{
+			Links: map[string]dnslink.NamespaceEntries{
+				"ipfs": {{Identifier: created.TargetHash()}},
+			},
+		}, nil)
+		mockResolver.EXPECT().LookupTXT(mock.Anything, "lumeweb-verify."+domain).Return([]string{
+			fmt.Sprintf("lumeweb-verify=%s", created.ValidationToken),
+		}, nil)
+		setMockResolver(ws, mockResolver)
+
+		result, err := ws.ValidateDNS(context.Background(), testUserID1, created.ID)
+		require.NoError(tb, err)
+		assert.True(tb, result.Valid, "on-chain + stray zone must pass the delegation gate as not applicable")
+		assert.Equal(tb, pluginCore.ValidationReasonValidated, result.Reason)
+
+		// No portal DNS read/write/delete may occur from the website flow.
+		mockDNS.AssertNotCalled(tb, "GetActiveDNSSECDS")
+		mockDNS.AssertNotCalled(tb, "EnableDNSSEC")
+		mockDNS.AssertNotCalled(tb, "EnsureSOAMNAME")
+		mockDNS.AssertNotCalled(tb, "CreateWebsiteDNSRecords")
+		mockDNS.AssertNotCalled(tb, "CreateWebsiteValidationRecord")
+		mockDNS.AssertNotCalled(tb, "UpdateWebsiteDNSRecords")
+		mockDNS.AssertNotCalled(tb, "DeleteWebsiteDNSRecords")
+		mockDNS.AssertNotCalled(tb, "DeleteZone")
 
 		final, err := ws.GetWebsite(context.Background(), testUserID1, created.ID)
 		require.NoError(tb, err)

--- a/internal/service/website/website.go
+++ b/internal/service/website/website.go
@@ -88,7 +88,7 @@ var _ pluginCore.WebsiteService = (*WebsiteServiceDefault)(nil)
 // used by WebsiteServiceDefault for delegation-aware validation.
 type delegatedDomainService interface {
 	UsesDelegationForOwnership(domain string) bool
-	VerifyDomain(ctx context.Context, wd *pluginDb.WebsiteDomain) (bool, error)
+	VerifyDomain(ctx context.Context, wd *pluginDb.WebsiteDomain) (domsvc.DelegationVerificationResult, error)
 	GetNamespaceForDomain(domain string) (string, bool)
 	GetWebsiteDomainByName(ctx context.Context, domain string) (*pluginDb.WebsiteDomain, error)
 	GetPendingWebsiteDomainsPaginated(ctx context.Context, status pluginDb.DomainStatus, limit, offset int) ([]pluginDb.WebsiteDomain, error)
@@ -303,7 +303,13 @@ func (s *WebsiteServiceDefault) CreateWebsite(ctx context.Context, website *plug
 
 			// Create website DNS records if hosting is enabled on the primary
 			// domain. Reuse an existing canonical ZoneID; only resolve/create a
-			// zone when the binding does not have one yet.
+			// zone when the binding does not have one yet. This is the
+			// provisioning half of the explicit enable path for a managed-DNS
+			// binding (pre-bound with dns_hosting_enabled=true before the
+			// website row exists). An on-chain (HIP-5) binding never reaches
+			// here: dns_hosting_enabled is coerced/refused false for it, and
+			// createWebsiteDNSRecords additionally no-ops for any class without
+			// portal authority.
 			if primaryWD != nil && primaryWD.DNSHostingEnabled && s.dnsSvc != nil {
 				var dnsZone *pluginDb.DNSZone
 				zoneCreated := false
@@ -824,7 +830,12 @@ func (s *WebsiteServiceDefault) UpdateWebsite(ctx context.Context, userID uint, 
 				}
 
 				// Update DNS records if target changed and DNS hosting is enabled
-				// on the primary domain.
+				// on the primary domain. dns_hosting_enabled is always false for
+				// on-chain (HIP-5) bindings (coerced at bind, refused at
+				// enable), so an inconsistent on-chain binding carrying a stray
+				// zone can never reach this managed-record write; the
+				// createWebsiteDNSRecords writer also no-ops for any class
+				// without portal authority.
 				// Note: Skip DNS only when staying as IPNS (peer ID doesn't change)
 				if targetHashChanged && primaryWD != nil && primaryWD.DNSHostingEnabled && primaryWD.ZoneID != 0 && !primaryWD.DelegationRecordsOwned() && s.dnsSvc != nil {
 					newTargetType := pluginDb.WebsiteTargetType(website.TargetType)
@@ -932,6 +943,14 @@ func (s *WebsiteServiceDefault) UpdateWebsite(ctx context.Context, userID uint, 
 func (s *WebsiteServiceDefault) handleDNSEnabledTransition(ctx context.Context, wd *pluginDb.WebsiteDomain) error {
 	ctx, span := core.TraceMethod(ctx, "WebsiteServiceDefault.handleDNSEnabledTransition")
 	defer span.End()
+
+	// An on-chain managed (HIP-5) binding can never be put under portal DNS
+	// hosting — the external contract serves its DNS. Refuse the transition
+	// even if an inconsistent stray zone reference slipped onto the binding:
+	// it must never authorize portal zone/record provisioning.
+	if wd.Class() == pluginDb.ClassOnChainManaged {
+		return onchainDNSHostingUnavailableError(wd.Domain)
+	}
 
 	// Load the owning website for target and validation-token state.
 	var website pluginDb.Website
@@ -1136,6 +1155,19 @@ func (s *WebsiteServiceDefault) handleDNSDisabledTransition(ctx context.Context,
 		return s.resetWebsiteValidationState(ctx, website)
 	}
 
+	// A non-portal-managed binding (on-chain even with a stray zone,
+	// self-hosted, unresolved) owns no portal DNS to tear down. Never delete
+	// records or a (possibly shared) zone for such a binding — only the
+	// website's validation state is reset.
+	if !wd.CanPublishManagedZoneRecords() {
+		s.Logger().Info("Skipping DNS zone teardown: binding is not portal-managed",
+			zap.Uint("website_id", website.ID),
+			zap.String("domain", wd.Domain),
+			zap.Uint("zone_id", wd.ZoneID),
+			zap.String("status", string(wd.Status)))
+		return s.resetWebsiteValidationState(ctx, website)
+	}
+
 	recordsDeleted := false
 
 	// Delete DNS records for this website (not the zone — other websites may share it)
@@ -1255,6 +1287,7 @@ func (s *WebsiteServiceDefault) DeleteWebsite(ctx context.Context, userID uint, 
 			var dnsZoneID uint
 			var websiteDomain string
 			var dnsDelegationOwned bool
+			var dnsManagedZone bool
 
 			err := db.RetryableComponentTransaction(s, ctx, func(tx *gorm.DB) *gorm.DB {
 				// First, check if the website exists and is not blocked
@@ -1282,6 +1315,7 @@ func (s *WebsiteServiceDefault) DeleteWebsite(ctx context.Context, userID uint, 
 					dnsZoneID = primaryWD.ZoneID
 					websiteDomain = primaryWD.Domain
 					dnsDelegationOwned = primaryWD.DelegationRecordsOwned()
+					dnsManagedZone = primaryWD.CanPublishManagedZoneRecords()
 				}
 
 				// Perform the soft delete
@@ -1325,7 +1359,10 @@ func (s *WebsiteServiceDefault) DeleteWebsite(ctx context.Context, userID uint, 
 				ctx, websiteDomain, userID, websiteID,
 			))
 
-			if dnsZoneID != 0 && s.dnsSvc != nil {
+			// Only portal-managed bindings authorize portal DNS teardown: an
+			// on-chain binding carrying a stray (possibly shared) zone must
+			// never have its records deleted by website deletion.
+			if dnsZoneID != 0 && dnsManagedZone && s.dnsSvc != nil {
 				var cleanupErr error
 				if dnsDelegationOwned {
 					// DNSLink/apex records are shared with delegation. Remove only
@@ -1668,45 +1705,63 @@ func (s *WebsiteServiceDefault) checkValidationToken(ctx context.Context, websit
 // DNS and validate independently, so a pending secondary must not block a
 // site whose primary hosting DNS is correct.
 //
-// A self-hosted primary (ZoneID == 0) owns no portal-managed zone, so the
-// delegation gate passes once its hosting DNS validated earlier in ValidateDNS.
-// The presence of a real PowerDNS zone (ZoneID != 0) is the authoritative
-// marker of a portal-hosted, delegatable binding. VerifyDomain structurally
-// cannot succeed for a zone-less binding (it no-ops with false), so routing one
-// through the delegation gate is an unreachable dead-end.
+// The delegation gate applies only to portal-managed bindings (the derived
+// hosting locus): a self-hosted, on-chain managed, or unresolved primary owns
+// no portal delegation to verify, so the gate passes (NotApplicable) once its
+// hosting DNS validated earlier in ValidateDNS. Routing a zone-less binding
+// through VerifyDomain would be an unreachable dead-end, and routing an
+// on-chain binding through it would risk portal DNS side effects from a stray
+// zone reference — both are short-circuited here by the classifier.
 //
 // Ownership for a self-hosted binding is proven by its hosting DNS, which
 // ValidateDNS already validated just before this gate: ICANN runs the TXT token
 // check, and for a delegated namespace (HNS) the DNSLink record resolves from
 // the owner-controlled HNS zone (only the domain owner can publish it there),
 // so a DNSLink that matches the website's exact target is itself an ownership
-// proof for that namespace.
+// proof for that namespace. NotApplicable is therefore NOT ownership proof on
+// its own; the DNSLink and TXT checks always run earlier in the flow.
 func (s *WebsiteServiceDefault) checkDelegation(ctx context.Context, primaryWD *pluginDb.WebsiteDomain) (bool, string, pluginCore.ValidationReason, error) {
 	if s.delegatedDomainSvc == nil {
 		return true, "", "", nil
 	}
 
-	if primaryWD.ZoneID == 0 {
+	// Only portal-managed bindings have a portal delegation to verify. This
+	// short-circuit (rather than delegating to VerifyDomain) also guarantees no
+	// PowerDNS work for on-chain/self-hosted/unresolved bindings, even when an
+	// on-chain binding incoherently carries a stray zone ID.
+	if !primaryWD.NeedsDelegationVerification() {
 		return true, "", "", nil
 	}
 
 	verifyCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
-	verified, verr := s.delegatedDomainSvc.VerifyDomain(verifyCtx, primaryWD)
-	if verr != nil || !verified {
+	res, verr := s.delegatedDomainSvc.VerifyDomain(verifyCtx, primaryWD)
+	if verr != nil {
 		s.Logger().Info("delegation not verified for primary domain",
 			zap.String("domain", primaryWD.Domain), zap.Error(verr))
 		return false, msgDelegationPending, pluginCore.ValidationReasonDelegationPending, nil
 	}
-	return true, "", "", nil
+	switch res.State {
+	case domsvc.DelegationVerified:
+		return true, "", "", nil
+	case domsvc.DelegationNotApplicable:
+		// Hosting class has no portal delegation; the gate passes (ownership
+		// was already proven by DNSLink/TXT earlier in the flow).
+		return true, "", "", nil
+	default:
+		return false, msgDelegationPending, pluginCore.ValidationReasonDelegationPending, nil
+	}
 }
 
 // createWebsiteDNSRecords writes only the DNS records that website hosting owns.
 // Delegation-owned bindings share DNSLink and apex records with the delegation
 // service, so website lifecycle operations may update only validation TXT.
+// The writer is a no-op for any non-portal-managed binding (on-chain even with
+// a stray zone, self-hosted, unresolved): those classes never authorize portal
+// DNS writes.
 func (s *WebsiteServiceDefault) createWebsiteDNSRecords(ctx context.Context, wd *pluginDb.WebsiteDomain, website *pluginDb.Website, validationToken string) error {
-	if s.dnsSvc == nil || wd.ZoneID == 0 {
+	if s.dnsSvc == nil || wd.ZoneID == 0 || !wd.CanPublishManagedZoneRecords() {
 		return nil
 	}
 

--- a/internal/testing/mocks/MockDomainProvider.go
+++ b/internal/testing/mocks/MockDomainProvider.go
@@ -85,23 +85,23 @@ func (_c *MockDomainProvider_ApexRecordType_Call) RunAndReturn(run func() core.R
 }
 
 // BuildDelegation provides a mock function for the type MockDomainProvider
-func (_mock *MockDomainProvider) BuildDelegation(ctx context.Context, zoneID uint, domain string, website *db.Website, config json.RawMessage) (any, error) {
+func (_mock *MockDomainProvider) BuildDelegation(ctx context.Context, zoneID uint, domain string, website *db.Website, config json.RawMessage) (json.RawMessage, error) {
 	ret := _mock.Called(ctx, zoneID, domain, website, config)
 
 	if len(ret) == 0 {
 		panic("no return value specified for BuildDelegation")
 	}
 
-	var r0 any
+	var r0 json.RawMessage
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, uint, string, *db.Website, json.RawMessage) (any, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uint, string, *db.Website, json.RawMessage) (json.RawMessage, error)); ok {
 		return returnFunc(ctx, zoneID, domain, website, config)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, uint, string, *db.Website, json.RawMessage) any); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uint, string, *db.Website, json.RawMessage) json.RawMessage); ok {
 		r0 = returnFunc(ctx, zoneID, domain, website, config)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(any)
+			r0 = ret.Get(0).(json.RawMessage)
 		}
 	}
 	if returnFunc, ok := ret.Get(1).(func(context.Context, uint, string, *db.Website, json.RawMessage) error); ok {
@@ -160,12 +160,12 @@ func (_c *MockDomainProvider_BuildDelegation_Call) Run(run func(ctx context.Cont
 	return _c
 }
 
-func (_c *MockDomainProvider_BuildDelegation_Call) Return(v any, err error) *MockDomainProvider_BuildDelegation_Call {
-	_c.Call.Return(v, err)
+func (_c *MockDomainProvider_BuildDelegation_Call) Return(delegation json.RawMessage, err error) *MockDomainProvider_BuildDelegation_Call {
+	_c.Call.Return(delegation, err)
 	return _c
 }
 
-func (_c *MockDomainProvider_BuildDelegation_Call) RunAndReturn(run func(ctx context.Context, zoneID uint, domain string, website *db.Website, config json.RawMessage) (any, error)) *MockDomainProvider_BuildDelegation_Call {
+func (_c *MockDomainProvider_BuildDelegation_Call) RunAndReturn(run func(ctx context.Context, zoneID uint, domain string, website *db.Website, config json.RawMessage) (json.RawMessage, error)) *MockDomainProvider_BuildDelegation_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -350,65 +350,46 @@ func (_c *MockDomainProvider_Nameservers_Call) RunAndReturn(run func() []string)
 	return _c
 }
 
-// OnCertAvailable provides a mock function for the type MockDomainProvider
-func (_mock *MockDomainProvider) OnCertAvailable(ctx context.Context, domain string, certPEM string) error {
-	ret := _mock.Called(ctx, domain, certPEM)
+// Policy provides a mock function for the type MockDomainProvider
+func (_mock *MockDomainProvider) Policy() core.ProviderPolicy {
+	ret := _mock.Called()
 
 	if len(ret) == 0 {
-		panic("no return value specified for OnCertAvailable")
+		panic("no return value specified for Policy")
 	}
 
-	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) error); ok {
-		r0 = returnFunc(ctx, domain, certPEM)
+	var r0 core.ProviderPolicy
+	if returnFunc, ok := ret.Get(0).(func() core.ProviderPolicy); ok {
+		r0 = returnFunc()
 	} else {
-		r0 = ret.Error(0)
+		r0 = ret.Get(0).(core.ProviderPolicy)
 	}
 	return r0
 }
 
-// MockDomainProvider_OnCertAvailable_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'OnCertAvailable'
-type MockDomainProvider_OnCertAvailable_Call struct {
+// MockDomainProvider_Policy_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Policy'
+type MockDomainProvider_Policy_Call struct {
 	*mock.Call
 }
 
-// OnCertAvailable is a helper method to define mock.On call
-//   - ctx context.Context
-//   - domain string
-//   - certPEM string
-func (_e *MockDomainProvider_Expecter) OnCertAvailable(ctx any, domain any, certPEM any) *MockDomainProvider_OnCertAvailable_Call {
-	return &MockDomainProvider_OnCertAvailable_Call{Call: _e.mock.On("OnCertAvailable", ctx, domain, certPEM)}
+// Policy is a helper method to define mock.On call
+func (_e *MockDomainProvider_Expecter) Policy() *MockDomainProvider_Policy_Call {
+	return &MockDomainProvider_Policy_Call{Call: _e.mock.On("Policy")}
 }
 
-func (_c *MockDomainProvider_OnCertAvailable_Call) Run(run func(ctx context.Context, domain string, certPEM string)) *MockDomainProvider_OnCertAvailable_Call {
+func (_c *MockDomainProvider_Policy_Call) Run(run func()) *MockDomainProvider_Policy_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		var arg1 string
-		if args[1] != nil {
-			arg1 = args[1].(string)
-		}
-		var arg2 string
-		if args[2] != nil {
-			arg2 = args[2].(string)
-		}
-		run(
-			arg0,
-			arg1,
-			arg2,
-		)
+		run()
 	})
 	return _c
 }
 
-func (_c *MockDomainProvider_OnCertAvailable_Call) Return(err error) *MockDomainProvider_OnCertAvailable_Call {
-	_c.Call.Return(err)
+func (_c *MockDomainProvider_Policy_Call) Return(policy core.ProviderPolicy) *MockDomainProvider_Policy_Call {
+	_c.Call.Return(policy)
 	return _c
 }
 
-func (_c *MockDomainProvider_OnCertAvailable_Call) RunAndReturn(run func(ctx context.Context, domain string, certPEM string) error) *MockDomainProvider_OnCertAvailable_Call {
+func (_c *MockDomainProvider_Policy_Call) RunAndReturn(run func() core.ProviderPolicy) *MockDomainProvider_Policy_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/testing/util/synthetic_domain_provider.go
+++ b/internal/testing/util/synthetic_domain_provider.go
@@ -1,0 +1,67 @@
+package util
+
+import (
+	"context"
+	"encoding/json"
+
+	pluginCore "go.lumeweb.com/portal-plugin-ipfs/core"
+	pluginDb "go.lumeweb.com/portal-plugin-ipfs/internal/db"
+)
+
+// SyntheticDomainProvider is a configurable DomainProvider test double for
+// exercising the provider capability matrix (arbitrary DNSSEC/TLSA/apex policy
+// combinations) without depending on the concrete ICANN/HNS providers. It
+// satisfies the domain package's DomainProvider interface; Policy() returns the
+// configured policy, and the compatibility adapters derive from it.
+type SyntheticDomainProvider struct {
+	ProtocolName string
+	PolicyValue  pluginCore.ProviderPolicy
+	// VerifyDelegationFunc controls VerifyDelegation; when nil it reports
+	// verified=true. Record calls here to assert verification was (not) invoked.
+	VerifyDelegationFunc func(ctx context.Context, domain, expectedDS string) (bool, error)
+}
+
+func (p *SyntheticDomainProvider) Protocol() string {
+	if p.ProtocolName == "" {
+		return "synthetic"
+	}
+	return p.ProtocolName
+}
+
+func (p *SyntheticDomainProvider) Validate(string) error { return nil }
+
+func (p *SyntheticDomainProvider) Inspect(context.Context, string) (bool, error) { return false, nil }
+
+func (p *SyntheticDomainProvider) BuildDelegation(ctx context.Context, zoneID uint, domain string, website *pluginDb.Website, config json.RawMessage) (json.RawMessage, error) {
+	return json.Marshal(map[string]any{"protocol": p.Protocol()})
+}
+
+func (p *SyntheticDomainProvider) VerifyDelegation(ctx context.Context, domain, expectedDS string) (bool, error) {
+	if p.VerifyDelegationFunc != nil {
+		return p.VerifyDelegationFunc(ctx, domain, expectedDS)
+	}
+	return true, nil
+}
+
+func (p *SyntheticDomainProvider) Policy() pluginCore.ProviderPolicy { return p.PolicyValue }
+
+func (p *SyntheticDomainProvider) Nameservers() []string { return nil }
+
+func (p *SyntheticDomainProvider) LiveNameservers(context.Context, string) ([]string, error) {
+	return nil, nil
+}
+
+// UsesManagedZoneTLSA derives from the configured policy.
+func (p *SyntheticDomainProvider) UsesManagedZoneTLSA() bool {
+	return p.PolicyValue.TLSA == pluginCore.TLSAManaged
+}
+
+// RequiresDNSSEC derives from the configured policy.
+func (p *SyntheticDomainProvider) RequiresDNSSEC() bool {
+	return p.PolicyValue.DNSSEC == pluginCore.DNSSECRequired
+}
+
+// ApexRecordType derives from the configured policy.
+func (p *SyntheticDomainProvider) ApexRecordType() pluginCore.RecordType {
+	return p.PolicyValue.ApexRecordType
+}


### PR DESCRIPTION
Makes DomainClass the exhaustive, authoritative derived hosting locus, adding a fourth unresolved class, and routes every portal DNS operation through it so an on-chain binding carrying a stray zone can never authorize portal side effects.

Requires verifying delegation via a typed NotApplicable/Pending/Verified result instead of an ambiguous boolean, and fails DNSSEC self-heal closed when a required zone has no live DS after healing.

Introduces an immutable ProviderPolicy (DNSSEC/TLSA/apex) with registration-time validation, exposes the live DS via the DNSSEC policy rather than the TLSA capability, adds a shared platform trust validator, and narrows the provider contract to a json.RawMessage boundary with optional certificate handling.

- `develop` <!-- branch-stack -->
  - **refactor(domain): harden domain hosting and provider consistency** :point\_left:

***

<!-- kody-pr-summary:start -->

## Summary

This pull request hardens domain hosting and provider consistency across the IPFS portal plugin. It introduces a single source of truth for provider capabilities via a new `ProviderPolicy` type, clarifies the domain hosting classification model, and enforces strict boundaries around portal-managed DNS operations.

## Key Changes

### 1. Provider Policy as Single Source of Truth

- Introduced `core/provider_policy.go` defining `DNSSECPolicy`, `TLSAPolicy`, and a unified `ProviderPolicy` struct that captures a namespace provider's hosting capabilities (DNSSEC requirement, DANE/TLSA management, and apex record type) in one place.
- Both the HNS and ICANN providers now expose a `Policy()` method returning their capability set, with the legacy boolean methods (`RequiresDNSSEC()`, `UsesManagedZoneTLSA()`, `ApexRecordType()`) deriving their values from it.
- Provider registration now validates the policy, rejecting invalid enum values or record types at registration time to prevent broken configurations from reaching hosting decisions.

### 2. Domain Hosting Classification Refined

- Expanded the `DomainClass` model from three states to four by adding `ClassUnresolved` for draft/error/empty bindings with no zone — these are no longer treated as self-hosted.
- Clarified precedence: on-chain managed status always wins over any zone reference; a non-zero zone ID marks a binding portal-managed; explicit self-hosted status with no zone is self-hosted; everything else is unresolved.
- Added semantic helpers (`HasPortalAuthority()`, `NeedsDelegationVerification()`, `CanPublishManagedZoneRecords()`) so callers express hosting intent without re-deriving it from raw fields.
- Hardened all DNS write paths: on-chain bindings carrying a stray zone ID can never authorize portal zone/record creation, deletion, or modification.

### 3. Deletion Verification Returns Typed Result

- `VerifyDomain` now returns a `DelegationVerificationResult` with a `State` field distinguishing `DelegationNotApplicable` (self-hosted/on-chain/unresolved), `DelegationPending`, and `DelegationVerified`.
- The janitor and website validation flows switch on the state instead of interpreting a bare boolean, preventing deadlocks on valid non-portal bindings and avoiding unnecessary PowerDNS work.
- DNSSEC self-heal now fails closed: if `EnableDNSSEC` succeeds but no live DS can be read afterward, verification errors rather than silently degrading to NS-only verification.

### 4. DNSSEC Gating Decoupled from DANE

- Live DS exposure in `dns-requirements` is now gated on the provider's DNSSEC policy, not the TLSA/DANE capability. A provider requiring DNSSEC but not publishing DANE still receives the live DS.
- DANE republishing is restricted to portal-managed bindings only.

### 5. Provider Interface Cleanup and Typed Delegations

- `BuildDelegation` now returns `json.RawMessage` instead of untyped `any`, with serialization occurring inside each provider.
- DANE/certificate handling moved to an optional `CertificateProvider` sub-interface; providers without DANE (e.g., ICANN) no longer implement a mandatory no-op.
- `RegisterProvider` exposed on the service for operator wiring of additional namespaces.

### 6. Platform Bindings Trust Validation

- Introduced `ValidatePlatformBinding`, a shared validator ensuring the root resolves live, namespaces match, the domain is the apex or label-boundary descendant, and the binding's zone matches the root's zone.
- Applied in `VerifyDomain` and after platform binding creation; mismatches abort auto-activation without mutating status.

<!-- kody-pr-summary:end -->
