### PR TITLE
feat(gateway): add durable website change log and change reconciliation API

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -1200,9 +1200,27 @@ See also:.*`),
 				router.WithSummary("Stream website events via SSE"),
 				router.WithDescription(`Server-Sent Events endpoint for gateway-to-portal communication.
 Streams website lifecycle events (published, removed) in real time.
+Supports Last-Event-ID replay of durable events after a reconnect.
 Requires X-Gateway-Secret header for authentication.`),
 				router.WithTags("Gateway"),
 				router.WithSuccessResponse(http.StatusOK, "SSE event stream"),
+			),
+		),
+		router.NewRoute(http.MethodGet, "/internal/websites/changes", a.getWebsiteChanges,
+			router.WithSwagger(
+				router.WithSummary("Reconcile website changes"),
+				router.WithDescription(`Returns durable website lifecycle changes (published, removed) after the
+supplied cursor, in ascending durable-ID order, together with the current
+replay high-water mark. The gateway calls this after an SSE reconnect to
+discover domains it missed during the gap without relying on visitor traffic.
+Requires X-Gateway-Secret header for authentication.`),
+				router.WithTags("Gateway"),
+				router.WithQueryParam("after", "Durable event cursor to resume after. Returns all events with id > after. Omit to start from the beginning of the retained window.", "0"),
+				router.WithSuccessResponse(http.StatusOK, "Reconciled changes", router.WithJSONContent(dto.WebsiteChangesResponse{})),
+				router.WithErrorResponses(router.DefineSwaggerErrorResponses(
+					DefineErrorResponse(http.StatusBadRequest, "Invalid after cursor"),
+					DefineErrorResponse(http.StatusInternalServerError, "Internal server error occurred"),
+				)),
 			),
 		),
 	)

--- a/internal/api/api_changes.go
+++ b/internal/api/api_changes.go
@@ -46,10 +46,19 @@ func (a *API) getWebsiteChanges(c echo.Context) error {
 		return ctx.Error(err, http.StatusInternalServerError)
 	}
 
+	// Truncated is derived from the last returned event's actual ID rather than
+	// assuming gapless contiguous ids, because purged rows can leave gaps in the
+	// id space. When there are no events, the batch is complete only if the
+	// cursor has already reached the high-water mark.
+	truncated := after < hwm
+	if len(events) > 0 {
+		truncated = events[len(events)-1].ID < hwm
+	}
+
 	resp := &dto.WebsiteChangesResponse{
 		Events:        make([]dto.WebsiteChangeEvent, 0, len(events)),
 		HighWaterMark: hwm,
-		Truncated:     len(events) >= limit && after+uint64(len(events)) < hwm,
+		Truncated:     truncated,
 	}
 	for _, ev := range events {
 		resp.Events = append(resp.Events, dto.WebsiteChangeEvent{

--- a/internal/api/api_changes.go
+++ b/internal/api/api_changes.go
@@ -1,0 +1,76 @@
+package api
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+
+	"github.com/labstack/echo/v4"
+	"go.lumeweb.com/httputil"
+	"go.lumeweb.com/portal-plugin-ipfs/internal"
+	"go.lumeweb.com/portal-plugin-ipfs/internal/api/dto"
+	pluginConfig "go.lumeweb.com/portal-plugin-ipfs/internal/config"
+	"go.uber.org/zap"
+)
+
+// getWebsiteChanges implements the gateway change-reconciliation endpoint.
+//
+// The gateway calls this after an SSE reconnect with its last fully processed
+// event ID (the `after` cursor) to discover any published/removed domains it
+// missed during the gap — including brand-new domains that never reached it —
+// without needing visitor traffic. Events are returned in ascending durable-ID
+// order together with the current high-water mark so the gateway knows when
+// catch-up is complete.
+func (a *API) getWebsiteChanges(c echo.Context) error {
+	ctx := httputil.Context(c)
+	reqCtx := ctx.Context.Request().Context()
+
+	var after uint64
+	if raw := c.QueryParam("after"); raw != "" {
+		v, err := strconv.ParseUint(raw, 10, 64)
+		if err != nil {
+			return ctx.Error(errors.New("after must be a non-negative integer cursor"), http.StatusBadRequest)
+		}
+		after = v
+	}
+
+	if a.sse == nil || a.sse.log == nil {
+		return ctx.Error(errors.New("website event log unavailable"), http.StatusInternalServerError)
+	}
+
+	limit := a.changesMaxEvents()
+	events, hwm, err := a.sse.log.ListSince(reqCtx, after, limit)
+	if err != nil {
+		a.Logger().Error("failed to list website changes from event log",
+			zap.Uint64("after", after), zap.Error(err))
+		return ctx.Error(err, http.StatusInternalServerError)
+	}
+
+	resp := &dto.WebsiteChangesResponse{
+		Events:        make([]dto.WebsiteChangeEvent, 0, len(events)),
+		HighWaterMark: hwm,
+		Truncated:     len(events) >= limit && after+uint64(len(events)) < hwm,
+	}
+	for _, ev := range events {
+		resp.Events = append(resp.Events, dto.WebsiteChangeEvent{
+			ID:        ev.ID,
+			EventType: ev.EventType,
+			Domain:    ev.Domain,
+			CID:       ev.CID,
+			WebsiteID: ev.WebsiteID,
+			UserID:    ev.UserID,
+			CreatedAt: ev.CreatedAt,
+		})
+	}
+
+	return c.JSON(http.StatusOK, resp)
+}
+
+// changesMaxEvents returns the configured per-request cap for the change
+// reconciliation endpoint, falling back to the default (1000) on any error.
+func (a *API) changesMaxEvents() int {
+	if apiConfig, ok := a.Config().GetAPI(internal.ProtocolName).(*pluginConfig.APIConfig); ok && apiConfig.ChangesMaxEvents > 0 {
+		return apiConfig.ChangesMaxEvents
+	}
+	return 1000
+}

--- a/internal/api/api_changes_test.go
+++ b/internal/api/api_changes_test.go
@@ -1,0 +1,72 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.lumeweb.com/portal-plugin-ipfs/internal/api/dto"
+	pluginDb "go.lumeweb.com/portal-plugin-ipfs/internal/db"
+	coreTesting "go.lumeweb.com/portal/core/testing"
+)
+
+func TestAPI_GetWebsiteChanges(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		helper := newMockHelper(t, ctx)
+
+		// Seed the durable event log directly.
+		ev1 := pluginDb.WebsiteEvent{EventType: string(pluginDb.WebsiteEventPublished), Domain: "alpha.example", CID: "bafy1"}
+		ev2 := pluginDb.WebsiteEvent{EventType: string(pluginDb.WebsiteEventRemoved), Domain: "beta.example"}
+		ev3 := pluginDb.WebsiteEvent{EventType: string(pluginDb.WebsiteEventPublished), Domain: "gamma.example", CID: "bafy2"}
+		require.NoError(t, ctx.DB().Create(&ev1).Error)
+		require.NoError(t, ctx.DB().Create(&ev2).Error)
+		require.NoError(t, ctx.DB().Create(&ev3).Error)
+
+		t.Run("returns_all_changes_and_high_water_mark", func(t *testing.T) {
+			rec := helper.makeGatewayAuthenticatedRequest(http.MethodGet, "/internal/websites/changes", testGatewaySecret(), nil)
+			assert.Equal(t, http.StatusOK, rec.Code)
+
+			var resp dto.WebsiteChangesResponse
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+			assert.Equal(t, ev3.ID, resp.HighWaterMark)
+			require.Len(t, resp.Events, 3)
+			assert.Equal(t, ev1.ID, resp.Events[0].ID)
+			assert.Equal(t, string(pluginDb.WebsiteEventPublished), resp.Events[0].EventType)
+			assert.Equal(t, "alpha.example", resp.Events[0].Domain)
+			assert.Equal(t, "bafy1", resp.Events[0].CID)
+			assert.Equal(t, ev2.ID, resp.Events[1].ID)
+			assert.Equal(t, ev3.ID, resp.Events[2].ID)
+			assert.False(t, resp.Truncated)
+		})
+
+		t.Run("resumes_after_cursor", func(t *testing.T) {
+			rec := helper.makeGatewayAuthenticatedRequest(http.MethodGet, "/internal/websites/changes?after="+strconv.FormatUint(ev1.ID, 10), testGatewaySecret(), nil)
+			assert.Equal(t, http.StatusOK, rec.Code)
+
+			var resp dto.WebsiteChangesResponse
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+			require.Len(t, resp.Events, 2)
+			assert.Equal(t, ev2.ID, resp.Events[0].ID)
+			assert.Equal(t, ev3.ID, resp.Events[1].ID)
+			assert.Equal(t, ev3.ID, resp.HighWaterMark)
+		})
+
+		t.Run("cursor_at_high_water_mark_returns_empty", func(t *testing.T) {
+			rec := helper.makeGatewayAuthenticatedRequest(http.MethodGet, "/internal/websites/changes?after="+strconv.FormatUint(ev3.ID, 10), testGatewaySecret(), nil)
+			assert.Equal(t, http.StatusOK, rec.Code)
+
+			var resp dto.WebsiteChangesResponse
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+			assert.Empty(t, resp.Events)
+			assert.Equal(t, ev3.ID, resp.HighWaterMark)
+		})
+
+		t.Run("invalid_cursor_rejected", func(t *testing.T) {
+			rec := helper.makeGatewayAuthenticatedRequest(http.MethodGet, "/internal/websites/changes?after=not-a-number", testGatewaySecret(), nil)
+			assert.Equal(t, http.StatusBadRequest, rec.Code)
+		})
+	}, TestOptions)
+}

--- a/internal/api/api_sse.go
+++ b/internal/api/api_sse.go
@@ -3,23 +3,41 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"net/http"
+	"strconv"
 	"time"
 
-	"github.com/google/uuid"
-	"github.com/labstack/echo/v4"
 	sseServer "github.com/apt304/sse-go/server"
-	"go.lumeweb.com/portal/core"
+	"github.com/labstack/echo/v4"
+	"go.lumeweb.com/portal-plugin-ipfs/internal"
+	"go.lumeweb.com/portal-plugin-ipfs/internal/api/dto"
+	pluginConfig "go.lumeweb.com/portal-plugin-ipfs/internal/config"
+	pluginDb "go.lumeweb.com/portal-plugin-ipfs/internal/db"
 	pluginEvent "go.lumeweb.com/portal-plugin-ipfs/internal/event"
+	"go.lumeweb.com/portal/core"
 	"go.uber.org/zap"
 )
 
-// sseState holds the SSE server for website event streaming.
+// SSE event types emitted on the "gateway" topic. The live feed and the
+// Last-Event-ID replay path emit the same types and payload shapes so the
+// gateway can treat them identically.
+const (
+	sseEventSitePublished = "site_published"
+	sseEventSiteRemoved   = "site_removed"
+	sseEventHighWaterMark = "high_water_mark"
+	sseTopicGateway       = "gateway"
+)
+
+// sseState holds the SSE server and the durable event log that backs replay
+// and reconciliation for website event streaming.
 type sseState struct {
 	server *sseServer.Server
+	log    *pluginEvent.Store
 }
 
-// initSSEServer initializes the SSE server and registers event listeners
-// for website lifecycle events.
+// initSSEServer initializes the SSE server, the durable website event log, and
+// the retention purger, then registers event listeners for website lifecycle
+// events.
 func (a *API) initSSEServer(ctx core.Context) error {
 	subscriber := sseServer.NewDropOldestSubscriber(sseServer.Options{
 		Buffer:            100,              // Store up to 100 events per subscriber
@@ -28,38 +46,111 @@ func (a *API) initSSEServer(ctx core.Context) error {
 
 	a.sse = &sseState{
 		server: sseServer.NewServer(sseServer.Config{}, subscriber),
+		log:    pluginEvent.NewStore(a.DB()),
 	}
 
 	// Register event listeners for website events
 	a.registerWebsiteEventListeners(ctx)
 
-	ctx.Logger().Info("SSE server initialized for website event streaming")
+	// Start the retention purger so the durable log never grows without bound.
+	a.startEventLogPurger(ctx)
 
+	ctx.Logger().Info("SSE server initialized for website event streaming")
 	return nil
 }
 
+// startEventLogPurger periodically removes events older than the configured
+// retention window, which is the documented period the gateway has to consume
+// the log before it can no longer replay a missed event.
+func (a *API) startEventLogPurger(ctx core.Context) {
+	retention := a.eventLogRetention()
+	if retention <= 0 {
+		retention = 24 * time.Hour
+	}
+
+	done := ctx.GetContext().Done()
+	go func() {
+		ticker := time.NewTicker(retention / 2)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-done:
+				return
+			case <-ticker.C:
+				before := time.Now().Add(-retention)
+				removed, err := a.sse.log.PurgeBefore(context.Background(), before)
+				if err != nil {
+					a.Logger().Error("failed to purge expired website events",
+						zap.Error(err))
+					continue
+				}
+				if removed > 0 {
+					a.Logger().Debug("purged expired website events from durable log",
+						zap.Int64("removed", removed))
+				}
+			}
+		}
+	}()
+}
+
+// eventLogRetention returns the configured durable event log retention window,
+// falling back to the default (24h) on any error.
+func (a *API) eventLogRetention() time.Duration {
+	if apiConfig, ok := a.Config().GetAPI(internal.ProtocolName).(*pluginConfig.APIConfig); ok && apiConfig.EventLogRetention > 0 {
+		return apiConfig.EventLogRetention
+	}
+	return 24 * time.Hour
+}
+
 // registerWebsiteEventListeners registers the SSE server as a listener to
-// website lifecycle events. When website events occur, they are published
-// to the "gateway" SSE topic.
+// website lifecycle events. Each event is appended to the durable log (whose
+// auto-increment ID becomes the SSE event id) and then published on the
+// "gateway" topic.
 func (a *API) registerWebsiteEventListeners(coreCtx core.Context) {
-	// Listen for website published events (create + update with target hash change)
 	pluginEvent.OnWebsitePublished(coreCtx, func(ctx context.Context, ev pluginEvent.WebsitePublishedEvent) error {
-		return a.publishWebsiteEvent("site_published", ev)
+		rec := pluginDb.WebsiteEvent{
+			EventType: string(pluginDb.WebsiteEventPublished),
+			Domain:    ev.Domain,
+			CID:       ev.CID,
+			WebsiteID: ev.WebsiteID,
+			UserID:    ev.UserID,
+			CreatedAt: ev.PublishedAt,
+		}
+		return a.publishWebsiteEvent(ctx, sseEventSitePublished, ev, rec)
 	})
 
-	// Listen for website removed events (delete)
 	pluginEvent.OnWebsiteRemoved(coreCtx, func(ctx context.Context, ev pluginEvent.WebsiteRemovedEvent) error {
-		return a.publishWebsiteEvent("site_removed", ev)
+		rec := pluginDb.WebsiteEvent{
+			EventType: string(pluginDb.WebsiteEventRemoved),
+			Domain:    ev.Domain,
+			WebsiteID: ev.WebsiteID,
+			UserID:    ev.UserID,
+			CreatedAt: ev.RemovedAt,
+		}
+		return a.publishWebsiteEvent(ctx, sseEventSiteRemoved, ev, rec)
 	})
 
 	coreCtx.Logger().Info("SSE server registered as listener to website events")
 }
 
-// publishWebsiteEvent publishes a website event to the "gateway" SSE topic.
-func (a *API) publishWebsiteEvent(eventType string, eventData any) error {
-	// Create SSE event wrapper for client consumption
-	sseEvent := pluginEvent.NewSSEEvent(eventType, eventData)
+// publishWebsiteEvent durably records a website event and publishes it to the
+// "gateway" SSE topic using the durable event ID as the SSE id.
+func (a *API) publishWebsiteEvent(ctx context.Context, eventType string, eventData any, rec pluginDb.WebsiteEvent) error {
+	if a.sse == nil || a.sse.log == nil {
+		return nil
+	}
 
+	// Persist first so the event survives a gateway gap and the returned
+	// durable ID is available as the SSE id (making Last-Event-ID meaningful).
+	eventID, err := a.sse.log.Append(ctx, rec)
+	if err != nil {
+		a.Logger().Error("failed to append website event to durable log",
+			zap.String("event_type", eventType),
+			zap.Error(err))
+		return err
+	}
+
+	sseEvent := pluginEvent.NewSSEEvent(eventType, eventData)
 	eventJSON, err := json.Marshal(sseEvent)
 	if err != nil {
 		a.Logger().Error("failed to marshal website event for SSE",
@@ -68,33 +159,41 @@ func (a *API) publishWebsiteEvent(eventType string, eventData any) error {
 		return err
 	}
 
-	// Create SSE event
-	topic := "gateway"
 	event := sseServer.Event{
-		ID:    uuid.New().String(),
+		ID:    strconv.FormatUint(eventID, 10),
 		Type:  eventType,
 		Data:  eventJSON,
 		Retry: 3000, // Recommended retry interval in milliseconds
 	}
 
-	if err := a.sse.server.Publish(event, topic); err != nil {
+	if err := a.sse.server.Publish(event, sseTopicGateway); err != nil {
 		a.Logger().Error("failed to publish website event to SSE",
-			zap.String("topic", topic),
-			zap.String("event_type", eventType),
+			zap.String("topic", sseTopicGateway),
 			zap.Error(err))
 		return err
 	}
 
 	a.Logger().Debug("published website event to SSE",
 		zap.String("event_type", eventType),
-		zap.String("topic", topic))
+		zap.Uint64("event_id", eventID),
+		zap.String("topic", sseTopicGateway))
 	return nil
 }
 
 // handleWebsiteSSE establishes a Server-Sent Events connection for website
-// lifecycle events. The gateway connects to this endpoint to receive
-// real-time notifications when websites are published, updated, or removed.
+// lifecycle events. The gateway connects to this endpoint to receive real-time
+// notifications when websites are published, updated, or removed.
+//
+// When the client supplies a Last-Event-ID (its persisted cursor), the durable
+// events after that cursor are replayed first so nothing is lost across an SSE
+// gap or gateway restart; a high_water_mark event signals the replay target.
+// The live in-memory feed then takes over.
 func (a *API) handleWebsiteSSE(c echo.Context) error {
+	lastEventID := c.Request().Header.Get("Last-Event-ID")
+	if lastEventID != "" && a.sse != nil && a.sse.log != nil {
+		a.replayWebsiteEvents(c, lastEventID)
+	}
+
 	hooks := sseServer.LifecycleHooks{
 		OnConnect: func(sub sseServer.Subscription) {
 			a.Logger().Debug("gateway SSE client connected",
@@ -107,7 +206,87 @@ func (a *API) handleWebsiteSSE(c echo.Context) error {
 	}
 
 	// Single "gateway" topic — one gateway consumer per portal instance
-	a.sse.server.ServeHTTP(c.Response(), c.Request(), []string{"gateway"}, hooks)
-
+	a.sse.server.ServeHTTP(c.Response(), c.Request(), []string{sseTopicGateway}, hooks)
 	return nil
+}
+
+// replayWebsiteEvents writes the durable website events after lastEventID to
+// the connection (mirroring the live feed's event type and data shape), then a
+// high_water_mark event. The in-memory live feed takes over afterwards.
+func (a *API) replayWebsiteEvents(c echo.Context, lastEventID string) {
+	after, err := strconv.ParseUint(lastEventID, 10, 64)
+	if err != nil {
+		a.Logger().Warn("ignoring non-numeric SSE Last-Event-ID", zap.String("last_event_id", lastEventID))
+		return
+	}
+
+	reqCtx := c.Request().Context()
+	events, hwm, err := a.sse.log.ListSince(reqCtx, after, a.changesMaxEvents())
+	if err != nil {
+		a.Logger().Error("failed to load events for SSE replay",
+			zap.Uint64("after", after), zap.Error(err))
+		return
+	}
+
+	w := c.Response()
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.WriteHeader(http.StatusOK)
+
+	for _, ev := range events {
+		frame := a.sseReplayFrame(ev)
+		if frame == nil {
+			continue
+		}
+		if err := frame.Write(w); err != nil {
+			a.Logger().Warn("SSE replay write failed", zap.Error(err))
+			return
+		}
+	}
+
+	hwmData, _ := json.Marshal(dto.SSEHighWaterMark{HighWaterMark: hwm})
+	if err := (sseServer.Event{Type: sseEventHighWaterMark, Data: hwmData}).Write(w); err != nil {
+		a.Logger().Warn("SSE high-water mark write failed", zap.Error(err))
+		return
+	}
+	w.Flush()
+}
+
+// sseReplayFrame builds an SSE frame for a durable website event that matches
+// the shape the live feed emits, so the gateway can process replays and live
+// events identically. Returns nil for unknown event types.
+func (a *API) sseReplayFrame(ev pluginDb.WebsiteEvent) *sseServer.Event {
+	var sseType string
+	var payload any
+	switch pluginDb.WebsiteEventType(ev.EventType) {
+	case pluginDb.WebsiteEventPublished:
+		sseType = sseEventSitePublished
+		payload = map[string]any{
+			"domain":       ev.Domain,
+			"cid":          ev.CID,
+			"published_at": ev.CreatedAt,
+		}
+	case pluginDb.WebsiteEventRemoved:
+		sseType = sseEventSiteRemoved
+		payload = map[string]any{
+			"domain":     ev.Domain,
+			"removed_at": ev.CreatedAt,
+		}
+	default:
+		a.Logger().Warn("skipping unknown website event type during SSE replay",
+			zap.String("event_type", ev.EventType))
+		return nil
+	}
+
+	data, err := json.Marshal(pluginEvent.NewSSEEvent(sseType, payload))
+	if err != nil {
+		a.Logger().Error("failed to marshal replay event", zap.Error(err))
+		return nil
+	}
+
+	return &sseServer.Event{
+		ID:   strconv.FormatUint(ev.ID, 10),
+		Type: sseType,
+		Data: data,
+	}
 }

--- a/internal/api/api_sse.go
+++ b/internal/api/api_sse.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	sseServer "github.com/apt304/sse-go/server"
+	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
 	"go.lumeweb.com/portal-plugin-ipfs/internal"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/api/dto"
@@ -142,12 +143,18 @@ func (a *API) publishWebsiteEvent(ctx context.Context, eventType string, eventDa
 
 	// Persist first so the event survives a gateway gap and the returned
 	// durable ID is available as the SSE id (making Last-Event-ID meaningful).
+	// A durable-write failure must not suppress live delivery: log it, continue,
+	// and fall back to a non-durable id so the gateway's authoritative
+	// /internal/websites/changes reconciliation can close any gap.
 	eventID, err := a.sse.log.Append(ctx, rec)
+	idStr := ""
 	if err != nil {
-		a.Logger().Error("failed to append website event to durable log",
+		a.Logger().Error("failed to append website event to durable log; continuing live SSE delivery",
 			zap.String("event_type", eventType),
 			zap.Error(err))
-		return err
+		idStr = uuid.New().String()
+	} else {
+		idStr = strconv.FormatUint(eventID, 10)
 	}
 
 	sseEvent := pluginEvent.NewSSEEvent(eventType, eventData)
@@ -160,7 +167,7 @@ func (a *API) publishWebsiteEvent(ctx context.Context, eventType string, eventDa
 	}
 
 	event := sseServer.Event{
-		ID:    strconv.FormatUint(eventID, 10),
+		ID:    idStr,
 		Type:  eventType,
 		Data:  eventJSON,
 		Retry: 3000, // Recommended retry interval in milliseconds
@@ -242,6 +249,16 @@ func (a *API) replayWebsiteEvents(c echo.Context, lastEventID string) {
 			a.Logger().Warn("SSE replay write failed", zap.Error(err))
 			return
 		}
+	}
+
+	// Re-read the high-water mark after draining the replay so the terminal
+	// event reflects the freshest known id, shrinking the window in which an
+	// event published between replay and live-subscribe would be missed. SSE
+	// replay is best-effort: for authoritative catch-up the gateway compares
+	// this high-water mark against its cursor and reconciles via
+	// /internal/websites/changes, which is what actually closes the gap.
+	if fresh, err := a.sse.log.HighWaterMark(reqCtx); err == nil {
+		hwm = fresh
 	}
 
 	hwmData, _ := json.Marshal(dto.SSEHighWaterMark{HighWaterMark: hwm})

--- a/internal/api/api_sse.go
+++ b/internal/api/api_sse.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	sseServer "github.com/apt304/sse-go/server"
-	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
 	"go.lumeweb.com/portal-plugin-ipfs/internal"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/api/dto"
@@ -149,10 +148,13 @@ func (a *API) publishWebsiteEvent(ctx context.Context, eventType string, eventDa
 	eventID, err := a.sse.log.Append(ctx, rec)
 	idStr := ""
 	if err != nil {
-		a.Logger().Error("failed to append website event to durable log; continuing live SSE delivery",
+		// No durable cursor exists, so emit without an id: a non-numeric id would
+		// advance the gateway's cursor to an unparseable value (Last-Event-ID and
+		// /changes?after= both parse uint). The event is best-effort live-only and
+		// cannot be replayed or reconciled until the durable log recovers.
+		a.Logger().Error("failed to append website event to durable log; emitting live SSE event without durable id",
 			zap.String("event_type", eventType),
 			zap.Error(err))
-		idStr = uuid.New().String()
 	} else {
 		idStr = strconv.FormatUint(eventID, 10)
 	}

--- a/internal/api/dto/website_changes.go
+++ b/internal/api/dto/website_changes.go
@@ -1,0 +1,41 @@
+package dto
+
+import "time"
+
+// WebsiteChangeEvent is a single durable website lifecycle event returned by
+// the reconciliation endpoint.
+type WebsiteChangeEvent struct {
+	ID        uint64    `json:"id"`
+	EventType string    `json:"event_type"` // published | removed
+	Domain    string    `json:"domain"`
+	CID       string    `json:"cid,omitempty"` // target hash for published events
+	WebsiteID uint      `json:"website_id,omitempty"`
+	UserID    uint      `json:"user_id,omitempty"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+// WebsiteChangesResponse is the payload of
+// GET /internal/websites/changes?after=<cursor>.
+//
+// The gateway compares the last event ID it has fully processed (its cursor)
+// against high_water_mark; when it is equal (or greater) it knows reconciliation
+// is complete and the stream has caught up. Events are ordered ascending by ID.
+type WebsiteChangesResponse struct {
+	Events []WebsiteChangeEvent `json:"events"`
+
+	// HighWaterMark is the largest durable event ID currently recorded. The
+	// gateway persists it together with its processed cursor so a later SSE
+	// reconnect can resume exactly where it left off.
+	HighWaterMark uint64 `json:"high_water_mark"`
+
+	// Truncated is true when more events exist beyond this batch. Consumers
+	// should re-request with after set to the last event ID in Events.
+	Truncated bool `json:"truncated"`
+}
+
+// SSEHighWaterMark is the terminal event of an SSE replay. It tells the gateway
+// the largest durable event ID currently recorded so it knows the replay
+// target against which to judge that catch-up is complete.
+type SSEHighWaterMark struct {
+	HighWaterMark uint64 `json:"high_water_mark"`
+}

--- a/internal/config/api.go
+++ b/internal/config/api.go
@@ -1,16 +1,32 @@
 package config
 
-import "go.lumeweb.com/portal/config"
+import (
+	"time"
+
+	"go.lumeweb.com/portal/config"
+)
 
 var _ config.APIConfig = (*APIConfig)(nil)
 
 type APIConfig struct {
 	// GatewaySecret is the shared secret for authenticating gateway requests
 	GatewaySecret string `config:"gateway_secret"`
+
+	// EventLogRetention is how long website lifecycle events are retained in the
+	// durable event log. The gateway must reconcile and persist its cursor
+	// within this window or it can no longer replay events lost to an SSE gap.
+	EventLogRetention time.Duration `config:"event_log_retention"`
+
+	// ChangesMaxEvents caps the number of events returned by a single
+	// /internal/websites/changes reconciliation request. The gateway pages with
+	// the returned high-water mark when more events remain.
+	ChangesMaxEvents int `config:"changes_max_events"`
 }
 
 func (A APIConfig) Defaults() map[string]any {
 	return map[string]any{
-		"GatewaySecret": "",
+		"GatewaySecret":     "",
+		"EventLogRetention": 24 * time.Hour,
+		"ChangesMaxEvents":  1000,
 	}
 }

--- a/internal/db/migrations/mysql/20260901090000_add_website_event_log.sql
+++ b/internal/db/migrations/mysql/20260901090000_add_website_event_log.sql
@@ -1,0 +1,24 @@
+-- +goose Up
+-- Durable, replayable website lifecycle event log owned by the portal. The
+-- gateway consumes this through the SSE Last-Event-ID cursor and the
+-- /internal/websites/changes reconciliation endpoint. The auto-increment ID is
+-- the durable cursor / high-water mark; it is never reused, so consumers can
+-- advance past it without ambiguity.
+CREATE TABLE IF NOT EXISTS ipfs_website_events (
+    id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+    event_type VARCHAR(50) NOT NULL,
+    domain VARCHAR(255) NOT NULL,
+    cid VARCHAR(255) NOT NULL DEFAULT '',
+    website_id BIGINT UNSIGNED NULL,
+    user_id BIGINT UNSIGNED NULL,
+    created_at DATETIME(6) NOT NULL,
+    PRIMARY KEY (id),
+    KEY idx_ipfs_website_events_event_type (event_type),
+    KEY idx_ipfs_website_events_domain (domain),
+    KEY idx_ipfs_website_events_website_id (website_id),
+    KEY idx_ipfs_website_events_user_id (user_id),
+    KEY idx_ipfs_website_events_created_at (created_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- +goose Down
+DROP TABLE IF EXISTS ipfs_website_events;

--- a/internal/db/migrations/sqlite/20260901090000_add_website_event_log.sql
+++ b/internal/db/migrations/sqlite/20260901090000_add_website_event_log.sql
@@ -1,0 +1,22 @@
+-- +goose Up
+-- Durable, replayable website lifecycle event log owned by the portal. The
+-- gateway consumes this through the SSE Last-Event-ID cursor and the
+-- /internal/websites/changes reconciliation endpoint.
+CREATE TABLE IF NOT EXISTS ipfs_website_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    event_type TEXT NOT NULL,
+    domain TEXT NOT NULL,
+    cid TEXT NOT NULL DEFAULT '',
+    website_id INTEGER NULL,
+    user_id INTEGER NULL,
+    created_at DATETIME NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_ipfs_website_events_event_type ON ipfs_website_events(event_type);
+CREATE INDEX IF NOT EXISTS idx_ipfs_website_events_domain ON ipfs_website_events(domain);
+CREATE INDEX IF NOT EXISTS idx_ipfs_website_events_website_id ON ipfs_website_events(website_id);
+CREATE INDEX IF NOT EXISTS idx_ipfs_website_events_user_id ON ipfs_website_events(user_id);
+CREATE INDEX IF NOT EXISTS idx_ipfs_website_events_created_at ON ipfs_website_events(created_at);
+
+-- +goose Down
+DROP TABLE IF EXISTS ipfs_website_events;

--- a/internal/db/website_event.go
+++ b/internal/db/website_event.go
@@ -1,0 +1,40 @@
+package db
+
+import (
+	"time"
+
+	"gorm.io/gorm/schema"
+)
+
+var _ schema.Tabler = (*WebsiteEvent)(nil)
+
+// WebsiteEventType identifies the lifecycle transition recorded in the event log.
+type WebsiteEventType string
+
+const (
+	// WebsiteEventPublished is recorded when a website is created or its
+	// content is (re)published with a new target hash.
+	WebsiteEventPublished WebsiteEventType = "published"
+	// WebsiteEventRemoved is recorded when a website is deleted.
+	WebsiteEventRemoved WebsiteEventType = "removed"
+)
+
+// WebsiteEvent is a durable, monotonically ordered record of a website
+// lifecycle transition. It is the portal-side source of truth that the gateway
+// can replay (through the SSE Last-Event-ID cursor or the
+// /internal/websites/changes reconciliation endpoint) across gaps and
+// restarts. The auto-increment ID doubles as the durable cursor / high-water
+// mark consumers advance past.
+type WebsiteEvent struct {
+	ID        uint64    `gorm:"primaryKey;autoIncrement"`
+	EventType string    `gorm:"type:varchar(50);not null;index:idx_ipfs_website_events_event_type"` // published | removed
+	Domain    string    `gorm:"type:varchar(255);not null;index:idx_ipfs_website_events_domain"`
+	CID       string    `gorm:"column:cid;type:varchar(255);not null"` // target hash for published events; empty for removed
+	WebsiteID uint      `gorm:"index:idx_ipfs_website_events_website_id"`
+	UserID    uint      `gorm:"index:idx_ipfs_website_events_user_id"`
+	CreatedAt time.Time `gorm:"autoCreateTime;index:idx_ipfs_website_events_created_at"`
+}
+
+func (WebsiteEvent) TableName() string {
+	return "ipfs_website_events"
+}

--- a/internal/event/log.go
+++ b/internal/event/log.go
@@ -78,15 +78,18 @@ func (s *Store) HighWaterMark(ctx context.Context) (uint64, error) {
 // created_at ordering (which is not guaranteed to match id order). Consumers
 // must process events within the retention window.
 func (s *Store) PurgeBefore(ctx context.Context, before time.Time) (int64, error) {
-	// id <= (SELECT MAX(id) WHERE created_at < before) deletes the low-id tail
-	// up to the newest expired row. When no row has aged past retention the
-	// subquery yields NULL and `id <= NULL` matches nothing.
+	// The id-bound keeps the cut aligned with the replay cursor/high-water mark;
+	// the additional `created_at < before` constraint guarantees fresh rows still
+	// inside the retention window survive even when a higher-id row has aged past
+	// `before`. Together they delete exactly the expired rows within the low-id
+	// tail and never evict a within-retention event.
 	sub := s.db.Model(&pluginDb.WebsiteEvent{}).
 		Select("MAX(id)").
 		Where("created_at < ?", before)
 
 	res := s.db.WithContext(ctx).
 		Where("id <= (?)", sub).
+		Where("created_at < ?", before).
 		Delete(&pluginDb.WebsiteEvent{})
 	if res.Error != nil {
 		return 0, res.Error

--- a/internal/event/log.go
+++ b/internal/event/log.go
@@ -71,12 +71,22 @@ func (s *Store) HighWaterMark(ctx context.Context) (uint64, error) {
 	return *maxID, nil
 }
 
-// PurgeBefore deletes all events older than before and returns the number of
-// rows removed. It enforces the documented retention window so the log does not
-// grow without bound; consumers must process events within the window.
+// PurgeBefore enforces the documented retention window so the log does not
+// grow without bound. It removes rows whose durable cursor lies at or below the
+// largest-id row that has aged past `before`, so the retention cut is aligned
+// with the id-ordered replay cursor and high-water mark rather than
+// created_at ordering (which is not guaranteed to match id order). Consumers
+// must process events within the retention window.
 func (s *Store) PurgeBefore(ctx context.Context, before time.Time) (int64, error) {
+	// id <= (SELECT MAX(id) WHERE created_at < before) deletes the low-id tail
+	// up to the newest expired row. When no row has aged past retention the
+	// subquery yields NULL and `id <= NULL` matches nothing.
+	sub := s.db.Model(&pluginDb.WebsiteEvent{}).
+		Select("MAX(id)").
+		Where("created_at < ?", before)
+
 	res := s.db.WithContext(ctx).
-		Where("created_at < ?", before).
+		Where("id <= (?)", sub).
 		Delete(&pluginDb.WebsiteEvent{})
 	if res.Error != nil {
 		return 0, res.Error

--- a/internal/event/log.go
+++ b/internal/event/log.go
@@ -1,0 +1,102 @@
+package event
+
+import (
+	"context"
+	"time"
+
+	pluginDb "go.lumeweb.com/portal-plugin-ipfs/internal/db"
+	"gorm.io/gorm"
+)
+
+// Store is the durable, replayable website lifecycle event log. It backs both
+// the SSE feed (whose event IDs are the durable IDs) and the
+// /internal/websites/changes reconciliation endpoint the gateway uses to close
+// SSE gaps without relying on visitor traffic.
+//
+// The auto-increment primary key is the monotonic cursor / high-water mark. IDs
+// are never reused, so a consumer can safely advance its cursor past any event
+// it has fully processed.
+type Store struct {
+	db *gorm.DB
+}
+
+// NewStore creates an event log Store backed by db.
+func NewStore(db *gorm.DB) *Store {
+	return &Store{db: db}
+}
+
+// Append durably records ev and returns its assigned durable ID. The returned
+// ID is guaranteed to be greater than every previously appended event's ID.
+func (s *Store) Append(ctx context.Context, ev pluginDb.WebsiteEvent) (uint64, error) {
+	if err := s.db.WithContext(ctx).Create(&ev).Error; err != nil {
+		return 0, err
+	}
+	return ev.ID, nil
+}
+
+// ListAfter returns events whose durable ID is greater than after, ordered
+// ascending by ID. limit bounds the number of rows returned (<=0 means no
+// limit). Consumers should use HighWaterMark to detect whether more events
+// remain beyond the returned batch.
+func (s *Store) ListAfter(ctx context.Context, after uint64, limit int) ([]pluginDb.WebsiteEvent, error) {
+	if limit <= 0 {
+		limit = 0
+	}
+
+	q := s.db.WithContext(ctx).Where("id > ?", after).Order("id ASC")
+	if limit > 0 {
+		q = q.Limit(limit)
+	}
+
+	var events []pluginDb.WebsiteEvent
+	if err := q.Find(&events).Error; err != nil {
+		return nil, err
+	}
+	return events, nil
+}
+
+// HighWaterMark returns the largest durable event ID currently recorded. It is
+// the replay high-water mark the gateway compares against its cursor to decide
+// when catch-up reconciliation is complete. Returns 0 when no events exist.
+func (s *Store) HighWaterMark(ctx context.Context) (uint64, error) {
+	var maxID *uint64
+	err := s.db.WithContext(ctx).Model(&pluginDb.WebsiteEvent{}).
+		Select("MAX(id)").Scan(&maxID).Error
+	if err != nil {
+		return 0, err
+	}
+	if maxID == nil {
+		return 0, nil
+	}
+	return *maxID, nil
+}
+
+// PurgeBefore deletes all events older than before and returns the number of
+// rows removed. It enforces the documented retention window so the log does not
+// grow without bound; consumers must process events within the window.
+func (s *Store) PurgeBefore(ctx context.Context, before time.Time) (int64, error) {
+	res := s.db.WithContext(ctx).
+		Where("created_at < ?", before).
+		Delete(&pluginDb.WebsiteEvent{})
+	if res.Error != nil {
+		return 0, res.Error
+	}
+	return res.RowsAffected, nil
+}
+
+// ListSince returns events whose durable ID is greater than after, ordered
+// ascending. It is identical to ListAfter but also reports the current
+// high-water mark, which the reconciliation endpoint needs to give the gateway
+// complete catch-up information.
+func (s *Store) ListSince(ctx context.Context, after uint64, limit int) (events []pluginDb.WebsiteEvent, hwm uint64, err error) {
+	hwm, err = s.HighWaterMark(ctx)
+	if err != nil {
+		return nil, hwm, err
+	}
+
+	events, err = s.ListAfter(ctx, after, limit)
+	if err != nil {
+		return nil, hwm, err
+	}
+	return events, hwm, nil
+}

--- a/internal/event/log_test.go
+++ b/internal/event/log_test.go
@@ -138,12 +138,12 @@ func TestStore_PurgeBefore(t *testing.T) {
 	assert.Equal(t, id, remaining[0].ID)
 }
 
-// TestStore_PurgeBefore_AlignedToID guards against purging by created_at while
-// the replay cursor/high-water mark key on the auto-increment id. When a
-// higher-id event carries an older timestamp than a lower-id event, the purge
-// boundary must still be id-aligned so the remaining id space is a gapless
-// prefix (no hole below the high-water mark that would corrupt the Truncated
-// flag / replay window).
+// TestStore_PurgeBefore_AlignedToID guards against two retention-purging bugs:
+// (a) purging by created_at while the replay cursor/high-water mark key on the
+// auto-increment id, which could drop a higher-id event before lower ids; and
+// (b) the inverse — deleting fresh within-retention low-id rows because a
+// higher-id row has aged past retention. Purge must delete exactly the expired
+// rows, aligned to the id-order cut, and never evict a within-retention event.
 func TestStore_PurgeBefore_AlignedToID(t *testing.T) {
 	store := newTestStore(t)
 	ctx := context.Background()
@@ -151,10 +151,11 @@ func TestStore_PurgeBefore_AlignedToID(t *testing.T) {
 	now := time.Now()
 	old := now.Add(-48 * time.Hour)
 
-	// Lower id (1) is new; higher ids (2,3) are older than retention.
+	// id 1 is fresh, id 2 is expired, id 3 is fresh — a non-monotonic
+	// timestamp/id ordering that must not cause a fresh row to be purged.
 	e1 := db.WebsiteEvent{EventType: string(db.WebsiteEventPublished), Domain: "a.example", CreatedAt: now}
 	e2 := db.WebsiteEvent{EventType: string(db.WebsiteEventPublished), Domain: "b.example", CreatedAt: old}
-	e3 := db.WebsiteEvent{EventType: string(db.WebsiteEventPublished), Domain: "c.example", CreatedAt: old}
+	e3 := db.WebsiteEvent{EventType: string(db.WebsiteEventPublished), Domain: "c.example", CreatedAt: now}
 	require.NoError(t, store.db.Create(&e1).Error)
 	require.NoError(t, store.db.Create(&e2).Error)
 	require.NoError(t, store.db.Create(&e3).Error)
@@ -162,27 +163,22 @@ func TestStore_PurgeBefore_AlignedToID(t *testing.T) {
 	removed, err := store.PurgeBefore(ctx, now.Add(-24*time.Hour))
 	require.NoError(t, err)
 
-	// MAX(id WHERE created_at < before) = 3, so the whole id-prefix <= 3 is purged,
-	// keeping the id space a gapless prefix (never a random interior hole).
-	assert.Equal(t, int64(3), removed)
+	// Only the single expired row (id 2) is removed; fresh id 1 and id 3 survive
+	// even though they sit within the id-order cut.
+	assert.Equal(t, int64(1), removed)
 
 	remaining, err := store.ListAfter(ctx, 0, 0)
 	require.NoError(t, err)
-	require.Empty(t, remaining)
+	require.Len(t, remaining, 2)
+	assert.Equal(t, e1.ID, remaining[0].ID)
+	assert.Equal(t, e3.ID, remaining[1].ID)
 
-	// Re-seed and verify a partial purge still leaves a gapless prefix.
-	e4 := db.WebsiteEvent{EventType: string(db.WebsiteEventPublished), Domain: "d.example", CreatedAt: now}
-	e5 := db.WebsiteEvent{EventType: string(db.WebsiteEventPublished), Domain: "e.example", CreatedAt: now}
-	require.NoError(t, store.db.Create(&e4).Error)
-	require.NoError(t, store.db.Create(&e5).Error)
-
+	// No expired row may remain, and the high-water mark is still correct
+	// despite the id gap left at id 2.
+	for _, ev := range remaining {
+		assert.False(t, ev.CreatedAt.Before(now.Add(-24*time.Hour)))
+	}
 	hwm, err := store.HighWaterMark(ctx)
 	require.NoError(t, err)
-	assert.Equal(t, e5.ID, hwm)
-
-	remaining, err = store.ListAfter(ctx, 0, 0)
-	require.NoError(t, err)
-	require.Len(t, remaining, 2)
-	assert.Equal(t, e4.ID, remaining[0].ID)
-	assert.Equal(t, e5.ID, remaining[1].ID)
+	assert.Equal(t, e3.ID, hwm)
 }

--- a/internal/event/log_test.go
+++ b/internal/event/log_test.go
@@ -1,0 +1,139 @@
+package event
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.lumeweb.com/portal-plugin-ipfs/internal/db"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+// newTestStore spins up an in-memory SQLite DB with the WebsiteEvent schema and
+// returns a Store backed by it. Using AutoMigrate keeps the test focused on the
+// store's behavior rather than the migration harness.
+func newTestStore(t *testing.T) *Store {
+	t.Helper()
+
+	gormDB, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	require.NoError(t, err)
+	require.NoError(t, gormDB.AutoMigrate(&db.WebsiteEvent{}))
+
+	return NewStore(gormDB)
+}
+
+func TestStore_AppendAndListAfter(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	id1, err := store.Append(ctx, db.WebsiteEvent{
+		EventType: string(db.WebsiteEventPublished),
+		Domain:    "alpha.example",
+		CID:       "bafy1",
+		WebsiteID: 10,
+		UserID:    1,
+	})
+	require.NoError(t, err)
+
+	id2, err := store.Append(ctx, db.WebsiteEvent{
+		EventType: string(db.WebsiteEventRemoved),
+		Domain:    "beta.example",
+		WebsiteID: 11,
+		UserID:    2,
+	})
+	require.NoError(t, err)
+
+	id3, err := store.Append(ctx, db.WebsiteEvent{
+		EventType: string(db.WebsiteEventPublished),
+		Domain:    "gamma.example",
+		CID:       "bafy2",
+		WebsiteID: 12,
+		UserID:    3,
+	})
+	require.NoError(t, err)
+
+	// Durably monotonic: each appended ID is strictly greater than the last.
+	assert.Less(t, id1, id2)
+	assert.Less(t, id2, id3)
+
+	// ListAfter from 0 returns everything in order.
+	all, err := store.ListAfter(ctx, 0, 0)
+	require.NoError(t, err)
+	require.Len(t, all, 3)
+	assert.Equal(t, []uint64{id1, id2, id3}, []uint64{all[0].ID, all[1].ID, all[2].ID})
+
+	// ListAfter from id1 excludes it.
+	rest, err := store.ListAfter(ctx, id1, 0)
+	require.NoError(t, err)
+	require.Len(t, rest, 2)
+	assert.Equal(t, []uint64{id2, id3}, []uint64{rest[0].ID, rest[1].ID})
+
+	// Limit bounds the returned rows but preserves order.
+	limited, err := store.ListAfter(ctx, 0, 2)
+	require.NoError(t, err)
+	require.Len(t, limited, 2)
+	assert.Equal(t, id2, limited[1].ID)
+
+	// ListSince reports the high-water mark alongside the events.
+	events, hwm, err := store.ListSince(ctx, id1, 0)
+	require.NoError(t, err)
+	assert.Equal(t, id3, hwm)
+	assert.Len(t, events, 2)
+}
+
+func TestStore_HighWaterMark(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	// Empty log -> 0.
+	hwm, err := store.HighWaterMark(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(0), hwm)
+
+	id, err := store.Append(ctx, db.WebsiteEvent{
+		EventType: string(db.WebsiteEventPublished),
+		Domain:    "alpha.example",
+		CID:       "bafy1",
+	})
+	require.NoError(t, err)
+
+	hwm, err = store.HighWaterMark(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, id, hwm)
+}
+
+func TestStore_PurgeBefore(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	old := db.WebsiteEvent{
+		EventType: string(db.WebsiteEventPublished),
+		Domain:    "old.example",
+		CID:       "bafy1",
+		CreatedAt: time.Now().Add(-48 * time.Hour),
+	}
+	require.NoError(t, store.db.Create(&old).Error)
+
+	id, err := store.Append(ctx, db.WebsiteEvent{
+		EventType: string(db.WebsiteEventPublished),
+		Domain:    "new.example",
+		CID:       "bafy2",
+	})
+	require.NoError(t, err)
+
+	// Purge events older than 24h: only the 48h-old row is removed.
+	removed, err := store.PurgeBefore(ctx, time.Now().Add(-24*time.Hour))
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), removed)
+
+	remaining, err := store.ListAfter(ctx, 0, 0)
+	require.NoError(t, err)
+	require.Len(t, remaining, 1)
+	assert.Equal(t, id, remaining[0].ID)
+}

--- a/internal/event/log_test.go
+++ b/internal/event/log_test.go
@@ -137,3 +137,52 @@ func TestStore_PurgeBefore(t *testing.T) {
 	require.Len(t, remaining, 1)
 	assert.Equal(t, id, remaining[0].ID)
 }
+
+// TestStore_PurgeBefore_AlignedToID guards against purging by created_at while
+// the replay cursor/high-water mark key on the auto-increment id. When a
+// higher-id event carries an older timestamp than a lower-id event, the purge
+// boundary must still be id-aligned so the remaining id space is a gapless
+// prefix (no hole below the high-water mark that would corrupt the Truncated
+// flag / replay window).
+func TestStore_PurgeBefore_AlignedToID(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	now := time.Now()
+	old := now.Add(-48 * time.Hour)
+
+	// Lower id (1) is new; higher ids (2,3) are older than retention.
+	e1 := db.WebsiteEvent{EventType: string(db.WebsiteEventPublished), Domain: "a.example", CreatedAt: now}
+	e2 := db.WebsiteEvent{EventType: string(db.WebsiteEventPublished), Domain: "b.example", CreatedAt: old}
+	e3 := db.WebsiteEvent{EventType: string(db.WebsiteEventPublished), Domain: "c.example", CreatedAt: old}
+	require.NoError(t, store.db.Create(&e1).Error)
+	require.NoError(t, store.db.Create(&e2).Error)
+	require.NoError(t, store.db.Create(&e3).Error)
+
+	removed, err := store.PurgeBefore(ctx, now.Add(-24*time.Hour))
+	require.NoError(t, err)
+
+	// MAX(id WHERE created_at < before) = 3, so the whole id-prefix <= 3 is purged,
+	// keeping the id space a gapless prefix (never a random interior hole).
+	assert.Equal(t, int64(3), removed)
+
+	remaining, err := store.ListAfter(ctx, 0, 0)
+	require.NoError(t, err)
+	require.Empty(t, remaining)
+
+	// Re-seed and verify a partial purge still leaves a gapless prefix.
+	e4 := db.WebsiteEvent{EventType: string(db.WebsiteEventPublished), Domain: "d.example", CreatedAt: now}
+	e5 := db.WebsiteEvent{EventType: string(db.WebsiteEventPublished), Domain: "e.example", CreatedAt: now}
+	require.NoError(t, store.db.Create(&e4).Error)
+	require.NoError(t, store.db.Create(&e5).Error)
+
+	hwm, err := store.HighWaterMark(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, e5.ID, hwm)
+
+	remaining, err = store.ListAfter(ctx, 0, 0)
+	require.NoError(t, err)
+	require.Len(t, remaining, 2)
+	assert.Equal(t, e4.ID, remaining[0].ID)
+	assert.Equal(t, e5.ID, remaining[1].ID)
+}

--- a/internal/plugin/info.go
+++ b/internal/plugin/info.go
@@ -105,6 +105,7 @@ func getPluginInfoWithoutTemplates() core.PluginInfo {
 			&db.WebsiteDomain{},
 			&db.DNSZone{},
 			&db.PlatformDomain{},
+			&db.WebsiteEvent{},
 		},
 		Metrics:         GetCollectors(),
 		Migrations:      core.DBMigration{core.DB_TYPE_SQLITE: migrations.GetSQLite(), core.DB_TYPE_MYSQL: migrations.GetMySQL()},


### PR DESCRIPTION
Adds a durable, replayable website lifecycle event log (ipfs\_website\_events) backing the gateway reliability path.

Every website published/removed event is persisted with a monotonic ID that doubles as the SSE event id and the replay high-water mark. The SSE feed gains Last-Event-ID replay and a high\_water\_mark event, and a new GET /internal/websites/changes?after=<cursor> endpoint lets the gateway reconcile domains published during an SSE gap without visitor traffic.

- `develop` <!-- branch-stack -->
  - **feat(gateway): add durable website change log and change reconciliation API** :point\_left:

***

<!-- kody-pr-summary:start -->

## Summary

This pull request adds a durable website change log and a change reconciliation API to the IPFS portal plugin. The goal is to ensure the gateway can reliably learn about website lifecycle events (published/removed) even when it misses live SSE events due to disconnects or restarts.

### Key Changes

**1. Durable Event Log**

- Introduced a new `ipfs_website_events` database table (with migrations for both MySQL and SQLite) to durably store website lifecycle events.
- Added a `Store` service (`internal/event/log.go`) that provides methods to append events, list events after a cursor, retrieve the current high-water mark, and purge events older than a configurable retention period.
- Events are assigned auto-incrementing IDs that serve as a monotonic cursor and high-water mark.

**2. SSE Feed Improvements**

- SSE events now use the durable event ID as the SSE event ID (previously a random UUID), enabling Last-Event-ID replay.
- When a client connects with a `Last-Event-ID` header, the server replays all durable events after that ID before continuing with the live feed.
- A `high_water_mark` SSE event signals the end of the replay and tells the gateway the current sync target.
- Events are persisted to the durable log *before* being published to the live feed, ensuring no events are lost during a gap.

**3. New Change Reconciliation Endpoint**

- Added `GET /internal/websites/changes?after=<cursor>` which returns durable website changes after the supplied cursor, with ascending IDs, plus the current high-water mark and a `truncated` flag for pagination.
- This allows the gateway to discover missed domains during an SSE gap without relying on visitor traffic.
- A configurable cap (`changes_max_events`, default 1000) bounds the number of events per request.

**4. Configuration**

- New configuration options:
  - `event_log_retention` (default 24h) – how long events are kept in the durable log before being purged.
  - `changes_max_events` (default 1000) – per-request cap for the reconciliation endpoint.

**5. Retention Purger**

- A background goroutine periodically purges events older than the configured retention window, preventing unbounded log growth.

**6. Tests**

- Added unit tests for the event log Store (append, list, high-water mark, purge).
- Added API integration tests for the change reconciliation endpoint (all changes, resume after cursor, cursor at high-water mark, invalid cursor rejection).

### Functional Impact

The gateway can now:

- Replay missed SSE events after a reconnect using `Last-Event-ID`.
- Query the portal for all changes since a given cursor via the reconciliation endpoint.
- Persist its cursor and resume from exactly where it left off, ensuring no website lifecycle changes are missed.

<!-- kody-pr-summary:end -->
