### PR TITLE
fix(config): make DNS slug format test robust to collisions

### DIFF
--- a/internal/config/namegen_test.go
+++ b/internal/config/namegen_test.go
@@ -14,19 +14,25 @@ func TestGenerateDNSSlug_Format(t *testing.T) {
 	// Generated labels are adjective-noun-number, DNS-safe (lowercase,
 	// hyphen-separated, <= 63 labels), and pronounceable/opaque — never a bare
 	// sequential counter that reveals usage volume.
-	seen := map[string]bool{}
+	seen := make(map[string]struct{})
 	for i := 0; i < 100; i++ {
 		slug := GenerateDNSSlug()
 		require.LessOrEqual(t, len(slug), 63)
 		assert.Regexp(t, slugPattern, slug, "slug %q should match adjective-noun-number", slug)
-		assert.False(t, seen[slug], "slug %q should vary across calls", slug)
-		seen[slug] = true
+		seen[slug] = struct{}{}
 
 		// Must pass a strict DNS-label validation (no underscores, no leading
 		// digits beyond allowed, no empty labels).
 		assert.NotContains(t, slug, "_")
 		assert.NotContains(t, slug, "..")
 	}
+
+	// The generator samples uniformly from an adjective-noun-suffix space of
+	// ~400k values, so over 100 draws a repeated slug is an ordinary birthday
+	// collision, not a regression — requiring 100 unique values would make this
+	// test flaky. Assert healthy variety instead: a degenerate constant or
+	// sequential generator collapses to ~1 distinct value and fails here.
+	assert.GreaterOrEqual(t, len(seen), 90, "generated slugs should vary across calls")
 }
 
 func TestGenerateDNSSlug_DNSValid(t *testing.T) {


### PR DESCRIPTION
Makes `TestGenerateDNSSlug_Format` tolerate ordinary random collisions.

`GenerateDNSSlug` samples an adjective-noun-suffix space of \~400k values, so a repeated slug over 100 draws is a birthday collision (\~1% per run), not a regression. The strict per-slug uniqueness assertion is replaced with a variety check (at least 90 distinct values), keeping the guard against a degenerate constant/sequential generator while removing the intermittent failure.

The platform subdomain claim path is unaffected; it already retries on duplicate-key errors.

- `develop` <!-- branch-stack -->
  - **fix(config): make DNS slug format test robust to collisions** :point\_left:

***

<!-- kody-pr-summary:start -->

This pull request modifies the DNS slug format test in the `internal/config/namegen_test.go` file to make it more robust against collisions.

**Key Changes:**

- Updated the uniqueness assertion logic: Previously, the test required all 100 generated slugs to be unique, which could cause flakiness due to birthday paradox collisions in the \~400k possible adjective-noun-suffix combinations.
- Changed the test to assert healthy variety instead: The test now requires at least 90 distinct slugs out of 100 generated values, which ensures the generator isn't degenerate (e.g., constant or sequential) while tolerating normal random collisions.
- Refactored the tracking map from `map[string]bool` to `map[string]struct{}` for more idiomatic Go code usage.

**Impact:**
This change eliminates potential test flakiness by allowing natural birthday collisions while still validating that the DNS slug generator produces diverse, varied output. The threshold of 90+ distinct values out of 100 draws ensures the generator functions correctly without being overly strict about uniqueness.

<!-- kody-pr-summary:end -->
