### PR TITLE
fix(deps): adopt LumeWeb go-libp2p fork for webtransport-go v0.13

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,7 @@ jobs:
     uses: LumeWeb/workflows/.github/workflows/build-plugin.yml@develop
     secrets: inherit
     with:
+      replacements: 'github.com/libp2p/go-libp2p=github.com/LumeWeb/go-libp2p@v0.0.0-20260902043403-e59b50d42d53'
       setup_script: |
         KUBO_VERSION=$(wget -qO- https://api.github.com/repos/ipfs/kubo/releases/latest | jq -r '.tag_name')
         wget -q https://github.com/ipfs/kubo/releases/download/${KUBO_VERSION}/kubo_${KUBO_VERSION}_linux-amd64.tar.gz

--- a/go.mod
+++ b/go.mod
@@ -303,7 +303,7 @@ require (
 	github.com/prometheus/procfs v0.21.1 // indirect
 	github.com/quic-go/qpack v0.6.0 // indirect
 	github.com/quic-go/quic-go v0.62.0 // indirect
-	github.com/quic-go/webtransport-go v0.12.0 // indirect
+	github.com/quic-go/webtransport-go v0.13.0 // indirect
 	github.com/redis/go-redis/v9 v9.22.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/robfig/cron/v3 v3.0.1 // indirect
@@ -394,6 +394,4 @@ require (
 	modernc.org/sqlite v1.54.0 // indirect
 )
 
-replace github.com/quic-go/quic-go => github.com/quic-go/quic-go v0.62.0
-
-replace github.com/quic-go/webtransport-go => github.com/quic-go/webtransport-go v0.13.0
+replace github.com/libp2p/go-libp2p => github.com/LumeWeb/go-libp2p v0.0.0-20260902043403-e59b50d42d53

--- a/go.sum
+++ b/go.sum
@@ -64,6 +64,8 @@ github.com/ClickHouse/clickhouse-go/v2 v2.47.0 h1:ZDAzrnKSOPTIsm4tdUNfrii2yc8dk4
 github.com/ClickHouse/clickhouse-go/v2 v2.47.0/go.mod h1:sPj7C7UYQ2MWHcfX+4eGN6nwnCqwUKfgO6PcwKpd6K8=
 github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
 github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
+github.com/LumeWeb/go-libp2p v0.0.0-20260902043403-e59b50d42d53 h1:KtuZymGvO8qMOWP1WhOUm2tDjYkm3rU+GT+Fy2T2bn4=
+github.com/LumeWeb/go-libp2p v0.0.0-20260902043403-e59b50d42d53/go.mod h1:RjqB+dxCWNZ33yw0yeK5Pu157oNxKuaTZY6vLed4t8w=
 github.com/Oudwins/zog v0.22.2 h1:neSFVFsn7cd4azB9+2hK1sn1By5UZGc8o28vNWJhUIE=
 github.com/Oudwins/zog v0.22.2/go.mod h1:c4ADJ2zNkJp37ZViNy1o3ZZoeMvO7UQVO7BaPtRoocg=
 github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMzGrKSKYe4AqU6PDYYpjk=


### PR DESCRIPTION
Migrates the quic stack to the LumeWeb go-libp2p fork, whose webtransport
transport uses the webtransport-go v0.13 ClientConn API, unblocking
quic-go v0.62.0 + webtransport-go v0.13.0.

Pins `github.com/libp2p/go-libp2p => github.com/LumeWeb/go-libp2p
v0.0.0-20260902043403-e59b50d42d53` and drops the now-redundant
quic-go/webtransport-go replace directives, since minimal version
selection already resolves v0.62.0/v0.13.0 through the fork's requirements.

Adds the matching replacement to the build workflow so CI builds the portal
artifact against the forked transport.

- `develop` <!-- branch-stack -->
  - **fix(deps): adopt LumeWeb go-libp2p fork for webtransport-go v0.13** :point\_left:

---

<!-- kody-pr-summary:start -->
This pull request updates the build workflow to adopt a LumeWeb fork of go-libp2p. Specifically, it adds a dependency replacement directive in the GitHub Actions build configuration that swaps the standard `github.com/libp2p/go-libp2p` package with `github.com/LumeWeb/go-libp2p@v0.0.0-20260902043403-e59b50d42d53`. This fork is being used to address issues related to webtransport-go v0.13 compatibility by leveraging the LumeWeb-maintained version of the library during the build process.
<!-- kody-pr-summary:end -->