### PR TITLE
fix(api): initialize SSE server after startup component wiring

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -123,15 +123,16 @@ func NewAPI() (core.API, []core.ContextBuilderOption, error) {
 
 				api.fileManagerService = core.GetService[pluginCore.FileManagerService](ctx, pluginCore.FILE_MANAGER_SERVICE)
 
+				// Initialize SSE server for website event streaming. This runs
+				// after all startup funcs complete so the API's DB is wired.
+				if err := api.initSSEServer(ctx); err != nil {
+					return fmt.Errorf("failed to initialize SSE server: %w", err)
+				}
+
 				return nil
 			})
 
 			api.ipfs = proto.(protocol.ProtoNode)
-
-			// Initialize SSE server for website event streaming
-			if err := api.initSSEServer(ctx); err != nil {
-				return fmt.Errorf("failed to initialize SSE server: %w", err)
-			}
 
 			return nil
 		}),


### PR DESCRIPTION
Initializes the SSE website event streaming server inside the `OnBootStartupFuncsCompleted` callback so it runs after the API component's DB is wired (`SetDB`).

The previous placement in the main startup func ran before component wiring, so startup could panic on a nil `a.DB()`. Matches the existing TUS handler setup.

Verified: `go build ./...` and `go vet ./internal/api/` pass.

- `develop` <!-- branch-stack -->
  - **fix(api): initialize SSE server after startup component wiring** :point\_left:

---

<!-- kody-pr-summary:start -->
This pull request fixes the initialization order of the SSE (Server-Sent Events) server in the API startup process.

**Problem**: The SSE server was being initialized too early in the startup sequence, before all startup functions had completed their component wiring. This caused the SSE server to potentially reference uninitialized dependencies, such as the database.

**Solution**: The SSE server initialization has been moved inside the startup function block, after all other startup components (like the file manager service) have been properly wired. This ensures the API's database and other dependencies are fully connected before the SSE server begins streaming website events.

The change wraps the SSE initialization in the same context as other startup functions, adding proper error handling to fail gracefully if SSE initialization fails after the component setup.
<!-- kody-pr-summary:end -->