### PR TITLE
feat(gateway): add swagger enum for website change event types

### DIFF
--- a/internal/api/api_changes.go
+++ b/internal/api/api_changes.go
@@ -10,6 +10,7 @@ import (
 	"go.lumeweb.com/portal-plugin-ipfs/internal"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/api/dto"
 	pluginConfig "go.lumeweb.com/portal-plugin-ipfs/internal/config"
+	pluginDb "go.lumeweb.com/portal-plugin-ipfs/internal/db"
 	"go.uber.org/zap"
 )
 
@@ -63,7 +64,7 @@ func (a *API) getWebsiteChanges(c echo.Context) error {
 	for _, ev := range events {
 		resp.Events = append(resp.Events, dto.WebsiteChangeEvent{
 			ID:        ev.ID,
-			EventType: ev.EventType,
+			EventType: pluginDb.WebsiteEventType(ev.EventType),
 			Domain:    ev.Domain,
 			CID:       ev.CID,
 			WebsiteID: ev.WebsiteID,

--- a/internal/api/api_changes_test.go
+++ b/internal/api/api_changes_test.go
@@ -34,7 +34,7 @@ func TestAPI_GetWebsiteChanges(t *testing.T) {
 			assert.Equal(t, ev3.ID, resp.HighWaterMark)
 			require.Len(t, resp.Events, 3)
 			assert.Equal(t, ev1.ID, resp.Events[0].ID)
-			assert.Equal(t, string(pluginDb.WebsiteEventPublished), resp.Events[0].EventType)
+			assert.Equal(t, pluginDb.WebsiteEventPublished, resp.Events[0].EventType)
 			assert.Equal(t, "alpha.example", resp.Events[0].Domain)
 			assert.Equal(t, "bafy1", resp.Events[0].CID)
 			assert.Equal(t, ev2.ID, resp.Events[1].ID)

--- a/internal/api/dto/enum_schema_test.go
+++ b/internal/api/dto/enum_schema_test.go
@@ -25,3 +25,23 @@ func TestUploadResultResponse_FieldEnums(t *testing.T) {
 		}
 	}
 }
+
+func TestWebsiteChangeEvent_FieldEnums(t *testing.T) {
+	schema := queryutil.NewSchemaProvider().ForType(&WebsiteChangeEvent{})
+	enums := schema.FieldEnums()
+
+	values, ok := enums["event_type"]
+	if !ok {
+		t.Fatalf("expected enum field \"event_type\", not found in %v", enums)
+	}
+
+	expected := []string{"published", "removed"}
+	if len(values) != len(expected) {
+		t.Fatalf("expected %d enum values, got %d (%v)", len(expected), len(values), values)
+	}
+	for i, v := range expected {
+		if values[i] != v {
+			t.Errorf("event_type[%d]: expected %q, got %q", i, v, values[i])
+		}
+	}
+}

--- a/internal/api/dto/website_changes.go
+++ b/internal/api/dto/website_changes.go
@@ -1,17 +1,21 @@
 package dto
 
-import "time"
+import (
+	"time"
+
+	"go.lumeweb.com/portal-plugin-ipfs/internal/db"
+)
 
 // WebsiteChangeEvent is a single durable website lifecycle event returned by
 // the reconciliation endpoint.
 type WebsiteChangeEvent struct {
-	ID        uint64    `json:"id"`
-	EventType string    `json:"event_type"` // published | removed
-	Domain    string    `json:"domain"`
-	CID       string    `json:"cid,omitempty"` // target hash for published events
-	WebsiteID uint      `json:"website_id,omitempty"`
-	UserID    uint      `json:"user_id,omitempty"`
-	CreatedAt time.Time `json:"created_at"`
+	ID        uint64              `json:"id"`
+	EventType db.WebsiteEventType `json:"event_type" jsonschema:"enum=published,enum=removed"`
+	Domain    string              `json:"domain"`
+	CID       string              `json:"cid,omitempty"` // target hash for published events
+	WebsiteID uint                `json:"website_id,omitempty"`
+	UserID    uint                `json:"user_id,omitempty"`
+	CreatedAt time.Time           `json:"created_at"`
 }
 
 // WebsiteChangesResponse is the payload of


### PR DESCRIPTION
Adds a swagger enum for the website change event feed's `event_type` field.

`dto.WebsiteChangeEvent.EventType` switches from a plain string to the typed
`db.WebsiteEventType` with `jsonschema:"enum=published,enum=removed"`, so the
OpenAPI spec documents `published` and `removed` as the valid values. Adds a
field-enum schema test covering both values.

- `develop` <!-- branch-stack -->
  - **feat(gateway): add swagger enum for website change event types** :point\_left:

---

<!-- kody-pr-summary:start -->
This pull request modifies the `WebsiteChangeEvent` DTO to use a strongly-typed enum for the `event_type` field instead of a plain string. 

Key changes:
- Changed `EventType` field type from `string` to `db.WebsiteEventType` enum type in the DTO
- Added Swagger/OpenAPI schema annotations (`jsonschema:"enum=published,enum=removed"`) to document the allowed values ("published" and "removed") in the API documentation
- Updated the API handler to cast the event type to the enum type when returning website change events
- Added test coverage to verify the enum field is properly documented in the Swagger schema with the correct expected values
- Updated existing tests to compare against the enum type instead of string values

The primary purpose is to add proper API documentation (Swagger enum) for the website change event types, making the allowed values ("published" and "removed") explicit in the API specification. This improves API discoverability and provides better developer experience by clearly documenting the valid event type values in the generated API documentation.
<!-- kody-pr-summary:end -->