### PR TITLE
fix(dns): debug-log nameserver and delegation verification failures

### DIFF
--- a/internal/service/dns/dns_service_zone.go
+++ b/internal/service/dns/dns_service_zone.go
@@ -358,6 +358,10 @@ func (s *DNSServiceDefault) ValidateNameservers(ctx context.Context, zoneID uint
 	}
 
 	if !valid {
+		s.Logger().Debug("no approved nameservers in DNS delegation",
+			zap.String("domain", zone.Domain),
+			zap.Strings("approved", approvedNameservers),
+			zap.Strings("live", liveNameservers))
 		zone.LastNameserverCheckAt = new(time.Now())
 		_ = db.RetryableComponentTransaction(s, ctx, func(tx *gorm.DB) *gorm.DB {
 			return tx.Save(zone)

--- a/internal/service/domain/delegated_domain_service.go
+++ b/internal/service/domain/delegated_domain_service.go
@@ -656,6 +656,12 @@ func (s *DelegatedDomainService) VerifyDomain(ctx context.Context,
 				zap.String("status", string(wd.Status)),
 				zap.Uint("zone_id", wd.ZoneID))
 		}
+		s.Logger().Debug("delegation verification not applicable for binding",
+			zap.Uint("id", wd.ID),
+			zap.String("domain", wd.Domain),
+			zap.String("namespace", string(wd.Namespace)),
+			zap.String("status", string(wd.Status)),
+			zap.Uint("zone_id", wd.ZoneID))
 		return DelegationVerificationResult{State: DelegationNotApplicable}, nil
 	}
 
@@ -719,6 +725,13 @@ func (s *DelegatedDomainService) VerifyDomain(ctx context.Context,
 		wd.Status = pluginDb.DomainStatusActive
 		state = DelegationVerified
 	} else {
+		s.Logger().Debug("delegation not visible at parent zone yet",
+			zap.Uint("id", wd.ID),
+			zap.String("domain", wd.Domain),
+			zap.String("namespace", string(wd.Namespace)),
+			zap.Uint("zone_id", wd.ZoneID),
+			zap.Bool("dnssec_required", provider.RequiresDNSSEC()),
+			zap.Bool("expected_ds_present", expectedDS != ""))
 		wd.Status = pluginDb.DomainStatusWaitingDelegation
 	}
 

--- a/internal/service/website/janitor.go
+++ b/internal/service/website/janitor.go
@@ -553,6 +553,11 @@ func (j *WebsiteJanitorJob) verifyPendingDelegations(ctx context.Context) error 
 				if res.State != domsvc.DelegationVerified {
 					// Still pending (or not applicable): leave it for a later
 					// run — the status was left as-is by VerifyDomain.
+					j.logger.Debug("delegation verification not complete",
+						zap.String("domain", wd.Domain),
+						zap.String("namespace", string(wd.Namespace)),
+						zap.Uint("id", wd.ID),
+						zap.Uint8("state", uint8(res.State)))
 					continue
 				}
 


### PR DESCRIPTION
The website janitor reported "no approved nameservers found in DNS" without showing what was actually found, making verification failures impossible to diagnose.

Adds debug logging to the silent verification paths:

- `ValidateNameservers` logs the approved nameserver list and the live NS records returned from DNS when validation fails
- `VerifyDomain` logs when delegation isn't yet visible at the parent zone, including whether the namespace requires DNSSEC and whether an expected DS record is present
- `VerifyDomain` logs when verification is skipped as not applicable, exposing the binding's hosting classification
- The janitor logs domains whose delegation verification returned pending or not-applicable instead of continuing silently

* `develop` <!-- branch-stack -->
  - **fix(dns): debug-log nameserver and delegation verification failures** :point\_left:

---

<!-- kody-pr-summary:start -->
## Summary

This pull request adds debug logging to DNS delegation and nameserver verification processes to improve observability when delegation checks fail or are not yet complete.

## Changes

### 1. DNS Service Zone (`internal/service/dns/dns_service_zone.go`)
Added debug logging when nameserver validation fails because there are no approved nameservers in the DNS delegation. The log includes the domain name, approved nameservers list, and live nameservers list to help diagnose delegation misconfigurations.

### 2. Delegated Domain Service (`internal/service/domain/delegated_domain_service.go`)
Added two new debug log statements in the `VerifyDomain` method:
- **Binding not applicable**: Logs when delegation verification is not applicable for a binding (e.g., when the domain is bound but doesn't require delegation verification), including the domain ID, domain name, namespace, status, and zone ID.
- **Delegation not yet visible**: Logs when the delegation is not yet visible at the parent zone, capturing domain details, DNSSEC requirements, and expected DS record presence.

### 3. Website Janitor Job (`internal/service/website/janitor.go`)
Added debug logging in the janitor's pending delegation verification loop when a delegation is still pending or not applicable, logging the domain name, namespace, ID, and current verification state.

## Purpose
These changes enhance operational observability by providing detailed debug information when:
- Nameserver validation fails due to no approved nameservers
- Delegation verification is skipped or not applicable
- Delegations are not yet visible at the parent zone
- Pending delegations remain incomplete during janitor runs

This helps operators diagnose DNS delegation issues more quickly without requiring full trace-level logging.
<!-- kody-pr-summary:end -->