### PR TITLE
fix(dns): surface discovered vs expected nameservers on verify failures

### DIFF
--- a/internal/api/api_domains.go
+++ b/internal/api/api_domains.go
@@ -14,6 +14,7 @@ import (
 	"go.lumeweb.com/portal-plugin-ipfs/internal/api/dto"
 	pluginDb "go.lumeweb.com/portal-plugin-ipfs/internal/db"
 	"go.lumeweb.com/portal-plugin-ipfs/internal/service/domain"
+	domsvc "go.lumeweb.com/portal-plugin-ipfs/internal/service/domain"
 	"go.lumeweb.com/queryutil"
 	queryutilHttp "go.lumeweb.com/queryutil/http"
 	"go.uber.org/zap"
@@ -353,10 +354,22 @@ func (a *API) verifyDomain(c echo.Context) error {
 		return ctx.Error(apiErr, apiErr.HttpStatus())
 	}
 
-	if _, err := a.delegatedDomainSvc.VerifyDomain(reqCtx, &wd); err != nil {
+	res, err := a.delegatedDomainSvc.VerifyDomain(reqCtx, &wd)
+	if err != nil {
 		a.Logger().Error("Failed to verify domain", zap.Error(err))
 		apiErr := NewError(ErrKeyValidationFailed, err)
 		return ctx.Error(apiErr, apiErr.HttpStatus())
+	}
+
+	if res.State != domsvc.DelegationVerified {
+		a.Logger().Info("delegation not verified",
+			zap.String("domain", wd.Domain),
+			zap.String("namespace", string(wd.Namespace)),
+			zap.Uint("id", wd.ID),
+			zap.Uint("zone_id", wd.ZoneID),
+			zap.Uint8("state", uint8(res.State)),
+			zap.Strings("approved_ns", res.ApprovedNS),
+			zap.Strings("live_ns", res.LiveNS))
 	}
 
 	resp := dto.DomainResponse{}

--- a/internal/service/domain/delegated_domain_service.go
+++ b/internal/service/domain/delegated_domain_service.go
@@ -120,6 +120,12 @@ const (
 // on-chain/self-hosted bindings.
 type DelegationVerificationResult struct {
 	State DelegationVerificationState
+	// ApprovedNS / LiveNS carry the expected vs discovered nameservers for
+	// pending delegations (mirroring the janitor's zone NS validation) so a
+	// stuck waiting_delegation is diagnosable from logs alone. Both are empty
+	// unless the state is pending.
+	ApprovedNS []string
+	LiveNS     []string
 }
 
 // NewDelegatedDomainService creates a DelegatedDomainService with the given
@@ -721,17 +727,32 @@ func (s *DelegatedDomainService) VerifyDomain(ctx context.Context,
 	}
 
 	state := DelegationPending
+	var approvedNS, liveNS []string
 	if verified {
 		wd.Status = pluginDb.DomainStatusActive
 		state = DelegationVerified
 	} else {
+		// Grab the expected vs discovered NS (same comparison the janitor's
+		// zone validation performs) so a stuck waiting_delegation can be
+		// diagnosed from logs alone. Best-effort: an NS lookup failure must
+		// not mask the pending outcome.
+		approvedNS = provider.Nameservers()
+		if live, nsErr := provider.LiveNameservers(ctx, wd.Domain); nsErr != nil {
+			s.Logger().Debug("failed to resolve live nameservers for pending delegation",
+				zap.String("domain", wd.Domain),
+				zap.Error(nsErr))
+		} else {
+			liveNS = live
+		}
 		s.Logger().Debug("delegation not visible at parent zone yet",
 			zap.Uint("id", wd.ID),
 			zap.String("domain", wd.Domain),
 			zap.String("namespace", string(wd.Namespace)),
 			zap.Uint("zone_id", wd.ZoneID),
 			zap.Bool("dnssec_required", provider.RequiresDNSSEC()),
-			zap.Bool("expected_ds_present", expectedDS != ""))
+			zap.Bool("expected_ds_present", expectedDS != ""),
+			zap.Strings("approved_ns", approvedNS),
+			zap.Strings("live_ns", liveNS))
 		wd.Status = pluginDb.DomainStatusWaitingDelegation
 	}
 
@@ -741,7 +762,7 @@ func (s *DelegatedDomainService) VerifyDomain(ctx context.Context,
 		}
 	}
 
-	return DelegationVerificationResult{State: state}, nil
+	return DelegationVerificationResult{State: state, ApprovedNS: approvedNS, LiveNS: liveNS}, nil
 }
 
 // selfHealZone re-ensures the portal-managed-zone invariants that are

--- a/internal/service/website/janitor.go
+++ b/internal/service/website/janitor.go
@@ -557,7 +557,9 @@ func (j *WebsiteJanitorJob) verifyPendingDelegations(ctx context.Context) error 
 						zap.String("domain", wd.Domain),
 						zap.String("namespace", string(wd.Namespace)),
 						zap.Uint("id", wd.ID),
-						zap.Uint8("state", uint8(res.State)))
+						zap.Uint8("state", uint8(res.State)),
+						zap.Strings("approved_ns", res.ApprovedNS),
+						zap.Strings("live_ns", res.LiveNS))
 					continue
 				}
 


### PR DESCRIPTION
Adds ApprovedNS/LiveNS to DelegationVerificationResult, populated pending
verification from the namespace provider, so stuck waiting\_delegation
domains can be diagnosed from logs alone.

Also logs delegation-not-verified outcomes in the verify API handler and
janitor with the comparison lists.

- `develop` <!-- branch-stack -->
  - **fix(dns): surface discovered vs expected nameservers on verify failures** :point\_left:

---

<!-- kody-pr-summary:start -->
## Summary

This pull request improves the diagnostics for DNS name server delegation verification failures by surfacing the discovered vs expected nameservers in logs when a domain's delegation cannot be verified.

## Changes

### Enhanced Logging with NS Comparison Data
- Extended the `DelegationVerificationResult` struct to include `ApprovedNS` (expected nameservers) and `LiveNS` (discovered nameservers).
- When a domain's delegation verification fails (i.e., the delegation is in a pending state), the service now performs a best-effort lookup of the live nameservers and includes both the approved and live nameserver lists in the verification result.
- This information is surfaced in debug logs within the delegation service itself, as well as in the API layer and janitor job logs when a verification fails.

### Non-Blocking NS Lookup
- The live nameserver lookup is performed as a best-effort operation; if it fails, the outcome (pending delegation) is not masked, and a debug log entry records the resolution failure.

### API Response Enhancement
- The API's `verifyDomain` handler now checks the returned verification state and logs an informational message with domain details (domain, namespace, ID, zone ID, state, approved/live NS) when the delegation is not in a verified state.

## Impact

This change enables operators to diagnose why a domain is stuck in a `waiting_delegation` state directly from logs, by comparing the expected nameservers (as configured) against what is actually discovered via DNS lookup, without requiring additional tooling or manual investigation.
<!-- kody-pr-summary:end -->