### PR TITLE
feat(api): expose domain status, namespace and ssl status as swagger enums

### DIFF
--- a/internal/api/api_domains_test.go
+++ b/internal/api/api_domains_test.go
@@ -135,7 +135,7 @@ func TestAPI_DomainDNSRequirements(t *testing.T) {
 			var resp dto.DomainResponse
 			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
 			assert.Equal(t, "lumeweb", resp.Domain)
-			assert.Equal(t, "hns", resp.Namespace)
+			assert.Equal(t, pluginDb.DomainNamespaceHNS, resp.Namespace)
 			require.NotNil(t, resp.Delegation)
 			assert.Equal(t, "delegated", resp.Delegation.Mode)
 			// No first-class DS field — the live DS is injected into
@@ -453,7 +453,7 @@ func TestAPI_DANERepublish(t *testing.T) {
 			var resp dto.DomainDANERepublishResponse
 			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
 			assert.Equal(t, "hns-repub.test", resp.Domain)
-			assert.Equal(t, "hns", resp.Namespace)
+			assert.Equal(t, pluginDb.DomainNamespaceHNS, resp.Namespace)
 			require.NotEmpty(t, resp.TLSARData)
 			require.NotEmpty(t, resp.OwnerName)
 			assert.Contains(t, resp.TLSARecord, "TLSA")
@@ -668,7 +668,7 @@ func TestAPI_DomainDNSRequirements_OnchainManaged(t *testing.T) {
 		var resp dto.DomainResponse
 		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
 		assert.Equal(t, "onchain", resp.Domain)
-		assert.Equal(t, string(pluginDb.DomainStatusOnchainManaged), resp.Status)
+		assert.Equal(t, pluginDb.DomainStatusOnchainManaged, resp.Status)
 		assert.False(t, resp.DNSHostingEnabled)
 		assert.Nil(t, resp.Delegation, "on-chain managed domains have no portal delegation/NS-DS guidance")
 	}, TestOptions)

--- a/internal/api/api_websites.go
+++ b/internal/api/api_websites.go
@@ -933,7 +933,7 @@ func (a *API) applyApexSSLStatus(ctx context.Context, resp *dto.WebsiteResponse,
 // sslStatusInfoFromDomain converts a domain binding's SSL state to the DTO.
 func sslStatusInfoFromDomain(wd *pluginDb.WebsiteDomain) *dto.SSLStatusInfo {
 	info := &dto.SSLStatusInfo{
-		Status: wd.SSLStatus,
+		Status: pluginDb.SSLStatus(wd.SSLStatus),
 		Error:  wd.SSLError,
 	}
 	if wd.SSLIssuedAt != nil {

--- a/internal/api/api_websites_test.go
+++ b/internal/api/api_websites_test.go
@@ -429,7 +429,7 @@ func TestAPI_GetSSLStatus(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, uint(1), response.ID)
 			assert.Equal(t, TestDomain, response.Domain)
-			assert.Equal(t, "ready", response.SSL.Status)
+			assert.Equal(t, pluginDb.SSLStatusReady, response.SSL.Status)
 		}, TestOptions)
 	})
 
@@ -464,7 +464,7 @@ func TestAPI_GetSSLStatus(t *testing.T) {
 			var response dto.WebsiteResponse
 			err := json.Unmarshal(rec.Body.Bytes(), &response)
 			require.NoError(t, err)
-			assert.Equal(t, "pending", response.SSL.Status)
+			assert.Equal(t, pluginDb.SSLStatusPending, response.SSL.Status)
 		}, TestOptions)
 	})
 
@@ -535,7 +535,7 @@ func TestAPI_UpdateSSLStatus_Webhook(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, uint(1), response.ID)
 			assert.Equal(t, TestDomain, response.Domain)
-			assert.Equal(t, "ready", response.SSL.Status)
+			assert.Equal(t, pluginDb.SSLStatusReady, response.SSL.Status)
 		}, TestOptions)
 	})
 
@@ -558,7 +558,7 @@ func TestAPI_UpdateSSLStatus_Webhook(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, uint(1), response.ID)
 			assert.Equal(t, TestDomain, response.Domain)
-			assert.Equal(t, "failed", response.SSL.Status)
+			assert.Equal(t, pluginDb.SSLStatusFailed, response.SSL.Status)
 			assert.Equal(t, "certificate validation failed", response.SSL.Error)
 		}, TestOptions)
 	})
@@ -582,7 +582,7 @@ func TestAPI_UpdateSSLStatus_Webhook(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, uint(1), response.ID)
 			assert.Equal(t, TestDomain, response.Domain)
-			assert.Equal(t, "pending", response.SSL.Status)
+			assert.Equal(t, pluginDb.SSLStatusPending, response.SSL.Status)
 		}, TestOptions)
 	})
 
@@ -605,7 +605,7 @@ func TestAPI_UpdateSSLStatus_Webhook(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, uint(1), response.ID)
 			assert.Equal(t, TestDomain, response.Domain)
-			assert.Equal(t, "issuing", response.SSL.Status)
+			assert.Equal(t, pluginDb.SSLStatusIssuing, response.SSL.Status)
 		}, TestOptions)
 	})
 
@@ -736,7 +736,7 @@ func TestAPI_UpdateSSLStatus_Webhook(t *testing.T) {
 			var response1 dto.WebsiteResponse
 			err := json.Unmarshal(rec1.Body.Bytes(), &response1)
 			require.NoError(t, err)
-			assert.Equal(t, "pending", response1.SSL.Status)
+			assert.Equal(t, pluginDb.SSLStatusPending, response1.SSL.Status)
 
 			reqBody2 := fmt.Sprintf(`{"status":"issuing","timestamp":"%s"}`, timestamp2.Format(time.RFC3339))
 			rec2 := helper.makeGatewayAuthenticatedRequest(http.MethodPost, "/internal/websites/"+TestDomain+"/ssl-status", testGatewaySecret(), []byte(reqBody2))
@@ -744,7 +744,7 @@ func TestAPI_UpdateSSLStatus_Webhook(t *testing.T) {
 			var response2 dto.WebsiteResponse
 			err = json.Unmarshal(rec2.Body.Bytes(), &response2)
 			require.NoError(t, err)
-			assert.Equal(t, "issuing", response2.SSL.Status)
+			assert.Equal(t, pluginDb.SSLStatusIssuing, response2.SSL.Status)
 
 			reqBody3 := fmt.Sprintf(`{"status":"ready","timestamp":"%s"}`, timestamp3.Format(time.RFC3339))
 			rec3 := helper.makeGatewayAuthenticatedRequest(http.MethodPost, "/internal/websites/"+TestDomain+"/ssl-status", testGatewaySecret(), []byte(reqBody3))
@@ -752,7 +752,7 @@ func TestAPI_UpdateSSLStatus_Webhook(t *testing.T) {
 			var response3 dto.WebsiteResponse
 			err = json.Unmarshal(rec3.Body.Bytes(), &response3)
 			require.NoError(t, err)
-			assert.Equal(t, "ready", response3.SSL.Status)
+			assert.Equal(t, pluginDb.SSLStatusReady, response3.SSL.Status)
 		}, TestOptions)
 	})
 }

--- a/internal/api/dto/domain.go
+++ b/internal/api/dto/domain.go
@@ -143,13 +143,13 @@ type DNSDelegation struct {
 
 // DomainResponse is a bound domain.
 type DomainResponse struct {
-	ID          uint           `json:"id"`
-	Domain      string         `json:"domain"`
-	Namespace   string         `json:"namespace"`
-	Status      string         `json:"status,omitempty"`
-	ZoneName    string         `json:"zone_name,omitempty"`
-	GatewayHost string         `json:"gateway_host,omitempty"`
-	Delegation  *DNSDelegation `json:"delegation,omitempty"`
+	ID          uint               `json:"id"`
+	Domain      string             `json:"domain"`
+	Namespace   db.DomainNamespace `json:"namespace" jsonschema:"enum=icann,enum=hns"`
+	Status      db.DomainStatus    `json:"status,omitempty" jsonschema:"enum=draft,enum=records_generated,enum=waiting_delegation,enum=active,enum=self_hosted,enum=error,enum=onchain_managed"`
+	ZoneName    string             `json:"zone_name,omitempty"`
+	GatewayHost string             `json:"gateway_host,omitempty"`
+	Delegation  *DNSDelegation     `json:"delegation,omitempty"`
 	// DNSHostingEnabled reports whether the portal manages DNS for this
 	// specific domain binding (the per-domain DNS hosting flag).
 	DNSHostingEnabled bool `json:"dns_hosting_enabled"`
@@ -161,15 +161,15 @@ type DomainResponse struct {
 func (r *DomainResponse) FromModel(m *db.WebsiteDomain) error {
 	r.ID = m.ID
 	r.Domain = m.Domain
-	r.Namespace = string(m.Namespace)
-	r.Status = string(m.Status)
+	r.Namespace = m.Namespace
+	r.Status = m.Status
 	r.ZoneName = m.ZoneName
 	r.GatewayHost = m.GatewayHost
 	r.DNSHostingEnabled = m.DNSHostingEnabled
 
 	if m.SSLStatus != "" {
 		r.SSL = &SSLStatusInfo{
-			Status: m.SSLStatus,
+			Status: db.SSLStatus(m.SSLStatus),
 			Error:  m.SSLError,
 		}
 		if m.SSLIssuedAt != nil {
@@ -202,17 +202,17 @@ func (r *DomainResponse) FromModel(m *db.WebsiteDomain) error {
 // embedding DomainResponse, because the gswagger schema generator rejects Go
 // embedded structs (potential infinite recursion).
 type DomainDANERepublishResponse struct {
-	ID          uint           `json:"id"`
-	Domain      string         `json:"domain"`
-	Namespace   string         `json:"namespace"`
-	Status      string         `json:"status,omitempty"`
-	ZoneName    string         `json:"zone_name,omitempty"`
-	GatewayHost string         `json:"gateway_host,omitempty"`
-	Delegation  *DNSDelegation `json:"delegation,omitempty"`
-	SSL         *SSLStatusInfo `json:"ssl,omitempty"`
-	TLSARecord  string         `json:"tlsa_record,omitempty"` // full "_443._tcp.<domain> ... TLSA ..." presentation
-	OwnerName   string         `json:"owner_name,omitempty"`  // "_443._tcp.<domain>"
-	TLSARData   string         `json:"tlsa_rdata,omitempty"`  // "3 1 1 <hex>"
+	ID          uint               `json:"id"`
+	Domain      string             `json:"domain"`
+	Namespace   db.DomainNamespace `json:"namespace" jsonschema:"enum=icann,enum=hns"`
+	Status      db.DomainStatus    `json:"status,omitempty" jsonschema:"enum=draft,enum=records_generated,enum=waiting_delegation,enum=active,enum=self_hosted,enum=error,enum=onchain_managed"`
+	ZoneName    string             `json:"zone_name,omitempty"`
+	GatewayHost string             `json:"gateway_host,omitempty"`
+	Delegation  *DNSDelegation     `json:"delegation,omitempty"`
+	SSL         *SSLStatusInfo     `json:"ssl,omitempty"`
+	TLSARecord  string             `json:"tlsa_record,omitempty"` // full "_443._tcp.<domain> ... TLSA ..." presentation
+	OwnerName   string             `json:"owner_name,omitempty"`  // "_443._tcp.<domain>"
+	TLSARData   string             `json:"tlsa_rdata,omitempty"`  // "3 1 1 <hex>"
 }
 
 // FromModel populates the DomainResponse-backed fields from a WebsiteDomain.
@@ -225,13 +225,13 @@ func (r *DomainDANERepublishResponse) FromModel(m *db.WebsiteDomain) error {
 func (r *DomainDANERepublishResponse) DomainResponseFromModel(m *db.WebsiteDomain) error {
 	r.ID = m.ID
 	r.Domain = m.Domain
-	r.Namespace = string(m.Namespace)
-	r.Status = string(m.Status)
+	r.Namespace = m.Namespace
+	r.Status = m.Status
 	r.ZoneName = m.ZoneName
 	r.GatewayHost = m.GatewayHost
 	if m.SSLStatus != "" {
 		r.SSL = &SSLStatusInfo{
-			Status: m.SSLStatus,
+			Status: db.SSLStatus(m.SSLStatus),
 			Error:  m.SSLError,
 		}
 		if m.SSLIssuedAt != nil {

--- a/internal/api/dto/domain_test.go
+++ b/internal/api/dto/domain_test.go
@@ -42,8 +42,8 @@ func TestDomainResponse_FromModel_HNS(t *testing.T) {
 
 	assert.Equal(t, uint(7), resp.ID)
 	assert.Equal(t, "lumeweb", resp.Domain)
-	assert.Equal(t, "hns", resp.Namespace)
-	assert.Equal(t, "records_generated", resp.Status)
+	assert.Equal(t, pluginDb.DomainNamespaceHNS, resp.Namespace)
+	assert.Equal(t, pluginDb.DomainStatusRecordsGenerated, resp.Status)
 	assert.Equal(t, "lumeweb.", resp.ZoneName)
 	assert.Equal(t, "gateway.lumeweb.com", resp.GatewayHost)
 
@@ -110,7 +110,7 @@ func TestDomainResponse_FromModel_NoDelegation(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, uint(1), resp.ID)
-	assert.Equal(t, "draft", resp.Status)
+	assert.Equal(t, pluginDb.DomainStatusDraft, resp.Status)
 	assert.Nil(t, resp.Delegation, "delegation should be nil when no DelegationData")
 	assert.Empty(t, resp.GatewayHost)
 }

--- a/internal/api/dto/enum_schema_test.go
+++ b/internal/api/dto/enum_schema_test.go
@@ -6,6 +6,50 @@ import (
 	"go.lumeweb.com/queryutil"
 )
 
+func TestDomainResponse_FieldEnums(t *testing.T) {
+	schema := queryutil.NewSchemaProvider().ForType(&DomainResponse{})
+	enums := schema.FieldEnums()
+
+	want := map[string][]string{
+		"status":    {"draft", "records_generated", "waiting_delegation", "active", "self_hosted", "error", "onchain_managed"},
+		"namespace": {"icann", "hns"},
+	}
+	for field, expected := range want {
+		values, ok := enums[field]
+		if !ok {
+			t.Fatalf("expected enum field %q, not found in %v", field, enums)
+		}
+		if len(values) != len(expected) {
+			t.Fatalf("%s: expected %d enum values, got %d (%v)", field, len(expected), len(values), values)
+		}
+		for i, v := range expected {
+			if values[i] != v {
+				t.Errorf("%s[%d]: expected %q, got %q", field, i, v, values[i])
+			}
+		}
+	}
+}
+
+func TestSSLStatusInfo_FieldEnums(t *testing.T) {
+	schema := queryutil.NewSchemaProvider().ForType(&SSLStatusInfo{})
+	enums := schema.FieldEnums()
+
+	values, ok := enums["status"]
+	if !ok {
+		t.Fatalf("expected enum field \"status\", not found in %v", enums)
+	}
+
+	expected := []string{"pending", "issuing", "ready", "failed"}
+	if len(values) != len(expected) {
+		t.Fatalf("expected %d enum values, got %d (%v)", len(expected), len(values), values)
+	}
+	for i, v := range expected {
+		if values[i] != v {
+			t.Errorf("status[%d]: expected %q, got %q", i, v, values[i])
+		}
+	}
+}
+
 func TestUploadResultResponse_FieldEnums(t *testing.T) {
 	schema := queryutil.NewSchemaProvider().ForType(&UploadResultResponse{})
 	enums := schema.FieldEnums()

--- a/internal/api/dto/website.go
+++ b/internal/api/dto/website.go
@@ -185,7 +185,7 @@ func (r *IPNSRepublishResponse) FromModel(any) error {
 //     a computed label). The namespace and DNS hosting are derived from the
 //     platform root, mirroring the domain-bind flow.
 type WebsiteRequest struct {
-	Domain     string               `json:"domain,omitempty"`               // primary domain (transparently created as a WebsiteDomain binding); omitted when claiming a platform subdomain
+	Domain     string               `json:"domain,omitempty"`              // primary domain (transparently created as a WebsiteDomain binding); omitted when claiming a platform subdomain
 	Namespace  *db.DomainNamespace  `json:"namespace,omitempty"`           // icann (default) or hns
 	TargetType db.WebsiteTargetType `json:"target_type"`                   // db.WebsiteTargetTypeIPFS or db.WebsiteTargetTypeIPNS
 	TargetHash string               `json:"target_hash"`                   // CID or IPNS peer ID
@@ -387,10 +387,10 @@ func (r *WebsiteUpdateRequest) ToModel() (*db.Website, error) {
 
 // SSLStatusInfo represents SSL certificate status information
 type SSLStatusInfo struct {
-	Status        string     `json:"status"`
-	Error         string     `json:"error,omitempty"`
-	IssuedAt      *time.Time `json:"issued_at,omitempty"`
-	LastUpdatedAt *time.Time `json:"last_updated_at,omitempty"`
+	Status        db.SSLStatus `json:"status" jsonschema:"enum=pending,enum=issuing,enum=ready,enum=failed"`
+	Error         string       `json:"error,omitempty"`
+	IssuedAt      *time.Time   `json:"issued_at,omitempty"`
+	LastUpdatedAt *time.Time   `json:"last_updated_at,omitempty"`
 }
 
 // WebsiteResponse represents a website response


### PR DESCRIPTION
Adds typed enum fields and `jsonschema` enum tags to the domain DTOs so the generated swagger — and the SDK built from it — models `status`, `namespace`, and `ssl.status` as enums instead of free-form strings.

- `DomainResponse` and `DomainDANERepublishResponse` use `db.DomainStatus` (all values including `onchain_managed`) and `db.DomainNamespace` (`icann`/`hns`)
- `SSLStatusInfo.Status` uses `db.SSLStatus` (`pending`/`issuing`/`ready`/`failed`)
- Adds `queryutil` FieldEnums tests locking the enum sets; updates existing dto test assertions for the new types

* `develop` <!-- branch-stack -->
  - **feat(api): expose domain status, namespace and ssl status as swagger enums** :point\_left:

***

<!-- kody-pr-summary:start -->

This pull request improves the API schema by exposing domain status, namespace, and SSL status as proper enums in the Swagger/OpenAPI documentation.

**What changed:**

- **Domain response DTOs** (`DomainResponse` and `DomainDANERepublishResponse`):
  - `Namespace` and `Status` fields now use the typed `db.DomainNamespace` and `db.DomainStatus` types instead of plain strings.
  - Added `jsonschema` tags declaring the allowed enum values:
    - `namespace`: `icann`, `hns`
    - `status`: `draft`, `records_generated`, `waiting_delegation`, `active`, `self_hosted`, `error`, `onchain_managed`

- **SSL status info** (`SSLStatusInfo`):
  - `Status` now uses the `db.SSLStatus` type instead of `string`.
  - Added `jsonschema` enum values: `pending`, `issuing`, `ready`, `failed`.

- **Internal handling**: Direct conversions from string to the typed enums are updated throughout the DTO mapping logic.

- **Tests**: Updated existing tests to use the typed constants and added new tests that verify the schema provider returns the correct enum values for the affected fields.

**Why:**

Previously the API response fields were plain strings, which meant API consumers could not discover the valid values from the generated Swagger specification. By using typed enums and `jsonschema` annotations, the OpenAPI documentation now accurately reflects the possible values for domain namespace, domain status, and SSL status.

<!-- kody-pr-summary:end -->
