### PR TITLE
feat(website): auto-validate broken site after target update

### DIFF
--- a/core/website.go
+++ b/core/website.go
@@ -104,4 +104,8 @@ type WebsiteService interface {
 
 	// WaitForPublishes blocks until all in-flight async publish operations complete
 	WaitForPublishes()
+
+	// WaitForValidations blocks until all in-flight background auto-validation
+	// operations complete
+	WaitForValidations()
 }

--- a/internal/service/website/website.go
+++ b/internal/service/website/website.go
@@ -32,6 +32,10 @@ import (
 	"gorm.io/gorm/clause"
 )
 
+// autoValidationTimeout bounds the background re-validation of a broken
+// website after a deploy so a hung resolver cannot leak a goroutine forever.
+const autoValidationTimeout = 30 * time.Second
+
 func (s *WebsiteServiceDefault) verificationTokenKey() string {
 	if s.dnsConfig != nil && s.dnsConfig.VerificationTokenKey != "" {
 		return s.dnsConfig.VerificationTokenKey
@@ -79,6 +83,7 @@ type WebsiteServiceDefault struct {
 	delegatedDomainSvc delegatedDomainService
 	resolver           DNSResolver
 	publishWg          sync.WaitGroup
+	validationWg       sync.WaitGroup
 }
 
 // Ensure WebsiteServiceDefault implements the interface
@@ -935,31 +940,10 @@ func (s *WebsiteServiceDefault) UpdateWebsite(ctx context.Context, userID uint, 
 	// validated target (the update itself proves the CID is pinned) should be
 	// able to revive it without waiting for the janitor or a manual validate.
 	// A failed validation never fails or rolls back the update — the site keeps
-	// its broken (or other) status for the existing recovery paths.
+	// its broken (or other) status for the existing recovery paths. It runs in
+	// the background so the deploy response never waits on external DNS.
 	if targetHashChanged && updatedWebsite != nil && oldStatus == pluginDb.WebsiteStatusBroken {
-		result, verr := s.ValidateDNS(ctx, userID, websiteID)
-		switch {
-		case verr != nil:
-			s.Logger().Warn("Auto-validation of broken website after update failed",
-				zap.Error(verr),
-				zap.Uint("website_id", websiteID),
-				zap.Uint("user_id", userID))
-		case !result.Valid:
-			s.Logger().Warn("Auto-validation of broken website after update did not validate",
-				zap.String("reason", string(result.Reason)),
-				zap.Uint("website_id", websiteID),
-				zap.Uint("user_id", userID))
-		default:
-			s.Logger().Info("Recovered broken website via auto-validation after update",
-				zap.Uint("website_id", websiteID),
-				zap.Uint("user_id", userID))
-		}
-		// Reload so the caller sees the auto-activated status/expiry from
-		// validation rather than the pre-validation snapshot.
-		var reloaded pluginDb.Website
-		if rerr := s.DB().WithContext(ctx).First(&reloaded, websiteID).Error; rerr == nil {
-			updatedWebsite = &reloaded
-		}
+		s.autoValidateBrokenWebsite(ctx, userID, websiteID)
 	}
 
 	// Send notification to admin
@@ -2016,6 +2000,53 @@ func (s *WebsiteServiceDefault) publishCIDAsync(ctx context.Context, peerID, cid
 
 func (s *WebsiteServiceDefault) WaitForPublishes() {
 	s.publishWg.Wait()
+}
+
+// autoValidateBrokenWebsite re-validates a broken website in the background
+// after a deploy re-pointed its target. The update path already proved the new
+// target is pinned, so DNS validation is the only remaining gate between the
+// site and recovery to active. Runs detached so HTTP deploy latency never
+// depends on external DNS; a failure only logs — janitor and manual validate
+// remain the fallback recovery paths.
+func (s *WebsiteServiceDefault) autoValidateBrokenWebsite(ctx context.Context, userID, websiteID uint) {
+	s.validationWg.Add(1)
+	go func() {
+		defer s.validationWg.Done()
+		defer func() {
+			if r := recover(); r != nil {
+				s.Logger().Error("Recovered from panic in autoValidateBrokenWebsite",
+					zap.Any("panic", r),
+					zap.Uint("website_id", websiteID),
+					zap.Uint("user_id", userID))
+			}
+		}()
+		vctx, cancel := context.WithTimeout(core.DetachContext(ctx), autoValidationTimeout)
+		defer cancel()
+
+		result, err := s.ValidateDNS(vctx, userID, websiteID)
+		switch {
+		case err != nil:
+			s.Logger().Warn("Auto-validation of broken website after update failed",
+				zap.Error(err),
+				zap.Uint("website_id", websiteID),
+				zap.Uint("user_id", userID))
+		case !result.Valid:
+			s.Logger().Warn("Auto-validation of broken website after update did not validate",
+				zap.String("reason", string(result.Reason)),
+				zap.Uint("website_id", websiteID),
+				zap.Uint("user_id", userID))
+		default:
+			s.Logger().Info("Recovered broken website via auto-validation after update",
+				zap.Uint("website_id", websiteID),
+				zap.Uint("user_id", userID))
+		}
+	}()
+}
+
+// WaitForValidations blocks until all background auto-validations complete.
+// Test convenience — production callers never wait on recovery work.
+func (s *WebsiteServiceDefault) WaitForValidations() {
+	s.validationWg.Wait()
 }
 
 // setIPNSTargetUpdates populates the updates map with IPNS target fields

--- a/internal/service/website/website.go
+++ b/internal/service/website/website.go
@@ -611,6 +611,7 @@ func (s *WebsiteServiceDefault) UpdateWebsite(ctx context.Context, userID uint, 
 	var dnsEnabledChanged bool
 	var enableDNS bool
 	var targetHashChanged bool
+	var oldStatus pluginDb.WebsiteStatus
 
 	err := core.MetricTrack(
 		UpdateWebsiteDuration.WithLabelValues(),
@@ -631,6 +632,7 @@ func (s *WebsiteServiceDefault) UpdateWebsite(ctx context.Context, userID uint, 
 				// Store old values for DNS updates and state transitions
 				oldTargetHash := website.TargetHash()
 				oldTargetType := pluginDb.WebsiteTargetType(website.TargetType)
+				oldStatus = pluginDb.WebsiteStatus(website.Status)
 				targetHashChanged = false
 				ipnsAutoCreated := false
 				var newTargetHashStr string
@@ -927,6 +929,37 @@ func (s *WebsiteServiceDefault) UpdateWebsite(ctx context.Context, userID uint, 
 		core.Fire(s.Context(), pluginEvent.EVENT_WEBSITE_PUBLISHED, pluginEvent.NewWebsitePublishedEvent(
 			ctx, s.primaryDomainName(ctx, updatedWebsite), updatedWebsite.TargetHash(), updatedWebsite.UserID, updatedWebsite.ID,
 		))
+	}
+
+	// Best-effort auto-recovery: a deploy that re-points a broken website to a
+	// validated target (the update itself proves the CID is pinned) should be
+	// able to revive it without waiting for the janitor or a manual validate.
+	// A failed validation never fails or rolls back the update — the site keeps
+	// its broken (or other) status for the existing recovery paths.
+	if targetHashChanged && updatedWebsite != nil && oldStatus == pluginDb.WebsiteStatusBroken {
+		result, verr := s.ValidateDNS(ctx, userID, websiteID)
+		switch {
+		case verr != nil:
+			s.Logger().Warn("Auto-validation of broken website after update failed",
+				zap.Error(verr),
+				zap.Uint("website_id", websiteID),
+				zap.Uint("user_id", userID))
+		case !result.Valid:
+			s.Logger().Warn("Auto-validation of broken website after update did not validate",
+				zap.String("reason", string(result.Reason)),
+				zap.Uint("website_id", websiteID),
+				zap.Uint("user_id", userID))
+		default:
+			s.Logger().Info("Recovered broken website via auto-validation after update",
+				zap.Uint("website_id", websiteID),
+				zap.Uint("user_id", userID))
+		}
+		// Reload so the caller sees the auto-activated status/expiry from
+		// validation rather than the pre-validation snapshot.
+		var reloaded pluginDb.Website
+		if rerr := s.DB().WithContext(ctx).First(&reloaded, websiteID).Error; rerr == nil {
+			updatedWebsite = &reloaded
+		}
 	}
 
 	// Send notification to admin

--- a/internal/service/website/website_test.go
+++ b/internal/service/website/website_test.go
@@ -846,10 +846,11 @@ func TestWebsiteService_UpdateWebsite_BrokenSite_AutoValidates(t *testing.T) {
 			"target_hash": newCID.String(),
 		})
 
+		websiteService.WaitForValidations()
+
 		// Assert
 		require.NoError(tb, err)
 		require.NotNil(tb, updatedWebsite)
-		assert.Equal(tb, string(pluginDb.WebsiteStatusActive), updatedWebsite.Status, "broken site should be auto-recovered when the deploy target validates")
 
 		final, err := websiteService.GetWebsite(context.Background(), testUserID1, createdWebsite.ID)
 		require.NoError(tb, err)
@@ -895,6 +896,8 @@ func TestWebsiteService_UpdateWebsite_BrokenSite_ValidationFails_StatusUnchanged
 		})
 
 		// Assert
+		websiteService.WaitForValidations()
+
 		require.NoError(tb, err, "failed auto-validation must not fail the update")
 		require.NotNil(tb, updatedWebsite)
 		assert.Equal(tb, newCID.String(), updatedWebsite.TargetHash())

--- a/internal/service/website/website_test.go
+++ b/internal/service/website/website_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	dnslink "github.com/dnslink-std/go"
+
 	"github.com/ipfs/go-cid"
 	"github.com/libp2p/go-libp2p/core/peer"
 	mh "github.com/multiformats/go-multihash"
@@ -800,6 +802,106 @@ func TestWebsiteService_UpdateWebsite_NotFound(t *testing.T) {
 		// Assert
 		assert.Error(tb, err)
 		assert.Nil(tb, updatedWebsite)
+	}, TestOptions)
+}
+
+func TestWebsiteService_UpdateWebsite_BrokenSite_AutoValidates(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		// Arrange
+		websiteService := core.GetService[pluginCore.WebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
+		require.NotNil(tb, websiteService)
+
+		testCID := util.GenerateTestCID(t, "broken-recover")
+		website := createTestIPFSWebsite(testUserID1, "broken-recover.com", testCID.String())
+		stubPinnedCID(t, ctx, testUserID1, testCID.String())
+
+		createdWebsite, err := websiteService.CreateWebsite(context.Background(), website)
+		require.NoError(tb, err)
+		require.NotNil(tb, createdWebsite)
+		_ = bindPrimaryDomain(tb, ctx, createdWebsite.ID, "broken-recover.com", false)
+
+		_, err = websiteService.UpdateWebsite(context.Background(), testUserID1, createdWebsite.ID, map[string]interface{}{
+			"status": string(pluginDb.WebsiteStatusBroken),
+		})
+		require.NoError(tb, err)
+
+		newCID := util.GenerateTestCID(t, "broken-recover-new")
+		stubPinnedCID(t, ctx, testUserID1, newCID.String())
+
+		// The auto-validation runs synchronously inside the update: with the
+		// target re-pointed (and proven pinned) it should re-resolve the
+		// DNSLink against the NEW target and activate the site. A broken
+		// website skips the TXT token check (shouldPerformTokenCheck gates it
+		// to pending_validation), so only ResolveDNSLink is expected.
+		mockResolver := mocks.NewMockDNSResolver(t)
+		mockResolver.EXPECT().ResolveDNSLink("broken-recover.com").Return(dnslink.Result{
+			Links: map[string]dnslink.NamespaceEntries{
+				"ipfs": {{Identifier: newCID.String()}},
+			},
+		}, nil)
+		setMockResolver(websiteService, mockResolver)
+
+		// Act - re-point the target of the broken website (a deploy)
+		updatedWebsite, err := websiteService.UpdateWebsite(context.Background(), testUserID1, createdWebsite.ID, map[string]interface{}{
+			"target_hash": newCID.String(),
+		})
+
+		// Assert
+		require.NoError(tb, err)
+		require.NotNil(tb, updatedWebsite)
+		assert.Equal(tb, string(pluginDb.WebsiteStatusActive), updatedWebsite.Status, "broken site should be auto-recovered when the deploy target validates")
+
+		final, err := websiteService.GetWebsite(context.Background(), testUserID1, createdWebsite.ID)
+		require.NoError(tb, err)
+		assert.Equal(tb, string(pluginDb.WebsiteStatusActive), final.Status)
+		assert.Equal(tb, newCID.String(), final.TargetHash())
+	}, TestOptions)
+}
+
+func TestWebsiteService_UpdateWebsite_BrokenSite_ValidationFails_StatusUnchanged(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		// Arrange
+		websiteService := core.GetService[pluginCore.WebsiteService](ctx, pluginCore.WEBSITE_SERVICE)
+		require.NotNil(tb, websiteService)
+
+		testCID := util.GenerateTestCID(t, "broken-fail")
+		website := createTestIPFSWebsite(testUserID1, "broken-fail.com", testCID.String())
+		stubPinnedCID(t, ctx, testUserID1, testCID.String())
+
+		createdWebsite, err := websiteService.CreateWebsite(context.Background(), website)
+		require.NoError(tb, err)
+		require.NotNil(tb, createdWebsite)
+		_ = bindPrimaryDomain(tb, ctx, createdWebsite.ID, "broken-fail.com", false)
+
+		_, err = websiteService.UpdateWebsite(context.Background(), testUserID1, createdWebsite.ID, map[string]interface{}{
+			"status": string(pluginDb.WebsiteStatusBroken),
+		})
+		require.NoError(tb, err)
+
+		newCID := util.GenerateTestCID(t, "broken-fail-new")
+		stubPinnedCID(t, ctx, testUserID1, newCID.String())
+
+		// DNSLink does not match the new target: auto-validation must be
+		// best-effort and never fail or roll back the deploy itself.
+		mockResolver := mocks.NewMockDNSResolver(t)
+		mockResolver.EXPECT().ResolveDNSLink("broken-fail.com").Return(dnslink.Result{
+			Links: map[string]dnslink.NamespaceEntries{},
+		}, nil)
+		setMockResolver(websiteService, mockResolver)
+
+		// Act
+		updatedWebsite, err := websiteService.UpdateWebsite(context.Background(), testUserID1, createdWebsite.ID, map[string]interface{}{
+			"target_hash": newCID.String(),
+		})
+
+		// Assert
+		require.NoError(tb, err, "failed auto-validation must not fail the update")
+		require.NotNil(tb, updatedWebsite)
+		assert.Equal(tb, newCID.String(), updatedWebsite.TargetHash())
+
+		final, err := websiteService.GetWebsite(context.Background(), testUserID1, createdWebsite.ID)
+		require.NoError(tb, err)
+		assert.Equal(tb, string(pluginDb.WebsiteStatusBroken), final.Status, "site stays broken for the normal recovery paths when validation fails")
 	}, TestOptions)
 }
 

--- a/internal/testing/mocks/MockWebsiteService.go
+++ b/internal/testing/mocks/MockWebsiteService.go
@@ -1657,3 +1657,36 @@ func (_c *MockWebsiteService_WaitForPublishes_Call) RunAndReturn(run func()) *Mo
 	_c.Run(run)
 	return _c
 }
+
+// WaitForValidations provides a mock function for the type MockWebsiteService
+func (_mock *MockWebsiteService) WaitForValidations() {
+	_mock.Called()
+	return
+}
+
+// MockWebsiteService_WaitForValidations_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'WaitForValidations'
+type MockWebsiteService_WaitForValidations_Call struct {
+	*mock.Call
+}
+
+// WaitForValidations is a helper method to define mock.On call
+func (_e *MockWebsiteService_Expecter) WaitForValidations() *MockWebsiteService_WaitForValidations_Call {
+	return &MockWebsiteService_WaitForValidations_Call{Call: _e.mock.On("WaitForValidations")}
+}
+
+func (_c *MockWebsiteService_WaitForValidations_Call) Run(run func()) *MockWebsiteService_WaitForValidations_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockWebsiteService_WaitForValidations_Call) Return() *MockWebsiteService_WaitForValidations_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *MockWebsiteService_WaitForValidations_Call) RunAndReturn(run func()) *MockWebsiteService_WaitForValidations_Call {
+	_c.Run(run)
+	return _c
+}


### PR DESCRIPTION
Deploying to a broken site left it broken: a target update proved the new CID is pinned but never re-ran validation, so the site stayed down until the janitor or a manual validate recovered it.

UpdateWebsite now captures the prior status and, after a target change commits, re-runs DNS validation once for a broken site. The update already gates on the target being pinned, so validation goes straight to the dnslink check and activates the site via the existing broken → active transition. A failed validation only logs a warning — the deploy itself never fails and the site keeps its status for the normal recovery paths. Active and pending sites are untouched.

- `develop` <!-- branch-stack -->
  - **feat(website): auto-validate broken site after target update** :point\_left:

***

<!-- kody-pr-summary:start -->

This pull request adds automatic validation and recovery for websites that are in a "broken" status when their target (CID) is updated via a deploy.

**Changes:**

- Tracks the website's status before an update.
- After a successful target update, if the site was previously broken, the system now attempts to re-validate the new target using DNSLink resolution.
- If validation succeeds, the site is automatically activated, eliminating the need to wait for the janitor or manual intervention.
- If validation fails or errors, the update is **not** rolled back and the website keeps its existing status (broken) for the normal recovery paths.
- The updated website object is reloaded from the database after validation so callers see the final status/expiry.

**Behavioral impact:** Deploying a new, valid content target to a broken website now revives it automatically. This is a best‑effort recovery that never blocks or fails the deploy itself.

<!-- kody-pr-summary:end -->
