### PR TITLE
fix(domain): detect HIP-5 from handover AA

### DIFF
--- a/internal/config/dns.go
+++ b/internal/config/dns.go
@@ -52,12 +52,6 @@ type DnsConfig struct {
 	// Verification token key used as the subdomain label for validation TXT records
 	VerificationTokenKey string `config:"verification_token_key"`
 
-	// HIP5BlockedTLDs lists TLDs that are blocked on the HNS root and therefore
-	// mark an NS record as a HIP-5 TX record (e.g. "eth", "bit"), on top of
-	// underscore-prefixed labels which are always treated as HIP-5. Empty means
-	// only underscore-prefixed protocol tags count.
-	HIP5BlockedTLDs []string `config:"hip5_blocked_tlds"`
-
 	// DANEKeyEncryptionKey is the base64-encoded 32-byte AES-256 key used to
 	// encrypt per-domain DANE private keys at rest in the portal DB. Must be 32
 	// bytes when base64-decoded. If empty, DANE key persistence is skipped.
@@ -75,7 +69,6 @@ func (c DnsConfig) Defaults() map[string]any {
 		"Nameservers":                  []string{},
 		"HNSNameservers":               []string{},
 		"HNSResolver":                  "",
-		"HIP5BlockedTLDs":              []string{"eth", "bit"},
 		"GatewayDomain":                "",
 		"GatewayIP":                    "",
 		"VerificationTokenKey":         "lumeweb-verify",

--- a/internal/service/domain/delegated_domain_service.go
+++ b/internal/service/domain/delegated_domain_service.go
@@ -1308,7 +1308,6 @@ func NewDelegatedDomainServiceFactory() (core.Service, []core.ContextBuilderOpti
 			var nsList []string
 			var hnsNSList []string
 			hnsResolver := ""
-			var hip5BlockedTLDs []string
 			if dnsCfg != nil {
 				nsList = dnsCfg.Nameservers
 				hnsNSList = dnsCfg.HNSNameservers
@@ -1318,7 +1317,6 @@ func NewDelegatedDomainServiceFactory() (core.Service, []core.ContextBuilderOpti
 					hnsNSList = nsList
 				}
 				hnsResolver = dnsCfg.HNSResolver
-				hip5BlockedTLDs = dnsCfg.HIP5BlockedTLDs
 			}
 			// Prefetch the IANA root zone list so provider Validate calls
 			// hit the in-memory snapshot instead of racing a cold network
@@ -1326,15 +1324,6 @@ func NewDelegatedDomainServiceFactory() (core.Service, []core.ContextBuilderOpti
 			go warmTLDList()
 			reg.Register(NewICANNProvider(nsList))
 			hnsProv := NewHNSProvider(hnsResolver, hnsNSList, TLSASource{})
-			// Apply the configured HIP-5 blocked-TLD set. The override is applied
-			// whenever the config is present (even an empty slice): an empty set
-			// intentionally disables blocked-TLD detection, leaving only
-			// underscore-prefixed protocol tags counted. A nil/absent dnsCfg
-			// keeps the constructor's built-in defaults, matching the DnsConfig
-			// defaults of ["eth","bit"].
-			if dnsCfg != nil {
-				hnsProv.SetHIP5BlockedTLDs(hip5BlockedTLDs)
-			}
 			dns := core.GetService[pluginCore.DNSService](ctx, pluginCore.DNS_SERVICE)
 			if dns != nil {
 				hnsProv.SetDNSService(dns)

--- a/internal/service/domain/delegated_domain_service_test.go
+++ b/internal/service/domain/delegated_domain_service_test.go
@@ -896,7 +896,7 @@ func TestDelegatedDomainService_ConvertToOnChain_NotHIP5Refused(t *testing.T) {
 	// Conversion is refused until the name genuinely serves a HIP-5 record; it
 	// never tears down DNS on the caller's word alone.
 	const domain = "staysnative"
-	nativeAddr, _ := startCustomPortDNSServer(t, domain+".", []string{"ns1.lumeweb."})
+	nativeAddr, _ := startCustomPortDNSServerWithAuthority(t, domain+".", []string{"ns1.lumeweb."}, false)
 
 	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 		db := ctx.DB()

--- a/internal/service/domain/hns_provider.go
+++ b/internal/service/domain/hns_provider.go
@@ -3,6 +3,7 @@ package domain
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"regexp"
@@ -123,10 +124,6 @@ type HNSProvider struct {
 	tlsaSource   TLSASource
 	tlsaMu       sync.RWMutex
 	dnsSvc       DNSZoneService
-	// hip5BlockedTLDs are TLDs that are blocked on the HNS root and therefore
-	// mark an NS record's final label as a HIP-5 protocol tag (e.g. "eth",
-	// "bit"), in addition to underscore-prefixed labels which are always HIP-5.
-	hip5BlockedTLDs map[string]bool
 }
 
 // TLSASource holds certificates keyed by domain for TLSA computation.
@@ -137,33 +134,10 @@ type TLSASource struct {
 
 func NewHNSProvider(resolver string, nsRecords []string, tlsa TLSASource) *HNSProvider {
 	return &HNSProvider{
-		resolverAddr:    resolver,
-		nsRecords:       nsRecords,
-		tlsaSource:      tlsa,
-		hip5BlockedTLDs: defaultHIP5BlockedTLDs(),
+		resolverAddr: resolver,
+		nsRecords:    nsRecords,
+		tlsaSource:   tlsa,
 	}
-}
-
-// defaultHIP5BlockedTLDs returns the TLDs that are blocked on the HNS root and
-// thus treated as HIP-5 protocol tags, alongside underscore-prefixed labels.
-// Operators may extend the set via SetHIP5BlockedTLDs.
-func defaultHIP5BlockedTLDs() map[string]bool {
-	return map[string]bool{
-		"eth": true,
-		"bit": true,
-	}
-}
-
-// SetHIP5BlockedTLDs replaces the set of TLDs marking an NS record's final
-// label as a HIP-5 protocol tag (see hip5BlockedTLDs). An empty list leaves
-// only underscore-prefixed labels counted as HIP-5. Must be called before the
-// provider serves requests (it is not synchronized with Inspect).
-func (p *HNSProvider) SetHIP5BlockedTLDs(tlds []string) {
-	m := make(map[string]bool, len(tlds))
-	for _, t := range tlds {
-		m[strings.ToLower(t)] = true
-	}
-	p.hip5BlockedTLDs = m
 }
 
 // SetDNSService injects the DNS zone service for DNSSEC enablement.
@@ -245,64 +219,35 @@ func (p *HNSProvider) Validate(domain string) error {
 	return nil
 }
 
-// Inspect reports whether the HNS name is managed on-chain via HIP-5: it
-// queries the HNS resolver for the name's NS records and checks whether any of
-// them is a HIP-5 TX record (whose final label is a HIP-5 protocol tag, e.g.
-// "_eth" or a blocked TLD like "eth"). Such a name serves its DNS from an
-// external contract, so the portal must not provision a PowerDNS zone for it
-// and proves ownership with a TXT token resolved through the resolver.
+// Inspect reports the source selected by the configured HNS handover resolver.
+// Handover returns authoritative on-chain answers with AA set and relayed
+// off-chain answers without AA. The owner and record type are intentionally
+// opaque here: source detection must follow handover's decision, not infer
+// HIP-5 from an NS target or perform a second lookup.
 //
-// Detection is best-effort: when the resolver is not configured or cannot
-// answer (name not yet registered on-chain, resolver unreachable), it returns
-// false so the name binds as native HNS and can be converted to on-chain
-// managed later by an explicit admin action — never silently guessed by the
-// janitor.
-//
-// The query runs under a short deadline of its own: Inspect is on the bind
-// hot path (every user HNS bind), so a slow/unreachable resolver must not
-// stall a bind for the DNS client's 5s timeout. A deadline expiration is
-// treated like any resolver failure: bind as native, to be reconciled later.
+// Unregistered names are treated as native HNS. Resolver configuration and
+// transport failures are returned so binding cannot create portal DNS state
+// while handover's source decision is unknown.
 func (p *HNSProvider) Inspect(ctx context.Context, domain string) (bool, error) {
 	if p.resolverAddr == "" {
+		// Keep native HNS usable when handover integration is not configured;
+		// configured resolver failures still fail closed below.
 		return false, nil
 	}
 	inspectCtx, cancel := context.WithTimeout(ctx, hip5InspectTimeout)
 	defer cancel()
-	nss, err := queryNS(inspectCtx, p.resolverAddr, dnsname.EnsureFQDN(domain))
+	reply, err := queryResolver(inspectCtx, p.resolverAddr, dnsname.EnsureFQDN(domain), dns.TypeNS)
 	if err != nil {
-		return false, nil
-	}
-	for _, ns := range nss {
-		if p.isHIP5TX(ns) {
-			return true, nil
+		var dnsErr *net.DNSError
+		if errors.As(err, &dnsErr) && dnsErr.IsNotFound {
+			return false, nil
 		}
+		return false, fmt.Errorf("HNS handover query failed (resolver %q): %w", p.resolverAddr, err)
 	}
-	return false, nil
+	return reply.Authoritative, nil
 }
 
-// hip5InspectTimeout bounds how long the HIP5 inspection DNS query may run.
-// It is deliberately shorter than the DNS client timeout (5s) so the bind
-// path never blocks on a slow resolver.
 const hip5InspectTimeout = 1500 * time.Millisecond
-
-// isHIP5TX detects a HIP-5 TX record by its final label, per HIP-0005 the
-// protocol tag: it is either structurally invalid on the HNS root
-// (underscore-prefixed, e.g. "_eth") or a TLD blocked by the HNS root
-// (e.g. "eth", "bit"). The labels before it are the chain-specific input (an
-// ETH hex address, a SOL base58 address, ...) and are deliberately not parsed
-// here — the HNS resolver already validated the record when it served it, and
-// the address format is not our concern.
-func (p *HNSProvider) isHIP5TX(ns string) bool {
-	labels := strings.Split(strings.TrimSuffix(ns, "."), ".")
-	if len(labels) < 2 {
-		return false
-	}
-	last := strings.ToLower(labels[len(labels)-1])
-	if strings.HasPrefix(last, "_") {
-		return true
-	}
-	return p.hip5BlockedTLDs[last]
-}
 
 func (p *HNSProvider) BuildDelegation(ctx context.Context, zoneID uint,
 	domain string, website *pluginDb.Website, config json.RawMessage) (json.RawMessage, error) {

--- a/internal/service/domain/hns_provider_test.go
+++ b/internal/service/domain/hns_provider_test.go
@@ -216,89 +216,6 @@ func TestHNSProvider_BuildDelegation_NoDSRecord(t *testing.T) {
 	}
 }
 
-func TestHNSProvider_isHIP5TX(t *testing.T) {
-	p := NewHNSProvider("", nil, TLSASource{})
-
-	tests := []struct {
-		name string
-		ns   string
-		want bool
-	}{
-		{
-			name: "eth contract address with underscore tag",
-			ns:   "0x667ab1d9f98817ffb28cd61b911f921181c669b3._eth.",
-			want: true,
-		},
-		{
-			name: "sol address with underscore tag",
-			ns:   "somebase58encodedaddress._sol.",
-			want: true,
-		},
-		{
-			name: "blocked TLD without underscore (eth)",
-			ns:   "0x36fc69f0983e536d1787cc83f481581f22cca2a1.eth.",
-			want: true,
-		},
-		{
-			name: "blocked TLD (bit)",
-			ns:   "0x00deadbeef.bit.",
-			want: true,
-		},
-		{
-			name: "blocked TLD is case-insensitive",
-			ns:   "0x36fc69f0983e536d1787cc83f481581f22cca2a1.ETH.",
-			want: true,
-		},
-		{
-			name: "subdomain under address",
-			ns:   "sub.0x36fc69f0983e536d1787cc83f481581f22cca2a1._eth.",
-			want: true,
-		},
-		{
-			name: "native HNS nameserver",
-			ns:   "ns1.lumeweb.",
-			want: false,
-		},
-		{
-			name: "single label",
-			ns:   "ns1.",
-			want: false,
-		},
-		{
-			name: "relative ns without trailing dot",
-			ns:   "ns1.lumeweb",
-			want: false,
-		},
-		{
-			name: "empty",
-			ns:   "",
-			want: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, p.isHIP5TX(tt.ns))
-		})
-	}
-}
-
-func TestHNSProvider_SetHIP5BlockedTLDs(t *testing.T) {
-	// Defaults treat "eth" and "bit" as HIP-5 protocol tags.
-	p := NewHNSProvider("", nil, TLSASource{})
-	assert.True(t, p.isHIP5TX("0xabc.eth."))
-
-	// Replacing the set with a custom TLD drops "eth" from detection.
-	p.SetHIP5BlockedTLDs([]string{"sol"})
-	assert.False(t, p.isHIP5TX("0xabc.eth."))
-	assert.True(t, p.isHIP5TX("0xabc.sol."))
-
-	// Clearing the list leaves only underscore-prefixed tags counted.
-	p.SetHIP5BlockedTLDs(nil)
-	assert.False(t, p.isHIP5TX("0xabc.sol."))
-	assert.True(t, p.isHIP5TX("0xabc._sol."))
-}
-
 func TestHNSProvider_Inspect_HIP5Detection(t *testing.T) {
 	const domain = "myname."
 
@@ -318,7 +235,7 @@ func TestHNSProvider_Inspect_NativeHNS(t *testing.T) {
 	const domain = "myname."
 
 	// The HNS resolver serves ordinary nameservers (native delegation).
-	addr, _ := startCustomPortDNSServer(t, domain, []string{"ns1.lumeweb.", "ns2.lumeweb."})
+	addr, _ := startCustomPortDNSServerWithAuthority(t, domain, []string{"ns1.lumeweb.", "ns2.lumeweb."}, false)
 
 	p := NewHNSProvider(addr, nil, TLSASource{})
 	onchain, err := p.Inspect(context.Background(), "myname")
@@ -327,8 +244,6 @@ func TestHNSProvider_Inspect_NativeHNS(t *testing.T) {
 }
 
 func TestHNSProvider_Inspect_NoResolverConfigured(t *testing.T) {
-	// Without a configured resolver, Inspect must default to native (false)
-	// rather than erroring, so binding can proceed.
 	p := NewHNSProvider("", nil, TLSASource{})
 	onchain, err := p.Inspect(context.Background(), "myname")
 	require.NoError(t, err)
@@ -336,10 +251,8 @@ func TestHNSProvider_Inspect_NoResolverConfigured(t *testing.T) {
 }
 
 func TestHNSProvider_Inspect_ResolverUnreachable(t *testing.T) {
-	// A resolver that cannot answer (nothing listening on the port) must be
-	// treated as native (false), not a hard error.
 	p := NewHNSProvider("127.0.0.1:1", nil, TLSASource{})
-	onchain, err := p.Inspect(context.Background(), "myname")
-	require.NoError(t, err)
-	assert.False(t, onchain)
+	_, err := p.Inspect(context.Background(), "myname")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "handover query failed")
 }

--- a/internal/service/domain/hns_resolver_integration_test.go
+++ b/internal/service/domain/hns_resolver_integration_test.go
@@ -31,11 +31,14 @@ import (
 // real local DNS server on an ephemeral port and asserting VerifyDelegation
 // resolves against it (not the system resolver).
 
-// startCustomPortDNSServer runs a real miekg/dns UDP+TCP server bound to an
-// ephemeral port on loopback. The handler answers NS queries for `name` with
-// the given nameservers and increments a counter so the test can assert the
-// query actually reached this server.
+// startCustomPortDNSServer runs an authoritative test resolver.
 func startCustomPortDNSServer(t *testing.T, name string, nsRecords []string, dsRecord ...string) (addr string, served *atomicCounter) {
+	return startCustomPortDNSServerWithAuthority(t, name, nsRecords, true, dsRecord...)
+}
+
+// startCustomPortDNSServerWithAuthority runs a test resolver with an explicit
+// AA flag so source-selection behavior can be tested independently of records.
+func startCustomPortDNSServerWithAuthority(t *testing.T, name string, nsRecords []string, authoritative bool, dsRecord ...string) (addr string, served *atomicCounter) {
 	t.Helper()
 
 	// The single DS record the server serves, if any.
@@ -49,7 +52,7 @@ func startCustomPortDNSServer(t *testing.T, name string, nsRecords []string, dsR
 		served.add(1)
 		m := new(dns.Msg)
 		m.SetReply(req)
-		m.Authoritative = true
+		m.Authoritative = authoritative
 		if len(req.Question) > 0 {
 			qtype := req.Question[0].Qtype
 			switch qtype {


### PR DESCRIPTION
Updates HNS domain inspection to use the handover resolver’s authoritative flag instead of parsing NS targets. On-chain responses with AA=1 are classified as HIP-5, while recursive off-chain responses remain native HNS. Resolver transport failures fail closed, and tests cover both source paths.

- `develop` <!-- branch-stack -->
  - **fix(domain): detect HIP-5 from handover AA** :point\_left:

---

<!-- kody-pr-summary:start -->
This pull request updates the HNS (Handshake) domain source detection to rely on the handover resolver's authoritative (AA) flag rather than inspecting NS record targets for protocol tags (e.g., `_eth`, `eth`, `bit`). As a result:

- The configurable `HIP5BlockedTLDs` option and its default list ("eth", "bit") are removed, as well as the `SetHIP5BlockedTLDs` provider override.
- `HNSProvider.Inspect` now queries the resolver for NS records and treats an authoritative response as on-chain (HIP-5 managed), while a non-authoritative response is considered native HNS. This follows the handover resolver's own decision instead of hard-coding TLD heuristics.
- Resolver configuration or transport failures now cause `Inspect` to return an error (fail closed), preventing the portal from creating DNS state when the handover source is unknown. Only a "not found" response still binds as native HNS.
- Tests and test helpers were adjusted to support explicit AA-flag testing and to reflect the new failure behavior.

This makes HIP-5 detection more accurate and robust, aligning gatekeeping with handover's authoritative answer.
<!-- kody-pr-summary:end -->