### PR TITLE
fix(domain): reclassify existing HIP-5 bindings

### DIFF
--- a/internal/service/domain/delegated_domain_service.go
+++ b/internal/service/domain/delegated_domain_service.go
@@ -654,9 +654,17 @@ func (s *DelegatedDomainService) VerifyDomain(ctx context.Context,
 		}
 		if onchain {
 			if err := s.convertInspectedBindingToOnChain(ctx, wd); err != nil {
-				return DelegationVerificationResult{}, fmt.Errorf("convert on-chain binding: %w", err)
+				if errors.Is(err, ErrDomainZoneShared) {
+					s.Logger().Info("HIP-5 binding shares its zone; skipping reclassification",
+						zap.Uint("id", wd.ID),
+						zap.String("domain", wd.Domain),
+						zap.Error(err))
+				} else {
+					return DelegationVerificationResult{}, fmt.Errorf("convert on-chain binding: %w", err)
+				}
+			} else {
+				return DelegationVerificationResult{State: DelegationNotApplicable}, nil
 			}
-			return DelegationVerificationResult{State: DelegationNotApplicable}, nil
 		}
 	}
 

--- a/internal/service/domain/delegated_domain_service.go
+++ b/internal/service/domain/delegated_domain_service.go
@@ -642,6 +642,24 @@ func (s *DelegatedDomainService) VerifyDomain(ctx context.Context,
 		return DelegationVerificationResult{State: DelegationVerified}, nil
 	}
 
+	// A binding created before handover source detection may still carry a
+	// portal-managed zone even though the name has since become HIP-5. Inspect
+	// that source before touching DNSSEC or portal delegation; the same response
+	// is then passed to the conversion helper so verification performs one query.
+	if wd.Namespace == pluginDb.DomainNamespaceHNS && wd.ZoneID != 0 &&
+		wd.Status != pluginDb.DomainStatusOnchainManaged {
+		onchain, inspectErr := provider.Inspect(ctx, wd.Domain)
+		if inspectErr != nil {
+			return DelegationVerificationResult{}, fmt.Errorf("domain inspection failed: %w", inspectErr)
+		}
+		if onchain {
+			if err := s.convertInspectedBindingToOnChain(ctx, wd); err != nil {
+				return DelegationVerificationResult{}, fmt.Errorf("convert on-chain binding: %w", err)
+			}
+			return DelegationVerificationResult{State: DelegationNotApplicable}, nil
+		}
+	}
+
 	// Only portal-managed bindings have portal delegation to verify
 	// (NeedsDelegationVerification, the authoritative derived hosting locus):
 	//   - self-hosted: the user runs the authoritative server; DNSSEC/DANE

--- a/internal/service/domain/delegated_domain_service_test.go
+++ b/internal/service/domain/delegated_domain_service_test.go
@@ -892,6 +892,37 @@ func TestDelegatedDomainService_ConvertToOnChain_HappyPath(t *testing.T) {
 	}, TestOptions)
 }
 
+func TestDelegatedDomainService_VerifyDomain_ReclassifiesExistingHIP5(t *testing.T) {
+	const domain = "verify-convertme"
+	const zoneID = uint(88)
+	hip5Addr, _ := startCustomPortDNSServer(t, domain+".", []string{"ignored.target."})
+
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		db := ctx.DB()
+		website := createTestWebsite(tb, db, 1, domain)
+		require.NoError(tb, db.Model(&website).Update("status", pluginDb.WebsiteStatusActive).Error)
+		wd := &pluginDb.WebsiteDomain{
+			WebsiteID: website.ID, UserID: 1, Domain: domain,
+			Namespace: pluginDb.DomainNamespaceHNS, ZoneID: zoneID,
+			Status: pluginDb.DomainStatusWaitingDelegation, DNSHostingEnabled: true,
+		}
+		require.NoError(tb, db.Create(wd).Error)
+
+		svc := core.GetService[*DelegatedDomainService](ctx, pluginCore.DELEGATED_DOMAIN_SERVICE)
+		hnsProv := svc.registry.Get("hns").(*HNSProvider)
+		hnsProv.resolverAddr = hip5Addr
+		mockDNS := core.GetService[*mocks.MockDNSService](ctx, pluginCore.DNS_SERVICE)
+		mockDNS.EXPECT().DeleteZone(mock.Anything, zoneID).Return(nil).Once()
+
+		result, err := svc.VerifyDomain(context.Background(), wd)
+		require.NoError(tb, err)
+		assert.Equal(tb, DelegationNotApplicable, result.State)
+		assert.Equal(tb, pluginDb.DomainStatusOnchainManaged, wd.Status)
+		assert.Zero(tb, wd.ZoneID)
+		assert.False(tb, wd.DNSHostingEnabled)
+	}, TestOptions)
+}
+
 func TestDelegatedDomainService_ConvertToOnChain_NotHIP5Refused(t *testing.T) {
 	// Conversion is refused until the name genuinely serves a HIP-5 record; it
 	// never tears down DNS on the caller's word alone.

--- a/internal/service/domain/delegated_domain_service_test.go
+++ b/internal/service/domain/delegated_domain_service_test.go
@@ -1016,6 +1016,42 @@ func TestDelegatedDomainService_ConvertToOnChain_SharedZoneRefused(t *testing.T)
 	}, TestOptions)
 }
 
+func TestDelegatedDomainService_VerifyDomain_SharedHIP5ZoneFallsThrough(t *testing.T) {
+	const domain = "verify-sharedzone"
+	const zoneID = uint(56)
+	hip5Addr, _ := startCustomPortDNSServer(t, domain+".", []string{"0xdeadbeef._eth."})
+
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		db := ctx.DB()
+		website := createTestWebsite(tb, db, 1, domain)
+		apex := &pluginDb.WebsiteDomain{
+			WebsiteID: website.ID, UserID: 1, Domain: domain,
+			Namespace: pluginDb.DomainNamespaceHNS, ZoneID: zoneID,
+			Status: pluginDb.DomainStatusWaitingDelegation, DNSHostingEnabled: true,
+		}
+		sub := &pluginDb.WebsiteDomain{
+			WebsiteID: website.ID, UserID: 1, Domain: "sub." + domain,
+			Namespace: pluginDb.DomainNamespaceHNS, ZoneID: zoneID,
+			Status: pluginDb.DomainStatusActive, DNSHostingEnabled: true,
+		}
+		require.NoError(tb, db.Create(apex).Error)
+		require.NoError(tb, db.Create(sub).Error)
+
+		svc := core.GetService[*DelegatedDomainService](ctx, pluginCore.DELEGATED_DOMAIN_SERVICE)
+		hnsProv := svc.registry.Get("hns").(*HNSProvider)
+		hnsProv.resolverAddr = hip5Addr
+		mockDNS := core.GetService[*mocks.MockDNSService](ctx, pluginCore.DNS_SERVICE)
+		mockDNS.EXPECT().GetActiveDNSSECDS(mock.Anything, zoneID).Return("60776 13 2 abc", nil).Once()
+		mockDNS.EXPECT().EnsureSOAMNAME(mock.Anything, zoneID, domain, mock.Anything).Return(nil).Once()
+
+		result, err := svc.VerifyDomain(context.Background(), apex)
+		require.NoError(tb, err)
+		assert.Equal(tb, DelegationPending, result.State)
+		assert.Equal(tb, pluginDb.DomainStatusWaitingDelegation, apex.Status)
+		mockDNS.AssertNotCalled(tb, "DeleteZone", mock.Anything, mock.Anything)
+	}, TestOptions)
+}
+
 func TestDelegatedDomainService_ConvertToOnChain_NotFound(t *testing.T) {
 	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 		svc := core.GetService[*DelegatedDomainService](ctx, pluginCore.DELEGATED_DOMAIN_SERVICE)

--- a/internal/service/domain/onchain.go
+++ b/internal/service/domain/onchain.go
@@ -19,27 +19,7 @@ var (
 )
 
 // ConvertToOnChain converts a bound domain into an on-chain managed (HIP-5)
-// binding — the explicit, one-way path for the HNS-DNS → on-chain-DNS
-// transition, used when the name's NS record now points at an external
-// contract (a HIP-5 TX record the owner set on-chain).
-//
-// The portal stops owning the PowerDNS-served DNS for the name: the managed
-// zone (and the DNSSEC/DS carried by it) is deleted and the binding is
-// re-marked onchain_managed with dns_hosting_enabled=false, so ownership is
-// proven with the TXT token through the resolver instead of NS/DS delegation.
-// DANE/SSL state (ProtocolData: key, cert, TLSA, owner) is deliberately KEPT —
-// DANE still applies on-chain; only the PowerDNS-published records and DNSSEC
-// (not a concept on-chain) are dropped. The owning website is reset to
-// pending_validation so the TXT-token verification flow re-runs.
-//
-// Safety (never tear down on the caller's word alone):
-//   - Refused until Inspect confirms the name genuinely serves a HIP-5 record.
-//   - The PowerDNS zone is deleted only when no other live binding shares it:
-//     a shared zone is the parent of other native bindings, and deleting it
-//     would destroy their records/DNSSEC. Conversion is refused for shared
-//     zones with a clear instruction to detach those bindings first — a HIP-5
-//     apex resolves every subdomain via the contract anyway.
-//   - Refused for a binding already onchain_managed.
+// binding after Inspect confirms that handover serves it authoritatively.
 func (s *DelegatedDomainService) ConvertToOnChain(ctx context.Context, websiteID, userID, domainID uint) (*pluginDb.WebsiteDomain, error) {
 	if s.DB() == nil {
 		return nil, fmt.Errorf("database not available")
@@ -49,7 +29,7 @@ func (s *DelegatedDomainService) ConvertToOnChain(ctx context.Context, websiteID
 	if err := s.DB().WithContext(ctx).
 		Where("id = ? AND website_id = ? AND user_id = ?", domainID, websiteID, userID).
 		First(&wd).Error; err != nil {
-		return nil, err // includes gorm.ErrRecordNotFound
+		return nil, err
 	}
 
 	if wd.Status == pluginDb.DomainStatusOnchainManaged {
@@ -60,24 +40,30 @@ func (s *DelegatedDomainService) ConvertToOnChain(ctx context.Context, websiteID
 	if provider == nil {
 		return nil, fmt.Errorf("unsupported namespace: %s", wd.Namespace)
 	}
-
 	onchain, err := provider.Inspect(ctx, wd.Domain)
 	if err != nil {
 		return nil, fmt.Errorf("domain inspection failed: %w", err)
 	}
 	if !onchain {
-		return nil, fmt.Errorf("%w: %q; its NS record does not point at an external contract", ErrDomainNotOnChain, wd.Domain)
+		return nil, fmt.Errorf("%w: %q; handover did not select an authoritative response", ErrDomainNotOnChain, wd.Domain)
 	}
 
-	// Serialize this conversion against CreateDomain's zone provisioning so a
-	// concurrent bind into the same zone can never have its zone (and records/
-	// DNSSEC) destroyed between our sharer check and the delete. Both paths key
-	// the same per-zone lock on the zone's canonical apex name.
+	if err := s.convertInspectedBindingToOnChain(ctx, &wd); err != nil {
+		return nil, err
+	}
+	return &wd, nil
+}
+
+// convertInspectedBindingToOnChain applies an already-confirmed handover
+// decision. Callers must hold the decision that the domain is on-chain; this
+// keeps VerifyDomain from issuing a second source-detection query.
+func (s *DelegatedDomainService) convertInspectedBindingToOnChain(ctx context.Context, wd *pluginDb.WebsiteDomain) error {
+	if wd.Status == pluginDb.DomainStatusOnchainManaged {
+		return nil
+	}
+
 	zoneID := wd.ZoneID
 	if err := s.withZoneLifecycleLock(zoneLifecycleKey(wd.Domain), func() error {
-		// Only the binding's sole-owner PowerDNS zone may be deleted. A zone
-		// shared with other live bindings (their parent/apex zone) must be kept
-		// — deleting it would destroy their records and DNSSEC.
 		if zoneID != 0 {
 			var sharers int64
 			if err := s.DB().WithContext(ctx).
@@ -91,13 +77,6 @@ func (s *DelegatedDomainService) ConvertToOnChain(ctx context.Context, websiteID
 			}
 		}
 
-		// Re-arm the website to pending_validation BEFORE committing the
-		// conversion. A failure here is clean (nothing has been converted yet
-		// and the caller can retry), whereas failing after the on-chain commit
-		// would leave an already-converted domain reported as a 500 and make
-		// retry hit "already on-chain managed". A blocked website stays blocked
-		// (only an admin can lift an admin block); a pending one needs no
-		// change.
 		var website pluginDb.Website
 		if err := s.DB().WithContext(ctx).First(&website, wd.WebsiteID).Error; err != nil {
 			return fmt.Errorf("failed to load website %d for on-chain conversion: %w", wd.WebsiteID, err)
@@ -109,11 +88,6 @@ func (s *DelegatedDomainService) ConvertToOnChain(ctx context.Context, websiteID
 			}
 		}
 
-		// Drop the PowerDNS-backed delegation state. ProtocolData (DANE key,
-		// cert, TLSA, owner) and per-domain SSL state are intentionally
-		// preserved: DANE/SSL still apply to the name — the records are simply
-		// served by the external contract now — and DNSSEC is not a concept
-		// on-chain.
 		updates := map[string]any{
 			"zone_id":             0,
 			"zone_name":           "",
@@ -122,7 +96,7 @@ func (s *DelegatedDomainService) ConvertToOnChain(ctx context.Context, websiteID
 			"dns_hosting_enabled": false,
 			"status":              pluginDb.DomainStatusOnchainManaged,
 		}
-		if err := s.DB().WithContext(ctx).Model(&wd).Updates(updates).Error; err != nil {
+		if err := s.DB().WithContext(ctx).Model(wd).Updates(updates).Error; err != nil {
 			return fmt.Errorf("failed to persist on-chain managed state: %w", err)
 		}
 		wd.ZoneID = 0
@@ -132,21 +106,6 @@ func (s *DelegatedDomainService) ConvertToOnChain(ctx context.Context, websiteID
 		wd.DNSHostingEnabled = false
 		wd.Status = pluginDb.DomainStatusOnchainManaged
 
-		// Delete the now-unreferenced PowerDNS zone LAST, best-effort. Order is
-		// deliberate: the DB runs first so a delete failure can never strand
-		// the binding pointing at a destroyed zone (the unrecoverable state). A
-		// leftover/unreferenced zone is harmless (nothing serves it — the name
-		// resolves via the contract) and is logged for ops cleanup.
-		//
-		// Re-count sharers immediately before the delete as defense-in-depth.
-		// The per-zone lock above serializes against CreateDomain for the
-		// common apex case, but the lock key can diverge from the real zone
-		// apex when a "subdomain" owns its zone (parent has none) and it does
-		// NOT serialize other zone_id writers (e.g. the website-enable path).
-		// Re-checking committed state right before DeleteZone catches any
-		// binding attached by those writers: if any live binding shares the
-		// zone, the delete is skipped and the (now-referenced) zone is left
-		// intact.
 		if zoneID != 0 && s.dnsSvc != nil {
 			var sharers int64
 			if err := s.DB().WithContext(ctx).
@@ -165,8 +124,7 @@ func (s *DelegatedDomainService) ConvertToOnChain(ctx context.Context, websiteID
 		}
 		return nil
 	}); err != nil {
-		return nil, err
+		return err
 	}
-
-	return &wd, nil
+	return nil
 }


### PR DESCRIPTION
Rechecks existing HNS bindings through handover before portal delegation verification. Authoritative responses transition stale portal-managed bindings to on-chain-managed state, clear portal DNS state, and remove only unshared zones. Shared zones remain protected; verification falls through to normal delegation handling without returning a server error.

- `develop` <!-- branch-stack -->
  - **fix(domain): reclassify existing HIP-5 bindings** :point\_left:
