### PR TITLE
fix(api): clarify non-applicable verification logs

### DIFF
--- a/internal/api/api_domains.go
+++ b/internal/api/api_domains.go
@@ -361,7 +361,15 @@ func (a *API) verifyDomain(c echo.Context) error {
 		return ctx.Error(apiErr, apiErr.HttpStatus())
 	}
 
-	if res.State != domsvc.DelegationVerified {
+	switch res.State {
+	case domsvc.DelegationNotApplicable:
+		a.Logger().Debug("delegation verification not applicable",
+			zap.String("domain", wd.Domain),
+			zap.String("namespace", string(wd.Namespace)),
+			zap.Uint("id", wd.ID),
+			zap.Uint("zone_id", wd.ZoneID),
+		)
+	case domsvc.DelegationPending:
 		a.Logger().Info("delegation not verified",
 			zap.String("domain", wd.Domain),
 			zap.String("namespace", string(wd.Namespace)),


### PR DESCRIPTION
Logs on-chain and self-hosted domains as having delegation verification not applicable instead of not verified. Keeps pending delegation failures at INFO while reducing expected on-chain verification noise to DEBUG.

- `develop` <!-- branch-stack -->
  - **fix(api): clarify non-applicable verification logs** :point\_left:

---

<!-- kody-pr-summary:start -->
## Description

This PR improves the logging behavior in the domain verification API endpoint to better differentiate between verification states.

### Changes

- **In `verifyDomain` handler**, replaced the previous simple check (`if res.State != DelegationVerified`) with a `switch` statement that handles two distinct cases:
  - **`DelegationNotApplicable`**: logs a debug-level message indicating that delegation verification is not applicable for the domain.
  - **`DelegationPending`**: retains the existing info-level log indicating that delegation has not yet been verified.

### Impact

- Log messages are now clearer and more accurate: non-applicable scenarios are no longer reported as “not verified” with the same severity as pending cases.
- Reduces unnecessary info-level logging for domains where verification is not relevant, while keeping visibility through debug logs when needed.

This change introduces no functional behavior modifications beyond log output, but improves operational clarity for monitoring and troubleshooting.
<!-- kody-pr-summary:end -->