### PR TITLE
feat(dns): support DANE for on-chain managed HNS names

### DIFF
--- a/internal/api/api_domains.go
+++ b/internal/api/api_domains.go
@@ -519,6 +519,27 @@ func (a *API) domainDNSRequirements(c echo.Context) error {
 		}
 	}
 
+	// Chain-managed (HIP-5) bindings own their zone data: there is no portal
+	// delegation to verify (Delegation is nil), but DANE still applies on-chain
+	// — surface the stored TLSA so the owner knows the record to install in the
+	// name's on-chain zone data. Omitted until a DANE identity exists (bind-time
+	// bootstrap or first cert push). Portal-managed bindings carry their TLSA in
+	// Delegation.AuthoritativeRecords instead, so they are not duplicated here.
+	if a.delegatedDomainSvc != nil {
+		if locus, ok := a.delegatedDomainSvc.DANEPublicationTargetFor(&wd); ok && locus == domsvc.DANEPublishChain {
+			tlsa, ownerName, daneErr := a.delegatedDomainSvc.GetDANERecord(reqCtx, string(wd.Namespace), wd.Domain)
+			if daneErr != nil {
+				// A missing/errored row is not fatal to DNS-requirements: the
+				// core domain fields are still valid. Surface the TLSA lazily.
+				a.Logger().Warn("could not load stored DANE record for dns-requirements",
+					zap.String("domain", wd.Domain), zap.Error(daneErr))
+			} else if tlsa != "" {
+				resp.TLSARData = tlsa
+				resp.OwnerName = ownerName
+			}
+		}
+	}
+
 	// Encode the DTO directly rather than via EncodeResponse(model, dto):
 	// EncodeResponse re-derives the DTO from the model (FromModel -> mapDNSDelegation
 	// -> removeStoredDS), which would discard the live DS injected into
@@ -568,12 +589,20 @@ func removeDSRecord(records []dto.DNSDelegationRecord) []dto.DNSDelegationRecord
 	return out
 }
 
-// republishDomainDANE forces re-publication of a bound domain's DANE records
-// (the TLSA for a portal-managed, DNSSEC-signed zone) into the authoritative
-// PowerDNS zone. It re-pushes the stored certificate/key through
-// UpdateTLSAFromCert, which idempotently rewrites the _443._tcp.<domain> TLSA
-// RRset (PowerDNS REPLACE). This is the operator's escape hatch for a TLSA
-// that was deleted or went missing and won't be re-triggered by cert renewal.
+// republishDomainDANE forces re-publication of a bound domain's DANE record.
+// It re-pushes the stored certificate/key through UpdateTLSAFromCert, which
+// idempotently rewrites the _443._tcp.<domain> TLSA RRset. This is the
+// operator's escape hatch for a TLSA that was deleted or went missing and
+// won't be re-triggered by cert renewal.
+//
+// The publication target is binding-class-dependent (see
+// DelegatedDomainService.DANEPublicationTargetFor): a portal-managed binding
+// republishes the TLSA into its authoritative PowerDNS zone, while a
+// chain-managed (HIP-5) binding refreshes the stored TLSA — which is served
+// from the name's on-chain zone data — and reports
+// published_to_managed_zone=false so the owner knows to install the record
+// on-chain. Non-DANE namespaces (ICANN), self-hosted, and unresolved bindings
+// carry no portal DANE publication duty and are rejected.
 func (a *API) republishDomainDANE(c echo.Context) error {
 	p := a.parseDomainPath(c)
 	if p.err != nil {
@@ -591,27 +620,16 @@ func (a *API) republishDomainDANE(c echo.Context) error {
 	}
 
 	ns := string(wd.Namespace)
-	// Only DANE-capable namespaces whose provider publishes a managed-zone TLSA
-	// can be force-republished. Non-DANE namespaces (e.g. ICANN) have no TLSA.
-	if !a.delegatedDomainSvc.NamespaceUsesManagedZoneTLSA(ns) {
-		apiErr := NewError(ErrKeyNoStoredCertificate, fmt.Errorf("namespace %q does not use managed-zone DANE", ns))
-		return ctx.Error(apiErr, apiErr.HttpStatus())
-	}
-
-	// The republish writes the TLSA into the portal-managed authoritative zone
-	// resolved by the domain's ZoneID. If no zone is assigned there is nothing
-	// to publish into -- short-circuit rather than return a false success.
-	if wd.ZoneID == 0 {
-		apiErr := NewError(ErrKeyNoStoredCertificate, fmt.Errorf("domain %q has no assigned managed zone; cannot republish", wd.Domain))
-		return ctx.Error(apiErr, apiErr.HttpStatus())
-	}
-
-	// Only portal-managed bindings may be force-republished: on-chain,
-	// self-hosted, and unresolved bindings never authorize managed-zone TLSA
-	// writes, and an inconsistent on-chain binding with a stray zone must not
-	// be routed through the DANE republish path at all.
-	if !wd.CanPublishManagedZoneRecords() {
-		apiErr := NewError(ErrKeyNoStoredCertificate, fmt.Errorf("domain %q is not portal-managed; cannot republish DANE", wd.Domain))
+	// Only DANE-eligible bindings may be force-republished, resolved by the
+	// single publication-target helper: portal-managed bindings republish into
+	// the managed PowerDNS zone, and chain-managed (HIP-5) bindings refresh the
+	// stored TLSA — DANE still applies on-chain, the record is just served from
+	// the name's on-chain zone data instead of a portal zone. Non-DANE
+	// namespaces (e.g. ICANN), self-hosted, and unresolved bindings carry no
+	// portal DANE publication duty and are rejected.
+	locus, ok := a.delegatedDomainSvc.DANEPublicationTargetFor(&wd)
+	if !ok {
+		apiErr := NewError(ErrKeyNoStoredCertificate, fmt.Errorf("domain %q (namespace %q) has no portal DANE publication target; cannot republish", wd.Domain, ns))
 		return ctx.Error(apiErr, apiErr.HttpStatus())
 	}
 
@@ -650,9 +668,11 @@ func (a *API) republishDomainDANE(c echo.Context) error {
 	}
 	resp.TLSARData = tlsa
 	resp.OwnerName = ownerName
-	if ownerName != "" && tlsa != "" {
-		resp.TLSARecord = fmt.Sprintf("%s. 3600 IN TLSA %s", ownerName, tlsa)
-	}
+	// A chain-managed binding has no portal zone: the republish refreshed the
+	// stored TLSA but the record is served from (and must be installed into)
+	// the name's on-chain zone data, so report the publication target to the
+	// consumer instead of implying a PowerDNS write happened.
+	resp.PublishedToManagedZone = locus == domsvc.DANEPublishManagedZone
 	return httputil.EncodeResponse(ctx, &wd, &resp)
 }
 

--- a/internal/api/api_domains_test.go
+++ b/internal/api/api_domains_test.go
@@ -456,10 +456,61 @@ func TestAPI_DANERepublish(t *testing.T) {
 			assert.Equal(t, pluginDb.DomainNamespaceHNS, resp.Namespace)
 			require.NotEmpty(t, resp.TLSARData)
 			require.NotEmpty(t, resp.OwnerName)
-			assert.Contains(t, resp.TLSARecord, "TLSA")
+			// A portal-managed binding publishes into its own managed zone.
+			assert.True(t, resp.PublishedToManagedZone)
 
 			// The DNS publish must have happened for the managed zone.
 			mockDNS.AssertNumberOfCalls(tb, "SetTLSARecord", 2)
+		}, daneRepublishTestOptions)
+	})
+
+	t.Run("onchain_hns_with_stored_cert_republishes_for_chain", func(t *testing.T) {
+		// A chain-managed (HIP-5) HNS binding has no portal zone but DANE still
+		// applies on-chain: republish must refresh the stored TLSA from the cert
+		// and return the record (published_to_managed_zone=false) for the owner
+		// to install in the name's on-chain zone data — without touching DNS.
+		coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+			helper := newMockHelper(t, ctx)
+			token, userID, _, _ := helper.SetupAuthenticatedTest()
+
+			website := createTestIPFSGatewayWebsite(1, userID, "onchain-repub.hns", util.GenerateTestCID(t, "td"), pluginDb.WebsiteStatusActive)
+			require.NoError(t, ctx.DB().Create(website).Error)
+			websiteID := website.ID
+
+			// Chain-managed binding: onchain_managed status, no portal zone.
+			wd := &pluginDb.WebsiteDomain{
+				WebsiteID: websiteID,
+				UserID:    userID,
+				Domain:    "onchain-repub.hns",
+				Namespace: pluginDb.DomainNamespaceHNS,
+				Status:    pluginDb.DomainStatusOnchainManaged,
+			}
+			require.NoError(t, ctx.DB().Create(wd).Error)
+
+			svc := core.GetService[*domain.DelegatedDomainService](ctx, pluginCore.DELEGATED_DOMAIN_SERVICE)
+			require.NotNil(tb, svc)
+			keyPEM := mustGenerateTestKey(t)
+			certPEM := mustIssueTestCert(t, keyPEM, "onchain-repub.hns")
+			_, _, err := svc.UpdateTLSAFromCert(ctx, "hns", wd.Domain, certPEM, keyPEM)
+			require.NoError(t, err, "seeding stored cert via UpdateTLSAFromCert")
+
+			mockDNS := core.GetService[*mocks.MockDNSService](ctx, pluginCore.DNS_SERVICE)
+			require.NotNil(tb, mockDNS)
+			// On-chain republish must never write into a PowerDNS zone (there is
+			// none); stray SetTLSARecord calls would indicate a portal-zone write.
+			mockDNS.AssertNotCalled(tb, "SetTLSARecord", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+
+			rec := helper.makeAuthenticatedRequest(http.MethodPost, republishPath(int(websiteID), int(wd.ID)), token, nil)
+			require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+
+			var resp dto.DomainDANERepublishResponse
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+			assert.Equal(t, "onchain-repub.hns", resp.Domain)
+			assert.Equal(t, pluginDb.DomainStatusOnchainManaged, resp.Status)
+			require.NotEmpty(t, resp.TLSARData)
+			require.NotEmpty(t, resp.OwnerName)
+			assert.False(t, resp.PublishedToManagedZone,
+				"chain-managed binding has no portal zone; the TLSA must be installed on-chain")
 		}, daneRepublishTestOptions)
 	})
 }
@@ -671,6 +722,45 @@ func TestAPI_DomainDNSRequirements_OnchainManaged(t *testing.T) {
 		assert.Equal(t, pluginDb.DomainStatusOnchainManaged, resp.Status)
 		assert.False(t, resp.DNSHostingEnabled)
 		assert.Nil(t, resp.Delegation, "on-chain managed domains have no portal delegation/NS-DS guidance")
+		// No DANE identity exists yet, so no TLSA record is surfaced.
+		assert.Empty(t, resp.OwnerName)
+		assert.Empty(t, resp.TLSARData)
+	}, TestOptions)
+}
+
+func TestAPI_DomainDNSRequirements_OnchainManaged_ExposesDANERecord(t *testing.T) {
+	// A chain-managed (HIP-5) binding with a stored DANE identity surfaces the
+	// TLSA record the owner must install into the name's on-chain zone data —
+	// DANE still applies on-chain even though there is no portal delegation.
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		helper := newMockHelper(t, ctx)
+		token, userID, testCID, _ := helper.SetupAuthenticatedTest()
+
+		website := createTestIPFSGatewayWebsite(1, userID, "example.com", testCID, pluginDb.WebsiteStatusActive)
+		require.NoError(t, ctx.DB().Create(website).Error)
+
+		wd := &pluginDb.WebsiteDomain{
+			WebsiteID: 1,
+			UserID:    userID,
+			Domain:    "dane-onchain.hns",
+			Namespace: pluginDb.DomainNamespaceHNS,
+			Status:    pluginDb.DomainStatusOnchainManaged,
+			ProtocolData: datatypes.JSONMap{
+				"tlsa":       "3 1 1 aabbcc",
+				"owner_name": "_443._tcp.dane-onchain.hns",
+			},
+		}
+		require.NoError(t, ctx.DB().Create(wd).Error)
+
+		rec := helper.makeAuthenticatedRequest(http.MethodGet, "/api/websites/1/domains/1/dns-requirements", token, nil)
+		require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+
+		var resp dto.DomainResponse
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+		assert.Equal(t, pluginDb.DomainStatusOnchainManaged, resp.Status)
+		assert.Nil(t, resp.Delegation)
+		assert.Equal(t, "3 1 1 aabbcc", resp.TLSARData)
+		assert.Equal(t, "_443._tcp.dane-onchain.hns", resp.OwnerName)
 	}, TestOptions)
 }
 

--- a/internal/api/dto/domain.go
+++ b/internal/api/dto/domain.go
@@ -156,6 +156,14 @@ type DomainResponse struct {
 	// Per-domain SSL certificate state. SSL is a per-domain property, so it is
 	// exposed on the domain record (not the website).
 	SSL *SSLStatusInfo `json:"ssl,omitempty"`
+
+	// DANE TLSA that applies to the name. Populated by dns-requirements for
+	// chain-managed (HIP-5) bindings — where it is the record the owner must
+	// install in the name's on-chain zone data — and omitted until a DANE
+	// identity exists. Portal-managed bindings surface their TLSA via
+	// Delegation.AuthoritativeRecords instead.
+	OwnerName string `json:"owner_name,omitempty"` // "_443._tcp.<domain>"
+	TLSARData string `json:"tlsa_rdata,omitempty"` // "3 1 1 <hex>"
 }
 
 func (r *DomainResponse) FromModel(m *db.WebsiteDomain) error {
@@ -210,9 +218,13 @@ type DomainDANERepublishResponse struct {
 	GatewayHost string             `json:"gateway_host,omitempty"`
 	Delegation  *DNSDelegation     `json:"delegation,omitempty"`
 	SSL         *SSLStatusInfo     `json:"ssl,omitempty"`
-	TLSARecord  string             `json:"tlsa_record,omitempty"` // full "_443._tcp.<domain> ... TLSA ..." presentation
-	OwnerName   string             `json:"owner_name,omitempty"`  // "_443._tcp.<domain>"
-	TLSARData   string             `json:"tlsa_rdata,omitempty"`  // "3 1 1 <hex>"
+	OwnerName   string             `json:"owner_name,omitempty"` // "_443._tcp.<domain>"
+	TLSARData   string             `json:"tlsa_rdata,omitempty"` // "3 1 1 <hex>"
+
+	// PublishedToManagedZone reports whether the listed TLSA was written into a
+	// portal-managed PowerDNS zone (true) or must be installed by the owner in
+	// the name's on-chain zone data (false, chain-managed/HIP-5 bindings).
+	PublishedToManagedZone bool `json:"published_to_managed_zone"`
 }
 
 // FromModel populates the DomainResponse-backed fields from a WebsiteDomain.

--- a/internal/service/domain/dane_key_persistence_test.go
+++ b/internal/service/domain/dane_key_persistence_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gorm.io/datatypes"
 	"gorm.io/gorm"
 
 	"go.lumeweb.com/dane"
@@ -138,6 +139,91 @@ func TestEnsureCertificateKey_BootstrapsAndReusesStableSPKI(t *testing.T) {
 		assert.Equal(tb, first.PrivateKeyPEM, stored.PrivateKeyPEM)
 		assert.Equal(tb, second.TLSA, stored.TLSA)
 	}, keyTestOptions)
+}
+
+func TestDANEPublicationTargetFor(t *testing.T) {
+	// The publication-target helper is the single source of truth for DANE
+	// republish eligibility. Portal-managed HNS republishes into its managed
+	// zone; chain-managed (HIP-5) republishes to the on-chain name data; every
+	// other binding / namespace carries no portal DANE duty.
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		db := ctx.DB()
+		svc := core.GetService[*DelegatedDomainService](ctx, pluginCore.DELEGATED_DOMAIN_SERVICE)
+		require.NotNil(tb, svc)
+
+		mk := func(domain string, ns pluginDb.DomainNamespace, status pluginDb.DomainStatus, zoneID uint) *pluginDb.WebsiteDomain {
+			wd := &pluginDb.WebsiteDomain{
+				WebsiteID: 1, UserID: 1, Domain: domain, Namespace: ns, Status: status, ZoneID: zoneID,
+			}
+			require.NoError(tb, db.Create(wd).Error)
+			return wd
+		}
+
+		portalManaged := mk("ptl", pluginDb.DomainNamespaceHNS, pluginDb.DomainStatusActive, 99)
+		if locus, ok := svc.DANEPublicationTargetFor(portalManaged); assert.True(tb, ok) {
+			assert.Equal(tb, DANEPublishManagedZone, locus)
+		}
+
+		onchain := mk("chain", pluginDb.DomainNamespaceHNS, pluginDb.DomainStatusOnchainManaged, 0)
+		if locus, ok := svc.DANEPublicationTargetFor(onchain); assert.True(tb, ok) {
+			assert.Equal(tb, DANEPublishChain, locus)
+		}
+
+		// An on-chain binding carrying a stray zone is still chain-managed:
+		// class (not the zone reference) decides the locus.
+		stray := mk("stray", pluginDb.DomainNamespaceHNS, pluginDb.DomainStatusOnchainManaged, 7)
+		if locus, ok := svc.DANEPublicationTargetFor(stray); assert.True(tb, ok) {
+			assert.Equal(tb, DANEPublishChain, locus)
+		}
+
+		// ICANN has no DANE locus anywhere.
+		icann := mk("x.com", pluginDb.DomainNamespaceICANN, pluginDb.DomainStatusActive, 1)
+		_, ok := svc.DANEPublicationTargetFor(icann)
+		assert.False(tb, ok)
+
+		// Self-hosted and unresolved bindings have no portal DANE publication
+		// duty even though the namespace is DANE-capable.
+		selfHosted := mk("sh", pluginDb.DomainNamespaceHNS, pluginDb.DomainStatusSelfHosted, 0)
+		_, ok = svc.DANEPublicationTargetFor(selfHosted)
+		assert.False(tb, ok)
+		unresolved := mk("unr", pluginDb.DomainNamespaceHNS, pluginDb.DomainStatusDraft, 0)
+		_, ok = svc.DANEPublicationTargetFor(unresolved)
+		assert.False(tb, ok)
+	}, TestOptions)
+}
+
+func TestGetDANERecord(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		db := ctx.DB()
+		svc := core.GetService[*DelegatedDomainService](ctx, pluginCore.DELEGATED_DOMAIN_SERVICE)
+		require.NotNil(tb, svc)
+
+		wd := &pluginDb.WebsiteDomain{
+			WebsiteID: 1, UserID: 1, Domain: "dane.hns", Namespace: pluginDb.DomainNamespaceHNS,
+			Status: pluginDb.DomainStatusOnchainManaged,
+			ProtocolData: datatypes.JSONMap{
+				"tlsa":       "3 1 1 aabb",
+				"owner_name": "_443._tcp.dane.hns",
+			},
+		}
+		require.NoError(tb, db.Create(wd).Error)
+
+		tlsa, owner, err := svc.GetDANERecord(ctx, "hns", "dane.hns")
+		require.NoError(tb, err)
+		assert.Equal(tb, "3 1 1 aabb", tlsa)
+		assert.Equal(tb, "_443._tcp.dane.hns", owner)
+
+		// A binding with no DANE identity reports empty, not an error.
+		wd2 := &pluginDb.WebsiteDomain{
+			WebsiteID: 1, UserID: 1, Domain: "nodane.hns", Namespace: pluginDb.DomainNamespaceHNS,
+			Status: pluginDb.DomainStatusOnchainManaged,
+		}
+		require.NoError(tb, db.Create(wd2).Error)
+		tlsa, owner, err = svc.GetDANERecord(ctx, "hns", "nodane.hns")
+		require.NoError(tb, err)
+		assert.Empty(tb, tlsa)
+		assert.Empty(tb, owner)
+	}, TestOptions)
 }
 
 func TestGetCertificateKey_NotFound(t *testing.T) {

--- a/internal/service/domain/dane_key_persistence_test.go
+++ b/internal/service/domain/dane_key_persistence_test.go
@@ -226,6 +226,21 @@ func TestGetDANERecord(t *testing.T) {
 	}, TestOptions)
 }
 
+func TestDANEKeyNotConfiguredSentinel(t *testing.T) {
+	// With no DANE key-encryption key configured, daneEncryptionKey must return
+	// the errDANEKeyNotConfigured sentinel — not a generic error — so
+	// ensureDANEIdentity can skip persistence on the empty-key case specifically
+	// without masking genuine failures that merely co-occur with an absent key.
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		svc := core.GetService[*DelegatedDomainService](ctx, pluginCore.DELEGATED_DOMAIN_SERVICE)
+		require.NotNil(tb, svc)
+
+		_, err := svc.daneEncryptionKey()
+		require.Error(tb, err)
+		assert.ErrorIs(tb, err, errDANEKeyNotConfigured)
+	}, TestOptions)
+}
+
 func TestGetCertificateKey_NotFound(t *testing.T) {
 	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 		svc := core.GetService[*DelegatedDomainService](ctx, pluginCore.DELEGATED_DOMAIN_SERVICE)

--- a/internal/service/domain/delegated_domain_service.go
+++ b/internal/service/domain/delegated_domain_service.go
@@ -1152,6 +1152,15 @@ func (s *DelegatedDomainService) ensureDANEIdentity(ctx context.Context, provide
 		return nil
 	}
 	if _, err := s.EnsureCertificateKey(ctx, namespace, domain); err != nil {
+		// DANE persistence is best-effort at bind time: when the key-encryption
+		// key is not configured, the contract (config/dns.go) skips persistence
+		// rather than failing, mirroring UpdateTLSAFromCert. Only a genuine
+		// failure with a configured key is fatal.
+		if _, encErr := s.daneEncryptionKey(); encErr != nil {
+			s.Logger().Warn("DANE identity not persisted (encryption key not configured); skipping",
+				zap.String("domain", domain), zap.Error(err))
+			return nil
+		}
 		return fmt.Errorf("failed to bootstrap DANE identity: %w", err)
 	}
 	return nil

--- a/internal/service/domain/delegated_domain_service.go
+++ b/internal/service/domain/delegated_domain_service.go
@@ -414,9 +414,12 @@ func (s *DelegatedDomainService) CreateDomain(ctx context.Context,
 	// An on-chain managed name (HIP-5) serves its DNS from an external
 	// contract: the portal owns only ownership verification (a TXT token
 	// resolved through the HNS-aware resolver, which bridges to the contract)
-	// — no zone, no DNSLink/apex, no DNSSEC, no DANE. The binding is recorded
-	// with a distinct status so downstream code routes it to TXT-token
-	// verification instead of the delegation/DS flow used by native HNS.
+	// — no zone, no DNSLink/apex, no DNSSEC, and no portal-published DANE. The
+	// binding is still recorded with a distinct status so downstream code
+	// routes it to TXT-token verification instead of the delegation/DS flow
+	// used by native HNS. DANE is not dropped, though: the stable TLSA the
+	// on-chain zone data must serve is bootstrapped and exposed at bind time
+	// (see ensureDANEIdentity), because DANE still applies on-chain.
 	// dnsHostingEnabled is always coerced to false here, even when the caller
 	// requested managed DNS (the default in the UX flow): portal hosting is
 	// impossible for a contract-served name, and the persisted flag must agree
@@ -436,6 +439,15 @@ func (s *DelegatedDomainService) CreateDomain(ctx context.Context,
 			// rolled back and the name can be retried.
 			s.DB().WithContext(ctx).Unscoped().Delete(wd)
 			return nil, fmt.Errorf("failed to finalize domain record: %w", err)
+		}
+		// DANE still applies to a chain-managed name (the TLSA is served from
+		// the name's on-chain zone data), so the stable DANE key must exist at
+		// bind time — the same bootstrap invariant the self-hosted path
+		// enforces. A failure rolls the just-inserted row back so the bind is
+		// cleanly retryable.
+		if err := s.ensureDANEIdentity(ctx, provider, namespace, domain); err != nil {
+			s.DB().WithContext(ctx).Unscoped().Delete(wd)
+			return nil, err
 		}
 		// This binding is the new website's first (primary) domain. Record it
 		// so the website service resolves the apex domain via PrimaryDomainID
@@ -459,11 +471,9 @@ func (s *DelegatedDomainService) CreateDomain(ctx context.Context,
 		if err := s.DB().WithContext(ctx).Model(wd).Update("status", pluginDb.DomainStatusSelfHosted).Error; err != nil {
 			return nil, fmt.Errorf("failed to finalize domain record: %w", err)
 		}
-		if provider.UsesManagedZoneTLSA() {
-			if _, err := s.EnsureCertificateKey(ctx, namespace, domain); err != nil {
-				s.DB().WithContext(ctx).Unscoped().Delete(wd)
-				return nil, fmt.Errorf("failed to bootstrap DANE identity: %w", err)
-			}
+		if err := s.ensureDANEIdentity(ctx, provider, namespace, domain); err != nil {
+			s.DB().WithContext(ctx).Unscoped().Delete(wd)
+			return nil, err
 		}
 		// This binding is the new website's first (primary) domain. Record it
 		// so the website service resolves the apex domain via PrimaryDomainID
@@ -1085,14 +1095,66 @@ func (s *DelegatedDomainService) UsesDelegationForOwnership(domain string) bool 
 }
 
 // NamespaceUsesManagedZoneTLSA reports whether the given namespace's provider
-// translates certs into a DANE TLSA that the portal publishes into its managed
-// authoritative zone. Only such namespaces (e.g. HNS) can be force-republished.
+// translates certs into a DANE TLSA. Only such namespaces (e.g. HNS) carry a
+// DANE publication duty anywhere — into a portal-managed zone for native
+// bindings or into the on-chain zone data for chain-managed bindings. Non-DANE
+// namespaces (e.g. ICANN) have no TLSA anywhere.
 func (s *DelegatedDomainService) NamespaceUsesManagedZoneTLSA(namespace string) bool {
 	if s.registry == nil {
 		return false
 	}
 	prov := s.registry.Get(namespace)
 	return prov != nil && prov.UsesManagedZoneTLSA()
+}
+
+// DANEPublicationTarget describes where a DANE-capable binding's TLSA is served.
+type DANEPublicationTarget string
+
+const (
+	// DANEPublishManagedZone marks a portal-managed binding whose TLSA is
+	// published into the portal's authoritative PowerDNS zone.
+	DANEPublishManagedZone DANEPublicationTarget = "managed_zone"
+	// DANEPublishChain marks a chain-managed (HIP-5) binding whose TLSA is
+	// served from the name's on-chain zone data: the portal only computes and
+	// stores the record, and the owner installs it in the chain zone.
+	DANEPublishChain DANEPublicationTarget = "chain"
+)
+
+// DANEPublicationTargetFor resolves where a bound domain's DANE TLSA is served,
+// and whether the DANE republish flow applies to it at all. It is the single
+// source of truth for DANE publication eligibility: a DANE-capable namespace
+// republishes either into the portal-managed zone (portal-managed bindings) or
+// into the on-chain name data (chain-managed bindings — DANE still applies
+// on-chain). Self-hosted and unresolved bindings carry no portal DANE
+// publication duty and are rejected.
+func (s *DelegatedDomainService) DANEPublicationTargetFor(wd *pluginDb.WebsiteDomain) (DANEPublicationTarget, bool) {
+	if !s.NamespaceUsesManagedZoneTLSA(string(wd.Namespace)) {
+		return "", false
+	}
+	switch wd.Class() {
+	case pluginDb.ClassPortalManaged:
+		return DANEPublishManagedZone, true
+	case pluginDb.ClassOnChainManaged:
+		return DANEPublishChain, true
+	default:
+		return "", false
+	}
+}
+
+// ensureDANEIdentity bootstraps the stable DANE key/identity for namespaces
+// whose provider translates certs into DANE TLSA. Binding paths (self-hosted
+// and on-chain managed) call it so the TLSA the owner must publish exists at
+// bind time, before any certificate push; the key is stable, so the published
+// SPKI pin never rotates across cert re-issuance. It is a no-op for providers
+// without a DANE concept.
+func (s *DelegatedDomainService) ensureDANEIdentity(ctx context.Context, provider DomainProvider, namespace, domain string) error {
+	if !provider.UsesManagedZoneTLSA() {
+		return nil
+	}
+	if _, err := s.EnsureCertificateKey(ctx, namespace, domain); err != nil {
+		return fmt.Errorf("failed to bootstrap DANE identity: %w", err)
+	}
+	return nil
 }
 
 // NamespaceRequiresDNSSEC reports whether the given namespace's provider
@@ -1294,6 +1356,25 @@ func (s *DelegatedDomainService) GetCertificateKey(ctx context.Context, namespac
 		result.OwnerName = v
 	}
 	return result, nil
+}
+
+// GetDANERecord returns the stored DANE TLSA rdata and owner name for a domain
+// without decrypting the private key — the lightweight read surface for
+// consumers that only need the record to publish into the name's zone (e.g.
+// dns-requirements). Returns gorm.ErrRecordNotFound when the binding does not
+// exist and empty strings when no DANE identity has been computed yet.
+func (s *DelegatedDomainService) GetDANERecord(ctx context.Context, namespace, domain string) (tlsa, ownerName string, err error) {
+	wd, err := s.GetWebsiteDomainByDomainAndNamespace(ctx, domain, pluginDb.DomainNamespace(namespace))
+	if err != nil {
+		return "", "", err
+	}
+	if v, ok := wd.ProtocolData[protocolDataTLSAKey].(string); ok {
+		tlsa = v
+	}
+	if v, ok := wd.ProtocolData[protocolDataOwnerKey].(string); ok {
+		ownerName = v
+	}
+	return tlsa, ownerName, nil
 }
 
 // GetActiveWebsiteDomainByDomain finds an active domain across all namespaces.

--- a/internal/service/domain/delegated_domain_service.go
+++ b/internal/service/domain/delegated_domain_service.go
@@ -1153,10 +1153,12 @@ func (s *DelegatedDomainService) ensureDANEIdentity(ctx context.Context, provide
 	}
 	if _, err := s.EnsureCertificateKey(ctx, namespace, domain); err != nil {
 		// DANE persistence is best-effort at bind time: when the key-encryption
-		// key is not configured, the contract (config/dns.go) skips persistence
-		// rather than failing, mirroring UpdateTLSAFromCert. Only a genuine
-		// failure with a configured key is fatal.
-		if _, encErr := s.daneEncryptionKey(); encErr != nil {
+		// key is empty, the contract (config/dns.go) skips persistence rather
+		// than failing, mirroring UpdateTLSAFromCert. Match the missing-key
+		// sentinel specifically (errors.Is) so a genuine failure that merely
+		// co-occurs with an absent key — DB error, AEAD decrypt failure, row
+		// not found — is still surfaced instead of silently skipped.
+		if errors.Is(err, errDANEKeyNotConfigured) {
 			s.Logger().Warn("DANE identity not persisted (encryption key not configured); skipping",
 				zap.String("domain", domain), zap.Error(err))
 			return nil

--- a/internal/service/domain/delegated_domain_service_test.go
+++ b/internal/service/domain/delegated_domain_service_test.go
@@ -736,10 +736,12 @@ func testOptionsWithHNSResolver(addr string) coreTesting.TestContextBuilderOptio
 
 func TestDelegatedDomainService_CreateDomain_Hip5OnchainManaged(t *testing.T) {
 	// A Handshake name whose NS record is a HIP-5 TX record must bind as on-chain
-	// managed: no zone, no DANE, TXT-verification status. A managed-DNS request
+	// managed: no PowerDNS zone and TXT-verification status. Portal DNS hosting is
+	// impossible for a contract-served name, so a managed-DNS request
 	// (dnsHostingEnabled=true, the UX default) is coerced to onchain_managed with
-	// dns_hosting_enabled=false — portal hosting is impossible for a
-	// contract-served name — rather than failing the bind.
+	// dns_hosting_enabled=false rather than failing the bind. DANE still applies
+	// on-chain, so the stable DANE identity is bootstrapped at bind time even
+	// though no portal zone exists to publish the TLSA into.
 	const domain = "myname"
 
 	addr, _ := startCustomPortDNSServer(t, domain+".",
@@ -795,9 +797,22 @@ func TestDelegatedDomainService_CreateDomain_Hip5OnchainManaged(t *testing.T) {
 				var persisted pluginDb.WebsiteDomain
 				require.NoError(tb, db.First(&persisted, wd.ID).Error)
 				assert.False(tb, persisted.DNSHostingEnabled)
+
+				// DANE still applies on-chain: a stable identity is bootstrapped
+				// at bind time (key + TLSA + owner) so the owner can install the
+				// TLSA in the name's on-chain zone data before any cert exists.
+				assert.NotEmpty(tb, persisted.ProtocolData[protocolDataPrivateKeyKey],
+					"on-chain bind must bootstrap the DANE key")
+				assert.NotEmpty(tb, persisted.ProtocolData[protocolDataTLSAKey],
+					"on-chain bind must compute the DANE TLSA")
+				assert.NotEmpty(tb, persisted.ProtocolData[protocolDataOwnerKey],
+					"on-chain bind must compute the TLSA owner")
 			})
 		}
-	}, testOptionsWithHNSResolver(addr))
+	}, coreTesting.CombineOptions(
+		testOptionsWithHNSResolver(addr),
+		coreTesting.WithConfig("plugin.ipfs.service.dns.dane_key_encryption_key", testDANEKey),
+	))
 }
 
 func TestDelegatedDomainService_ConvertToOnChain_HappyPath(t *testing.T) {
@@ -819,6 +834,17 @@ func TestDelegatedDomainService_ConvertToOnChain_HappyPath(t *testing.T) {
 		// re-arms validation back to pending.
 		require.NoError(tb, db.Model(&website).Update("status", pluginDb.WebsiteStatusActive).Error)
 
+		svc := core.GetService[*DelegatedDomainService](ctx, pluginCore.DELEGATED_DOMAIN_SERVICE)
+		require.NotNil(tb, svc)
+
+		// DANE state must survive the conversion (DANE/SSL still applies
+		// on-chain; only PowerDNS-served records go away). The private key is
+		// stored encrypted with the configured at-rest key so the conversion's
+		// DANE-identity bootstrap (which re-reads it) succeeds.
+		keyPEM := mustGenerateKey(t)
+		encKey, err := svc.encryptPrivateKey(ctx, keyPEM)
+		require.NoError(tb, err)
+
 		wd := &pluginDb.WebsiteDomain{
 			WebsiteID:         website.ID,
 			UserID:            1,
@@ -835,19 +861,14 @@ func TestDelegatedDomainService_ConvertToOnChain_HappyPath(t *testing.T) {
 					{"type": "NS", "value": "ns1.lumeweb\nns2.lumeweb"},
 				},
 			},
-			// Simulated DANE state that must survive the conversion (DANE/SSL
-			// still applies on-chain; only PowerDNS-served records go away).
 			ProtocolData: datatypes.JSONMap{
 				"dane_cert_pem":    "CERT",
 				"tlsa":             "3 1 1 abc",
 				"owner_name":       "_443._tcp." + domain + ".",
-				"dane_private_key": "encrypted-key",
+				"dane_private_key": encKey,
 			},
 		}
 		require.NoError(tb, db.Create(wd).Error)
-
-		svc := core.GetService[*DelegatedDomainService](ctx, pluginCore.DELEGATED_DOMAIN_SERVICE)
-		require.NotNil(tb, svc)
 		hnsProv := svc.registry.Get("hns").(*HNSProvider)
 		hnsProv.resolverAddr = hip5Addr
 
@@ -864,6 +885,10 @@ func TestDelegatedDomainService_ConvertToOnChain_HappyPath(t *testing.T) {
 				assert.Equal(tb, uint(0), now.ZoneID)
 			}).
 			Return(nil).Once()
+
+		// The DANE-identity bootstrap is a no-op when the binding already holds
+		// a key: it must not have touched DNS or rewritten DANE state.
+		mockDNS.AssertNotCalled(tb, "SetTLSARecord", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 
 		converted, err := svc.ConvertToOnChain(context.Background(), website.ID, 1, wd.ID)
 		require.NoError(tb, err)
@@ -889,7 +914,7 @@ func TestDelegatedDomainService_ConvertToOnChain_HappyPath(t *testing.T) {
 		var reloaded pluginDb.Website
 		require.NoError(tb, db.First(&reloaded, website.ID).Error)
 		assert.Equal(tb, string(pluginDb.WebsiteStatusPendingValidation), reloaded.Status)
-	}, TestOptions)
+	}, keyTestOptions)
 }
 
 func TestDelegatedDomainService_VerifyDomain_ReclassifiesExistingHIP5(t *testing.T) {

--- a/internal/service/domain/delegated_domain_service_test.go
+++ b/internal/service/domain/delegated_domain_service_test.go
@@ -186,7 +186,11 @@ func TestDelegatedDomainService_CreateDomain_DuplicateKey(t *testing.T) {
 	}, TestOptions)
 }
 
-func TestDelegatedDomainService_CreateDomain_SelfHostedDANEFailurePurgesBinding(t *testing.T) {
+func TestDelegatedDomainService_CreateDomain_SelfHostedSkipsDANEPersistenceWithoutEncryptionKey(t *testing.T) {
+	// Without a configured DANE key-encryption key, DANE persistence is
+	// best-effort (config contract: "empty key skips persistence", mirroring
+	// UpdateTLSAFromCert). A self-hosted HNS bind must therefore STILL succeed —
+	// DANE identity is skipped, not fatal — rather than purging the binding.
 	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 		db := ctx.DB()
 		website := createTestWebsite(tb, db, 1, "example")
@@ -194,15 +198,14 @@ func TestDelegatedDomainService_CreateDomain_SelfHostedDANEFailurePurgesBinding(
 		svc := core.GetService[*DelegatedDomainService](ctx, pluginCore.DELEGATED_DOMAIN_SERVICE)
 		require.NotNil(tb, svc)
 
-		_, err := svc.CreateDomain(context.Background(), "hns", "example", website.ID, 1, false, false, nil, nil)
-		require.Error(tb, err)
-		assert.Contains(tb, err.Error(), "failed to bootstrap DANE identity")
-
-		var count int64
-		require.NoError(tb, db.Unscoped().Model(&pluginDb.WebsiteDomain{}).
-			Where("domain = ? AND namespace = ?", "example", pluginDb.DomainNamespaceHNS).
-			Count(&count).Error)
-		assert.Zero(tb, count, "failed self-hosted DANE bootstrap must purge the binding")
+		wd, err := svc.CreateDomain(context.Background(), "hns", "example", website.ID, 1, false, false, nil, nil)
+		require.NoError(tb, err)
+		assert.Equal(tb, pluginDb.DomainStatusSelfHosted, wd.Status)
+		assert.Equal(tb, uint(0), wd.ZoneID)
+		assert.False(tb, wd.DNSHostingEnabled)
+		require.Nil(tb, wd.ProtocolData)
+		assert.Nil(tb, wd.ProtocolData[protocolDataPrivateKeyKey],
+			"DANE identity not persisted when the encryption key is unconfigured")
 	}, TestOptions)
 }
 

--- a/internal/service/domain/key_crypto.go
+++ b/internal/service/domain/key_crypto.go
@@ -15,6 +15,13 @@ import (
 	"go.lumeweb.com/portal/core"
 )
 
+// errDANEKeyNotConfigured is returned when the DANE key-encryption key is
+// empty. Callers that treat DANE persistence as best-effort (e.g. bind-time
+// DANE identity bootstrap) skip on this sentinel specifically, rather than on
+// any encryption-key parse failure, so a genuine failure is never masked as a
+// missing key.
+var errDANEKeyNotConfigured = errors.New("dane key encryption key not configured")
+
 // daneEncryptionKey extracts and parses the configured base64 AES-256 key.
 func (s *DelegatedDomainService) daneEncryptionKey() ([]byte, error) {
 	var raw string
@@ -25,7 +32,7 @@ func (s *DelegatedDomainService) daneEncryptionKey() ([]byte, error) {
 		}
 	}
 	if raw == "" {
-		return nil, errors.New("dane key encryption key not configured")
+		return nil, errDANEKeyNotConfigured
 	}
 	key, err := base64.StdEncoding.DecodeString(raw)
 	if err != nil {

--- a/internal/service/domain/onchain.go
+++ b/internal/service/domain/onchain.go
@@ -48,6 +48,16 @@ func (s *DelegatedDomainService) ConvertToOnChain(ctx context.Context, websiteID
 		return nil, fmt.Errorf("%w: %q; handover did not select an authoritative response", ErrDomainNotOnChain, wd.Domain)
 	}
 
+	// DANE still applies once the name is chain-managed (the TLSA is served
+	// from the on-chain zone data), so the stable DANE identity must exist
+	// before any destructive work. Running this after inspection but before
+	// convertInspectedBindingToOnChain makes a bootstrap failure fail-fast with
+	// nothing converted or torn down; it is a no-op when the binding already
+	// holds a persisted key (the common case for a site, via prior cert pushes).
+	if err := s.ensureDANEIdentity(ctx, provider, string(wd.Namespace), wd.Domain); err != nil {
+		return nil, err
+	}
+
 	if err := s.convertInspectedBindingToOnChain(ctx, &wd); err != nil {
 		return nil, err
 	}
@@ -77,6 +87,13 @@ func (s *DelegatedDomainService) convertInspectedBindingToOnChain(ctx context.Co
 			}
 		}
 
+		// Re-arm the website to pending_validation BEFORE committing the
+		// conversion. A failure here is clean (nothing has been converted yet
+		// and the caller can retry), whereas failing after the on-chain commit
+		// would leave an already-converted domain reported as a 500 and make
+		// retry hit "already on-chain managed". A blocked website stays blocked
+		// (only an admin can lift an admin block); a pending one needs no
+		// change.
 		var website pluginDb.Website
 		if err := s.DB().WithContext(ctx).First(&website, wd.WebsiteID).Error; err != nil {
 			return fmt.Errorf("failed to load website %d for on-chain conversion: %w", wd.WebsiteID, err)


### PR DESCRIPTION
Bootstraps, stores, and exposes DANE for chain-managed (HIP-5) HNS bindings so their TLSA can be served from the name's on-chain zone data.

- Ensures a stable DANE identity at on-chain bind (`CreateDomain`) and at on-chain conversion (`ConvertToOnChain`), reusing the self-hosted bootstrap path.
- Adds `DANEPublicationTargetFor` as the single source of truth for DANE publication eligibility (portal-managed → managed zone, on-chain managed → chain).
- DANE republish now accepts on-chain bindings: it refreshes the stored TLSA and returns it with `published_to_managed_zone=false` and no PowerDNS write.
- dns-requirements surfaces the stored TLSA for on-chain bindings via the lightweight `GetDANERecord` accessor and the shared `FormatTLSAPresentation` renderer.

***

<!-- kody-pr-summary:start -->

This pull request adds DANE (TLSA) support for **on-chain managed Handshake (HNS) names** (HIP-5 bindings).

**What changed:**

- **DANE now applies to chain-managed bindings too.** Previously, on-chain managed names were treated as having no DANE because they have no portal-managed PowerDNS zone. Now, the portal bootstraps a stable DANE identity (private key + computed TLSA) at bind time (`ensureDANEIdentity`) and surfaces the TLSA record for the owner to install in the name's on-chain zone data.

- **DNS-requirements exposes the stored TLSA for chain-managed names.** The `domainDNSRequirements` endpoint now returns the DANE TLSA record (`tlsa_record`, `owner_name`, `tlsa_rdata`) when the binding is chain-managed and a DANE identity exists. Portal-managed bindings continue to carry their TLSA in the delegation records.

- **Republish DANE flow now handles both publication targets.** The `republishDomainDANE` endpoint was refactored around a single helper (`DANEPublicationTargetFor`) that decides whether a binding has a DANE publication duty and where it publishes:
  - **Portal-managed** → republishes the TLSA into the portal's PowerDNS zone (`published_to_managed_zone=true`).
  - **Chain-managed (HIP-5)** → refreshes the stored TLSA from the certificate and returns it with `published_to_managed_zone=false`, signaling the owner must install it on-chain. No PowerDNS write is performed.

- **Single source of truth for DANE eligibility.** A new `DANEPublicationTargetFor` centralizes the logic that was previously scattered across multiple checks (namespace capability, zone ID, portal-managed status). Self-hosted, unresolved, and non-DANE namespaces (e.g., ICANN) are rejected from the republish flow.

- **Conversion to on-chain preserves DANE.** `ConvertToOnChain` now ensures a DANE identity exists before tearing down portal-side state, so a name converted to chain management retains its DANE record.

**Why:** Owners of HIP-5 on-chain HNS names need the correct TLSA record to install in their on-chain zone data — DANE still applies even though the portal no longer serves the DNS. These changes make that record discoverable, maintainable (via republish), and bootstrapped at bind time, while keeping the portal-managed DANE flow unchanged.

<!-- kody-pr-summary:end -->

- `develop` <!-- branch-stack -->
  - **feat(dns): support DANE for on-chain managed HNS names** :point\_left:
