### PR TITLE
fix(dns): republish chain-managed DANE without a stored certificate

### DIFF
--- a/internal/api/api_domains.go
+++ b/internal/api/api_domains.go
@@ -633,22 +633,42 @@ func (a *API) republishDomainDANE(c echo.Context) error {
 		return ctx.Error(apiErr, apiErr.HttpStatus())
 	}
 
-	cert, err := a.delegatedDomainSvc.GetCertificateKey(reqCtx, ns, wd.Domain)
-	if err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			apiErr := NewError(ErrKeyNoStoredCertificate, err)
+	var tlsa, ownerName string
+	if locus == domsvc.DANEPublishChain {
+		// Chain-managed (HIP-5): DANE still applies on-chain, so republish just
+		// refreshes the stored TLSA from the stable DANE key — the source of
+		// truth for the SPKI pin — and returns it for the owner to install in
+		// the name's on-chain zone data. No stored certificate and no PowerDNS
+		// zone write are involved: TLSA 3 1 1 pins the key, not a cert, and a
+		// chain-managed name owns no portal zone.
+		tlsa, ownerName, err = a.delegatedDomainSvc.RepublishChainDANERecord(reqCtx, ns, wd.Domain)
+		if err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				apiErr := NewError(ErrKeyNoStoredCertificate, err)
+				return ctx.Error(apiErr, apiErr.HttpStatus())
+			}
+			a.Logger().Error("Failed to republish on-chain DANE record", zap.Error(err), zap.String("domain", wd.Domain))
+			apiErr := NewError(ErrKeyFileProcessingFailed, err)
 			return ctx.Error(apiErr, apiErr.HttpStatus())
 		}
-		a.Logger().Error("Failed to load stored certificate for DANE republish", zap.Error(err), zap.String("domain", wd.Domain))
-		apiErr := NewError(ErrKeyFileProcessingFailed, err)
-		return ctx.Error(apiErr, apiErr.HttpStatus())
-	}
+	} else {
+		cert, err := a.delegatedDomainSvc.GetCertificateKey(reqCtx, ns, wd.Domain)
+		if err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				apiErr := NewError(ErrKeyNoStoredCertificate, err)
+				return ctx.Error(apiErr, apiErr.HttpStatus())
+			}
+			a.Logger().Error("Failed to load stored certificate for DANE republish", zap.Error(err), zap.String("domain", wd.Domain))
+			apiErr := NewError(ErrKeyFileProcessingFailed, err)
+			return ctx.Error(apiErr, apiErr.HttpStatus())
+		}
 
-	tlsa, ownerName, err := a.delegatedDomainSvc.UpdateTLSAFromCert(reqCtx, ns, wd.Domain, cert.CertPEM, cert.PrivateKeyPEM)
-	if err != nil {
-		a.Logger().Error("Failed to republish DANE TLSA", zap.Error(err), zap.String("domain", wd.Domain))
-		apiErr := NewError(ErrKeyFileProcessingFailed, err)
-		return ctx.Error(apiErr, apiErr.HttpStatus())
+		tlsa, ownerName, err = a.delegatedDomainSvc.UpdateTLSAFromCert(reqCtx, ns, wd.Domain, cert.CertPEM, cert.PrivateKeyPEM)
+		if err != nil {
+			a.Logger().Error("Failed to republish DANE TLSA", zap.Error(err), zap.String("domain", wd.Domain))
+			apiErr := NewError(ErrKeyFileProcessingFailed, err)
+			return ctx.Error(apiErr, apiErr.HttpStatus())
+		}
 	}
 
 	// Reload wd after the publish: UpdateTLSAFromCert rewrites the row's

--- a/internal/api/api_domains_test.go
+++ b/internal/api/api_domains_test.go
@@ -21,6 +21,7 @@ import (
 	"go.lumeweb.com/portal/core"
 	coreTesting "go.lumeweb.com/portal/core/testing"
 	"gorm.io/datatypes"
+	"gorm.io/gorm"
 )
 
 func TestAPI_DeleteDomain(t *testing.T) {
@@ -512,6 +513,58 @@ func TestAPI_DANERepublish(t *testing.T) {
 			assert.False(t, resp.PublishedToManagedZone,
 				"chain-managed binding has no portal zone; the TLSA must be installed on-chain")
 		}, daneRepublishTestOptions)
+	})
+
+	t.Run("onchain_hns_with_stored_tlsa_but_no_private_key_republishes", func(t *testing.T) {
+		// A chain-managed (HIP-5) HNS binding frequently has a stored TLSA/cert
+		// but no stored private key — the key is only persisted when the DANE
+		// key-encryption key is configured, and legacy certificates may predate
+		// key bootstrap. Republish must NOT require a stored certificate: it
+		// must refresh/return the stored TLSA (published_to_managed_zone=false)
+		// instead of failing with NoStoredCertificate.
+		coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+			helper := newMockHelper(t, ctx)
+			token, userID, _, _ := helper.SetupAuthenticatedTest()
+
+			website := createTestIPFSGatewayWebsite(1, userID, "onchain-notlsa.hns", util.GenerateTestCID(t, "td"), pluginDb.WebsiteStatusActive)
+			require.NoError(t, ctx.DB().Create(website).Error)
+			websiteID := website.ID
+
+			wd := &pluginDb.WebsiteDomain{
+				WebsiteID: websiteID,
+				UserID:    userID,
+				Domain:    "onchain-notlsa.hns",
+				Namespace: pluginDb.DomainNamespaceHNS,
+				Status:    pluginDb.DomainStatusOnchainManaged,
+			}
+			require.NoError(t, ctx.DB().Create(wd).Error)
+
+			// Seed the TLSA/cert WITHOUT the DANE key-encryption key: the push
+			// stores tlsa/owner/cert but skips persisting the private key,
+			// reproducing the no-stored-certificate condition.
+			svc := core.GetService[*domain.DelegatedDomainService](ctx, pluginCore.DELEGATED_DOMAIN_SERVICE)
+			require.NotNil(tb, svc)
+			keyPEM := mustGenerateTestKey(t)
+			certPEM := mustIssueTestCert(t, keyPEM, "onchain-notlsa.hns")
+			_, _, err := svc.UpdateTLSAFromCert(ctx, "hns", wd.Domain, certPEM, keyPEM)
+			require.NoError(t, err, "seeding stored TLSA via UpdateTLSAFromCert")
+
+			// Confirm the degenerate precondition: TLSA present, private key absent.
+			tlsa, _, dErr := svc.GetDANERecord(ctx, "hns", wd.Domain)
+			require.NoError(t, dErr)
+			require.NotEmpty(t, tlsa, "TLSA must be stored for the precondition")
+			_, gErr := svc.GetCertificateKey(ctx, "hns", wd.Domain)
+			require.ErrorIs(t, gErr, gorm.ErrRecordNotFound, "private key must be absent for the precondition")
+
+			rec := helper.makeAuthenticatedRequest(http.MethodPost, republishPath(int(websiteID), int(wd.ID)), token, nil)
+			require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+
+			var resp dto.DomainDANERepublishResponse
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+			require.NotEmpty(t, resp.TLSARData, "republish must return the stored TLSA")
+			require.NotEmpty(t, resp.OwnerName)
+			assert.False(t, resp.PublishedToManagedZone)
+		}, TestOptions)
 	})
 }
 

--- a/internal/service/domain/dane_key_persistence_test.go
+++ b/internal/service/domain/dane_key_persistence_test.go
@@ -241,6 +241,84 @@ func TestDANEKeyNotConfiguredSentinel(t *testing.T) {
 	}, TestOptions)
 }
 
+func TestRepublishChainDANERecord(t *testing.T) {
+	t.Run("recomputes_from_stored_key_when_encryption_key_configured", func(t *testing.T) {
+		// With the key-encryption key configured, RepublishChainDANERecord
+		// derives the TLSA fresh from the stable DANE key (source of truth) and
+		// persists it, even when no cert was ever pushed.
+		coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+			svc := core.GetService[*DelegatedDomainService](ctx, pluginCore.DELEGATED_DOMAIN_SERVICE)
+			require.NotNil(tb, svc)
+
+			require.NoError(tb, ctx.DB().Create(&pluginDb.WebsiteDomain{
+				WebsiteID: 1, UserID: 1, Domain: "chain.hns", Namespace: pluginDb.DomainNamespaceHNS,
+				Status: pluginDb.DomainStatusOnchainManaged,
+			}).Error)
+
+			tlsa, owner, err := svc.RepublishChainDANERecord(ctx, "hns", "chain.hns")
+			require.NoError(tb, err)
+			require.NotEmpty(tb, tlsa)
+			require.NotEmpty(tb, owner)
+
+			// The recomputed record must persist as the stored DANE identity.
+			storedTLSa, storedOwner, err := svc.GetDANERecord(ctx, "hns", "chain.hns")
+			require.NoError(tb, err)
+			assert.Equal(tb, tlsa, storedTLSa)
+			assert.Equal(tb, owner, storedOwner)
+		}, keyTestOptions)
+	})
+
+	t.Run("falls_back_to_stored_tlsa_without_encryption_key", func(t *testing.T) {
+		// The real-world flaw: a chain-managed name whose cert was pushed but
+		// whose private key was never persisted (no key-encryption key). The
+		// stored TLSA must be returned rather than a NoStoredCertificate error.
+		coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+			svc := core.GetService[*DelegatedDomainService](ctx, pluginCore.DELEGATED_DOMAIN_SERVICE)
+			require.NotNil(tb, svc)
+
+			wd := &pluginDb.WebsiteDomain{
+				WebsiteID: 1, UserID: 1, Domain: "chain-fallback.hns", Namespace: pluginDb.DomainNamespaceHNS,
+				Status: pluginDb.DomainStatusOnchainManaged,
+			}
+			require.NoError(tb, ctx.DB().Create(wd).Error)
+
+			keyPEM := mustGenerateKey(tb)
+			certPEM, _ := issueCertFromKey(tb, keyPEM, "chain-fallback.hns")
+			// No key-encryption key configured: the push stores tlsa/owner/cert
+			// but skips persisting the private key.
+			_, _, err := svc.UpdateTLSAFromCert(ctx, "hns", wd.Domain, certPEM, keyPEM)
+			require.NoError(tb, err)
+
+			// Precondition: TLSA present, private key absent.
+			stored, _, err := svc.GetDANERecord(ctx, "hns", wd.Domain)
+			require.NoError(tb, err)
+			require.NotEmpty(tb, stored)
+			_, err = svc.GetCertificateKey(ctx, "hns", wd.Domain)
+			require.ErrorIs(tb, err, gorm.ErrRecordNotFound)
+
+			tlsa, owner, err := svc.RepublishChainDANERecord(ctx, "hns", wd.Domain)
+			require.NoError(tb, err)
+			assert.Equal(tb, stored, tlsa)
+			require.NotEmpty(tb, owner)
+		}, TestOptions)
+	})
+
+	t.Run("errors_when_no_identity_exists", func(t *testing.T) {
+		coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+			svc := core.GetService[*DelegatedDomainService](ctx, pluginCore.DELEGATED_DOMAIN_SERVICE)
+			require.NotNil(tb, svc)
+
+			require.NoError(tb, ctx.DB().Create(&pluginDb.WebsiteDomain{
+				WebsiteID: 1, UserID: 1, Domain: "empty.hns", Namespace: pluginDb.DomainNamespaceHNS,
+				Status: pluginDb.DomainStatusOnchainManaged,
+			}).Error)
+
+			_, _, err := svc.RepublishChainDANERecord(ctx, "hns", "empty.hns")
+			require.ErrorIs(tb, err, gorm.ErrRecordNotFound)
+		}, TestOptions)
+	})
+}
+
 func TestGetCertificateKey_NotFound(t *testing.T) {
 	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 		svc := core.GetService[*DelegatedDomainService](ctx, pluginCore.DELEGATED_DOMAIN_SERVICE)

--- a/internal/service/domain/dane_key_persistence_test.go
+++ b/internal/service/domain/dane_key_persistence_test.go
@@ -268,6 +268,40 @@ func TestRepublishChainDANERecord(t *testing.T) {
 		}, keyTestOptions)
 	})
 
+	t.Run("preserves_installed_tlsa_without_rotating_key", func(t *testing.T) {
+		// Regression: republish must NOT rotate an installed on-chain identity.
+		// The key-encryption key IS configured here (so generating a fresh key
+		// would be possible), but a binding with an already-installed TLSA and no
+		// stored private key must return that exact TLSA and persist no new key —
+		// otherwise the SPKI pin rotates and the live DANE record breaks.
+		coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+			svc := core.GetService[*DelegatedDomainService](ctx, pluginCore.DELEGATED_DOMAIN_SERVICE)
+			require.NotNil(tb, svc)
+
+			wd := &pluginDb.WebsiteDomain{
+				WebsiteID: 1, UserID: 1, Domain: "chain-installed.hns", Namespace: pluginDb.DomainNamespaceHNS,
+				Status: pluginDb.DomainStatusOnchainManaged,
+				ProtocolData: datatypes.JSONMap{
+					"tlsa":       "3 1 1 aabbcc",
+					"owner_name": "_443._tcp.chain-installed.hns",
+				},
+			}
+			require.NoError(tb, ctx.DB().Create(wd).Error)
+
+			tlsa, owner, err := svc.RepublishChainDANERecord(ctx, "hns", "chain-installed.hns")
+			require.NoError(tb, err)
+			assert.Equal(tb, "3 1 1 aabbcc", tlsa)
+			assert.Equal(tb, "_443._tcp.chain-installed.hns", owner)
+
+			// The installed identity must be preserved verbatim: no private key
+			// is persisted and the TLSA is unchanged, so no rotation occurred.
+			_, gErr := svc.GetCertificateKey(ctx, "hns", "chain-installed.hns")
+			assert.ErrorIs(tb, gErr, gorm.ErrRecordNotFound, "republish must not persist a new key for an installed identity")
+			stored, _, _ := svc.GetDANERecord(ctx, "hns", "chain-installed.hns")
+			assert.Equal(tb, "3 1 1 aabbcc", stored)
+		}, keyTestOptions)
+	})
+
 	t.Run("falls_back_to_stored_tlsa_without_encryption_key", func(t *testing.T) {
 		// The real-world flaw: a chain-managed name whose cert was pushed but
 		// whose private key was never persisted (no key-encryption key). The

--- a/internal/service/domain/dane_key_persistence_test.go
+++ b/internal/service/domain/dane_key_persistence_test.go
@@ -302,6 +302,31 @@ func TestRepublishChainDANERecord(t *testing.T) {
 		}, keyTestOptions)
 	})
 
+	t.Run("recomputes_owner_when_stored_record_has_none", func(t *testing.T) {
+		// A stored TLSA with a missing/corrupt owner_name must still yield a
+		// usable owner — the owner name is deterministic from the domain, so
+		// republish recomputes it instead of returning a bare TLSA.
+		coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+			svc := core.GetService[*DelegatedDomainService](ctx, pluginCore.DELEGATED_DOMAIN_SERVICE)
+			require.NotNil(tb, svc)
+
+			wd := &pluginDb.WebsiteDomain{
+				WebsiteID: 1, UserID: 1, Domain: "chain-noowner.hns", Namespace: pluginDb.DomainNamespaceHNS,
+				Status: pluginDb.DomainStatusOnchainManaged,
+				ProtocolData: datatypes.JSONMap{
+					"tlsa": "3 1 1 aabbcc",
+					// no owner_name
+				},
+			}
+			require.NoError(tb, ctx.DB().Create(wd).Error)
+
+			tlsa, owner, err := svc.RepublishChainDANERecord(ctx, "hns", "chain-noowner.hns")
+			require.NoError(tb, err)
+			assert.Equal(tb, "3 1 1 aabbcc", tlsa)
+			assert.Equal(tb, "_443._tcp.chain-noowner.hns", owner)
+		}, TestOptions)
+	})
+
 	t.Run("falls_back_to_stored_tlsa_without_encryption_key", func(t *testing.T) {
 		// The real-world flaw: a chain-managed name whose cert was pushed but
 		// whose private key was never persisted (no key-encryption key). The

--- a/internal/service/domain/delegated_domain_service.go
+++ b/internal/service/domain/delegated_domain_service.go
@@ -1388,15 +1388,24 @@ func (s *DelegatedDomainService) GetDANERecord(ctx context.Context, namespace, d
 	return tlsa, ownerName, nil
 }
 
-// RepublishChainDANERecord force-refreshes the stored DANE TLSA for a
-// chain-managed (HIP-5) binding and returns the record the owner must install
-// in the name's on-chain zone data. DANE TLSA 3 1 1 pins the stable DANE key's
-// SPKI, so the record is recomputed from the key — the source of truth — rather
-// than from a certificate, and no PowerDNS zone write occurs. When the DANE
-// key-encryption key is unset so a fresh key cannot be persisted, it falls back
-// to the already-stored TLSA (bind-time best-effort policy); if no identity
-// exists at all it returns gorm.ErrRecordNotFound.
+// RepublishChainDANERecord returns the DANE TLSA the owner must install in a
+// chain-managed (HIP-5) binding's on-chain zone data. Republish must preserve
+// an already-installed identity — deriving from the key would rotate the SPKI
+// pin and invalidate the live on-chain record — so an existing stored TLSA is
+// returned unchanged. Only a binding with no on-chain identity yet is
+// bootstrapped from the stable DANE key (the source of truth for TLSA 3 1 1,
+// never a certificate), and no PowerDNS zone write occurs. If no identity
+// exists and a fresh key cannot be persisted (key-encryption key unset), it
+// returns gorm.ErrRecordNotFound.
 func (s *DelegatedDomainService) RepublishChainDANERecord(ctx context.Context, namespace, domain string) (tlsa, ownerName string, err error) {
+	// Preserve the already-installed on-chain identity instead of rotating the
+	// SPKI pin: a stored TLSA is authoritative for what is live on-chain.
+	if tlsa, ownerName, err := s.GetDANERecord(ctx, namespace, domain); err != nil {
+		return "", "", err
+	} else if tlsa != "" {
+		return tlsa, ownerName, nil
+	}
+
 	sc, err := s.EnsureCertificateKey(ctx, namespace, domain)
 	if err == nil {
 		return sc.TLSA, sc.OwnerName, nil
@@ -1404,14 +1413,7 @@ func (s *DelegatedDomainService) RepublishChainDANERecord(ctx context.Context, n
 	if !errors.Is(err, errDANEKeyNotConfigured) {
 		return "", "", fmt.Errorf("refresh on-chain DANE identity: %w", err)
 	}
-	tlsa, ownerName, err = s.GetDANERecord(ctx, namespace, domain)
-	if err != nil {
-		return "", "", err
-	}
-	if tlsa == "" {
-		return "", "", gorm.ErrRecordNotFound
-	}
-	return tlsa, ownerName, nil
+	return "", "", gorm.ErrRecordNotFound
 }
 
 // GetActiveWebsiteDomainByDomain finds an active domain across all namespaces.

--- a/internal/service/domain/delegated_domain_service.go
+++ b/internal/service/domain/delegated_domain_service.go
@@ -1388,6 +1388,32 @@ func (s *DelegatedDomainService) GetDANERecord(ctx context.Context, namespace, d
 	return tlsa, ownerName, nil
 }
 
+// RepublishChainDANERecord force-refreshes the stored DANE TLSA for a
+// chain-managed (HIP-5) binding and returns the record the owner must install
+// in the name's on-chain zone data. DANE TLSA 3 1 1 pins the stable DANE key's
+// SPKI, so the record is recomputed from the key — the source of truth — rather
+// than from a certificate, and no PowerDNS zone write occurs. When the DANE
+// key-encryption key is unset so a fresh key cannot be persisted, it falls back
+// to the already-stored TLSA (bind-time best-effort policy); if no identity
+// exists at all it returns gorm.ErrRecordNotFound.
+func (s *DelegatedDomainService) RepublishChainDANERecord(ctx context.Context, namespace, domain string) (tlsa, ownerName string, err error) {
+	sc, err := s.EnsureCertificateKey(ctx, namespace, domain)
+	if err == nil {
+		return sc.TLSA, sc.OwnerName, nil
+	}
+	if !errors.Is(err, errDANEKeyNotConfigured) {
+		return "", "", fmt.Errorf("refresh on-chain DANE identity: %w", err)
+	}
+	tlsa, ownerName, err = s.GetDANERecord(ctx, namespace, domain)
+	if err != nil {
+		return "", "", err
+	}
+	if tlsa == "" {
+		return "", "", gorm.ErrRecordNotFound
+	}
+	return tlsa, ownerName, nil
+}
+
 // GetActiveWebsiteDomainByDomain finds an active domain across all namespaces.
 func (s *DelegatedDomainService) GetActiveWebsiteDomainByDomain(ctx context.Context, domain string) (*pluginDb.WebsiteDomain, error) {
 	var wd pluginDb.WebsiteDomain

--- a/internal/service/domain/delegated_domain_service.go
+++ b/internal/service/domain/delegated_domain_service.go
@@ -1399,10 +1399,16 @@ func (s *DelegatedDomainService) GetDANERecord(ctx context.Context, namespace, d
 // returns gorm.ErrRecordNotFound.
 func (s *DelegatedDomainService) RepublishChainDANERecord(ctx context.Context, namespace, domain string) (tlsa, ownerName string, err error) {
 	// Preserve the already-installed on-chain identity instead of rotating the
-	// SPKI pin: a stored TLSA is authoritative for what is live on-chain.
+	// SPKI pin: a stored TLSA is authoritative for what is live on-chain. The
+	// owner name is deterministic from the domain, so if the stored record has
+	// no owner_name (missing/corrupt metadata) recompute it rather than return a
+	// bare TLSA the client cannot install.
 	if tlsa, ownerName, err := s.GetDANERecord(ctx, namespace, domain); err != nil {
 		return "", "", err
 	} else if tlsa != "" {
+		if ownerName == "" {
+			ownerName = dane.TLSAOwnerName(domain, DaneTLSAPort, DaneTLSATransport)
+		}
 		return tlsa, ownerName, nil
 	}
 


### PR DESCRIPTION
Fixes on-chain (HIP-5) HNS `dane republish` failing with `NoStoredCertificate` even when a valid TLSA exists. Chain-managed names persist the DANE TLSA + owner but may never store the private key (key-encryption key unset, or a cert predating key bootstrap), while republish required `GetCertificateKey` and errored.

Branches the republish handler on publication locus: the chain path derives the TLSA from the stable DANE key (source of truth) with a fallback to the stored record, never requiring a certificate or writing to a PowerDNS zone.

- `develop` <!-- branch-stack -->
  - **fix(dns): republish chain-managed DANE without a stored certificate** :point\_left:

***

<!-- kody-pr-summary:start -->

## Summary

Fixes DANE republish for chain-managed (HIP-5) domains when no stored certificate or private key is available.

**Problem**\
The republish endpoint previously always required a stored certificate and private key (`GetCertificateKey`) and attempted a PowerDNS zone write. For chain-managed bindings, this failed with `NoStoredCertificate` when the DANE key-encryption key was not configured (so the private key was never persisted) or when only a TLSA record existed from a previous bind.

**Changes**

- The API now branches on the domain's publish locus:
  - **Chain-managed (HIP-5):** Uses the new `RepublishChainDANERecord` service method, which:
    - Recomputes the TLSA from the stable DANE key when the key-encryption key is configured (source of truth for the SPKI pin).
    - Falls back to the already-stored TLSA when the key-encryption key is unset (bind-time best-effort policy).
    - Returns the TLSA and owner name for the owner to install on-chain, without performing any PowerDNS zone write.
    - Returns `gorm.ErrRecordNotFound` only when no identity (TLSA) exists at all.
  - **Non-chain:** Retains the existing certificate‑based update flow.
- Added tests covering:
  - Recomputation from the stored key when the encryption key is available.
  - Fallback to stored TLSA when no private key is persisted.
  - Error when no identity exists.
  - API-level republish success when a TLSA exists but the private key is absent.

<!-- kody-pr-summary:end -->
